### PR TITLE
Removed eval usage from template

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -13,6 +13,7 @@ New Features:
 Fixed Issues:
 
 * [#16935](http://dev.ckeditor.com/ticket/16935): Fixed: [Chrome] Blurring editor in [Source Mode](http://ckeditor.com/addon/sourcearea) throws an error.
+* [#13381](http://dev.ckeditor.com/ticket/13381): Fixed: Dynamic code evaluation call in [`CKEDITOR.template`](http://docs.ckeditor.com/#!/api/CKEDITOR.template) removed. CKEditor can be used with `unsafe-inline` Content Security Policy. Thanks to [Caridy Patiño](http://caridy.name)!
 * [#16825](http://dev.ckeditor.com/ticket/16825): Fixed: [Chrome] Error thrown when destroying focused inline editor.
 * [#16857](http://dev.ckeditor.com/ticket/16857): Fixed: Ctrl + Shift + V blocked by copy formatting.
 * [#14714](http://dev.ckeditor.com/ticket/14714): [Webkit/Blink] Fixed: Exception thrown on refocusing a blurred inline editor.

--- a/core/template.js
+++ b/core/template.js
@@ -9,8 +9,7 @@
  */
 
 ( function() {
-	var cache = {},
-		rePlaceholder = /{([^}]+)}/g;
+	var rePlaceholder = /{([^}]+)}/g;
 
 	/**
 	 * Lightweight template used to build the output string from variables.
@@ -24,29 +23,16 @@
 	 * @param {String} source The template source.
 	 */
 	CKEDITOR.template = function( source ) {
-		// For example, if we have this "source":
-		//	'<div style="{style}">{editorName}</div>'
-		// ... the resulting function body will be (apart from the "buffer" handling):
-		//	return [ '<div style="', data['style'] == undefined ? '{style}' : data['style'], '">', data['editorName'] == undefined ? '{editorName}' : data['editorName'], '</div>' ].join('');
+		this.source = String( source );
+	};
 
-		// Try to read from the cache.
-		if ( cache[ source ] ) {
-			this.output = cache[ source ];
-		}
-		else {
-			// less performant solution when CSP is disabling indirect evaluation
-			cache[ source ] = function( data, buffer ) {
-				var output = '';
 
-				output += String( source ).replace( rePlaceholder, function( fullMatch, dataKey ) {
-					return data[ dataKey ] !== undefined ? data[ dataKey ] : fullMatch;
-				} );
+	CKEDITOR.template.prototype.output = function( data, buffer ) {
+		var output = this.source.replace( rePlaceholder, function( fullMatch, dataKey ) {
+			return data[ dataKey ] !== undefined ? data[ dataKey ] : fullMatch;
+		} );
 
-				return buffer ? buffer.push( output ) : output;
-			};
-
-			this.output = cache[ source ];
-		}
+		return buffer ? buffer.push( output ) : output;
 	};
 } )();
 

--- a/core/template.js
+++ b/core/template.js
@@ -26,6 +26,7 @@
 		/**
 		 * Current template source.
 		 *
+		 * @readonly
 		 * @member CKEDITOR.template
 		 * @property {String}
 		 */
@@ -35,7 +36,8 @@
 	/**
 	 * Processes the template, filling its variables with the provided data.
 	 *
-	 * @method output
+	 * @method
+	 * @member CKEDITOR.template
 	 * @param {Object} data An object containing properties which values will be
 	 * used to fill the template variables. The property names must match the
 	 * template variables names. Variables without matching properties will be

--- a/core/template.js
+++ b/core/template.js
@@ -23,10 +23,28 @@
 	 * @param {String} source The template source.
 	 */
 	CKEDITOR.template = function( source ) {
+		/**
+		 * Current template source.
+		 *
+		 * @member CKEDITOR.template
+		 * @property {String}
+		 */
 		this.source = String( source );
 	};
 
-
+	/**
+	 * Processes the template, filling its variables with the provided data.
+	 *
+	 * @method output
+	 * @param {Object} data An object containing properties which values will be
+	 * used to fill the template variables. The property names must match the
+	 * template variables names. Variables without matching properties will be
+	 * kept untouched.
+	 * @param {Array} [buffer] An array into which the output data will be pushed into.
+	 * The number of entries appended to the array is unknown.
+	 * @returns {String/Number} If `buffer` has not been provided, the processed
+	 * template output data, otherwise the new length of `buffer`.
+	 */
 	CKEDITOR.template.prototype.output = function( data, buffer ) {
 		var output = this.source.replace( rePlaceholder, function( fullMatch, dataKey ) {
 			return data[ dataKey ] !== undefined ? data[ dataKey ] : fullMatch;
@@ -35,17 +53,3 @@
 		return buffer ? buffer.push( output ) : output;
 	};
 } )();
-
-/**
- * Processes the template, filling its variables with the provided data.
- *
- * @method output
- * @param {Object} data An object containing properties which values will be
- * used to fill the template variables. The property names must match the
- * template variables names. Variables without matching properties will be
- * kept untouched.
- * @param {Array} [buffer] An array into which the output data will be pushed into.
- * The number of entries appended to the array is unknown.
- * @returns {String/Number} If `buffer` has not been provided, the processed
- * template output data, otherwise the new length of `buffer`.
- */

--- a/tests/tickets/8584/csp.html
+++ b/tests/tickets/8584/csp.html
@@ -1,0 +1,10 @@
+<head>
+	<meta http-equiv="Content-Security-Policy" content="script-src 'self' 'unsafe-inline'">
+</head>
+<body>
+	<textarea id="editor1">Sample content</textarea>
+
+	<script>
+		CKEDITOR.replace( 'editor1' );
+	</script>
+</body>

--- a/tests/tickets/8584/csp.md
+++ b/tests/tickets/8584/csp.md
@@ -1,0 +1,8 @@
+@bender-tags: tc, 4.7.0, 8584, editor
+@bender-ui: collapsed
+@bender-ckeditor-plugins: wysiwygarea, toolbar, undo, pastefromword, sourcearea, elementspath, list, link, basicstyles
+
+Check if the editor is usable:
+
+* the whole UI is rendered correctly,
+* there are no errors in console, especially connected with `Content-Security-Policy`.

--- a/tests/tickets/8584/csp.md
+++ b/tests/tickets/8584/csp.md
@@ -1,6 +1,6 @@
 @bender-tags: tc, 4.7.0, 8584, editor
 @bender-ui: collapsed
-@bender-ckeditor-plugins: wysiwygarea, toolbar, undo, pastefromword, sourcearea, elementspath, list, link, basicstyles
+@bender-ckeditor-plugins: wysiwygarea, toolbar, undo, pastefromword, sourcearea, elementspath, list, link, basicstyles, stylescombo, font
 
 Check if the editor is usable:
 


### PR DESCRIPTION
This PR is based on #254 and fixes part of [ticket #8584](http://dev.ckeditor.com/ticket/8584), replacing template system based on implicit `eval` with a template system based only on regular expressions.