### PR TITLE
Update node version

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,6 +2,9 @@
 	"name": "ckeditor-dev",
 	"version": "4.5.7",
 	"description": "The development version of CKEditor - JavaScript WYSIWYG web text editor.",
+	"engines": {
+		"node": ">=4.0.0"
+	},
 	"devDependencies": {
 		"benderjs-coverage": "^0.2.1",
 		"benderjs": "^0.4.1",


### PR DESCRIPTION
The tests do not run unless the node version is specified to be 4.0 or greater