### PR TITLE
Allow configuration to set magicline elements

### DIFF
--- a/plugins/magicline/plugin.js
+++ b/plugins/magicline/plugin.js
@@ -36,7 +36,7 @@
 				holdDistance: 0 | triggerOffset * ( config.magicline_holdDistance || 0.5 ),
 				boxColor: config.magicline_color || '#ff0000',
 				rtl: config.contentsLangDirection == 'rtl',
-				triggers: config.magicline_everywhere ? DTD_BLOCK : { table:1,hr:1,div:1,ul:1,ol:1,dl:1,form:1,blockquote:1 }
+				triggers: config.magicline_everywhere ? DTD_BLOCK : config.magicline_triggers || { table:1,hr:1,div:1,ul:1,ol:1,dl:1,form:1,blockquote:1 }
 			},
 			scrollTimeout, checkMouseTimeoutPending, checkMouseTimeout, checkMouseTimer;
 

--- a/skins/moono/dialog_iequirks.css
+++ b/skins/moono/dialog_iequirks.css
@@ -17,5 +17,5 @@ Quirks mode only.
 /* [IE7-8] Filter on footer causes background artifacts when opening dialog. */
 .cke_dialog_footer
 {
-	filter: ;
+	filter: "";
 }


### PR DESCRIPTION
This pull requests gives you the option to pass in an object specifying the elements you want magicline to trigger. Right now it's either everything or the random elements that was hardcoded in the plugin.
