### PR TITLE
Add support for Firefox in Travis builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,6 +15,9 @@ matrix:
       env: BUILD=1 BROWSER=Firefox
   fast_finish: true
 
+addons:
+  firefox: "latest"
+
 before_script:
   - 'npm install benderjs-cli -g'
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,11 +9,11 @@ matrix:
       env: BUILD=0 BROWSER=Chrome
     - node_js: 4
       env: BUILD=1 BROWSER=Chrome
+  allow_failures:
     - node_js: 4
       env: BUILD=0 BROWSER=Firefox
     - node_js: 4
       env: BUILD=1 BROWSER=Firefox
-  fast_finish: true
 
 addons:
   firefox: "latest"

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,12 +3,16 @@ dist: trusty
 
 language: node_js
 
+node_js:
+  - 4
+
+env:
+  - BUILD=0 BROWSER=Chrome
+  - BUILD=1 BROWSER=Chrome
+  - BUILD=0 BROWSER=Firefox
+  - BUILD=1 BROWSER=Firefox
+
 matrix:
-  include:
-    - node_js: 4
-      env: BUILD=0 BROWSER=Chrome
-    - node_js: 4
-      env: BUILD=1 BROWSER=Chrome
   allow_failures:
     - node_js: 4
       env: BUILD=0 BROWSER=Firefox

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,9 +6,13 @@ language: node_js
 matrix:
   include:
     - node_js: 4
-      env: BUILD=0
+      env: BUILD=0 BROWSER=Chrome
     - node_js: 4
-      env: BUILD=1
+      env: BUILD=1 BROWSER=Chrome
+    - node_js: 4
+      env: BUILD=0 BROWSER=Firefox
+    - node_js: 4
+      env: BUILD=1 BROWSER=Firefox
   fast_finish: true
 
 before_script:

--- a/bender.ci.js
+++ b/bender.ci.js
@@ -3,7 +3,7 @@
 'use strict';
 var config = require( './bender' );
 
-config.startBrowser = 'Chrome';
+config.startBrowser = process.env.BROWSER || 'Chrome';
 config.mathJaxLibPath = 'https://cdn.mathjax.org/mathjax/latest/MathJax.js?config=TeX-AMS_HTML';
 
 module.exports = config;


### PR DESCRIPTION
This PR adds support for Firefox in our CI builds.

Note that for the time being I've added it into `allow_failures` matrix, which basically means that even though it's tests fail overall build will be marked as success. This is for transistional period, and to test the stability.

I already see [one uploadimage test](https://dev.ckeditor.com/ticket/16861) failing __most__ of the time.

Also note that I did remove `fast_finish` flag on purpose, so that Travis will wait with reporting job as done until Firefox is done (we still care about it).

Also used `addons: firefox "latest"` to make sure it's running latest Firefox version, as by default Travis uses Firefox 38 which is... kida outdated. I suppose it's due to the fact that it's the last version fully compatible with selenium, but that's a different story.