### PR TITLE
Update image.js

### DIFF
--- a/plugins/image/dialogs/image.js
+++ b/plugins/image/dialogs/image.js
@@ -217,6 +217,8 @@
 
 					this.firstLoad = false;
 					this.dontResetSize = false;
+
+					updatePreview(this);
 				};
 
 			var onImgLoadErrorEvent = function() {


### PR DESCRIPTION
We have to update preview after the original image was loaded.
If we do that - the preview will have correct size after dialog is opened.
At this moment an image with a reduced size has 100% dimensions in dialog preview block before we make any changes and another update is triggered.