### PR TITLE
handle some <figure> edge cases

### DIFF
--- a/plugins/image2/plugin.js
+++ b/plugins/image2/plugin.js
@@ -923,12 +923,12 @@
 				data.align = 'center';
 
 				// Image can be wrapped in link <a><img/></a>.
-				image = el.getFirst( 'img' ) || el.getFirst( 'a' ).getFirst( 'img' );
+				image = el.getFirst( 'img' ) || el.getFirst( 'a' ) && el.getFirst( 'a' ).getFirst( 'img' );
 			}
 
 			// No center wrapper has been found.
 			else if ( name == 'figure' && el.hasClass( captionedClass ) ) {
-				image = el.getFirst( 'img' ) || el.getFirst( 'a' ).getFirst( 'img' );
+				image = el.getFirst( 'img' ) || el.getFirst( 'a' ) && el.getFirst( 'a' ).getFirst( 'img' );
 
 				// Upcast linked image like <a><img/></a>.
 			} else if ( isLinkedOrStandaloneImage( el ) ) {


### PR DESCRIPTION
fix error if `<figure class="image">` has no `<img>` or `<a>` element as child
