### PR TITLE
null check on listeners

### DIFF
--- a/core/focusmanager.js
+++ b/core/focusmanager.js
@@ -235,8 +235,10 @@
 		remove: function( element ) {
 			element.removeCustomData( SLOT_NAME );
 			var listeners = element.removeCustomData( SLOT_NAME_LISTENERS );
-			element.removeListener( 'blur', listeners.blur );
-			element.removeListener( 'focus', listeners.focus );
+			if ( listeners ) {
+				element.removeListener( 'blur', listeners.blur );
+				element.removeListener( 'focus', listeners.focus );
+			}
 		}
 
 	};


### PR DESCRIPTION
We are getting an issue in IE10(and IE11 on Windows 8) where we could trigger the remove function to get called twice and the second call would complain that blur could not be found on a null or undefined object.

It was intermittent but the odds went up significantly when I would click on the background area of the toolbar and then very quickly click the mathjax button in the toolbar (which uses a dialog).

We have found that adding this if-conditional check locally has resolved the issue.