### PR TITLE
Linked an example template file in API docs

### DIFF
--- a/plugins/templates/plugin.js
+++ b/plugins/templates/plugin.js
@@ -74,8 +74,8 @@
  *			'http://www.example.com/user_templates.js'
  *		];
  *
- * For an example template file see
- * [`templates/default.js`](https://github.com/ckeditor/ckeditor-dev/blob/master/plugins/templates/templates/default.js).
+ * For an example template file
+ * [see `templates/default.js`](https://github.com/ckeditor/ckeditor-dev/blob/master/plugins/templates/templates/default.js).
  *
  * @cfg
  * @member CKEDITOR.config

--- a/plugins/templates/plugin.js
+++ b/plugins/templates/plugin.js
@@ -74,6 +74,9 @@
  *			'http://www.example.com/user_templates.js'
  *		];
  *
+ * For an example template file see
+ * [`templates/default.js`](https://github.com/ckeditor/ckeditor-dev/blob/master/plugins/templates/templates/default.js).
+ *
  * @cfg
  * @member CKEDITOR.config
  */


### PR DESCRIPTION
As [one of our users points out](http://ckeditor.com/addon/templates#comment-3196671844) template docs could use some improvements.

In terms of API docs one thing missing for me is a better explanation on how the template files should look like, the best example is to point to working code.