### PR TITLE
Force the plugin to keep advanced attributes

### DIFF
--- a/core/htmldataprocessor.js
+++ b/core/htmldataprocessor.js
@@ -907,7 +907,7 @@
 		// Different protection pattern is used for those that
 		// live in attributes to avoid from being HTML encoded.
 		// Why so serious? See #9205, #8216, #7805, #11754, #11846.
-		data = data.replace( /<\w+(?:\s+(?:(?:[^\s=>]+\s*=\s*(?:[^'"\s>]+|'[^']*'|"[^"]*"))|[^\s=>]+))+\s*>/g, function( match ) {
+		data = data.replace( /<\w+(?:\s+(?:(?:[^\s=\/>]+\s*=\s*(?:[^'"\s\/>]+|'[^']*'|"[^"]*"))|[^\s=\/>]+))+\s*\/?>/g, function( match ) {
 			return match.replace( /<!--\{cke_protected\}([^>]*)-->/g, function( match, data ) {
 				store[ store.id ] = decodeURIComponent( data );
 				return '{cke_protected_' + ( store.id++ ) + '}';

--- a/plugins/link/plugin.js
+++ b/plugins/link/plugin.js
@@ -677,12 +677,15 @@
 			if ( set[ 'data-cke-saved-href' ] )
 				set.href = set[ 'data-cke-saved-href' ];
 
-			var removed = CKEDITOR.tools.extend( {
+			var removed = {
 				target: 1,
 				onclick: 1,
 				'data-cke-pa-onclick': 1,
 				'data-cke-saved-name': 1
-			}, advAttrNames );
+			};
+
+			if ( data.advanced )
+				CKEDITOR.tools.extend( removed, advAttrNames );
 
 			// Remove all attributes which are not currently set.
 			for ( var s in set )


### PR DESCRIPTION
The advanced attributes shouldn't be stripped when an advanced tab is disabled for link dialog