### PR TITLE
Allow the editor to be destroyed before being fully initialized

### DIFF
--- a/core/editor.js
+++ b/core/editor.js
@@ -180,7 +180,9 @@
 
 		// Return the editor instance immediately to enable early stage event registrations.
 		CKEDITOR.tools.setTimeout( function() {
-			initConfig( this, instanceConfig );
+			if( this.status !== 'destroyed' ) {
+				initConfig( this, instanceConfig );
+			}
 		}, 0, this );
 	}
 
@@ -758,8 +760,10 @@
 
 			this.editable( null );
 
-			this.filter.destroy();
-			delete this.filter;
+			if( this.filter ) {
+				this.filter.destroy();
+				delete this.filter;
+			}
 			delete this.activeFilter;
 
 			this.status = 'destroyed';

--- a/tests/core/editor/destroy.js
+++ b/tests/core/editor/destroy.js
@@ -32,6 +32,8 @@ bender.test(
         element,
         editor;
 
+    this.editor.destroy();
+
     element = CKEDITOR.document.getById( name );
 
     editor = CKEDITOR.replace( element );

--- a/tests/core/editor/destroy.js
+++ b/tests/core/editor/destroy.js
@@ -25,5 +25,19 @@ bender.test(
 			} );
 
 		} );
-	}
+	},
+
+  'test destroy editor before it is fully initialized': function() {
+    var name = 'test_editor',
+        element,
+        editor;
+
+    element = CKEDITOR.document.getById( name );
+
+    editor = CKEDITOR.replace( element );
+    assert.isMatching( editor.status, 'unloaded', 'The editor is not initialized' );
+    editor.destroy();
+
+    assert.isTrue( true, 'The editor can be destroyed before being fully initialized' );
+  }
 } );


### PR DESCRIPTION
This seems to be related to http://dev.ckeditor.com/ticket/11502

I understand that this is not a solution to all problems ( I'm not familiar enough with the implementation of CKEditor ), but it seems to cover some basic needs without changing the APIs.