### PR TITLE
Fix for radio button onChange event in IE9+ (http://dev.ckeditor.com/…

### DIFF
--- a/plugins/dialogui/plugin.js
+++ b/plugins/dialogui/plugin.js
@@ -1290,7 +1290,7 @@ CKEDITOR.plugins.add( 'dialogui', {
 			 */
 			eventProcessors: {
 				onChange: function( dialog, func ) {
-					if ( !CKEDITOR.env.ie )
+					if ( !CKEDITOR.env.ie || ( CKEDITOR.env.version > 8 ) )
 						return commonEventProcessors.onChange.apply( this, arguments );
 					else {
 						dialog.on( 'load', function() {

--- a/tests/tickets/12733/1.html
+++ b/tests/tickets/12733/1.html
@@ -1,0 +1,34 @@
+<div id="editor1">
+	<img alt="CKEditor logo" src="%BASE_PATH%_assets/logo.png" />
+</div>
+
+<script>
+	CKEDITOR.replace('editor1');
+	
+	CKEDITOR.on( 'dialogDefinition', function( ev ) {
+		var dialogName = ev.data.name,
+			dialogDefinition = ev.data.definition,
+			editor = ev.editor;
+			
+		if ( dialogName == 'image' ) {			
+			// Get a reference to the "Image Info" tab.
+			var infoTab = dialogDefinition.getContents( 'info' );					
+			infoTab.add( {
+				type: 'radio',
+				id: 'customId',
+				label: 'Test Label',
+				title: 'Test Title',
+				className: 'radioClass',
+				required: false,
+				items: [
+					['Test0', 'Test0', 'Test0'],
+					['Test1', 'Test1', 'Test1'],
+					['Test2', 'Test2', 'Test2']
+				],				
+				onChange: function( event ){
+					console.log('changed');
+				}
+			});
+		}
+	});
+</script>

--- a/tests/tickets/12733/1.md
+++ b/tests/tickets/12733/1.md
@@ -1,0 +1,11 @@
+@bender-tags: 4.5.3, tc
+@bender-ui: collapsed
+@bender-ckeditor-plugins: wysiwygarea, toolbar, image
+
+----
+
+1. Open the console.
+2. Edit the image (e.g. by double clicking it).
+3. Click any of the radio buttons at the bottom.
+
+**Expected:** On each selection change the text *changed* should be logged to the console.


### PR DESCRIPTION
This is the proposed fix for the radio button onChange even, which currently doesn't work in IE9+
The original ticket can be found here: http://dev.ckeditor.com/ticket/12733