### PR TITLE
Fix: querySelector failed when enabling editor on element with numeric id

### DIFF
--- a/core/dom/document.js
+++ b/core/dom/document.js
@@ -288,7 +288,7 @@ CKEDITOR.tools.extend( CKEDITOR.dom.document.prototype, {
 	 * @returns {CKEDITOR.dom.nodeList}
 	 */
 	find: function( selector ) {
-		return new CKEDITOR.dom.nodeList( this.$.querySelectorAll( selector ) );
+		return new CKEDITOR.dom.nodeList( this.$.querySelectorAll( CKEDITOR.dom.element.escapeQuery(selector) ) );
 	},
 
 	/**
@@ -300,7 +300,7 @@ CKEDITOR.tools.extend( CKEDITOR.dom.document.prototype, {
 	 * @returns {CKEDITOR.dom.element}
 	 */
 	findOne: function( selector ) {
-		var el = this.$.querySelector( selector );
+		var el = this.$.querySelector( CKEDITOR.dom.element.escapeQuery(selector) );
 
 		return el ? new CKEDITOR.dom.element( el ) : null;
 	},

--- a/core/dom/element.js
+++ b/core/dom/element.js
@@ -115,6 +115,24 @@ CKEDITOR.dom.element.clearMarkers = function( database, element, removeFromDatab
 	}
 };
 
+/**
+ * This function will escape numeric identifiers in selector (i.e "#123" will become "#\31\32\33")
+ *
+ * @static
+ * @param {String} selector to be escaped
+ * @returns {String} escaped selector
+ */
+CKEDITOR.dom.element.escapeQuery = function( selector ) {
+	var segments = selector.split(/(#\d+)/);
+	for (var i = 0; i < segments.length; i++) {
+		var segment = segments[i];
+		if (segment.charAt(0) === '#') {
+			segments[i] = segment = segment.replace(/\d/g, '\\3$&');
+		}
+	}
+	return segments.join('');
+};
+
 ( function() {
 	CKEDITOR.tools.extend( CKEDITOR.dom.element.prototype, {
 		/**
@@ -1893,7 +1911,7 @@ CKEDITOR.dom.element.clearMarkers = function( database, element, removeFromDatab
 		find: function( selector ) {
 			var removeTmpId = createTmpId( this ),
 				list = new CKEDITOR.dom.nodeList(
-					this.$.querySelectorAll( getContextualizedSelector( this, selector ) )
+					this.$.querySelectorAll(CKEDITOR.dom.element.escapeQuery( getContextualizedSelector( this, selector) ) )
 				);
 
 			removeTmpId();
@@ -1920,7 +1938,7 @@ CKEDITOR.dom.element.clearMarkers = function( database, element, removeFromDatab
 		 */
 		findOne: function( selector ) {
 			var removeTmpId = createTmpId( this ),
-				found = this.$.querySelector( getContextualizedSelector( this, selector ) );
+				found = this.$.querySelector(CKEDITOR.dom.element.escapeQuery( getContextualizedSelector( this, selector) ) );
 
 			removeTmpId();
 


### PR DESCRIPTION
Assuming you have `<div id="1"></div>` and do `CKEDITOR.inline("1"`), this will fail, because #1 is not a valid query selector. More info here:
http://stackoverflow.com/questions/20306204/using-queryselector-with-ids-that-are-numbers
