### PR TITLE
Fix typos and make comments consistent in build.sh

### DIFF
--- a/dev/builder/build.sh
+++ b/dev/builder/build.sh
@@ -2,7 +2,7 @@
 # Copyright (c) 2003-2015, CKSource - Frederico Knabben. All rights reserved.
 # For licensing, see LICENSE.md or http://ckeditor.com/license
 
-# Build CKEditor using the default settings (and build.js)
+# Build CKEditor using the default settings (and build.js).
 
 set -e
 
@@ -14,7 +14,7 @@ CKBUILDER_URL="http://download.cksource.com/CKBuilder/$CKBUILDER_VERSION/ckbuild
 
 PROGNAME=$(basename $0)
 MSG_UPDATE_FAILED="Warning: The attempt to update ckbuilder.jar failed. The existing file will be used."
-MSG_DOWNLOAD_FAILED="It was not possible to download ckbuilder.jar"
+MSG_DOWNLOAD_FAILED="It was not possible to download ckbuilder.jar."
 ARGS=" $@ "
 
 function error_exit
@@ -31,7 +31,7 @@ function command_exists
 # Move to the script directory.
 cd $(dirname $0)
 
-# Download/update ckbuilder.jar
+# Download/update ckbuilder.jar.
 mkdir -p ckbuilder/$CKBUILDER_VERSION
 cd ckbuilder/$CKBUILDER_VERSION
 if [ -f ckbuilder.jar ]; then
@@ -55,7 +55,7 @@ cd ../..
 echo ""
 echo "Starting CKBuilder..."
 
-JAVA_ARGS=${ARGS// -t / } # Remove -t from arrgs
+JAVA_ARGS=${ARGS// -t / } # Remove -t from args.
 
 VERSION="4.5.5 DEV"
 REVISION=$(git rev-parse --verify --short HEAD)
@@ -73,7 +73,7 @@ fi
 
 java -jar ckbuilder/$CKBUILDER_VERSION/ckbuilder.jar --build ../../ release $JAVA_ARGS --version="$VERSION" --revision="$REVISION" --overwrite
 
-# Copy and build tests
+# Copy and build tests.
 if [[ "$ARGS" == *\ \-t\ * ]]; then
 	echo ""
 	echo "Copying tests..."


### PR DESCRIPTION
I first noticed `arrgs` instead of `args`, then looked for other nitpicks to fix :)