### PR TITLE
Set toolbarconfigurator button "type" attribute

### DIFF
--- a/samples/toolbarconfigurator/js/fulltoolbareditor.js
+++ b/samples/toolbarconfigurator/js/fulltoolbareditor.js
@@ -324,6 +324,8 @@ window.ToolbarConfigurator = {};
 
 		$button.addClass( 'button-a' );
 
+		$button.setAttribute( 'type', 'button' );
+
 		if ( typeof cssClasses == 'string' ) {
 			cssClasses = cssClasses.split( ' ' );
 


### PR DESCRIPTION
Love the new configurator! I've had good success integrating it with our [php-based CRM](https://civicrm.org/blogs/colemanw/big-changes-wysiwyg-editing-47) to allow users to configure their editing experience in-app. One little problem was that the missing "type" attribute on the buttons would cause premature form submission. Thanks for considering this change.