### PR TITLE
Fixed: null pointer when try to access inexistent widgetElement

### DIFF
--- a/plugins/widget/plugin.js
+++ b/plugins/widget/plugin.js
@@ -2498,16 +2498,18 @@
 					widget = widgetsRepo.instances[ attrs[ 'data-cke-widget-id' ] ];
 					if ( widget ) {
 						widgetElement = element.getFirst( isParserWidgetElement );
-						toBeDowncasted.push( {
-							wrapper: element,
-							element: widgetElement,
-							widget: widget,
-							editables: {}
-						} );
+						if ( widgetElement ) {
+							toBeDowncasted.push( {
+								wrapper: element,
+								element: widgetElement,
+								widget: widget,
+								editables: {}
+							} );
 
-						// If widget did not have data-cke-widget attribute before upcasting remove it.
-						if ( widgetElement.attributes[ 'data-cke-widget-keep-attr' ] != '1' )
-							delete widgetElement.attributes[ 'data-widget' ];
+							// If widget did not have data-cke-widget attribute before upcasting remove it.
+							if ( widgetElement.attributes[ 'data-cke-widget-keep-attr' ] != '1' )
+								delete widgetElement.attributes[ 'data-widget' ];
+						}
 					}
 				}
 				// Nested editable.


### PR DESCRIPTION
We have a problem with our plugin, which can be solved this way
I also think this check is necessary, because of DOM manipulations which could be done by other plugins or by the frontend user itself.
please apply this patch, thank you
