### PR TITLE
Allowing editing the link text in the dialog

### DIFF
--- a/plugins/link/dialogs/link.js
+++ b/plugins/link/dialogs/link.js
@@ -116,6 +116,22 @@
 				label: linkLang.info,
 				title: linkLang.info,
 				elements: [ {
+					type: 'text',
+					id: 'text',
+					label: linkLang.text,
+					required: true,
+					setup: function( data ) {
+						if ( data.text )
+							this.setValue( data.text );
+					},
+					commit: function( data ) {
+						if ( !data.text )
+							data.text = '';
+
+						data.text = this.getValue();
+					}
+				},
+				{
 					id: 'linkType',
 					type: 'select',
 					label: linkLang.type,
@@ -795,6 +811,7 @@
 				}
 
 				var data = plugin.parseLinkAttributes( editor, element );
+				data.text = element.getText();
 
 				// Record down the selected element in the dialog.
 				this._.selectedElement = element;
@@ -839,6 +856,7 @@
 
 					element.setAttributes( attributes.set );
 					element.removeAttributes( attributes.removed );
+					element.setText( data.text );
 
 					// Update text view when user changes protocol (#4612).
 					if ( href == textView || data.type == 'email' && textView.indexOf( '@' ) != -1 ) {

--- a/plugins/link/dialogs/link.js
+++ b/plugins/link/dialogs/link.js
@@ -811,7 +811,8 @@
 				}
 
 				var data = plugin.parseLinkAttributes( editor, element );
-				data.text = element.getText();
+				if (element)
+					data.text = element.getText();
 
 				// Record down the selected element in the dialog.
 				this._.selectedElement = element;

--- a/plugins/link/dialogs/link.js
+++ b/plugins/link/dialogs/link.js
@@ -813,6 +813,8 @@
 				var data = plugin.parseLinkAttributes( editor, element );
 				if (element)
 					data.text = element.getText();
+				else
+					data.text = editor.getSelection().getSelectedText();
 
 				// Record down the selected element in the dialog.
 				this._.selectedElement = element;
@@ -845,6 +847,14 @@
 						element: 'a',
 						attributes: attributes.set
 					} );
+
+					// Replace the text in the editor with the text from the dialog.
+					if ( data.text ) {
+						var dialogText = new CKEDITOR.dom.text( data.text, editor.document );
+						range.deleteContents();
+						range.insertNode( dialogText );
+						range.select();
+					}
 
 					style.type = CKEDITOR.STYLE_INLINE; // need to override... dunno why.
 					style.applyToRange( range, editor );

--- a/plugins/link/lang/af.js
+++ b/plugins/link/lang/af.js
@@ -54,6 +54,7 @@ CKEDITOR.plugins.setLang( 'link', 'af', {
 	targetFrameName: 'Naam van doelraam',
 	targetPopup: '<opspringvenster>',
 	targetPopupName: 'Naam van opspringvenster',
+	text: 'Text', // MISSING
 	title: 'Skakel',
 	toAnchor: 'Anker in bladsy',
 	toEmail: 'E-pos',

--- a/plugins/link/lang/ar.js
+++ b/plugins/link/lang/ar.js
@@ -54,6 +54,7 @@ CKEDITOR.plugins.setLang( 'link', 'ar', {
 	targetFrameName: 'اسم الإطار المستهدف',
 	targetPopup: '<نافذة منبثقة>',
 	targetPopupName: 'اسم النافذة المنبثقة',
+	text: 'النص',
 	title: 'رابط',
 	toAnchor: 'مكان في هذا المستند',
 	toEmail: 'بريد إلكتروني',

--- a/plugins/link/lang/bg.js
+++ b/plugins/link/lang/bg.js
@@ -54,6 +54,7 @@ CKEDITOR.plugins.setLang( 'link', 'bg', {
 	targetFrameName: 'Име на целевият прозорец',
 	targetPopup: '<изкачащ прозорец>',
 	targetPopupName: 'Име на изкачащ прозорец',
+	text: 'Text', // MISSING
 	title: 'Връзка',
 	toAnchor: 'Връзка към котва в текста',
 	toEmail: 'E-mail',

--- a/plugins/link/lang/bn.js
+++ b/plugins/link/lang/bn.js
@@ -54,6 +54,7 @@ CKEDITOR.plugins.setLang( 'link', 'bn', {
 	targetFrameName: 'টার্গেট ফ্রেমের নাম',
 	targetPopup: '<পপআপ উইন্ডো>',
 	targetPopupName: 'পপআপ উইন্ডোর নাম',
+	text: 'Text', // MISSING
 	title: 'লিংক',
 	toAnchor: 'এই পেজে নোঙর কর',
 	toEmail: 'ইমেইল',

--- a/plugins/link/lang/bs.js
+++ b/plugins/link/lang/bs.js
@@ -54,6 +54,7 @@ CKEDITOR.plugins.setLang( 'link', 'bs', {
 	targetFrameName: 'Target Frame Name', // MISSING
 	targetPopup: '<popup prozor>',
 	targetPopupName: 'Naziv popup prozora',
+	text: 'Text', // MISSING
 	title: 'Link',
 	toAnchor: 'Sidro na ovoj stranici',
 	toEmail: 'E-Mail',

--- a/plugins/link/lang/ca.js
+++ b/plugins/link/lang/ca.js
@@ -54,6 +54,7 @@ CKEDITOR.plugins.setLang( 'link', 'ca', {
 	targetFrameName: 'Nom del marc de destí',
 	targetPopup: '<finestra emergent>',
 	targetPopupName: 'Nom finestra popup',
+	text: 'Text', // MISSING
 	title: 'Enllaç',
 	toAnchor: 'Àncora en aquesta pàgina',
 	toEmail: 'Correu electrònic',

--- a/plugins/link/lang/cs.js
+++ b/plugins/link/lang/cs.js
@@ -54,6 +54,7 @@ CKEDITOR.plugins.setLang( 'link', 'cs', {
 	targetFrameName: 'Název cílového rámu',
 	targetPopup: '<vyskakovací okno>',
 	targetPopupName: 'Název vyskakovacího okna',
+	text: 'Text', // MISSING
 	title: 'Odkaz',
 	toAnchor: 'Kotva v této stránce',
 	toEmail: 'E-mail',

--- a/plugins/link/lang/cy.js
+++ b/plugins/link/lang/cy.js
@@ -54,6 +54,7 @@ CKEDITOR.plugins.setLang( 'link', 'cy', {
 	targetFrameName: 'Enw Ffrâm y Targed',
 	targetPopup: '<ffenestr bop>',
 	targetPopupName: 'Enw Ffenestr Bop',
+	text: 'Text', // MISSING
 	title: 'Dolen',
 	toAnchor: 'Dolen at angor yn y testun',
 	toEmail: 'E-bost',

--- a/plugins/link/lang/da.js
+++ b/plugins/link/lang/da.js
@@ -54,6 +54,7 @@ CKEDITOR.plugins.setLang( 'link', 'da', {
 	targetFrameName: 'Destinationsvinduets navn',
 	targetPopup: '<popup vindue>',
 	targetPopupName: 'Popupvinduets navn',
+	text: 'Text', // MISSING
 	title: 'Egenskaber for hyperlink',
 	toAnchor: 'Bogmærke på denne side',
 	toEmail: 'E-mail',

--- a/plugins/link/lang/de.js
+++ b/plugins/link/lang/de.js
@@ -54,6 +54,7 @@ CKEDITOR.plugins.setLang( 'link', 'de', {
 	targetFrameName: 'Ziel-Fenster-Name',
 	targetPopup: '<Pop-up Fenster>',
 	targetPopupName: 'Pop-up Fenster-Name',
+	text: 'Text', // MISSING
 	title: 'Link',
 	toAnchor: 'Anker in dieser Seite',
 	toEmail: 'E-Mail',

--- a/plugins/link/lang/el.js
+++ b/plugins/link/lang/el.js
@@ -54,6 +54,7 @@ CKEDITOR.plugins.setLang( 'link', 'el', {
 	targetFrameName: 'Όνομα Πλαισίου Προορισμού',
 	targetPopup: '<αναδυόμενο παράθυρο>',
 	targetPopupName: 'Όνομα Αναδυόμενου Παραθύρου',
+	text: 'Text', // MISSING
 	title: 'Σύνδεσμος',
 	toAnchor: 'Άγκυρα σε αυτήν τη σελίδα',
 	toEmail: 'E-Mail',

--- a/plugins/link/lang/en-au.js
+++ b/plugins/link/lang/en-au.js
@@ -54,6 +54,7 @@ CKEDITOR.plugins.setLang( 'link', 'en-au', {
 	targetFrameName: 'Target Frame Name',
 	targetPopup: '<popup window>',
 	targetPopupName: 'Popup Window Name',
+	text: 'Text',
 	title: 'Link',
 	toAnchor: 'Link to anchor in the text',
 	toEmail: 'E-mail',

--- a/plugins/link/lang/en-ca.js
+++ b/plugins/link/lang/en-ca.js
@@ -54,6 +54,7 @@ CKEDITOR.plugins.setLang( 'link', 'en-ca', {
 	targetFrameName: 'Target Frame Name',
 	targetPopup: '<popup window>',
 	targetPopupName: 'Popup Window Name',
+	text: 'Text',
 	title: 'Link',
 	toAnchor: 'Link to anchor in the text',
 	toEmail: 'E-mail',

--- a/plugins/link/lang/en-gb.js
+++ b/plugins/link/lang/en-gb.js
@@ -54,6 +54,7 @@ CKEDITOR.plugins.setLang( 'link', 'en-gb', {
 	targetFrameName: 'Target Frame Name',
 	targetPopup: '<popup window>',
 	targetPopupName: 'Popup Window Name',
+	text: 'Text',
 	title: 'Link',
 	toAnchor: 'Link to anchor in the text',
 	toEmail: 'E-mail',

--- a/plugins/link/lang/en.js
+++ b/plugins/link/lang/en.js
@@ -54,6 +54,7 @@ CKEDITOR.plugins.setLang( 'link', 'en', {
 	targetFrameName: 'Target Frame Name',
 	targetPopup: '<popup window>',
 	targetPopupName: 'Popup Window Name',
+	text: 'Text',
 	title: 'Link',
 	toAnchor: 'Link to anchor in the text',
 	toEmail: 'E-mail',

--- a/plugins/link/lang/eo.js
+++ b/plugins/link/lang/eo.js
@@ -54,6 +54,7 @@ CKEDITOR.plugins.setLang( 'link', 'eo', {
 	targetFrameName: 'Nomo de CelKadro',
 	targetPopup: '<ŝprucfenestro>',
 	targetPopupName: 'Nomo de Ŝprucfenestro',
+	text: 'Text', // MISSING
 	title: 'Ligilo',
 	toAnchor: 'Ankri en tiu ĉi paĝo',
 	toEmail: 'Retpoŝto',

--- a/plugins/link/lang/es.js
+++ b/plugins/link/lang/es.js
@@ -54,6 +54,7 @@ CKEDITOR.plugins.setLang( 'link', 'es', {
 	targetFrameName: 'Nombre del Marco Destino',
 	targetPopup: '<ventana emergente>',
 	targetPopupName: 'Nombre de Ventana Emergente',
+	text: 'Text', // MISSING
 	title: 'Vínculo',
 	toAnchor: 'Referencia en esta página',
 	toEmail: 'E-Mail',

--- a/plugins/link/lang/et.js
+++ b/plugins/link/lang/et.js
@@ -54,6 +54,7 @@ CKEDITOR.plugins.setLang( 'link', 'et', {
 	targetFrameName: 'Sihtmärk raami nimi',
 	targetPopup: '<hüpikaken>',
 	targetPopupName: 'Hüpikakna nimi',
+	text: 'Text', // MISSING
 	title: 'Link',
 	toAnchor: 'Ankur sellel lehel',
 	toEmail: 'E-post',

--- a/plugins/link/lang/eu.js
+++ b/plugins/link/lang/eu.js
@@ -54,6 +54,7 @@ CKEDITOR.plugins.setLang( 'link', 'eu', {
 	targetFrameName: 'Helburuko markoaren izena',
 	targetPopup: '<laster-leihoa>',
 	targetPopupName: 'Laster-leihoaren izena',
+	text: 'Text', // MISSING
 	title: 'Esteka',
 	toAnchor: 'Estekatu testuko aingurara',
 	toEmail: 'E-posta',

--- a/plugins/link/lang/fa.js
+++ b/plugins/link/lang/fa.js
@@ -54,6 +54,7 @@ CKEDITOR.plugins.setLang( 'link', 'fa', {
 	targetFrameName: 'نام فریم مقصد',
 	targetPopup: '<پنجرهٴ پاپاپ>',
 	targetPopupName: 'نام پنجرهٴ پاپاپ',
+	text: 'Text', // MISSING
 	title: 'پیوند',
 	toAnchor: 'لنگر در همین صفحه',
 	toEmail: 'پست الکترونیکی',

--- a/plugins/link/lang/fi.js
+++ b/plugins/link/lang/fi.js
@@ -54,6 +54,7 @@ CKEDITOR.plugins.setLang( 'link', 'fi', {
 	targetFrameName: 'Kohdekehyksen nimi',
 	targetPopup: '<popup ikkuna>',
 	targetPopupName: 'Popup ikkunan nimi',
+	text: 'Text', // MISSING
 	title: 'Linkki',
 	toAnchor: 'Ankkuri tässä sivussa',
 	toEmail: 'Sähköposti',

--- a/plugins/link/lang/fo.js
+++ b/plugins/link/lang/fo.js
@@ -54,6 +54,7 @@ CKEDITOR.plugins.setLang( 'link', 'fo', {
 	targetFrameName: 'Vís navn vindeygans',
 	targetPopup: '<popup vindeyga>',
 	targetPopupName: 'Popup vindeygans navn',
+	text: 'Text', // MISSING
 	title: 'Tilknýti',
 	toAnchor: 'Tilknýti til marknastein í tekstinum',
 	toEmail: 'Teldupostur',

--- a/plugins/link/lang/fr-ca.js
+++ b/plugins/link/lang/fr-ca.js
@@ -54,6 +54,7 @@ CKEDITOR.plugins.setLang( 'link', 'fr-ca', {
 	targetFrameName: 'Nom du cadre de destination',
 	targetPopup: '<fenêtre popup>',
 	targetPopupName: 'Nom de la fenêtre popup',
+	text: 'Text', // MISSING
 	title: 'Lien',
 	toAnchor: 'Ancre dans cette page',
 	toEmail: 'Courriel',

--- a/plugins/link/lang/fr.js
+++ b/plugins/link/lang/fr.js
@@ -54,6 +54,7 @@ CKEDITOR.plugins.setLang( 'link', 'fr', {
 	targetFrameName: 'Nom du Cadre destination',
 	targetPopup: '<fenêtre popup>',
 	targetPopupName: 'Nom de la fenêtre popup',
+	text: 'Text', // MISSING
 	title: 'Lien',
 	toAnchor: 'Ancre',
 	toEmail: 'E-mail',

--- a/plugins/link/lang/gl.js
+++ b/plugins/link/lang/gl.js
@@ -54,6 +54,7 @@ CKEDITOR.plugins.setLang( 'link', 'gl', {
 	targetFrameName: 'Nome do marco de destino',
 	targetPopup: '<xanela emerxente>',
 	targetPopupName: 'Nome da xanela emerxente',
+	text: 'Text', // MISSING
 	title: 'Ligazón',
 	toAnchor: 'Ligar coa ancoraxe no testo',
 	toEmail: 'Correo',

--- a/plugins/link/lang/gu.js
+++ b/plugins/link/lang/gu.js
@@ -54,6 +54,7 @@ CKEDITOR.plugins.setLang( 'link', 'gu', {
 	targetFrameName: 'ટાર્ગેટ ફ્રેમ નું નામ',
 	targetPopup: '<પૉપ-અપ વિન્ડો>',
 	targetPopupName: 'પૉપ-અપ વિન્ડો નું નામ',
+	text: 'Text', // MISSING
 	title: 'લિંક',
 	toAnchor: 'આ પેજનો ઍંકર',
 	toEmail: 'ઈ-મેલ',

--- a/plugins/link/lang/he.js
+++ b/plugins/link/lang/he.js
@@ -54,6 +54,7 @@ CKEDITOR.plugins.setLang( 'link', 'he', {
 	targetFrameName: 'שם מסגרת היעד',
 	targetPopup: '<חלון קופץ>',
 	targetPopupName: 'שם החלון הקופץ',
+	text: 'Text', // MISSING
 	title: 'קישור',
 	toAnchor: 'עוגן בעמוד זה',
 	toEmail: 'דוא"ל',

--- a/plugins/link/lang/hi.js
+++ b/plugins/link/lang/hi.js
@@ -54,6 +54,7 @@ CKEDITOR.plugins.setLang( 'link', 'hi', {
 	targetFrameName: 'टार्गेट फ़्रेम का नाम',
 	targetPopup: '<पॉप-अप विन्डो>',
 	targetPopupName: 'पॉप-अप विन्डो का नाम',
+	text: 'Text', // MISSING
 	title: 'लिंक',
 	toAnchor: 'इस पेज का ऐंकर',
 	toEmail: 'ई-मेल',

--- a/plugins/link/lang/hr.js
+++ b/plugins/link/lang/hr.js
@@ -54,6 +54,7 @@ CKEDITOR.plugins.setLang( 'link', 'hr', {
 	targetFrameName: 'Ime ciljnog okvira',
 	targetPopup: '<popup prozor>',
 	targetPopupName: 'Naziv popup prozora',
+	text: 'Text', // MISSING
 	title: 'Link',
 	toAnchor: 'Sidro na ovoj stranici',
 	toEmail: 'E-Mail',

--- a/plugins/link/lang/hu.js
+++ b/plugins/link/lang/hu.js
@@ -54,6 +54,7 @@ CKEDITOR.plugins.setLang( 'link', 'hu', {
 	targetFrameName: 'Keret neve',
 	targetPopup: '<felugró ablakban>',
 	targetPopupName: 'Felugró ablak neve',
+	text: 'Text', // MISSING
 	title: 'Hivatkozás tulajdonságai',
 	toAnchor: 'Horgony az oldalon',
 	toEmail: 'E-Mail',

--- a/plugins/link/lang/id.js
+++ b/plugins/link/lang/id.js
@@ -54,6 +54,7 @@ CKEDITOR.plugins.setLang( 'link', 'id', {
 	targetFrameName: 'Target Frame Name', // MISSING
 	targetPopup: '<popup window>', // MISSING
 	targetPopupName: 'Popup Window Name', // MISSING
+	text: 'Text', // MISSING
 	title: 'Tautan',
 	toAnchor: 'Link to anchor in the text', // MISSING
 	toEmail: 'E-mail', // MISSING

--- a/plugins/link/lang/is.js
+++ b/plugins/link/lang/is.js
@@ -54,6 +54,7 @@ CKEDITOR.plugins.setLang( 'link', 'is', {
 	targetFrameName: 'Nafn markglugga',
 	targetPopup: '<sprettigluggi>',
 	targetPopupName: 'Nafn sprettiglugga',
+	text: 'Text', // MISSING
 	title: 'Stikla',
 	toAnchor: 'Bókamerki á þessari síðu',
 	toEmail: 'Netfang',

--- a/plugins/link/lang/it.js
+++ b/plugins/link/lang/it.js
@@ -54,6 +54,7 @@ CKEDITOR.plugins.setLang( 'link', 'it', {
 	targetFrameName: 'Nome del riquadro di destinazione',
 	targetPopup: '<finestra popup>',
 	targetPopupName: 'Nome finestra popup',
+	text: 'Text', // MISSING
 	title: 'Collegamento',
 	toAnchor: 'Ancora nel testo',
 	toEmail: 'E-Mail',

--- a/plugins/link/lang/ja.js
+++ b/plugins/link/lang/ja.js
@@ -54,6 +54,7 @@ CKEDITOR.plugins.setLang( 'link', 'ja', {
 	targetFrameName: 'ターゲットのフレーム名',
 	targetPopup: '<ポップアップウィンドウ>',
 	targetPopupName: 'ポップアップウィンドウ名',
+	text: 'Text', // MISSING
 	title: 'ハイパーリンク',
 	toAnchor: 'ページ内のアンカー',
 	toEmail: 'E-Mail',

--- a/plugins/link/lang/ka.js
+++ b/plugins/link/lang/ka.js
@@ -54,6 +54,7 @@ CKEDITOR.plugins.setLang( 'link', 'ka', {
 	targetFrameName: 'Frame-ის სახელი',
 	targetPopup: '<popup ფანჯარა>',
 	targetPopupName: 'Popup ფანჯრის სახელი',
+	text: 'Text', // MISSING
 	title: 'ბმული',
 	toAnchor: 'ბმული ტექსტში ღუზაზე',
 	toEmail: 'ელფოსტა',

--- a/plugins/link/lang/km.js
+++ b/plugins/link/lang/km.js
@@ -54,6 +54,7 @@ CKEDITOR.plugins.setLang( 'link', 'km', {
 	targetFrameName: 'ឈ្មោះ​ស៊ុម​ជា​គោល​ដៅ',
 	targetPopup: '<វីនដូ​ផុស​ឡើង>',
 	targetPopupName: 'ឈ្មោះ​វីនដូត​ផុស​ឡើង',
+	text: 'Text', // MISSING
 	title: 'តំណ',
 	toAnchor: 'ត​ភ្ជាប់​ទៅ​យុថ្កា​ក្នុង​អត្ថបទ',
 	toEmail: 'អ៊ីមែល',

--- a/plugins/link/lang/ko.js
+++ b/plugins/link/lang/ko.js
@@ -54,6 +54,7 @@ CKEDITOR.plugins.setLang( 'link', 'ko', {
 	targetFrameName: '타겟 프레임 이름',
 	targetPopup: '<팝업 창>',
 	targetPopupName: '팝업 창 이름',
+	text: 'Text', // MISSING
 	title: '링크',
 	toAnchor: '책갈피',
 	toEmail: '이메일',

--- a/plugins/link/lang/ku.js
+++ b/plugins/link/lang/ku.js
@@ -54,6 +54,7 @@ CKEDITOR.plugins.setLang( 'link', 'ku', {
 	targetFrameName: 'ناوی ئامانجی چووارچێوە',
 	targetPopup: '<پەنجەرەی سەرهەڵدەر>',
 	targetPopupName: 'ناوی پەنجەرەی سەرهەڵدەر',
+	text: 'Text', // MISSING
 	title: 'بەستەر',
 	toAnchor: 'بەستەر بۆ لەنگەر له دەق',
 	toEmail: 'ئیمەیل',

--- a/plugins/link/lang/lt.js
+++ b/plugins/link/lang/lt.js
@@ -54,6 +54,7 @@ CKEDITOR.plugins.setLang( 'link', 'lt', {
 	targetFrameName: 'Paskirties kadro vardas',
 	targetPopup: '<išskleidžiamas langas>',
 	targetPopupName: 'Paskirties lango vardas',
+	text: 'Text', // MISSING
 	title: 'Nuoroda',
 	toAnchor: 'Žymė šiame puslapyje',
 	toEmail: 'El.paštas',

--- a/plugins/link/lang/lv.js
+++ b/plugins/link/lang/lv.js
@@ -54,6 +54,7 @@ CKEDITOR.plugins.setLang( 'link', 'lv', {
 	targetFrameName: 'Mērķa ietvara nosaukums',
 	targetPopup: '<uznirstošā logā>',
 	targetPopupName: 'Uznirstošā loga nosaukums',
+	text: 'Text', // MISSING
 	title: 'Hipersaite',
 	toAnchor: 'Iezīme šajā lapā',
 	toEmail: 'E-pasts',

--- a/plugins/link/lang/mk.js
+++ b/plugins/link/lang/mk.js
@@ -54,6 +54,7 @@ CKEDITOR.plugins.setLang( 'link', 'mk', {
 	targetFrameName: 'Target Frame Name', // MISSING
 	targetPopup: '<popup window>', // MISSING
 	targetPopupName: 'Popup Window Name', // MISSING
+	text: 'Text', // MISSING
 	title: 'Link', // MISSING
 	toAnchor: 'Link to anchor in the text', // MISSING
 	toEmail: 'E-mail', // MISSING

--- a/plugins/link/lang/mn.js
+++ b/plugins/link/lang/mn.js
@@ -54,6 +54,7 @@ CKEDITOR.plugins.setLang( 'link', 'mn', {
 	targetFrameName: 'Очих фремын нэр',
 	targetPopup: '<popup цонх>',
 	targetPopupName: 'Popup цонхны нэр',
+	text: 'Text', // MISSING
 	title: 'Холбоос',
 	toAnchor: 'Энэ бичвэр дэх зангуу руу очих холбоос',
 	toEmail: 'Э-захиа',

--- a/plugins/link/lang/ms.js
+++ b/plugins/link/lang/ms.js
@@ -54,6 +54,7 @@ CKEDITOR.plugins.setLang( 'link', 'ms', {
 	targetFrameName: 'Nama Bingkai Sasaran',
 	targetPopup: '<tetingkap popup>',
 	targetPopupName: 'Nama Tetingkap Popup',
+	text: 'Text', // MISSING
 	title: 'Sambungan',
 	toAnchor: 'Pautan dalam muka surat ini',
 	toEmail: 'E-Mail',

--- a/plugins/link/lang/nb.js
+++ b/plugins/link/lang/nb.js
@@ -54,6 +54,7 @@ CKEDITOR.plugins.setLang( 'link', 'nb', {
 	targetFrameName: 'Målramme',
 	targetPopup: '<popup-vindu>',
 	targetPopupName: 'Navn på popup-vindu',
+	text: 'Text', // MISSING
 	title: 'Lenke',
 	toAnchor: 'Lenke til anker i teksten',
 	toEmail: 'E-post',

--- a/plugins/link/lang/nl.js
+++ b/plugins/link/lang/nl.js
@@ -54,6 +54,7 @@ CKEDITOR.plugins.setLang( 'link', 'nl', {
 	targetFrameName: 'Naam doelframe',
 	targetPopup: '<popupvenster>',
 	targetPopupName: 'Naam popupvenster',
+	text: 'Text', // MISSING
 	title: 'Link',
 	toAnchor: 'Interne link in pagina',
 	toEmail: 'E-mail',

--- a/plugins/link/lang/no.js
+++ b/plugins/link/lang/no.js
@@ -54,6 +54,7 @@ CKEDITOR.plugins.setLang( 'link', 'no', {
 	targetFrameName: 'Målramme',
 	targetPopup: '<popup-vindu>',
 	targetPopupName: 'Navn på popup-vindu',
+	text: 'Text', // MISSING
 	title: 'Lenke',
 	toAnchor: 'Lenke til anker i teksten',
 	toEmail: 'E-post',

--- a/plugins/link/lang/pl.js
+++ b/plugins/link/lang/pl.js
@@ -54,6 +54,7 @@ CKEDITOR.plugins.setLang( 'link', 'pl', {
 	targetFrameName: 'Nazwa ramki docelowej',
 	targetPopup: '<wyskakujące okno>',
 	targetPopupName: 'Nazwa wyskakującego okna',
+	text: 'Text', // MISSING
 	title: 'Odnośnik',
 	toAnchor: 'Odnośnik wewnątrz strony (kotwica)',
 	toEmail: 'Adres e-mail',

--- a/plugins/link/lang/pt-br.js
+++ b/plugins/link/lang/pt-br.js
@@ -54,6 +54,7 @@ CKEDITOR.plugins.setLang( 'link', 'pt-br', {
 	targetFrameName: 'Nome do Frame de Destino',
 	targetPopup: '<janela popup>',
 	targetPopupName: 'Nome da Janela Pop-up',
+	text: 'Text', // MISSING
 	title: 'Editar Link',
 	toAnchor: 'Âncora nesta página',
 	toEmail: 'E-Mail',

--- a/plugins/link/lang/pt.js
+++ b/plugins/link/lang/pt.js
@@ -54,6 +54,7 @@ CKEDITOR.plugins.setLang( 'link', 'pt', {
 	targetFrameName: 'Nome do Frame Destino',
 	targetPopup: '<janela de popup>',
 	targetPopupName: 'Nome da Janela de Popup',
+	text: 'Text', // MISSING
 	title: 'Hiperligação',
 	toAnchor: 'Referência a esta página',
 	toEmail: 'Email',

--- a/plugins/link/lang/ro.js
+++ b/plugins/link/lang/ro.js
@@ -54,6 +54,7 @@ CKEDITOR.plugins.setLang( 'link', 'ro', {
 	targetFrameName: 'Numele frameului ţintă',
 	targetPopup: '<fereastra popup>',
 	targetPopupName: 'Numele ferestrei popup',
+	text: 'Text', // MISSING
 	title: 'Link (Legătură web)',
 	toAnchor: 'Ancoră în această pagină',
 	toEmail: 'E-Mail',

--- a/plugins/link/lang/ru.js
+++ b/plugins/link/lang/ru.js
@@ -54,6 +54,7 @@ CKEDITOR.plugins.setLang( 'link', 'ru', {
 	targetFrameName: 'Имя целевого фрейма',
 	targetPopup: '<всплывающее окно>',
 	targetPopupName: 'Имя всплывающего окна',
+	text: 'Text', // MISSING
 	title: 'Ссылка',
 	toAnchor: 'Ссылка на якорь в тексте',
 	toEmail: 'Email',

--- a/plugins/link/lang/si.js
+++ b/plugins/link/lang/si.js
@@ -54,6 +54,7 @@ CKEDITOR.plugins.setLang( 'link', 'si', {
 	targetFrameName: 'Target Frame Name', // MISSING
 	targetPopup: '<popup window>', // MISSING
 	targetPopupName: 'Popup Window Name', // MISSING
+	text: 'Text', // MISSING
 	title: 'සබැඳිය',
 	toAnchor: 'Link to anchor in the text', // MISSING
 	toEmail: 'E-mail', // MISSING

--- a/plugins/link/lang/sk.js
+++ b/plugins/link/lang/sk.js
@@ -54,6 +54,7 @@ CKEDITOR.plugins.setLang( 'link', 'sk', {
 	targetFrameName: 'Názov rámu cieľa',
 	targetPopup: '<vyskakovacie okno>',
 	targetPopupName: 'Názov vyskakovacieho okna',
+	text: 'Text', // MISSING
 	title: 'Odkaz',
 	toAnchor: 'Odkaz na kotvu v texte',
 	toEmail: 'E-mail',

--- a/plugins/link/lang/sl.js
+++ b/plugins/link/lang/sl.js
@@ -54,6 +54,7 @@ CKEDITOR.plugins.setLang( 'link', 'sl', {
 	targetFrameName: 'Ime ciljnega okvirja',
 	targetPopup: '<pojavno okno>',
 	targetPopupName: 'Ime pojavnega okna',
+	text: 'Text', // MISSING
 	title: 'Povezava',
 	toAnchor: 'Zaznamek na tej strani',
 	toEmail: 'Elektronski naslov',

--- a/plugins/link/lang/sq.js
+++ b/plugins/link/lang/sq.js
@@ -54,6 +54,7 @@ CKEDITOR.plugins.setLang( 'link', 'sq', {
 	targetFrameName: 'Emri i Kornizës së Synuar',
 	targetPopup: '<popup window>',
 	targetPopupName: 'Emri i Dritares së Dialogut',
+	text: 'Text', // MISSING
 	title: 'Nyja',
 	toAnchor: 'Lidhu me spirancën në tekst',
 	toEmail: 'Posta Elektronike',

--- a/plugins/link/lang/sr-latn.js
+++ b/plugins/link/lang/sr-latn.js
@@ -54,6 +54,7 @@ CKEDITOR.plugins.setLang( 'link', 'sr-latn', {
 	targetFrameName: 'Naziv odredišnog frejma',
 	targetPopup: '<popup prozor>',
 	targetPopupName: 'Naziv popup prozora',
+	text: 'Text', // MISSING
 	title: 'Link',
 	toAnchor: 'Sidro na ovoj stranici',
 	toEmail: 'E-Mail',

--- a/plugins/link/lang/sr.js
+++ b/plugins/link/lang/sr.js
@@ -54,6 +54,7 @@ CKEDITOR.plugins.setLang( 'link', 'sr', {
 	targetFrameName: 'Назив одредишног фрејма',
 	targetPopup: '<искачући прозор>',
 	targetPopupName: 'Назив искачућег прозора',
+	text: 'Text', // MISSING
 	title: 'Линк',
 	toAnchor: 'Сидро на овој страници',
 	toEmail: 'Eлектронска пошта',

--- a/plugins/link/lang/sv.js
+++ b/plugins/link/lang/sv.js
@@ -54,6 +54,7 @@ CKEDITOR.plugins.setLang( 'link', 'sv', {
 	targetFrameName: 'Målets ramnamn',
 	targetPopup: '<popup-fönster>',
 	targetPopupName: 'Popup-fönstrets namn',
+	text: 'Text', // MISSING
 	title: 'Länk',
 	toAnchor: 'Länk till ankare i texten',
 	toEmail: 'E-post',

--- a/plugins/link/lang/th.js
+++ b/plugins/link/lang/th.js
@@ -54,6 +54,7 @@ CKEDITOR.plugins.setLang( 'link', 'th', {
 	targetFrameName: 'ชื่อทาร์เก็ตเฟรม',
 	targetPopup: '<เปิดหน้าจอเล็ก (Pop-up)>',
 	targetPopupName: 'ระบุชื่อหน้าจอเล็ก (Pop-up)',
+	text: 'Text', // MISSING
 	title: 'ลิงค์เชื่อมโยงเว็บ อีเมล์ รูปภาพ หรือไฟล์อื่นๆ',
 	toAnchor: 'จุดเชื่อมโยง (Anchor)',
 	toEmail: 'ส่งอีเมล์ (E-Mail)',

--- a/plugins/link/lang/tr.js
+++ b/plugins/link/lang/tr.js
@@ -54,6 +54,7 @@ CKEDITOR.plugins.setLang( 'link', 'tr', {
 	targetFrameName: 'Hedef Çerçeve Adı',
 	targetPopup: '<yeni açılan pencere>',
 	targetPopupName: 'Yeni Açılan Pencere Adı',
+	text: 'Text', // MISSING
 	title: 'Link',
 	toAnchor: 'Bu sayfada çapa',
 	toEmail: 'E-Posta',

--- a/plugins/link/lang/tt.js
+++ b/plugins/link/lang/tt.js
@@ -54,6 +54,7 @@ CKEDITOR.plugins.setLang( 'link', 'tt', {
 	targetFrameName: 'Target Frame Name', // MISSING
 	targetPopup: '<popup window>',
 	targetPopupName: 'Попап тәрәзәсе исеме',
+	text: 'Text', // MISSING
 	title: 'Сылталама',
 	toAnchor: 'Якорьне текст белән бәйләү',
 	toEmail: 'Электрон почта',

--- a/plugins/link/lang/ug.js
+++ b/plugins/link/lang/ug.js
@@ -54,6 +54,7 @@ CKEDITOR.plugins.setLang( 'link', 'ug', {
 	targetFrameName: 'نىشان كاندۇك ئاتى',
 	targetPopup: '‹قاڭقىش كۆزنەك›',
 	targetPopupName: 'قاڭقىش كۆزنەك ئاتى',
+	text: 'Text', // MISSING
 	title: 'ئۇلانما',
 	toAnchor: 'بەت ئىچىدىكى لەڭگەرلىك نۇقتا ئۇلانمىسى',
 	toEmail: 'ئېلخەت',

--- a/plugins/link/lang/uk.js
+++ b/plugins/link/lang/uk.js
@@ -54,6 +54,7 @@ CKEDITOR.plugins.setLang( 'link', 'uk', {
 	targetFrameName: 'Ім\'я цільового фрейму',
 	targetPopup: '<випливаюче вікно>',
 	targetPopupName: 'Ім\'я випливаючого вікна',
+	text: 'Text', // MISSING
 	title: 'Посилання',
 	toAnchor: 'Якір на цю сторінку',
 	toEmail: 'Ел. пошта',

--- a/plugins/link/lang/vi.js
+++ b/plugins/link/lang/vi.js
@@ -54,6 +54,7 @@ CKEDITOR.plugins.setLang( 'link', 'vi', {
 	targetFrameName: 'Tên khung đích',
 	targetPopup: '<cửa sổ popup>',
 	targetPopupName: 'Tên cửa sổ Popup',
+	text: 'Text', // MISSING
 	title: 'Liên kết',
 	toAnchor: 'Neo trong trang này',
 	toEmail: 'Thư điện tử',

--- a/plugins/link/lang/zh-cn.js
+++ b/plugins/link/lang/zh-cn.js
@@ -54,6 +54,7 @@ CKEDITOR.plugins.setLang( 'link', 'zh-cn', {
 	targetFrameName: '目标框架名称',
 	targetPopup: '<弹出窗口>',
 	targetPopupName: '弹出窗口名称',
+	text: 'Text', // MISSING
 	title: '超链接',
 	toAnchor: '页内锚点链接',
 	toEmail: '电子邮件',

--- a/plugins/link/lang/zh.js
+++ b/plugins/link/lang/zh.js
@@ -54,6 +54,7 @@ CKEDITOR.plugins.setLang( 'link', 'zh', {
 	targetFrameName: '目標框架名稱',
 	targetPopup: '<快顯視窗>',
 	targetPopupName: '快顯視窗名稱',
+	text: 'Text', // MISSING
 	title: '連結',
 	toAnchor: '文字中的錨點連結',
 	toEmail: '電子郵件',


### PR DESCRIPTION
Premise: If I have a link in the editor, and I want to add text to the beginning or end of the link text, placing the cursor at either end of the link would just add regular text (outside the <a> tag). If select the text of the link and type some text, only the first character I type becomes the text of the link, and the rest of the text is just regular text. The only way I found was to view the source and do the edits there (which is not ideal).

Ideally, I would love the editor to just "know" that I want to add text to the link if there are no spaces between the link and the cursor. But I understand this is complicated (and is honestly beyond my knowledge in ckeditor).

Instead, I've allowed editing the text of the link from the dialog! Seems intuitive to be able to edit the text from there, and doesn't really conflict with the ideal solution I mentioned earlier when/if it gets implemented.

I also added the label "Text" to the lang files.