### PR TITLE
bbcode / don't remove adv dialog tabs for all instances

### DIFF
--- a/plugins/bbcode/plugin.js
+++ b/plugins/bbcode/plugin.js
@@ -5,6 +5,9 @@
 
 ( function() {
 	CKEDITOR.on( 'dialogDefinition', function( ev ) {
+		
+		if (!('bbcode' in ev.editor.plugins)) { return; }  // Only remove advanced tabs if bbcode is in current editor instance
+		
 		var tab,
 			name = ev.data.name,
 			definition = ev.data.definition;


### PR DESCRIPTION
This makes the dialogDefinition listener installed by the bbcode plugin look at whether the bbcode plugin is actually in the current editor instance that the listener is removing the advanced dialog tabs for.  I have a mix of bbcode editor instances (for text snippets) and non-bbcode editor instances.  While I am moving to get rid of my legacy bbcode based text snippets, being able to use both types of editor instances for now without limiting the "normal" editor instances is helpful.