### PR TITLE
Fixing #13703 by checking if current selection is actually adjacent to widget

### DIFF
--- a/core/selection.js
+++ b/core/selection.js
@@ -356,10 +356,41 @@
 
 			var next = range[ keystroke < 38 ? 'getPreviousEditableNode' : 'getNextEditableNode' ]();
 
+			// Special case for widgets.  We want to select it instead of delete it.
 			if ( next && next.type == CKEDITOR.NODE_ELEMENT && next.getAttribute( 'contenteditable' ) == 'false' ) {
-				editor.getSelection().fake( next );
-				evt.data.preventDefault();
-				evt.cancel();
+				var currentBlock = editor.elementPath( range.startContainer ).block,
+					nextBlock = editor.elementPath( next ).block;
+
+				// If the widget is not in a block (hence, the root editable() is it's block), OR
+				// 	  the widget is in the same block as the cursor, select the widget.
+				// We special-case this to allow the browser to handle the merging of blocks when deleting the space between them.
+				if ( !nextBlock || nextBlock.equals( currentBlock ) ) {
+					editor.getSelection().fake( next );
+					evt.data.preventDefault();
+					evt.cancel();
+				} else if ( CKEDITOR.env.gecko && ( keystroke === 8 || keystroke === 48 ) ) {
+					// Firefox has a bug from 2011 that prevents backspace/delete from working as expected around contenteditable=false
+					// https://bugzilla.mozilla.org/show_bug.cgi?id=685445
+					var isDelete = keystroke === 8,
+						first = isDelete ? nextBlock : currentBlock,
+						firstChildren = first.getChildren(),
+						firstLastChild = firstChildren.getItem( firstChildren.count() - 1 ),
+						second = isDelete ? currentBlock : nextBlock,
+						bookmark = sel.createBookmarks();
+
+					// If there's a hanging BR at the end of the paragraph, remove it before concatenating
+					if ( firstLastChild.getName() === 'br' ) {
+						firstLastChild.remove();
+					}
+					//Manually move the children into the first block, after the widget
+					second.moveChildren( first );
+					second.remove();
+					sel.selectBookmarks( bookmark );
+
+					evt.data.preventDefault();
+					evt.cancel();
+
+				}
 			}
 		};
 	}

--- a/tests/plugins/widget/manual/deletingspacearoundwidgets.html
+++ b/tests/plugins/widget/manual/deletingspacearoundwidgets.html
@@ -1,0 +1,38 @@
+<head>
+	<link rel="stylesheet" href="/apps/ckeditor/contents.css">
+	<style>
+		i { color: red; }
+	</style>
+</head>
+<h2>Classic editor</h2>
+<div id="editor1">
+	<p><i>1></i></p>
+	<p>[[Test1]]</p>
+	<p><2</p>
+
+</div>
+
+<h2>Inline editor</h2>
+<div id="editor2" contenteditable="true">
+	<p><i>1></i></p>
+	<p>[[Test1]]</p>
+	<p><2</p>
+</div>
+
+<script>
+	if ( CKEDITOR.env.ie && CKEDITOR.env.version < 9 ) {
+		CKEDITOR.tools.enableHtml5Elements( document );
+	}
+
+	CKEDITOR.addCss( 'i {	color:red	}' );
+	CKEDITOR.disableAutoInline = true;
+
+	CKEDITOR.replace( 'editor1', {
+		height: 400,
+		allowedContent: true
+	} );
+
+	CKEDITOR.inline( 'editor2', {
+		allowedContent: true
+	} );
+</script>

--- a/tests/plugins/widget/manual/deletingspacearoundwidgets.md
+++ b/tests/plugins/widget/manual/deletingspacearoundwidgets.md
@@ -1,0 +1,29 @@
+@bender-tags: widget, tc, 13703
+@bender-ui: collapsed
+@bender-ckeditor-plugins: widget, wysiwygarea, toolbar, floatingspace, elementspath, enterkey, placeholder
+
+### Test if backspace properly merges adjacent block components
+
+We're testing to ensure that when we press delete/backspace, block tags are merged. As such, the 1> is in an &lt;i&gt;
+tag to ensure that we can properly navigate tag hierarchy
+
+Run all steps in both classic and inline editors.
+
+1. Find 1>
+2. Put cursor at right of >
+3. Press delete ('forward delete')
+ #### Expected
+ Space between > and the placeholder was deleted, text now on one line: 1>[Test1]
+
+4. Press delete again.
+ #### Expected
+ Placeholder widget was selected, not deleted
+
+5. Find <2 press backspace
+ #### Expected
+ Text should be on one single line: 1>[Test1]<2
+
+6. Press backspace again
+ #### Expected
+ Placeholder widget was selected, not deleted
+


### PR DESCRIPTION
…before preventing keydown.

With a passing test! I don't know where this test should actually go, as it isn't ACTUALLY testing fake selections, rather it's testing that a fake selection doesn't happen, and that a deletion is happening instead.

Note: Your tests seem to be order-specific.  I initially tried to insert my test prior to the preceding test, and that test failed.  As soon as I moved the test down, they passed.