### PR TITLE
Optional per menu prevent drag or drop configuration for floating panels.  #10373

### DIFF
--- a/plugins/colorbutton/plugin.js
+++ b/plugins/colorbutton/plugin.js
@@ -39,6 +39,7 @@ CKEDITOR.plugins.add( 'colorbutton', {
 
 				panel: {
 					css: CKEDITOR.skin.getPath( 'editor' ),
+          preventDrag: true,
 					attributes: { role: 'listbox', 'aria-label': lang.panelTitle }
 				},
 

--- a/plugins/floatpanel/plugin.js
+++ b/plugins/floatpanel/plugin.js
@@ -157,6 +157,7 @@ CKEDITOR.plugins.add( 'floatpanel', {
 					left = position.x + ( offsetX || 0 ) - positionedAncestorPosition.x,
 					top = position.y + ( offsetY || 0 ) - positionedAncestorPosition.y;
 
+        
 				// Floating panels are off by (-1px, 0px) in RTL mode. (#3438)
 				if ( rtl && ( corner == 1 || corner == 4 ) )
 					left += offsetParent.$.offsetWidth;
@@ -365,20 +366,47 @@ CKEDITOR.plugins.add( 'floatpanel', {
 
 					// Set the panel frame focus, so the blur event gets fired.
 					CKEDITOR.tools.setTimeout( function() {
-
 						this.focus();
 
 						// We need this get fired manually because of unfired focus() function.
 						this.allowBlur( true );
 						this._.editor.fire( 'panelShow', this );
-					}, 0, this );
-				}, CKEDITOR.env.air ? 200 : 0, this );
-				this.visible = 1;
 
+            if(CKEDITOR.config.disableMenuDrag){
+              this.setDragOff();
+            }else{
+              this.setDragOn();
+            }
+					}, 0, this );
+
+
+				}, CKEDITOR.env.air ? 200 : 0, this );
+
+				this.visible = 1;
 				if ( this.onShow )
 					this.onShow.call( this );
 
 			},
+      getFrameBody: function(cfg){
+        var t = cfg || this._; 
+        if(t && t.iframe && t.iframe.$){
+          var el   = t.iframe.$;
+          return el.contentDocument || el.contentWindow;
+        }
+      },
+      setDragOn: function(){
+        var body = this.getFrameBody();
+        if(body && body.ondragstart){
+          body.ondragstart = null;
+        }
+      },
+      setDragOff: function(){
+        var body = this.getFrameBody();
+        if(body && !body.ondragstart){
+          body.ondragstart = function(){return false;}
+        }
+    
+      },
 
 			/**
 			 * Restores last focused element or simply focus panel window.

--- a/plugins/floatpanel/plugin.js
+++ b/plugins/floatpanel/plugin.js
@@ -368,17 +368,16 @@ CKEDITOR.plugins.add( 'floatpanel', {
 					CKEDITOR.tools.setTimeout( function() {
 						this.focus();
 
+            if(this._.definition && this._.definition.preventDrag){
+              this.setDragOff();
+            }else{//Required since we turn the event off.
+              this.setDragOn();
+            }
+            
 						// We need this get fired manually because of unfired focus() function.
 						this.allowBlur( true );
 						this._.editor.fire( 'panelShow', this );
-
-            if(CKEDITOR.config.disableMenuDrag){
-              this.setDragOff();
-            }else{
-              this.setDragOn();
-            }
 					}, 0, this );
-
 
 				}, CKEDITOR.env.air ? 200 : 0, this );
 
@@ -387,25 +386,17 @@ CKEDITOR.plugins.add( 'floatpanel', {
 					this.onShow.call( this );
 
 			},
-      getFrameBody: function(cfg){
-        var t = cfg || this._; 
-        if(t && t.iframe && t.iframe.$){
-          var el   = t.iframe.$;
-          return el.contentDocument || el.contentWindow;
-        }
-      },
       setDragOn: function(){
-        var body = this.getFrameBody();
-        if(body && body.ondragstart){
-          body.ondragstart = null;
+        var body = this._.iframe.getFrameDocument().getBody();
+        if(body && body.$ && body.$.ondragstart){
+          body.$.ondragstart = null;
         }
       },
       setDragOff: function(){
-        var body = this.getFrameBody();
-        if(body && !body.ondragstart){
-          body.ondragstart = function(){return false;}
+        var body = this._.iframe.getFrameDocument().getBody();
+        if(body && body.$ && !body.$.ondragstart){
+          body.$.ondragstart =  function(){return false;};
         }
-    
       },
 
 			/**

--- a/plugins/font/plugin.js
+++ b/plugins/font/plugin.js
@@ -41,6 +41,7 @@
 			panel: {
 				css: [ CKEDITOR.skin.getPath( 'editor' ) ].concat( config.contentsCss ),
 				multiSelect: false,
+        preventDrag: true,
 				attributes: { 'aria-label': lang.panelTitle }
 			},
 

--- a/plugins/format/plugin.js
+++ b/plugins/format/plugin.js
@@ -44,6 +44,7 @@ CKEDITOR.plugins.add( 'format', {
 			panel: {
 				css: [ CKEDITOR.skin.getPath( 'editor' ) ].concat( config.contentsCss ),
 				multiSelect: false,
+        preventDrag: true,
 				attributes: { 'aria-label': lang.panelTitle }
 			},
 

--- a/plugins/stylescombo/plugin.js
+++ b/plugins/stylescombo/plugin.js
@@ -63,7 +63,8 @@
 				panel: {
 					css: [ CKEDITOR.skin.getPath( 'editor' ) ].concat( config.contentsCss ),
 					multiSelect: true,
-					attributes: { 'aria-label': lang.panelTitle }
+          preventDrag: true,
+					attributes: { 'aria-label': lang.panelTitle },
 				},
 
 				init: function() {


### PR DESCRIPTION
Made some of the changes I believe you wanted in the valid rejection of:
https://github.com/ckeditor/ckeditor-dev/pull/52

Now when creating a panel you can provide prevent drag as a param.  Panels that do not have this parameter can still drag and drop, tested on FF, Chrome, Safari.
