### PR TITLE
Added event-facilities to the autoloader

### DIFF
--- a/core/loader.js
+++ b/core/loader.js
@@ -103,6 +103,35 @@ if ( !CKEDITOR.loader ) {
 			};
 
 		var pendingLoad = [];
+		var handlers = {
+			ready: []
+		};
+		
+		function unregister(event,callback){
+			handlers[event] = handlers[event].filter(function(handler){
+				return handler.callback !== callback;
+			});
+		}
+		
+		function register(event,handler){
+			switch( event ) {
+				case 'ready':
+					if ( pendingLoad.length <= 0 ) {
+						handler.callback();
+						if ( handler.one ) return;
+					}
+					break;
+			}
+			
+			handlers[event].push(handler);
+		}
+		
+		function trigger(event){
+			handlers[event] = handlers[event].filter(function(handler){
+				handler.callback();
+				return !handler.one
+			});
+		}
 
 		return {
 			/**
@@ -112,6 +141,15 @@ if ( !CKEDITOR.loader ) {
 			 *		alert( CKEDITOR.loader.loadedScripts );
 			 */
 			loadedScripts: [],
+			off: function(event,callback){
+				unregister(event,callback);
+			},
+			one: function(event,callback){
+				register(event,{callback:callback,one:true});
+			},
+			on: function(event,callback){
+				register(event,{callback:callback});
+			},
 			/**
 			 * Table of script names and their dependencies.
 			 *
@@ -125,8 +163,10 @@ if ( !CKEDITOR.loader ) {
 			loadPending: function() {
 				var scriptName = pendingLoad.shift();
 
-				if ( !scriptName )
+				if ( !scriptName ) {
+					trigger('ready');
 					return;
+				}
 
 				var scriptSrc = getUrl( 'core/' + scriptName + '.js' );
 


### PR DESCRIPTION
Added event-facilities to the autoloader

This allows to listen for when all required scripts have been loaded asynchronously, when ckeditor itself is loaded on demand after the document is already finished.

Previously there was no way to wait until everything was available and only then initialize the editor.