### PR TITLE
[FIX] Allow for the iframe having been removed already

### DIFF
--- a/plugins/wysiwygarea/plugin.js
+++ b/plugins/wysiwygarea/plugin.js
@@ -487,16 +487,19 @@
 				// Memory leak proof.
 				this.clearCustomData();
 				doc.getDocumentElement().clearCustomData();
-				iframe.clearCustomData();
+				if ( iframe )
+					iframe.clearCustomData();
 				CKEDITOR.tools.removeFunction( this._.frameLoadedHandler );
 
-				var onResize = iframe.removeCustomData( 'onResize' );
-				onResize && onResize.removeListener();
+				if ( iframe ) {
+					var onResize = iframe.removeCustomData( 'onResize' );
+					onResize && onResize.removeListener();
 
-				// IE BUG: When destroying editor DOM with the selection remains inside
-				// editing area would break IE7/8's selection system, we have to put the editing
-				// iframe offline first. (#3812 and #5441)
-				iframe.remove();
+					// IE BUG: When destroying editor DOM with the selection remains inside
+					// editing area would break IE7/8's selection system, we have to put the editing
+					// iframe offline first. (#3812 and #5441)
+					iframe.remove();
+				}
 			}
 		}
 	} );


### PR DESCRIPTION
When integrating ckeditor in Odoo, we encounter TypeError: iframe is null in http://localhost:9069/web_ckeditor4/static/lib/ckeditor/plugins/wysiwygarea/plugin.js:520 when the editor is created in a ajax popup. The editor is destroyed when the popup is closed, but by then the Odoo framework has already cleared out the DOM.

Same as https://github.com/ckeditor/ckeditor-dev/pull/56, but I thought I'd try again.