### PR TITLE
Fix change event not fired on type after paste

### DIFF
--- a/plugins/undo/plugin.js
+++ b/plugins/undo/plugin.js
@@ -1079,6 +1079,10 @@
 			// It would result with calling undoManager.type() on any following key.
 			editable.attachListener( editable, 'paste', that.ignoreInputEventListener, that, null, 999 );
 			editable.attachListener( editable, 'drop', that.ignoreInputEventListener, that, null, 999 );
+			// After paste we need to re-enable input event listener
+			editor.on('afterPaste', function () {
+				that.ignoreInputEvent = false;
+			});
 
 			// Click should create a snapshot if needed, but shouldn't cause change event.
 			// Don't pass onNavigationKey directly as a listener because it accepts one argument which

--- a/tests/plugins/undo/change.js
+++ b/tests/plugins/undo/change.js
@@ -182,6 +182,7 @@
 			} );
 		},
 
+		// 13763
 		'test change event not fired on type after paste': function() {
 			this.editorBot.setHtmlWithSelection( '<p>foo^</p>' );
 

--- a/tests/plugins/undo/change.js
+++ b/tests/plugins/undo/change.js
@@ -1,5 +1,5 @@
 /* bender-tags: editor,unit */
-/* bender-ckeditor-plugins: undo,basicstyles,toolbar,wysiwygarea */
+/* bender-ckeditor-plugins: undo,clipboard,basicstyles,toolbar,wysiwygarea */
 /* global undoEventDispatchTestsTools */
 
 ( function() {
@@ -180,6 +180,26 @@
 				// After setting text - caret is moved to beginning. We don't care - it does not change nothing.
 				keyTools.keyEvent( keyCodesEnum.LEFT, null, true );
 			} );
+		},
+
+		'test change event not fired on type after paste': function() {
+			this.editorBot.setHtmlWithSelection( '<p>foo^</p>' );
+
+			var that = this,
+				keys = this.keyTools.keyCodesEnum;
+
+			bender.tools.emulatePaste( this.editor, 'PASTE' );
+
+			this.editor.once( 'afterPaste', function() {
+				resume( function() {
+					changeCounter = 0;
+					that.checkChange( function() {
+						that.keyTools.keyEvent( keys.KEY_G );
+					} );
+				} );
+			} );
+
+			wait();
 		}
 	} );
 

--- a/tests/tickets/13763/1.html
+++ b/tests/tickets/13763/1.html
@@ -1,0 +1,12 @@
+<div id="editor1">
+	<p>Paste something here:</p>
+</div>
+<div id="changes"></div>
+
+<script>
+    var i = 1;
+    var changes = $( "#changes" );
+    CKEDITOR.replace( 'editor1' ).on("change", function () {
+        changes.append( $( "<div />" ).text( "change " + i++ ) );
+    });
+</script>

--- a/tests/tickets/13763/1.md
+++ b/tests/tickets/13763/1.md
@@ -1,0 +1,10 @@
+@bender-tags: 13763, jquery
+@bender-ui: collapsed
+@bender-ckeditor-plugins: undo,clipboard,basicstyles,toolbar,wysiwygarea
+
+----
+
+1. Paste some text into the editor.
+2. Type a single character after pasting.
+
+**Expected:** There should be exactly two change events shown below the editor.


### PR DESCRIPTION
Steps to reproduce the bug:
- Setup change event listener to record change events in the console. Something like this:
    ```js
    var i = 0;
    editor.on("change", function () {
        console.log("change", i++);
    });
    ```
- Paste some text into the editor and note change event number in console.
- Type a single character.

Expected:
Change event should fire after typing (should see new change event number since paste).

Observed:
Change event is not fired.
