### PR TITLE
Use 'indexOf' strategy instead of 'in'

### DIFF
--- a/core/style.js
+++ b/core/style.js
@@ -401,7 +401,7 @@ CKEDITOR.STYLE_OBJECT = 3;
 				name = element.getName();
 
 			// If the element name is the same as the style name.
-			if ( typeof this.element == 'string' ? name == this.element : name in this.element ) {
+			if ( typeof this.element == 'string' ? name == this.element : this.element.indexOf(name) !== -1 ) {
 				// If no attributes are defined in the element.
 				if ( !fullMatch && !element.hasAttributes() )
 					return true;


### PR DESCRIPTION
Problem: the usage of [in](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/in) was incorrect. It was being used like so:

```
var trees = ["redwood", "bay", "cedar", "oak", "maple"];
"bay" in trees
```

The following will return false, as usage of `in` in an array must be an index value, not a key. Only in objects can you use it like so. In this case, if `this.element` is an array, like `this.element = ['p', 'ul', 'ol']`, then the usage of `element.getName() in this.element` was returning false.

I wrote the fix to move away from using `in`, and replaced it with using the `indexOf` strategy instead.