### PR TITLE
Ckeditor: Add a new event that is triggered when the template is clicked.

### DIFF
--- a/plugins/templates/dialogs/templates.js
+++ b/plugins/templates/dialogs/templates.js
@@ -51,10 +51,16 @@
 			item.getFirst().setHtml( html );
 
 			item.on( 'click', function() {
+				hookTemplate( template );
 				insertTemplate( template.html );
 			} );
 
 			return item;
+		}
+
+		// Add an event that provides the whole template with all of its properties.
+		function hookTemplate( template ) {
+			editor.fire('clickTemplate', { templateData: template });
 		}
 
 		// Insert the specified template content into editor.


### PR DESCRIPTION
- Pass the template in its entirety so that all of its properties can be accessed.
- Use case:
- I needed to store some server side information in the template and inject that
  information in a separate field when the template is injected into the editor.

If you feel I made a poor choice in naming conventions please comment and I'll be more than happy to modify them.
