### PR TITLE
Update regex for detecting URLs in autolink plugin

### DIFF
--- a/plugins/autolink/plugin.js
+++ b/plugins/autolink/plugin.js
@@ -6,8 +6,8 @@
 ( function() {
 	'use strict';
 
-	// Regex by Imme Emosol.
-	var validUrlRegex = /^(https?|ftp):\/\/(-\.)?([^\s\/?\.#-]+\.?)+(\/[^\s]*)?[^\s\.,]$/ig,
+	// Regex by @dperini.
+	var validUrlRegex = /^(?:(?:https?|ftp):\/\/)(?:\S+(?::\S*)?@)?(?:(?!(?:10|127)(?:\.\d{1,3}){3})(?!(?:169\.254|192\.168)(?:\.\d{1,3}){2})(?!172\.(?:1[6-9]|2\d|3[0-1])(?:\.\d{1,3}){2})(?:[1-9]\d?|1\d\d|2[01]\d|22[0-3])(?:\.(?:1?\d{1,2}|2[0-4]\d|25[0-5])){2}(?:\.(?:[1-9]\d?|1\d\d|2[0-4]\d|25[0-4]))|(?:(?:[a-z\u00a1-\uffff0-9]-*)*[a-z\u00a1-\uffff0-9]+)(?:\.(?:[a-z\u00a1-\uffff0-9]-*)*[a-z\u00a1-\uffff0-9]+)*(?:\.(?:[a-z\u00a1-\uffff]{2,}))\.?)(?::\d{2,5})?(?:[/?#]\S*)?$/i,
 		doubleQuoteRegex = /"/g;
 
 	CKEDITOR.plugins.add( 'autolink', {


### PR DESCRIPTION
I would like to see the regular expression used in the autolink plugin for detecting URLs changed into a more accurate one. URLs like https://my-website.com are not detected properly. The currently used expression by Imme Emosol (@imme-emosol) is very good, but is trumped by Diego Perini (@dperini), whose expression (arguably) works perfectly. This is shown in Mathias Bynens's (@mathiasbynens) [comparison](https://mathiasbynens.be/demo/url-regex) of URL detection regular expressions.