### PR TITLE
Doc: Fix `config.toolbar` documentation missing '/'

### DIFF
--- a/plugins/toolbar/plugin.js
+++ b/plugins/toolbar/plugin.js
@@ -677,8 +677,9 @@ CKEDITOR.UI_SEPARATOR = 'separator';
 CKEDITOR.config.toolbarLocation = 'top';
 
 /**
- * The toolbox (alias toolbar) definition. It is a toolbar name or an array of
- * toolbars (strips), each one being also an array, containing a list of UI items.
+ * The toolbox (alias toolbar) definition. It is either a toolbar name or an
+ * array of toolbars (strips), each one being either an array (containing a list
+ * of UI items) or a `'/'` string to produce a break (new line in toolbar).
  *
  * If set to `null`, the toolbar will be generated automatically using all available buttons
  * and {@link #toolbarGroups} as a toolbar groups layout.
@@ -699,6 +700,16 @@ CKEDITOR.config.toolbarLocation = 'top';
  *		config.toolbar_Basic = [
  *			[ 'Source', '-', 'Bold', 'Italic' ]
  *		];
+ *
+ *		// Defines a toolbar with two strips on a line, and a third strip on a
+ *		// separated line.
+ *		config.toolbar = [
+ *			[ 'Source', '-', 'Bold', 'Italic' ],
+ *			['Font', 'FontSize'],
+ *			'/',
+ *			['NumberedList', 'BulletedList']
+ *		];
+ *
  *		// Load toolbar_Name where Name = Basic.
  *		config.toolbar = 'Basic';
  *


### PR DESCRIPTION
Update the documentation to show the usage of `'/'` to produce toolbar lines.

Example:

```js
config.toolbar = [
    [ 'Source', '-', 'Bold', 'Italic' ],
    ['Font', 'FontSize'],
    '/',
    ['NumberedList', 'BulletedList']
];
```

This feature can be seen directly in source: https://github.com/ckeditor/ckeditor-dev/blob/12f0de3/plugins/toolbar/plugin.js#L216-L221