### PR TITLE
Sharedspace plugin now supports ckeditor elements and not only ids

### DIFF
--- a/plugins/sharedspace/plugin.js
+++ b/plugins/sharedspace/plugin.js
@@ -35,9 +35,14 @@
 		}
 	} );
 
-	function create( editor, spaceName, targetId ) {
-		var target = CKEDITOR.document.getById( targetId ),
-			innerHtml, space;
+	function create( editor, spaceName, targetP ) {
+		var target, innerHtml, space;
+
+		if ( typeof targetP === 'string' ) {
+			target = CKEDITOR.document.getById( targetP ); //Its an id... search for it
+		} else {
+			target =  new CKEDITOR.dom.element( targetP );
+		}
 
 		if ( target ) {
 			// Have other plugins filling the space.
@@ -120,6 +125,13 @@
  *		// elements path will remain attached to the editor UI.
  *		config.sharedSpaces = {
  *			top: 'someElementId'
+ *		};
+ *
+ *	    // Place the toolbar inside the HTMLElement "htmlElement". The
+ *		// elements path will remain attached to the editor UI.
+ *		var htmlElement = document.getElementById('someElementId')
+ *		config.sharedSpaces = {
+ *			top: htmlElement
  *		};
  *
  * **Note:** The [Maximize](http://ckeditor.com/addon/maximize) and [Editor Resize](http://ckeditor.com/addon/resize)

--- a/tests/plugins/sharedspace/sharedspace.html
+++ b/tests/plugins/sharedspace/sharedspace.html
@@ -1,5 +1,6 @@
 <div id="editor_test1_top"></div>
 <div id="editor_test2_top"></div>
+<div id="editor_test3_top"></div>
 <textarea id="editor_test1">
 	<h2 style="font-style:italic">Foo</h2>
 	<p><big>Bar</big><strong>Bom</strong></p>
@@ -8,3 +9,7 @@
 	<h2 style="font-style:italic">Foo</h2>
 	<p><big>Bar</big><strong>Bom</strong></p>
 </div>
+<textarea id="editor_test3">
+	<h2 style="font-style:italic">Foo</h2>
+	<p><big>Bar</big><strong>Bom</strong></p>
+</textarea>

--- a/tests/plugins/sharedspace/sharedspace.js
+++ b/tests/plugins/sharedspace/sharedspace.js
@@ -47,7 +47,19 @@
 			}, function( bot ) {
 				assertEditor( bot.editor );
 			} );
+		},
+		'test themed creator_dom_element': function() {
+			bender.editorBot.create( {
+				name: 'editor_test3',
+				config: {
+					extraPlugins: 'stylescombo,basicstyles',
+					sharedSpaces: {
+						top: document.getElementById( 'editor_test3_top' )
+					}
+				}
+			}, function( bot ) {
+				assertEditor( bot.editor );
+			} );
 		}
 	} );
-
 } )();


### PR DESCRIPTION
The sharedspace plugin should support passing passing dom elements and not only ids.

In angular js it has no sense to use ids in directives. (Reusable components).