### PR TITLE
Added missing type information

### DIFF
--- a/plugins/templates/plugin.js
+++ b/plugins/templates/plugin.js
@@ -74,7 +74,7 @@
  *			'http://www.example.com/user_templates.js'
  *		];
  *
- * @cfg
+ * @cfg {String[]}
  * @member CKEDITOR.config
  */
 CKEDITOR.config.templates_files = [
@@ -87,7 +87,7 @@ CKEDITOR.config.templates_files = [
  *
  *		config.templates_replaceContent = false;
  *
- * @cfg
+ * @cfg {Boolean}
  * @member CKEDITOR.config
  */
 CKEDITOR.config.templates_replaceContent = true;


### PR DESCRIPTION
Few config options in template plugin docs are missing var type. This PR fixes it.