### PR TITLE
widget definition insert method now includes editor as argument

### DIFF
--- a/plugins/widget/plugin.js
+++ b/plugins/widget/plugin.js
@@ -1853,7 +1853,7 @@
 				// Otherwise...
 				// ... use insert method is was defined.
 				else if ( widgetDef.insert )
-					widgetDef.insert();
+					widgetDef.insert( editor );
 				// ... or create a brand-new widget from template.
 				else if ( widgetDef.template ) {
 					var defaults = typeof widgetDef.defaults == 'function' ? widgetDef.defaults() : widgetDef.defaults,


### PR DESCRIPTION
The `insert` member of a widget definition is a no-arg function and the current editor instance is not readily available to any implementation of `insert`, short of a workaround that constructs a new widget definition for every editor instance or does something clever with closures. Revise the definition of `insert` to include the editor as an argument.

This widget definition API change will be fully backwards compatible.

I tried creating a ticket at dev.ckeditor.com for this pull request but got
```
Trac detected an internal error:
error: nothing to repeat
There was an internal error in Trac.
```