### PR TITLE
Support for strikethrough / s in bbcode plugin

### DIFF
--- a/plugins/bbcode/plugin.js
+++ b/plugins/bbcode/plugin.js
@@ -26,9 +26,9 @@
 		}
 	} );
 
-	var bbcodeMap = { b: 'strong', u: 'u', i: 'em', color: 'span', size: 'span', quote: 'blockquote', code: 'code', url: 'a', email: 'span', img: 'span', '*': 'li', list: 'ol', s: 'span' },
-		convertMap = { strong: 'b', b: 'b', u: 'u', em: 'i', i: 'i', code: 'code', li: '*' },
-		tagnameMap = { strong: 'b', em: 'i', u: 'u', li: '*', ul: 'list', ol: 'list', code: 'code', a: 'link', img: 'img', blockquote: 'quote' },
+	var bbcodeMap = { b: 'strong', u: 'u', i: 'em', s: 's', color: 'span', size: 'span', quote: 'blockquote', code: 'code', url: 'a', email: 'span', img: 'span', '*': 'li', list: 'ol' },
+		convertMap = { strong: 'b', b: 'b', u: 'u', em: 'i', i: 'i', s: 's', code: 'code', li: '*' },
+		tagnameMap = { strong: 'b', em: 'i', u: 'u', s: 's', li: '*', ul: 'list', ol: 'list', code: 'code', a: 'link', img: 'img', blockquote: 'quote' },
 		stylesMap = { color: 'color', size: 'font-size' },
 		attributesMap = { url: 'href', email: 'mailhref', quote: 'cite', list: 'listType' };
 
@@ -153,9 +153,9 @@
 						}
 					}
 
-					// Three special handling - image, email and strikethrough, protect them
+					// Two special handling - image and email, protect them
 					// as "span" with an attribute marker.
-					if ( part == 'email' || part == 'img' || part == 's' )
+					if ( part == 'email' || part == 'img' )
 						attribs.bbcode = part;
 
 					this.onTagOpen( tagName, attribs, CKEDITOR.dtd.$empty[ tagName ] );
@@ -609,8 +609,6 @@
 							} else if ( bbcode == 'email' ) {
 								element.name = 'a';
 								element.attributes.href = 'mailto:' + element.children[ 0 ].value;
-							} else if ( bbcode == 's' ) {
-								element.attributes.style = 'text-decoration: line-through';
 							}
 
 							delete element.attributes.bbcode;

--- a/plugins/bbcode/plugin.js
+++ b/plugins/bbcode/plugin.js
@@ -26,7 +26,7 @@
 		}
 	} );
 
-	var bbcodeMap = { b: 'strong', u: 'u', i: 'em', color: 'span', size: 'span', quote: 'blockquote', code: 'code', url: 'a', email: 'span', img: 'span', '*': 'li', list: 'ol' },
+	var bbcodeMap = { b: 'strong', u: 'u', i: 'em', color: 'span', size: 'span', quote: 'blockquote', code: 'code', url: 'a', email: 'span', img: 'span', '*': 'li', list: 'ol', s: 'span' },
 		convertMap = { strong: 'b', b: 'b', u: 'u', em: 'i', i: 'i', code: 'code', li: '*' },
 		tagnameMap = { strong: 'b', em: 'i', u: 'u', li: '*', ul: 'list', ol: 'list', code: 'code', a: 'link', img: 'img', blockquote: 'quote' },
 		stylesMap = { color: 'color', size: 'font-size' },
@@ -153,9 +153,9 @@
 						}
 					}
 
-					// Two special handling - image and email, protect them
+					// Three special handling - image, email and strikethrough, protect them
 					// as "span" with an attribute marker.
-					if ( part == 'email' || part == 'img' )
+					if ( part == 'email' || part == 'img' || part == 's' )
 						attribs.bbcode = part;
 
 					this.onTagOpen( tagName, attribs, CKEDITOR.dtd.$empty[ tagName ] );
@@ -609,6 +609,8 @@
 							} else if ( bbcode == 'email' ) {
 								element.name = 'a';
 								element.attributes.href = 'mailto:' + element.children[ 0 ].value;
+							} else if ( bbcode == 's' ) {
+								element.attributes.style = 'text-decoration: line-through';
 							}
 
 							delete element.attributes.bbcode;

--- a/tests/plugins/bbcode/bbcode.js
+++ b/tests/plugins/bbcode/bbcode.js
@@ -31,6 +31,7 @@ bender.test( {
 		this.assertToBBCode( '[b]foo[/b]', '<strong>foo</strong>' );
 		this.assertToBBCode( '[i]foo[/i]', '<em>foo</em>' );
 		this.assertToBBCode( '[u]foo[/u]', '<u>foo</u>' );
+		this.assertToBBCode( '[s]foo[/s]', '<s>foo</s>' );
 		this.assertToBBCode( '[url]http://example.org[/url]', '<a href="http://example.org">http://example.org</a>' );
 		this.assertToBBCode( '[url=http://example.com]example[/url]', '<a href="http://example.com">example</a>' );
 		this.assertToBBCode( '[img]http://a.cksource.com/c/1/inc/img/demo-little-red.jpg[/img]',
@@ -47,6 +48,7 @@ bender.test( {
 		this.assertToHtml( '<strong>foo</strong>', '[b]foo[/b]' );
 		this.assertToHtml( '<em>foo</em>', '[i]foo[/i]' );
 		this.assertToHtml( '<u>foo</u>', '[u]foo[/u]' );
+		this.assertToHtml( '<s>foo</s>', '[s]foo[/s]' );
 
 		this.assertToHtml( '<a href="http://example.org">http://example.org</a>', '[url]http://example.org[/url]' );
 		this.assertToHtml( '<a href="http://example.com">example</a>', '[url=http://example.com]example[/url]' );


### PR DESCRIPTION
This small change adds support for the `s` tag in BBCode, resulting in strikethrough text. This seems to be widely supported by different BBCode implementations.
