### PR TITLE
save plugin inline editor ajax save optional feat.

### DIFF
--- a/plugins/save/lang/en.js
+++ b/plugins/save/lang/en.js
@@ -3,5 +3,6 @@ Copyright (c) 2003-2014, CKSource - Frederico Knabben. All rights reserved.
 For licensing, see LICENSE.md or http://ckeditor.com/license
 */
 CKEDITOR.plugins.setLang( 'save', 'en', {
-	toolbar: 'Save'
+	toolbar: 'Save',
+	ko: 'Error: Save operation has failed.'
 } );

--- a/plugins/save/plugin.js
+++ b/plugins/save/plugin.js
@@ -1,4 +1,4 @@
-﻿/**
+/**
  * @license Copyright (c) 2003-2014, CKSource - Frederico Knabben. All rights reserved.
  * For licensing, see LICENSE.md or http://ckeditor.com/license
  */
@@ -29,6 +29,43 @@
 			}
 		}
 	};
+	
+	var saveInlineCmd = {
+		
+		exec: function(editor) {
+			
+			if ( editor.fire( 'save' ) ) {
+			
+				var containerId = editor.container.getId(),
+				content = editor.getData(), 
+				encodedContent = encodeURIComponent(content).replace(
+					/[!'()*]/g, 
+					function(c) {
+						return '%' + c.charCodeAt(0).toString(16);
+					}
+				),
+				actionUrl = editor.container.$.getAttribute('data-actionUrl'),
+				callback = function(responseText){
+					if (responseText === null){
+						alert(editor.lang.save.ko);
+					} else {
+						editor.commands.save.disable();
+						alert(responseText);
+					}
+				};
+				
+				CKEDITOR.ajax.post( 
+					actionUrl, 
+					'editorID='+containerId+'&editabledata='+encodedContent, 
+					null, 
+					callback
+				);
+				
+			}
+			
+		}
+		
+	};
 
 	var pluginName = 'save';
 
@@ -38,18 +75,40 @@
 		icons: 'save', // %REMOVE_LINE_CORE%
 		hidpi: true, // %REMOVE_LINE_CORE%
 		init: function( editor ) {
-			// Save plugin is for replace mode only.
-			if ( editor.elementMode != CKEDITOR.ELEMENT_MODE_REPLACE )
+			
+			if ( editor.elementMode === CKEDITOR.ELEMENT_MODE_REPLACE ){
+				
+				var command = editor.addCommand( pluginName, saveCmd );
+				command.modes = { wysiwyg: !!( editor.element.$.form ) };
+				
+			} else if ( 
+				editor.elementMode === CKEDITOR.ELEMENT_MODE_INLINE 
+				&& ('ajax' in CKEDITOR) 
+				&& editor.element.$.hasAttribute('data-actionUrl') 
+			){
+				
+				var command = editor.addCommand( pluginName, saveInlineCmd );
+				
+				// On inline editors the save button is disabled unless the editor is dirty.
+				// This makes easier to keep track of what editors contain unsaved changes
+				// when having multiple inline editors on the same page.
+				editor.on('change', function(){ editor.checkDirty()?editor.commands.save.enable():editor.commands.save.disable(); });
+				editor.on('instanceReady', function () { editor.commands.save.disable(); });
+
+			} else {
+				
+				// Save plugin is only for replace mode, 
+				// and also inline mode if ckeditor ajax plugin is available 
+				// and the container has a data-actionUrl attribute.
 				return;
-
-			var command = editor.addCommand( pluginName, saveCmd );
-			command.modes = { wysiwyg: !!( editor.element.$.form ) };
-
+			}
+			
 			editor.ui.addButton && editor.ui.addButton( 'Save', {
 				label: editor.lang.save.toolbar,
 				command: pluginName,
 				toolbar: 'document,10'
 			} );
+
 		}
 	} );
 } )();

--- a/plugins/save/plugin.js
+++ b/plugins/save/plugin.js
@@ -31,6 +31,7 @@
 	};
 	
 	var saveInlineCmd = {
+		readOnly: 1,
 		
 		exec: function(editor) {
 			


### PR DESCRIPTION
Leaves the current functionality for `CKEDITOR.ELEMENT_MODE_REPLACE` without any modifications, adding a few extra lines for handling `CKEDITOR.ELEMENT_MODE_INLINE` editors: 

If a target is specified on an inline editor container's html5 `data-actionUrl` param and the AJAX plugin is available, the standard save button will show up in the editor. 

The button will show up disabled and it will be enabled only when the editor content is dirty. 

When clicked, it will trigger an AJAX POST request containing the editor id and content (post params `editorID` and `editabledata`, urlencoded).