### PR TITLE
Fix IE 11 error

### DIFF
--- a/core/env.js
+++ b/core/env.js
@@ -193,7 +193,12 @@ if ( !CKEDITOR.env ) {
 			if ( edge ) {
 				version = parseFloat( edge[ 1 ] );
 			} else if ( env.quirks || !document.documentMode ) {
-				version = parseFloat( agent.match( /msie (\d+)/ )[ 1 ] );
+				// for IE 11: "mozilla/5.0 (windows nt 6.3; trident/7.0; rv:11.0) like gecko"
+				if (trident){
+					version = parseFloat( agent.match( /rv:(\d+)/ )[ 1 ] );
+				} else {
+					version = parseFloat( agent.match( /msie (\d+)/ )[ 1 ] );
+				}
 			} else {
 				version = document.documentMode;
 			}


### PR DESCRIPTION
Fixes an error I get when using IE11 in Windows 10, using Emulation. I don't know if it runs in the same situation without being run in emulation.

The error is:
"unable to get property '1' of undefined or null reference"

The agent does not contain the string 'msie' so the returned array is null.
