### PR TITLE
When widget doesn't get removed from content

### DIFF
--- a/plugins/widget/plugin.js
+++ b/plugins/widget/plugin.js
@@ -2688,16 +2688,22 @@
 					widget = widgetsRepo.instances[ attrs[ 'data-cke-widget-id' ] ];
 					if ( widget ) {
 						widgetElement = element.getFirst( Widget.isParserWidgetElement );
-						toBeDowncasted.push( {
-							wrapper: element,
-							element: widgetElement,
-							widget: widget,
-							editables: {}
-						} );
+						if (widgetElement) { 
+							toBeDowncasted.push( {
+								wrapper: element,
+								element: widgetElement,
+								widget: widget,
+								editables: {}
+							} );
 
-						// If widget did not have data-cke-widget attribute before upcasting remove it.
-						if ( widgetElement.attributes[ 'data-cke-widget-keep-attr' ] != '1' )
-							delete widgetElement.attributes[ 'data-widget' ];
+							// If widget did not have data-cke-widget attribute before upcasting remove it.
+							if ( widgetElement.attributes[ 'data-cke-widget-keep-attr' ] != '1' )
+								delete widgetElement.attributes[ 'data-widget' ];
+						}
+						else {
+							// Odd case where content was saved with widget, this should correct it
+							widget.wrapper.remove(); 
+						}
 					}
 				}
 				// Nested editable.


### PR DESCRIPTION
Odd bug I ran across when the content contained partial widget data upon loading.   The system would throw an error due to widgetElement being null.  On this rare occasion this code will remove the widget wrapper allowing the code to function as expected.
