### PR TITLE
Support oembed responses of type link

### DIFF
--- a/plugins/embedbase/plugin.js
+++ b/plugins/embedbase/plugin.js
@@ -472,6 +472,8 @@
 					response.html = response.html.replace( /<iframe/g, '<iframe tabindex="-1"' );
 
 					return response.html;
+				} else if (response.type == 'link') {
+				    return response.description; 
 				}
 
 				return null;


### PR DESCRIPTION
When attempting to embed a github gist with embed.ly I get back that the response type is link. This change allows such a response to work.
