### PR TITLE
allow customization of the dialog for URL entry

### DIFF
--- a/plugins/embedbase/dialogs/embedbase.js
+++ b/plugins/embedbase/dialogs/embedbase.js
@@ -9,6 +9,8 @@ CKEDITOR.dialog.add( 'embedBase', function( editor ) {
 	'use strict';
 
 	var lang = editor.lang.embedbase;
+	var urlLabel = lang.url ? lang.url : editor.lang.common.url;
+	var description = lang.description ? lang.description : '';
 
 	return {
 		title: lang.title,
@@ -75,9 +77,14 @@ CKEDITOR.dialog.add( 'embedBase', function( editor ) {
 
 				elements: [
 					{
+						type: 'html',
+						id: 'description',
+						html: description
+					},
+					{
 						type: 'text',
 						id: 'url',
-						label: editor.lang.common.url,
+						label: urlLabel,
 
 						setup: function( widget ) {
 							this.setValue( widget.data.url );


### PR DESCRIPTION
I think this dialog is a little rough, so I'd like to be able to modify the label without impacting other ckeditor messages and add a little explanation :
- allow custom URL label for this plugin
- allow adding custom HTML description on the URL entry dialog, before the text input
