### PR TITLE
Potential fix for issue 9556

### DIFF
--- a/core/htmldataprocessor.js
+++ b/core/htmldataprocessor.js
@@ -259,7 +259,7 @@
 				}
 
 				// From IE DOM, at the end of a text block, or before block boundary.
-				if ( CKEDITOR.env.ie && isOutput && ( !atBlockEnd || node.parent.name in textBlockTags ) )
+				if ( CKEDITOR.env.ie && isOutput && ( !atBlockEnd || node.parent && node.parent.name in textBlockTags ) )
 					return true;
 
 				// From the output.


### PR DESCRIPTION
https://dev.ckeditor.com/ticket/9556

A simple way of reproducing this issue is to type the word, 'Hello' in
to a blank document, press enter, then type the letter 'w'. The
auto-correct mechanism will attempt to join the two text nodes as one,
with the most common suggestion being 'yellow'.

The core of this issue is mobile safari's reliance on detecting when
the enter key has been pressed. It's not mentioned in the ticket, but
when you press enter the next line of the document is also not
auto-capitialized.

I have found only two ways of fixing this issue, the first and most
obvious is to ask the user to disable the auto-correct setting in their
device. The second is to allow the browser to execute the event
normally (not preventDefault), and execute a deferred function. The
deferred function should first; execute the undo command (this will
remove the browser created element), then execute the enter logic
normally.

This does open the door for a potential visual issue. While in debug
(running _source) mode the cursor sometimes shows on the previous node,
then is placed back on the new node. In production mode I do not see
this issue.

It should also be mentioned that this fixes both the auto-correct and
auto-capitalization issues.

Test environment;
I am using the iPad 2 and running iOS 6.0.1.