### PR TITLE
Add config to map smileys to one or more BBcode-representations.

### DIFF
--- a/plugins/bbcode/samples/bbcode.html
+++ b/plugins/bbcode/samples/bbcode.html
@@ -82,16 +82,36 @@ CKEDITOR.replace( 'editor1', {
 						[ 'NumberedList', 'BulletedList', '-', 'Blockquote' ],
 						[ 'Maximize' ]
 					],
-					// Strip CKEditor smileys to those commonly used in BBCode.
-					smiley_images: [
-						'regular_smile.png', 'sad_smile.png', 'wink_smile.png', 'teeth_smile.png', 'tongue_smile.png',
-						'embarrassed_smile.png', 'omg_smile.png', 'whatchutalkingabout_smile.png', 'angel_smile.png',
-						'shades_smile.png', 'cry_smile.png', 'kiss.png'
-					],
-					smiley_descriptions: [
-						'smiley', 'sad', 'wink', 'laugh', 'cheeky', 'blush', 'surprise',
-						'indecision', 'angel', 'cool', 'crying', 'kiss'
-					]
+
+					// Map the smileys defined via the setting config.smiley_descriptions
+					// to their BBcode-representations.
+					// Each smiley defined in config.smiley_descriptions must also be
+					// configured here.
+					// The first stated BBcode-representation will be used as the standard,
+					// which will be used, when a smiley is inserted via the editor.
+					bbode_smiley_map = {
+						'smiley': 		[':)', ':-)'],
+						'sad': 			[':(', ':-('],
+						'wink': 		[';)', ';-)'],
+						'laugh': 		[':D', ':-D'],
+						'frown': 		[':/', ':-/'],
+						'cheeky': 		[':P', ':-P'],
+						'blush': 		[':*)', ':-*)'],
+						'surprise': 	[':o', ':-o'],
+						'indecision': 	[':|', ':-)'],
+						'angry': 		['&gt;:(', '&gt;:-('],
+						'angel': 		['o:)', 'o:-)'],
+						'cool': 		['8)', '8-)'],
+						'devil': 		['&gt;:)', '&gt;:-)'],
+						'crying': 		[';(', ';-('],
+						'enlightened':	[':light:'],
+						'no': 			[':no:'],
+						'yes': 			[':yes:'],
+						'heart': 		['&gt;3'],
+						'broken heart':	['&gt;/3'],
+						'kiss': 		[':*', ':-*'],
+						'mail': 		[':mail:'],
+					},
 				});
 
 			</script>


### PR DESCRIPTION
hi there!

until now the mappings of smileys to their BBcode-representations was hardcoded into the BBcode-plugin. this resulted in errors when adding or modifying the smileys via the configs of the smiley-plugin.

additionally, this mapping was a 1:1 mapping, meaning e.g. the bbcode ":(" would map to the "sad"-smiley, but the bbcode ":-(" wouldn't.

my changes introduce a new config-setting (config.bbode_smiley_map), which allows mapping of a smiley (via it's description defined in config.smiley_descriptions) to one or more BBcode-representations.

i guess this would also close the ticket 8198.

best wishes,
mandark
