### PR TITLE
Check for wildcard edge case when checkApplicable

### DIFF
--- a/core/style.js
+++ b/core/style.js
@@ -374,7 +374,7 @@ CKEDITOR.STYLE_OBJECT = 3;
 				case CKEDITOR.STYLE_OBJECT:
 					return !!elementPath.contains( this.element );
 				case CKEDITOR.STYLE_BLOCK:
-					return !!elementPath.blockLimit.getDtd()[ this.element ];
+					return !!(elementPath.blockLimit.getDtd()[ this.element ] || this.element === '*');
 			}
 
 			return true;

--- a/core/style.js
+++ b/core/style.js
@@ -372,7 +372,7 @@ CKEDITOR.STYLE_OBJECT = 3;
 
 			switch ( this.type ) {
 				case CKEDITOR.STYLE_OBJECT:
-					return !!elementPath.contains( this.element );
+					return !!(elementPath.contains( this.element ) || this.element === '*');
 				case CKEDITOR.STYLE_BLOCK:
 					return !!(elementPath.blockLimit.getDtd()[ this.element ] || this.element === '*');
 			}


### PR DESCRIPTION
In the style definition, when the user has not specified an element property, the element will default to the wildcard '*' string.

When we check whether an element is viable for manipulation, we should include the wildcard as a valid item.