### PR TITLE
Fixed richcombo focus issue in Chrome

### DIFF
--- a/plugins/floatpanel/plugin.js
+++ b/plugins/floatpanel/plugin.js
@@ -408,7 +408,9 @@ CKEDITOR.plugins.add( 'floatpanel', {
 						this.focus();
 
 						// Focus the block now.
+						block.element.hide();
 						block.element.focus();
+						block.element.show();
 
 						// #10623, #10951 - restore the viewport's scroll position after focusing list element.
 						if ( CKEDITOR.env.webkit )

--- a/plugins/richcombo/plugin.js
+++ b/plugins/richcombo/plugin.js
@@ -270,7 +270,9 @@ CKEDITOR.plugins.add( 'richcombo', {
 					// The "panelShow" event is fired assinchronously, after the
 					// onShow method call.
 					editor.once( 'panelShow', function() {
+						list.hide();
 						list.focus( !list.multiSelect && me.getValue() );
+						list.show();
 					} );
 				};
 


### PR DESCRIPTION
I have bug with richcombo focus in Chrome. CKEditor richcombo breaks page because of using focus.
Video recording: https://drive.google.com/file/d/0Bxtv10NlSOEbWXNJbkNFVGQyUG8/view
My pull request fixes this Chrome issue.