### PR TITLE
[Plugin][ColorButton] Fix color name displayed

### DIFF
--- a/plugins/colorbutton/plugin.js
+++ b/plugins/colorbutton/plugin.js
@@ -177,15 +177,21 @@ CKEDITOR.plugins.add( 'colorbutton', {
 
 				var parts = colors[ i ].split( '/' ),
 					colorName = parts[ 0 ],
-					colorCode = parts[ 1 ] || colorName;
+					colorCode = parts[ 1 ] || colorName,
+					colorLabel;
 
 				// The data can be only a color code (without #) or colorName + color code
 				// If only a color code is provided, then the colorName is the color with the hash
 				// Convert the color from RGB to RRGGBB for better compatibility with IE and <font>. See #5676
-				if ( !parts[ 1 ] )
+				// Additionally, if the data is a single color code then let's try to translate it or fallback on the
+				// color code. If the data is a color name/code, then use directly the color name provided.
+				if ( !parts[ 1 ] ) {
 					colorName = '#' + colorName.replace( /^(.)(.)(.)$/, '$1$1$2$2$3$3' );
+					colorLabel = editor.lang.colorbutton.colors[ colorCode ] || colorCode;
+				} else {
+					colorLabel = colorName;
+				}
 
-				var colorLabel = editor.lang.colorbutton.colors[ colorCode ] || colorCode;
 				output.push( '<td>' +
 					'<a class="cke_colorbox" _cke_focus=1 hidefocus=true' +
 						' title="', colorLabel, '"' +


### PR DESCRIPTION
Hey!

I maintain the Symfony2 integration of CKEditor and someone reports me the custom color label are not working in egeloen/IvoryCKEditorBundle#204

Basically, something like explain in the doc is not working: http://docs.ckeditor.com/#!/api/CKEDITOR.config-cfg-fileTools_defaultFileName#cfg-colorButton_colors

After debugging it, I notice the plugin fallbacks on the `colorCode` if the color trans is not found but IMO, if someone provides a explicit color label, it should be used directly and the current color code should only be involved if the label is not provided at all.

For the testing part, I'm not familiar with it and so, I was not able to add one... If someone can point me the way to go I can add them :)
