### PR TITLE
Fix: skip empty nodes in getByAddress to match the logic in getIndex.

### DIFF
--- a/core/dom/document.js
+++ b/core/dom/document.js
@@ -175,6 +175,12 @@ CKEDITOR.tools.extend( CKEDITOR.dom.document.prototype, {
 				if ( normalized === true && candidate.nodeType == 3 && candidate.previousSibling && candidate.previousSibling.nodeType == 3 )
 					continue;
 
+				// Fixes https://dev.ckeditor.com/ticket/13089
+				// Also see core/dom/node.js in getIndex - it skips over empty
+				// nodes, So we need to skip them here as well.
+				if ( normalized === true && candidate.nodeType == 3 && !candidate.nodeValue)
+					continue;
+
 				currentIndex++;
 
 				if ( currentIndex == target ) {


### PR DESCRIPTION
This is my proposed fix for https://dev.ckeditor.com/ticket/13089 - please see ticket for more information.  Not sure if it is the right way to fix the problem for everyone, but it solved the problem in my application.