### PR TITLE
Fix exception when tabbing out of readonly editor

### DIFF
--- a/plugins/indent/plugin.js
+++ b/plugins/indent/plugin.js
@@ -361,7 +361,7 @@
 		 * @returns {CKEDITOR.dom.element}
 		 */
 		getContext: function( path ) {
-			return path.contains( this.context );
+			return path ? path.contains( this.context ) : null;
 		}
 	};
 


### PR DESCRIPTION
Indent plugin wasn't correctly handling the case where the editor is
read only; in that case, the path sent to getContext is null (since
there's no selection) and null objects aren't so great for
dereferencing. Added a null check for path.
