### PR TITLE
Ticket #12838: Fix for saving undo images to account for firing the 'change' event

### DIFF
--- a/plugins/undo/plugin.js
+++ b/plugins/undo/plugin.js
@@ -379,6 +379,10 @@
 				}
 			}
 
+			// create new content image after change event is fired 
+			// to update the image before pushing it to snapshots
+			var image = new Image( editor );
+
 			// Drop future snapshots.
 			snapshots.splice( this.index + 1, snapshots.length - this.index - 1 );
 


### PR DESCRIPTION
When the change event is fired, if the receiving function changes the text in any way, the UndoManager does not update the save image to the changed version. Therefore, it saves the version before the change was fired, which is the incorrect version for the snapshot.

Steps to reproduce:

1. Create an onChange function that receives the 'change' event and edits the text when executed
2. Make a change that would trigger the event with the correct parameters to edit the text
3. Try to undo the change

Expected: Will undo the change
Actual: Undo only reverts to intermediate step (which may or may not trigger the onChange event again)

Fix: replace old image with a new image after the change event is fired.