### PR TITLE
Add `image2_altRequired` option to `image2` config

### DIFF
--- a/plugins/image2/dialogs/image2.js
+++ b/plugins/image2/dialogs/image2.js
@@ -41,6 +41,8 @@ CKEDITOR.dialog.add( 'image2', function( editor ) {
 		// Editor instance configuration.
 		config = editor.config,
 
+		hasFileBrowser = !!( config.filebrowserImageBrowseUrl || config.filebrowserBrowseUrl ),
+
 		// Content restrictions defined by the widget which
 		// impact on dialog structure and presence of fields.
 		features = editor.widgets.registered.image.features,
@@ -341,8 +343,7 @@ CKEDITOR.dialog.add( 'image2', function( editor ) {
 		heightField[ method ]();
 	}
 
-	var hasFileBrowser = !!( config.filebrowserImageBrowseUrl || config.filebrowserBrowseUrl ),
-		srcBoxChildren = [
+	var srcBoxChildren = [
 			{
 				id: 'src',
 				type: 'text',

--- a/plugins/image2/dialogs/image2.js
+++ b/plugins/image2/dialogs/image2.js
@@ -431,7 +431,8 @@ CKEDITOR.dialog.add( 'image2', function( editor ) {
 						},
 						commit: function( widget ) {
 							widget.setData( 'alt', this.getValue() );
-						}
+						},
+						validate: editor.config.image2_altRequired === true ? CKEDITOR.dialog.validate.notEmpty( lang.altMissing ) : null
 					},
 					{
 						type: 'hbox',

--- a/plugins/image2/lang/en.js
+++ b/plugins/image2/lang/en.js
@@ -16,5 +16,6 @@ CKEDITOR.plugins.setLang( 'image2', 'en', {
 	resizer: 'Click and drag to resize',
 	title: 'Image Properties',
 	uploadTab: 'Upload',
-	urlMissing: 'Image source URL is missing.'
+	urlMissing: 'Image source URL is missing.',
+	altMissing: 'Alternative text is missing.'
 } );

--- a/plugins/image2/plugin.js
+++ b/plugins/image2/plugin.js
@@ -1440,7 +1440,7 @@
 						displayTextField.hide();
 					} else {
 						// Make sure that display text is visible, as it might be hidden by image2 integration
-						// before. 
+						// before.
 						displayTextField.show();
 						onShow.apply( this, arguments );
 					}

--- a/plugins/image2/plugin.js
+++ b/plugins/image2/plugin.js
@@ -1697,3 +1697,13 @@ CKEDITOR.config.image2_captionedClass = 'image';
  * @cfg {String[]} [image2_alignClasses=null]
  * @member CKEDITOR.config
  */
+
+/**
+ * Determines whether alternative text is required.
+ *
+ *		config.image2_altRequired = false;
+ *
+ * @since 4.6.0
+ * @cfg {Boolean} [image2_altRequired=false]
+ * @member CKEDITOR.config
+ */

--- a/tests/plugins/image2/validator.js
+++ b/tests/plugins/image2/validator.js
@@ -1,0 +1,85 @@
+/* bender-tags: editor,unit,widget */
+/* bender-ckeditor-plugins: image2,toolbar */
+
+( function() {
+	'use strict';
+
+	bender.editors = {
+		defaultConfig: {
+			name: 'default'
+		},
+		altRequired: {
+			name: 'altRequired',
+			config: {
+				image2_altRequired: true
+			}
+		}
+	};
+
+	bender.test( {
+		spies: [],
+
+		tearDown: function() {
+			var currentDialog = CKEDITOR.dialog.getCurrent();
+
+			if ( currentDialog ) {
+				currentDialog.hide();
+			}
+
+			var spy;
+
+			while ( spy = this.spies.pop() ) {
+				spy.restore();
+			}
+
+		},
+
+		'test altRequired not set and empty alt is used': function() {
+			var bot = this.editorBots.defaultConfig;
+
+			bot.setData( '', function() {
+				bot.editor.focus();
+				bot.dialog( 'image', function( dialog ) {
+					dialog.setValueOf( 'info', 'src', '_assets/foo.png' );
+					dialog.getButton( 'ok' ).click();
+					assert.areEqual( null, CKEDITOR.dialog.getCurrent(), 'Dialog should be closed' );
+				} );
+			} );
+		},
+
+		'test altRequired is set and empty alt is used': function() {
+			var bot = this.editorBots.altRequired,
+				spy = sinon.stub( window, 'alert' );
+
+			this.spies.push( spy );
+
+			bot.setData( '', function() {
+				bot.editor.focus();
+				bot.dialog( 'image', function( dialog ) {
+					dialog.setValueOf( 'info', 'src', '_assets/foo.png' );
+					dialog.getButton( 'ok' ).click();
+					assert.isTrue( spy.calledOnce );
+					assert.areEqual( spy.args[0][0], bot.editor.lang.image2.altMissing, 'Should have proper alert message.' );
+
+					assert.areEqual( '', bot.editor.getData(), 'Content should not be set' );
+					assert.areNotEqual( null, CKEDITOR.dialog.getCurrent(), 'Dialog should be not be closed' );
+				} );
+			} );
+		},
+
+		'test altRequired is set and non-empty alt is used': function() {
+			var bot = this.editorBots.altRequired;
+
+			bot.setData( '', function() {
+				bot.editor.focus();
+				bot.dialog( 'image', function( dialog ) {
+					dialog.setValueOf( 'info', 'src', '_assets/foo.png' );
+					dialog.setValueOf( 'info', 'alt', 'bar' );
+					dialog.getButton( 'ok' ).click();
+					assert.areEqual( null, CKEDITOR.dialog.getCurrent(), 'Dialog should be closed' );
+				} );
+			} );
+		}
+
+	} );
+} )();


### PR DESCRIPTION
Optionally make the "Alternative Text" field in `image2` plugin required.