### PR TITLE
Don't use document.write if document.readyState is 'interactive'

### DIFF
--- a/ckeditor.js
+++ b/ckeditor.js
@@ -20,7 +20,7 @@ else {
 	CKEDITOR._autoLoad = 'ckeditor';
 
 	// Include the loader script.
-	if ( document.body && ( !document.readyState || document.readyState == 'complete' ) ) {
+	if ( document.body && ( !document.readyState || document.readyState == 'interactive' || document.readyState == 'complete' ) ) {
 		var script = document.createElement( 'script' );
 		script.type = 'text/javascript';
 		script.src = CKEDITOR.getUrl( 'core/loader.js' );

--- a/core/loader.js
+++ b/core/loader.js
@@ -202,7 +202,7 @@ if ( !CKEDITOR.loader ) {
 				// If the page is fully loaded, we can't use document.write
 				// but if the script is run while the body is loading then it's safe to use it
 				// Unfortunately, Firefox <3.6 doesn't support document.readyState, so it won't get this improvement
-				if ( document.body && ( !document.readyState || document.readyState == 'complete' ) ) {
+				if ( document.body && ( !document.readyState || document.readyState == 'interactive' || document.readyState == 'complete' ) ) {
 					pendingLoad.push( scriptName );
 
 					if ( !defer )


### PR DESCRIPTION
Trying to load CKEditor from source breaks in Chrome, because the conditionals in the main ckeditor.js script and core/loader.js only check if `document.readyState == 'complete'`. However, a `readyState` of `'interactive'` on the document element also indicates that document.write can no longer be used, because `'interactive'` indicates that the document has finished loading and has been parsed (but sub-resources such as images, stylesheets and frames are still loading).

[Reference](https://developer.mozilla.org/en-US/docs/Web/API/Document/readyState)
