### PR TITLE
Fixed Uncaught SecurityError for Chrome/IE

### DIFF
--- a/plugins/lineutils/plugin.js
+++ b/plugins/lineutils/plugin.js
@@ -59,8 +59,9 @@
 			win: editor.window
 		}, def, true );
 
-		this.frame = this.win.getFrame();
 		this.inline = this.editable.isInline();
+		if ( !this.inline )
+			this.frame = this.win.getFrame();
 		this.target = this[ this.inline ? 'editable' : 'doc' ];
 	}
 


### PR DESCRIPTION
This PR fixes the issue when trying to init CKEditor inline within an iframe