### PR TITLE
#12796 - Fix list unwrapping

### DIFF
--- a/plugins/indentlist/plugin.js
+++ b/plugins/indentlist/plugin.js
@@ -232,13 +232,13 @@
 			range;
 
 		while ( ( range = iterator.getNextRange() ) ) {
-			var rangeRoot = range.getCommonAncestor(),
-				nearestListBlock = rangeRoot;
+			var nearestListBlock = range.getCommonAncestor();
 
 			while ( nearestListBlock && !( nearestListBlock.type == CKEDITOR.NODE_ELEMENT && context[ nearestListBlock.getName() ] ) ) {
 				// Avoid having plugin propagate to parent of editor in inline mode by canceling the indentation. (#12796)
 				if ( editor.editable().equals( nearestListBlock ) ) {
-					return 0;
+					nearestListBlock = false;
+					break;
 				}
 				nearestListBlock = nearestListBlock.getParent();
 			}

--- a/plugins/indentlist/plugin.js
+++ b/plugins/indentlist/plugin.js
@@ -235,8 +235,13 @@
 			var rangeRoot = range.getCommonAncestor(),
 				nearestListBlock = rangeRoot;
 
-			while ( nearestListBlock && !( nearestListBlock.type == CKEDITOR.NODE_ELEMENT && context[ nearestListBlock.getName() ] ) )
+			while ( nearestListBlock && !( nearestListBlock.type == CKEDITOR.NODE_ELEMENT && context[ nearestListBlock.getName() ] ) ) {
+				// Avoid having plugin propagate to parent of editor in inline mode by canceling the indentation. (#12796)
+				if ( editor.element.equals( nearestListBlock ) ) {
+					return 0;
+				}
 				nearestListBlock = nearestListBlock.getParent();
+			}
 
 			// Avoid having selection boundaries out of the list.
 			// <ul><li>[...</li></ul><p>...]</p> => <ul><li>[...]</li></ul><p>...</p>

--- a/plugins/indentlist/plugin.js
+++ b/plugins/indentlist/plugin.js
@@ -237,7 +237,7 @@
 
 			while ( nearestListBlock && !( nearestListBlock.type == CKEDITOR.NODE_ELEMENT && context[ nearestListBlock.getName() ] ) ) {
 				// Avoid having plugin propagate to parent of editor in inline mode by canceling the indentation. (#12796)
-				if ( editor.element.equals( nearestListBlock ) ) {
+				if ( editor.editable().equals( nearestListBlock ) ) {
 					return 0;
 				}
 				nearestListBlock = nearestListBlock.getParent();

--- a/tests/tickets/12796/1.html
+++ b/tests/tickets/12796/1.html
@@ -1,0 +1,12 @@
+<ul>
+	<li id="outerListItem">
+		<div contenteditable="true" id="editor1">
+			<ul>
+				<li>1</li>
+			</ul>
+			<ol>
+				<li>2</li>
+			</ol>
+		</div>
+	</li>
+</ul>

--- a/tests/tickets/12796/1.html
+++ b/tests/tickets/12796/1.html
@@ -1,12 +1,5 @@
 <ul>
 	<li id="outerListItem">
-		<div contenteditable="true" id="editor1">
-			<ul>
-				<li>1</li>
-			</ul>
-			<ol>
-				<li>2</li>
-			</ol>
-		</div>
+		<div contenteditable="true" id="editor1"></div>
 	</li>
 </ul>

--- a/tests/tickets/12796/1.js
+++ b/tests/tickets/12796/1.js
@@ -22,6 +22,10 @@ bender.test( {
 			var body = CKEDITOR.document.getBody();
 			assert.isTrue( body.contains( originalEditableParent ), 'editable\'s parent was not removed from the body element' );
 			assert.areSame( originalEditableParent, originalEditable.getParent(), 'editable\'s parent did not change' );
+
+			// It is not necessarily the most expected result (I would expect both lists to be outdented),
+			// but this is how the alogirthm works in an iframed editor at the moment.
+			assert.areSame( '<p>1</p><ol><li>2</li></ol>', editor.getData(), 'the first of the selected lists was outdented' );
 		} );
 	}
 } );

--- a/tests/tickets/12796/1.js
+++ b/tests/tickets/12796/1.js
@@ -14,11 +14,14 @@ bender.test( {
 			editor.focus();
 			bender.tools.selection.setWithHtml( editor, '<ul>[<li>1</li></ul><ol><li>2</li>]</ol>' );
 
+			var originalEditable = editor.editable(),
+				originalEditableParent = originalEditable.getParent();
+
 			bot.execCommand( 'outdent' );
 
-			var parentId = CKEDITOR.document.getById( 'editor1' ).getParent().$.id;
-
-			assert.areEqual( 'outerListItem', parentId, 'editor unwrapped parent li' );
+			var body = CKEDITOR.document.getBody();
+			assert.isTrue( body.contains( originalEditableParent ), 'editable\'s parent was not removed from the body element' );
+			assert.areSame( originalEditableParent, originalEditable.getParent(), 'editable\'s parent did not change' );
 		} );
 	}
 } );

--- a/tests/tickets/12796/1.js
+++ b/tests/tickets/12796/1.js
@@ -1,0 +1,24 @@
+/* bender-tags: editor,unit */
+/* bender-ckeditor-plugins: toolbar,floatingspace,list */
+
+CKEDITOR.disableAutoInline = true;
+
+bender.test( {
+	'test outdent does not unwrap parent li': function() {
+		bender.editorBot.create( {
+			creator: 'inline',
+			name: 'editor1'
+		}, function( bot ) {
+			var editor = bot.editor;
+
+			editor.focus();
+			bender.tools.selection.setWithHtml( editor, '<ul>[<li>1</li></ul><ol><li>2</li>]</ol>' );
+
+			bot.execCommand( 'outdent' );
+
+			var parentId = CKEDITOR.document.getById( 'editor1' ).getParent().$.id;
+
+			assert.areEqual( 'outerListItem', parentId, 'editor unwrapped parent li' );
+		} );
+	}
+} );

--- a/tests/tickets/12796/1.js
+++ b/tests/tickets/12796/1.js
@@ -4,7 +4,7 @@
 CKEDITOR.disableAutoInline = true;
 
 bender.test( {
-	'test outdent does not unwrap parent li': function() {
+	'test outdent does not unwrap parent li with multiple lists and both lists selected': function() {
 		bender.editorBot.create( {
 			creator: 'inline',
 			name: 'editor1'
@@ -12,7 +12,7 @@ bender.test( {
 			var editor = bot.editor;
 
 			editor.focus();
-			bender.tools.selection.setWithHtml( editor, '<ul>[<li>1</li></ul><ol><li>2</li>]</ol>' );
+			bender.tools.selection.setWithHtml( editor, '<ul><li>[1</li></ul><ol><li>2]</li></ol>' );
 
 			var originalEditable = editor.editable(),
 				originalEditableParent = originalEditable.getParent();
@@ -24,7 +24,7 @@ bender.test( {
 			assert.areSame( originalEditableParent, originalEditable.getParent(), 'editable\'s parent did not change' );
 
 			// It is not necessarily the most expected result (I would expect both lists to be outdented),
-			// but this is how the alogirthm works in an iframed editor at the moment.
+			// but this is how the algorithm works in an iframed editor at the moment.
 			assert.areSame( '<p>1</p><ol><li>2</li></ol>', editor.getData(), 'the first of the selected lists was outdented' );
 		} );
 	}

--- a/tests/tickets/12796/2.html
+++ b/tests/tickets/12796/2.html
@@ -1,0 +1,5 @@
+<ul>
+  <li id="outerListItem">
+    <div contenteditable="true" id="editor1"></div>
+  </li>
+</ul>

--- a/tests/tickets/12796/2.js
+++ b/tests/tickets/12796/2.js
@@ -1,0 +1,31 @@
+/* bender-tags: editor,unit */
+/* bender-ckeditor-plugins: toolbar,floatingspace,list */
+
+CKEDITOR.disableAutoInline = true;
+
+bender.test( {
+  'test outdent does not unwrap parent li with multiple lists and one list selected': function() {
+    bender.editorBot.create( {
+      creator: 'inline',
+      name: 'editor1'
+    }, function( bot ) {
+      var editor = bot.editor;
+
+      editor.focus();
+      bender.tools.selection.setWithHtml( editor, '<ul><li>[1]</li></ul><ol><li>2</li></ol>' );
+
+      var originalEditable = editor.editable(),
+        originalEditableParent = originalEditable.getParent();
+
+      bot.execCommand( 'outdent' );
+
+      var body = CKEDITOR.document.getBody();
+      assert.isTrue( body.contains( originalEditableParent ), 'editable\'s parent was not removed from the body element' );
+      assert.areSame( originalEditableParent, originalEditable.getParent(), 'editable\'s parent did not change' );
+
+      // It is not necessarily the most expected result (I would expect both lists to be outdented),
+      // but this is how the algorithm works in an iframed editor at the moment.
+      assert.areSame( '<p>1</p><ol><li>2</li></ol>', editor.getData(), 'the first of the selected lists was outdented' );
+    } );
+  }
+} );

--- a/tests/tickets/12796/3.html
+++ b/tests/tickets/12796/3.html
@@ -1,0 +1,5 @@
+<ul>
+  <li id="outerListItem">
+    <div contenteditable="true" id="editor1"></div>
+  </li>
+</ul>

--- a/tests/tickets/12796/3.js
+++ b/tests/tickets/12796/3.js
@@ -1,0 +1,31 @@
+/* bender-tags: editor,unit */
+/* bender-ckeditor-plugins: toolbar,floatingspace,list */
+
+CKEDITOR.disableAutoInline = true;
+
+bender.test( {
+  'test outdent does not unwrap parent li with a single list': function() {
+    bender.editorBot.create( {
+      creator: 'inline',
+      name: 'editor1'
+    }, function( bot ) {
+      var editor = bot.editor;
+
+      editor.focus();
+      bender.tools.selection.setWithHtml( editor, '<ul><li>[1]</li></ul>' );
+
+      var originalEditable = editor.editable(),
+        originalEditableParent = originalEditable.getParent();
+
+      bot.execCommand( 'outdent' );
+
+      var body = CKEDITOR.document.getBody();
+      assert.isTrue( body.contains( originalEditableParent ), 'editable\'s parent was not removed from the body element' );
+      assert.areSame( originalEditableParent, originalEditable.getParent(), 'editable\'s parent did not change' );
+
+      // It is not necessarily the most expected result (I would expect both lists to be outdented),
+      // but this is how the algorithm works in an iframed editor at the moment.
+      assert.areSame( '<p>1</p>', editor.getData(), 'the first of the selected lists was outdented' );
+    } );
+  }
+} );


### PR DESCRIPTION
This pull attempts to fix http://dev.ckeditor.com/ticket/12796 by returning immediately when executing indent/outdent on a list where the common ancestor of the selected nodes happens to be the editor itself  or another block element that is in the editor, but not contained within an ol or ul (such as a div).

The while loop without this conditional causes the selection to propagate up to parent list elements outside of an editor in inline mode and modify them, breaking the editor itself.

If some default behavior is desired rather than just returning immediately before calling indent, let me know.