### PR TITLE
added <base> to panel to fix 404s on style sheets when baseHref is used

### DIFF
--- a/plugins/panel/plugin.js
+++ b/plugins/panel/plugin.js
@@ -74,7 +74,7 @@
 
 	var frameDocTpl = CKEDITOR.addTemplate( 'panel-frame-inner', '<!DOCTYPE html>' +
 		'<html class="cke_panel_container {env}" dir="{dir}" lang="{langCode}">' +
-			'<head>{css}</head>' +
+			'<head>{base}{css}</head>' +
 			'<body class="cke_{dir}"' +
 				' style="margin:0;padding:0" onload="{onload}"></body>' +
 		'<\/html>' );
@@ -113,7 +113,8 @@
 
 						doc.write( frameDocTpl.output( CKEDITOR.tools.extend( {
 							css: CKEDITOR.tools.buildStyleHtml( this.css ),
-							onload: 'window.parent.CKEDITOR.tools.callFunction(' + onLoad + ');'
+							onload: 'window.parent.CKEDITOR.tools.callFunction(' + onLoad + ');',
+							base: editor.config.baseHref ? '<base href="' + editor.config.baseHref + '" data-cke-temp="1" />' : ''
 						}, data ) ) );
 
 						var win = doc.getWindow();


### PR DESCRIPTION
Added base to panel to fix a problem when using baseHref and the style combo box

Bug is stylesheets will not use the baseHref and cause a 404

This does not contain the IE10 and earlier fix found at line 446 in plugins/wysiwygarea/plugin.js

This has been tested in
Firefox 47
IE11
Chrome 54
