### PR TITLE
appendBogus function adds a attribute 'data-cke-bogus' 

### DIFF
--- a/core/dom/element.js
+++ b/core/dom/element.js
@@ -335,6 +335,7 @@ CKEDITOR.dom.element.clearMarkers = function( database, element, removeFromDatab
 				var bogus = this.getDocument().createElement( 'br' );
 
 				CKEDITOR.env.gecko && bogus.setAttribute( 'type', '_moz' );
+				bogus.setAttribute( 'data-cke-bogus', 'true' );
 
 				this.append( bogus );
 			}


### PR DESCRIPTION
I changed the appendBogus function to add a attribute 'data-cke-bogus', that allows to seperate bogus elements from user-edited breaks.

I need this for our companies use-case, where we need to keep the HTML untouched. It messes with change detection and some legacy systems that are upset with tailing br's in a li.
 
I know there is 
http://dev.ckeditor.com/ticket/5767 and 
http://dev.ckeditor.com/ticket/6133
but I am not happy with it. I don't want the bogus br's, but there probably is a good reason for it, but in my case I need to strip them out on save. So I added an special attribute to distiguish them.
What do you think? 