### PR TITLE
Colorbutton plugin improvements.

### DIFF
--- a/plugins/colorbutton/plugin.js
+++ b/plugins/colorbutton/plugin.js
@@ -103,6 +103,7 @@ CKEDITOR.plugins.add( 'colorbutton', {
 		function renderColors( panel, type, colorBoxId ) {
 			var output = [],
 				colors = config.colorButton_colors.split( ',' ),
+				colorsPerRow = config.colorButton_colorsPerRow || 6,
 				// Tells if we should include "More Colors..." button.
 				moreColorsEnabled = editor.plugins.colordialog && config.colorButton_enableMore !== false,
 				// aria-setsize and aria-posinset attributes are used to indicate size of options, because
@@ -164,10 +165,7 @@ CKEDITOR.plugins.add( 'colorbutton', {
 					' role="option" aria-posinset="1" aria-setsize="', total, '">' +
 						'<table role="presentation" cellspacing=0 cellpadding=0 width="100%">' +
 							'<tr>' +
-								'<td>' +
-									'<span class="cke_colorbox" id="', colorBoxId, '"></span>' +
-								'</td>' +
-								'<td colspan=7 align=center>', lang.auto, '</td>' +
+								'<td colspan=8 align=center><span class="cke_colorbox" id="', colorBoxId, '"></span>', lang.auto, '</td>' +
 							'</tr>' +
 						'</table>' +
 					'</a>' );
@@ -176,7 +174,7 @@ CKEDITOR.plugins.add( 'colorbutton', {
 
 			// Render the color boxes.
 			for ( var i = 0; i < colors.length; i++ ) {
-				if ( ( i % 8 ) === 0 )
+				if ( ( i % colorsPerRow ) === 0 )
 					output.push( '</tr><tr>' );
 
 				var parts = colors[ i ].split( '/' ),
@@ -244,6 +242,9 @@ CKEDITOR.plugins.add( 'colorbutton', {
  * a name and the slash character. For example, `'FontColor1/FF9900'` will be
  * displayed as the color `#FF9900` in the selector, but will be output as `'FontColor1'`.
  *
+ * **Since 4.6.0:** The default color palette has change. It contains less colors and in more
+ * pastel shades than the previous one.
+ *
  * Read more in the [documentation](#!/guide/dev_colorbutton)
  * and see the [SDK sample](http://sdk.ckeditor.com/samples/colorbutton.html).
  *
@@ -255,11 +256,10 @@ CKEDITOR.plugins.add( 'colorbutton', {
  * @cfg {String} [colorButton_colors=see source]
  * @member CKEDITOR.config
  */
-CKEDITOR.config.colorButton_colors = '000,800000,8B4513,2F4F4F,008080,000080,4B0082,696969,' +
-	'B22222,A52A2A,DAA520,006400,40E0D0,0000CD,800080,808080,' +
-	'F00,FF8C00,FFD700,008000,0FF,00F,EE82EE,A9A9A9,' +
-	'FFA07A,FFA500,FFFF00,00FF00,AFEEEE,ADD8E6,DDA0DD,D3D3D3,' +
-	'FFF0F5,FAEBD7,FFFFE0,F0FFF0,F0FFFF,F0F8FF,E6E6FA,FFF';
+CKEDITOR.config.colorButton_colors = '1ABC9C,2ECC71,3498DB,9B59B6,34495E,F1C40F,' +
+	'16A085,27AE60,2980B9,8E44AD,2C3E50,F39C12,' +
+	'E67E22,E74C3C,ECF0F1,95A5A6,DDD,FFF,' +
+	'D35400,C0392B,BDC3C7,7F8C8D,999,000';
 
 /**
  * Stores the style definition that applies the text foreground color.
@@ -313,5 +313,17 @@ CKEDITOR.config.colorButton_backStyle = {
  *		config.colorButton_enableAutomatic = false;
  *
  * @cfg {Boolean} [colorButton_enableAutomatic=true]
+ * @member CKEDITOR.config
+ */
+
+/**
+ * Defines how many colors will be shown per row in the color selectors.
+ *
+ * Read more in the [documentation](#!/guide/dev_colorbutton)
+ * and see the [SDK sample](http://sdk.ckeditor.com/samples/colorbutton.html).
+ *
+ *		config.colorButton_colorsPerRow = 8;
+ *
+ * @cfg {Number} [colorButton_colorsPerRow=6]
  * @member CKEDITOR.config
  */


### PR DESCRIPTION
Changes directly related to [14569](http://dev.ckeditor.com/ticket/14569) ticket. This PR changes the default `colorbutton` palette, adds `colorButton_colorsPerRow` config option which makes number of colors per row in color selector configurable. It also changes `Automatic` button html, so the text can be easily centered with CSS.
