### PR TITLE
Stop removing disabled items from menu.

### DIFF
--- a/plugins/menu/plugin.js
+++ b/plugins/menu/plugin.js
@@ -175,8 +175,8 @@ CKEDITOR.plugins.add( 'menu', {
 						for ( var itemName in listenerItems ) {
 							var item = this.editor.getMenuItem( itemName );
 
-							if ( item && ( !item.command || this.editor.getCommand( item.command ).state ) ) {
-								item.state = listenerItems[ itemName ];
+							if ( item ) {
+								item.state = item.command ? this.editor.getCommand( item.command ).state : listenerItems[ itemName ];
 								this.add( item );
 							}
 						}

--- a/plugins/table/plugin.js
+++ b/plugins/table/plugin.js
@@ -97,12 +97,13 @@ CKEDITOR.plugins.add( 'table', {
 
 		// If the "contextmenu" plugin is loaded, register the listeners.
 		if ( editor.contextMenu ) {
-			editor.contextMenu.addListener( function() {
-				// menu item state is resolved on commands.
-				return {
-					tabledelete: CKEDITOR.TRISTATE_OFF,
-					table: CKEDITOR.TRISTATE_OFF
-				};
+			editor.contextMenu.addListener( function( element, selection, path ) {
+				if ( path.contains( 'table', 1 ) ) {
+					return {
+						tabledelete: CKEDITOR.TRISTATE_OFF,
+						table: CKEDITOR.TRISTATE_OFF
+					};
+				}
 			} );
 		}
 	}


### PR DESCRIPTION
Fix for http://dev.ckeditor.com/ticket/12723

Context menu now contains permanent cut/copy menu items (disabled when selection is empty). Is it ok?

We could also modify `contextmenu` plugin, so it would hide disabled items. Not sure.
