### PR TITLE
Check if iframe exists before clearing custom data

### DIFF
--- a/plugins/wysiwygarea/plugin.js
+++ b/plugins/wysiwygarea/plugin.js
@@ -497,19 +497,21 @@
 				// Memory leak proof.
 				this.clearCustomData();
 				doc.getDocumentElement().clearCustomData();
-				iframe.clearCustomData();
-				CKEDITOR.tools.removeFunction( this._.frameLoadedHandler );
+				if (iframe) {
+					iframe.clearCustomData();
+					CKEDITOR.tools.removeFunction( this._.frameLoadedHandler );
 
-				var onResize = iframe.removeCustomData( 'onResize' );
-				onResize && onResize.removeListener();
+					var onResize = iframe.removeCustomData( 'onResize' );
+					onResize && onResize.removeListener();
 
+
+					// IE BUG: When destroying editor DOM with the selection remains inside
+					// editing area would break IE7/8's selection system, we have to put the editing
+					// iframe offline first. (#3812 and #5441)
+					iframe.remove();
+				}
 
 				editor.fire( 'contentDomUnload' );
-
-				// IE BUG: When destroying editor DOM with the selection remains inside
-				// editing area would break IE7/8's selection system, we have to put the editing
-				// iframe offline first. (#3812 and #5441)
-				iframe.remove();
 			}
 		}
 	});


### PR DESCRIPTION
The issue was introduced when someone uses ckeditor as an AngularJS directive. 

I wrote a directive that before initializing an instance of CKEDITOR if first destroys all existing ones. 
So far so good. But if I have a ckeditor instance initilized and I remove the directive with angularJS (eg inside repear) then the iframe becomes null and thus a error popsup. 

'Uncaught TypeError: Cannot call method 'clearCustomData' of null'

This is the case scenario: 

1. Bind an instance to an element using the CKEDITOR.replace
2. Having the instance open remove the element using ANGULARJS
3. Try to use destroy on all existing instances. 
4. Error. 'Uncaught TypeError: Cannot call method 'clearCustomData' of null'