### PR TITLE
#13887 remove any non-ascii or white space character

### DIFF
--- a/plugins/link/dialogs/link.js
+++ b/plugins/link/dialogs/link.js
@@ -464,7 +464,7 @@
 							if ( !data.target )
 								data.target = {};
 
-							data.target.name = this.getValue().replace( /\W/gi, '' );
+							data.target.name = this.getValue().replace( /([^\x00-\x7F]|\s)/gi, '' );
 						}
 					} ]
 				},


### PR DESCRIPTION
Relevant ticket: https://dev.ckeditor.com/ticket/13887#ticket

The issue with the current code is it removes valid ascii characters from the target attribute value. To fix this it should instead check for any character that is non-ascii or white space.