### PR TITLE
#12077 Add support for download attribute to link plugin

### DIFF
--- a/plugins/link/dialogs/link.js
+++ b/plugins/link/dialogs/link.js
@@ -110,7 +110,7 @@
 		return {
 			title: linkLang.title,
 			minWidth: 350,
-			minHeight: 230,
+			minHeight: 240,
 			contents: [
 				{
 				id: 'info',
@@ -826,7 +826,27 @@
 							commit: commitAdvParams
 						}
 						]
-					}
+					},
+						{
+							type: 'hbox',
+							widths: [ '45%', '55%' ],
+							children: [
+								{
+									type: 'checkbox',
+									id: 'download',
+									label: linkLang.download,
+									setup: function( data ) {
+										if ( data.download !== undefined )
+											this.setValue( 'checked', 'checked' );
+									},
+									commit: function( data ) {
+										if ( this.getValue() ) {
+											data.download = this.getValue();
+										}
+									}
+								}
+							]
+						}
 					]
 				}
 				]

--- a/plugins/link/lang/de.js
+++ b/plugins/link/lang/de.js
@@ -46,6 +46,7 @@ CKEDITOR.plugins.setLang( 'link', 'de', {
 	popupToolbar: 'Symbolleiste',
 	popupTop: 'Obere Position',
 	rel: 'Beziehung',
+	download: 'Download erzwingen',
 	selectAnchor: 'Anker auswählen',
 	styles: 'Style',
 	tabIndex: 'Tab-Index',

--- a/plugins/link/lang/en-au.js
+++ b/plugins/link/lang/en-au.js
@@ -46,6 +46,7 @@ CKEDITOR.plugins.setLang( 'link', 'en-au', {
 	popupToolbar: 'Toolbar',
 	popupTop: 'Top Position',
 	rel: 'Relationship', // MISSING
+	download: 'Force Download',
 	selectAnchor: 'Select an Anchor',
 	styles: 'Style',
 	tabIndex: 'Tab Index',

--- a/plugins/link/lang/en-ca.js
+++ b/plugins/link/lang/en-ca.js
@@ -46,6 +46,7 @@ CKEDITOR.plugins.setLang( 'link', 'en-ca', {
 	popupToolbar: 'Toolbar',
 	popupTop: 'Top Position',
 	rel: 'Relationship', // MISSING
+	download: 'Force Download',
 	selectAnchor: 'Select an Anchor',
 	styles: 'Style',
 	tabIndex: 'Tab Index',

--- a/plugins/link/lang/en-gb.js
+++ b/plugins/link/lang/en-gb.js
@@ -46,6 +46,7 @@ CKEDITOR.plugins.setLang( 'link', 'en-gb', {
 	popupToolbar: 'Toolbar',
 	popupTop: 'Top Position',
 	rel: 'Relationship',
+	download: 'Force Download',
 	selectAnchor: 'Select an Anchor',
 	styles: 'Style',
 	tabIndex: 'Tab Index',

--- a/plugins/link/lang/en.js
+++ b/plugins/link/lang/en.js
@@ -46,6 +46,7 @@ CKEDITOR.plugins.setLang( 'link', 'en', {
 	popupToolbar: 'Toolbar',
 	popupTop: 'Top Position',
 	rel: 'Relationship',
+	download: 'Force Download',
 	selectAnchor: 'Select an Anchor',
 	styles: 'Style',
 	tabIndex: 'Tab Index',

--- a/plugins/link/plugin.js
+++ b/plugins/link/plugin.js
@@ -50,7 +50,7 @@
 				required = 'a[href]';
 
 			if ( CKEDITOR.dialog.isTabEnabled( editor, 'link', 'advanced' ) )
-				allowed = allowed.replace( ']', ',accesskey,charset,dir,id,lang,name,rel,tabindex,title,type]{*}(*)' );
+				allowed = allowed.replace( ']', ',accesskey,charset,dir,id,lang,name,rel,tabindex,title,type,download]{*}(*)' );
 			if ( CKEDITOR.dialog.isTabEnabled( editor, 'link', 'target' ) )
 				allowed = allowed.replace( ']', ',target,onclick]' );
 
@@ -518,6 +518,11 @@
 					};
 				}
 
+				var download = element.getAttribute( 'download' );
+				if ( download !== null ) {
+					retval.download = true;
+				}
+
 				var advanced = {};
 
 				for ( var a in advAttrNames ) {
@@ -655,6 +660,11 @@
 					set.target = data.target.name;
 			}
 
+			// Force download attribute.
+			if ( data.download ) {
+				set[ 'download' ] = '';
+			}
+
 			// Advanced attributes.
 			if ( data.advanced ) {
 				for ( var a in advAttrNames ) {
@@ -676,7 +686,8 @@
 				target: 1,
 				onclick: 1,
 				'data-cke-pa-onclick': 1,
-				'data-cke-saved-name': 1
+				'data-cke-saved-name': 1,
+				'download': 1
 			}, advAttrNames );
 
 			// Remove all attributes which are not currently set.


### PR DESCRIPTION
This change adds a checkbox to set the HTML5 download attribute in the advanced tab of the link dialog, allowing to force a download.

Please note that setting a custom file name for the download as mentioned in the comments of the related ticket was not implemented this time. Having two fields (checkbox + textfield) managing one single attribute would have led to a much more complicated change.

![download-flag](https://cloud.githubusercontent.com/assets/7569142/4335875/293748da-4001-11e4-9a5a-28d4384ee2d7.png)
