### PR TITLE
Do not rely on navigator.product to detect UA

### DIFF
--- a/core/env.js
+++ b/core/env.js
@@ -159,7 +159,7 @@ if ( !CKEDITOR.env ) {
 		 *
 		 * @property {Boolean}
 		 */
-		env.gecko = ( navigator.product == 'Gecko' && !env.webkit && !env.ie );
+		env.gecko = ( !env.webkit && !env.ie && agent.match('gecko') && !agent.match('goanna') );
 
 		/**
 		 * Indicates that CKEditor is running in a Blink-based browser like Chrome.


### PR DESCRIPTION
This property has been removed from the web standards. Besides that, generally all
browsers set it to Gecko, so it is meaningless.

Refs #206.
