### PR TITLE
Fix to ensure any ascendant tables found are within editor

### DIFF
--- a/plugins/tableresize/plugin.js
+++ b/plugins/tableresize/plugin.js
@@ -385,6 +385,12 @@
 
 					table = target.getAscendant( 'table', 1 );
 
+					// Make sure the table we found is inside the container
+					// (eg. we should not use tables the editor is embedded within)
+					if ( !editor.container.contains(table) )
+						return;
+
+
 					if ( !( pillars = table.getCustomData( '_cke_table_pillars' ) ) ) {
 						// Cache table pillars calculation result.
 						table.setCustomData( '_cke_table_pillars', ( pillars = buildTableColumnPillars( table ) ) );


### PR DESCRIPTION
When tableresize plugin attempts to determine if mouse is currently
over a table, it performs a search of the ascendants of the event
target.  However this search will continue outside of the editable
container, and thus find tables in which the editable may be
embedded.  This fix adds a check to ensure any found table is in
fact a descendant of the editable container.