### PR TITLE
fix variable name typo in dialogui plugin

### DIFF
--- a/plugins/dialogui/plugin.js
+++ b/plugins/dialogui/plugin.js
@@ -404,7 +404,7 @@ CKEDITOR.plugins.add( 'dialogui', {
 					this._[ 'default' ] = this._.initValue = elementDefinition.items[ 0 ][ 1 ];
 
 				if ( elementDefinition.validate )
-					this.validate = elementDefinition.valdiate;
+					this.validate = elementDefinition.validate;
 
 				var children = [],
 					me = this;


### PR DESCRIPTION
as noticed by my colleague @BFriedrichs