### PR TITLE
Fixed cloning equals nodes for correct editor.getSelection working (#16813 bug)

### DIFF
--- a/core/dom/range.js
+++ b/core/dom/range.js
@@ -204,10 +204,17 @@ CKEDITOR.dom.range = function( root ) {
 		// This allows us to not think about startNode == endNode case later on.
 		// We do that only when cloning, because in other cases we can safely split this text node
 		// and hence we can easily handle this case as many others.
-		if ( isClone && endNode.type == CKEDITOR.NODE_TEXT && startNode.equals( endNode ) ) {
-			startNode = range.document.createText( startNode.substring( startOffset, endOffset ) );
-			docFrag.append( startNode );
-			return;
+		if ( isClone && endNode.type == CKEDITOR.NODE_TEXT ) {
+			var checkEqualsNode = startNode;
+			if ( startNode != CKEDITOR.NODE_TEXT ) {
+				if ( startNode.$.childNodes[0] && startNode.$.childNodes[0].nodeType == 3 ) {
+					checkEqualsNode = new CKEDITOR.dom.node( startNode.$.childNodes[0] );
+				}
+			}
+			if ( checkEqualsNode.equals( endNode ) ) {
+				docFrag.append( range.document.createText( endNode.substring( startOffset, endOffset ) ) );
+				return;
+			}
 		}
 
 		// For text containers, we must simply split the node and point to the

--- a/tests/tickets/16813/1.js
+++ b/tests/tickets/16813/1.js
@@ -1,0 +1,30 @@
+/* bender-tags: editor */
+/* bender-ckeditor-plugins: format,toolbar */
+
+bender.editor = {
+	creator: 'inline',
+	config: {
+		allowedContent: true
+	}
+};
+
+bender.test( {
+	'test selecting first few words, toggle combo and getting selected html': function() {
+		var bot = this.editorBot, editor = this.editor;
+		bot.setData( '<p><u>Bring rich editor features to your <b>products</b> and <b>websites</b>!</u></p>', function() {
+			var text = editor.editable().getFirst().getFirst().getFirst(),
+				range = editor.createRange();
+			range.setStart( text, 0 );
+			range.setEnd( text, 26 );
+			range.select();
+			assert.areSame( 'Bring rich editor features', range.cloneContents().getHtml() );
+			assert.areSame( '<u>Bring rich editor features</u>', editor.getSelectedHtml( true ) );
+			bot.combo( 'Format', function() {
+				editor.focus();
+				assert.areSame( 'Bring rich editor features', range.cloneContents().getHtml() );
+				assert.areSame( '<u>Bring rich editor features</u>', editor.getSelectedHtml( true ) );
+				editor.destroy();
+			} );
+		} );
+	}
+} );


### PR DESCRIPTION
This is my solution to fix the bug: https://dev.ckeditor.com/ticket/16813