### PR TITLE
#5547: Prefer attributes vs. inline style for height/width in image plugin

### DIFF
--- a/plugins/image/dialogs/image.js
+++ b/plugins/image/dialogs/image.js
@@ -599,20 +599,39 @@
 										commit: function( type, element, internalCommit ) {
 											var value = this.getValue();
 											if ( type == IMAGE ) {
-												if ( value && editor.activeFilter.check( 'img{width,height}' ) )
-													element.setStyle( 'width', CKEDITOR.tools.cssLength( value ) );
-												else
+												if ( value ) {
+													if ( editor.activeFilter.check( 'img[width]' ) ) {
+														element.setAttribute( 'width', value );
+														element.removeStyle( 'width' );
+													} else if ( editor.activeFilter.check( 'img{width}' ) ) {
+														element.setStyle( 'width', CKEDITOR.tools.cssLength( value ) );
+														element.removeAttribute( 'width' );
+													}
+												} else {
+													element.removeAttribute( 'width' );
 													element.removeStyle( 'width' );
-
-												!internalCommit && element.removeAttribute( 'width' );
+												}
 											} else if ( type == PREVIEW ) {
 												var aMatch = value.match( regexGetSize );
 												if ( !aMatch ) {
 													var oImageOriginal = this.getDialog().originalElement;
-													if ( oImageOriginal.getCustomData( 'isReady' ) == 'true' )
-														element.setStyle( 'width', oImageOriginal.$.width + 'px' );
+													if ( oImageOriginal.getCustomData( 'isReady' ) == 'true' ) {
+														if ( editor.activeFilter.check( 'img[width]' ) ) {
+															element.setAttribute( 'width',  oImageOriginal.$.width );
+															element.removeStyle( 'width' );
+														} else if ( editor.activeFilter.check( 'img{width}' ) ) {
+															element.setStyle( 'width',  oImageOriginal.$.width + 'px' );
+															element.removeAttribute( 'width' );
+														}
+													}
 												} else {
-													element.setStyle( 'width', CKEDITOR.tools.cssLength( value ) );
+													if ( editor.activeFilter.check( 'img[width]' ) ) {
+														element.setAttribute( 'width',  value );
+														element.removeStyle( 'width' );
+													} else if ( editor.activeFilter.check( 'img{width}' ) ) {
+														element.setStyle( 'width',  CKEDITOR.tools.cssLength( value ) );
+														element.removeAttribute( 'width' );
+													}
 												}
 											} else if ( type == CLEANUP ) {
 												element.removeAttribute( 'width' );
@@ -640,20 +659,39 @@
 										commit: function( type, element, internalCommit ) {
 											var value = this.getValue();
 											if ( type == IMAGE ) {
-												if ( value && editor.activeFilter.check( 'img{width,height}' ) )
-													element.setStyle( 'height', CKEDITOR.tools.cssLength( value ) );
-												else
-													element.removeStyle( 'height' );
-
-												!internalCommit && element.removeAttribute( 'height' );
+												if ( value ) {
+													if ( editor.activeFilter.check( 'img[height]' ) ) {
+														element.setAttribute( 'height', value );
+														element.removeStyle( 'height' );
+													} else if ( editor.activeFilter.check( 'img{height}' ) ) {
+														element.setStyle( 'height', CKEDITOR.tools.cssLength( value ) );
+														element.removeAttribute( 'height' );
+													}
+												} else {
+													element.removeAttribute( 'width' );
+													element.removeStyle( 'width' );
+												}
 											} else if ( type == PREVIEW ) {
 												var aMatch = value.match( regexGetSize );
 												if ( !aMatch ) {
 													var oImageOriginal = this.getDialog().originalElement;
-													if ( oImageOriginal.getCustomData( 'isReady' ) == 'true' )
-														element.setStyle( 'height', oImageOriginal.$.height + 'px' );
+													if ( oImageOriginal.getCustomData( 'isReady' ) == 'true' ) {
+														if ( editor.activeFilter.check( 'img[height]' ) ) {
+															element.setAttribute( 'height',  oImageOriginal.$.height );
+															element.removeStyle( 'height' );
+														} else if ( editor.activeFilter.check( 'img{height}' ) ) {
+															element.setStyle( 'height',  oImageOriginal.$.height + 'px' );
+															element.removeAttribute( 'height' );
+														}
+													}
 												} else {
-													element.setStyle( 'height', CKEDITOR.tools.cssLength( value ) );
+													if ( editor.activeFilter.check( 'img[height]' ) ) {
+														element.setAttribute( 'height',  value );
+														element.removeStyle( 'height' );
+													} else if ( editor.activeFilter.check( 'img{height}' ) ) {
+														element.setStyle( 'height',  CKEDITOR.tools.cssLength( value ) );
+														element.removeAttribute( 'height' );
+													}
 												}
 											} else if ( type == CLEANUP ) {
 												element.removeAttribute( 'height' );


### PR DESCRIPTION
This is a pull request that properly fixes the trac issue [#5547](https://dev.ckeditor.com/ticket/5547). This work is based in part on the patch from [comment #21](https://dev.ckeditor.com/ticket/5547#comment:21) by user @pivotal on that issue.

The solution does a couple things differently than that patch:
1. first checks to verify that the activeFilter allows width and height _attributes_ using `img[width]` and `img[height]` [allowed content rule](http://docs.ckeditor.com/#!/guide/dev_allowed_content_rules-section-string-format); if so it updates or adds those attributes, _and removes any inline height/width css styles_.
2. if not, it then checks to verify that the activeFilter allows width and height rules in inline css styles using `img{width}` and `img{height}` test; if so it updates/adds the inline css styles and removes the height/width attributes.
3. Finally, if neither the attributes or inline styles are supported, it removes both.

Yes, I realize  [#5547](https://dev.ckeditor.com/ticket/5547) was closed with the suggestion to use `image2` instead, however the `image` plugin is still in the repository which makes this still fair game for a fix.  Image2 is also not supported by the Drupal 7 wysiwyg or media modules (haven't tested ckeditor module because this is for an existing site and we don't have the bandwidth to switch at this point).

There was one line (below) dealing with attribute removal for "Non-internal commits" that I wasn't entirely sure of its purpose, but since since the removal is now handled in other parts of the patch, I opted to simply remove this, because it seemed now out of place.

```
!internalCommit && element.removeAttribute( 'width' );
```

Thanks for your review of this pull request.  I will also add a comment referring here and add an updated diff patch file on the trak issue as well.  
