### PR TITLE
T/16857 Ctrl + Shift + V blocked by copy formatting.

### DIFF
--- a/plugins/copyformatting/plugin.js
+++ b/plugins/copyformatting/plugin.js
@@ -1099,7 +1099,7 @@
 			var keystrokePaste = editor.config.copyFormatting_keystrokePaste;
 
 			if ( keystrokePaste ) {
-				this._initialKeystrokePasteCommand = editor.keystrokeHandler[ keystrokePaste ];
+				this._initialKeystrokePasteCommand = editor.keystrokeHandler.keystrokes[ keystrokePaste ];
 				editor.setKeystroke( keystrokePaste, 'applyFormatting' );
 			}
 		},

--- a/plugins/copyformatting/plugin.js
+++ b/plugins/copyformatting/plugin.js
@@ -377,8 +377,9 @@
 		breakOnElements: [ 'ul', 'ol', 'table' ],
 
 		/**
-		 * Stores a name of command (if any) initially bound to the keystroke used also for format applying
-		 * ({@link CKEDITOR.config#copyFormatting_keystrokePaste}). Used to restore the default command.
+		 * Stores a name of command (if any) initially bound to the keystroke used for format applying
+		 * ({@link CKEDITOR.config#copyFormatting_keystrokePaste}), to restore it after copy formatting
+		 * is deactivated.
 		 *
 		 * @private
 		 * @property {String}
@@ -1090,7 +1091,7 @@
 		},
 
 		/**
-		 * Attaches the {@link CKEDITOR.plugins.copyformatting} paste keystroke handler to the given editor instance.
+		 * Attaches the paste keystroke handler to the given editor instance.
 		 *
 		 * @private
 		 * @param {CKEDITOR.editor} editor
@@ -1105,7 +1106,7 @@
 		},
 
 		/**
-		 * Detaches the {@link CKEDITOR.plugins.copyformatting} paste keystroke handler from the given editor instance.
+		 * Detaches the paste keystroke handler from the given editor instance.
 		 *
 		 * @private
 		 * @param {CKEDITOR.editor} editor

--- a/tests/plugins/copyformatting/keystrokes.js
+++ b/tests/plugins/copyformatting/keystrokes.js
@@ -1,0 +1,110 @@
+/* bender-tags: copyformatting */
+/* bender-ckeditor-plugins: wysiwygarea, toolbar, copyformatting, pastetext */
+
+( function() {
+	'use strict';
+
+	var defaultKeystroke = CKEDITOR.CTRL + CKEDITOR.SHIFT + 86, // CTRL + SHIFT + V
+		customKeystroke = CKEDITOR.CTRL + CKEDITOR.SHIFT + 77; // CTRL + SHIFT + M
+
+	bender.editors = {
+		editor1: {
+			name: 'editor1',
+			config: {
+				allowedContent: true
+			}
+		},
+		editor2: {
+			name: 'editor2',
+			config: {
+				allowedContent: true,
+				copyFormatting_keystrokePaste: customKeystroke
+			}
+		}
+
+	};
+
+	bender.test( {
+		'test default paste keystroke set on editor init': function() {
+			assert.areEqual( 'pastetext', this.editors.editor1.keystrokeHandler.keystrokes[ defaultKeystroke ] );
+		},
+
+		'test copy keystroke set on editor init': function() {
+			assert.areEqual( 'copyFormatting', this.editors.editor1.keystrokeHandler.keystrokes[ CKEDITOR.config.copyFormatting_keystrokeCopy ] );
+		},
+
+		'test keystroke detached when copied format canceled (normal)': function() {
+			var editor = this.editors.editor1;
+
+			bender.tools.selection.setWithHtml( editor, '<p>Copy <em>for{}mat</em></p>' );
+
+			editor.execCommand( 'copyFormatting' );
+
+			assert.areEqual( 'applyFormatting', editor.keystrokeHandler.keystrokes[ defaultKeystroke ] );
+
+			editor.execCommand( 'copyFormatting' );
+
+			assert.areEqual( 'pastetext', editor.keystrokeHandler.keystrokes[ defaultKeystroke ] );
+		},
+
+		'test keystroke detached when copied format canceled (sticky)': function() {
+			var editor = this.editors.editor1;
+
+			bender.tools.selection.setWithHtml( editor, '<p>Copy <em>for{}mat</em></p>' );
+
+			editor.execCommand( 'copyFormatting', { sticky: true } );
+
+			assert.areEqual( 'applyFormatting', editor.keystrokeHandler.keystrokes[ defaultKeystroke ] );
+
+			editor.execCommand( 'copyFormatting' );
+
+			assert.areEqual( 'pastetext', editor.keystrokeHandler.keystrokes[ defaultKeystroke ] );
+		},
+
+		'test keystroke attached on format copy (normal) and detached on format apply': function() {
+			var editor = this.editors.editor1;
+
+			bender.tools.selection.setWithHtml( editor, '<p>Copy <em>for{}mat</em></p>' );
+
+			editor.execCommand( 'copyFormatting' );
+
+			assert.areEqual( 'applyFormatting', editor.keystrokeHandler.keystrokes[ defaultKeystroke ] );
+
+			editor.execCommand( 'applyFormatting' );
+
+			assert.areEqual( 'pastetext', editor.keystrokeHandler.keystrokes[ defaultKeystroke ] );
+		},
+
+		'test keystroke attached on format copy (sticky) and not detached on format apply': function() {
+			var editor = this.editors.editor1;
+
+			bender.tools.selection.setWithHtml( editor, '<p>Copy <em>for{}mat</em></p>' );
+
+			editor.execCommand( 'copyFormatting', { sticky: true } );
+
+			assert.areEqual( 'applyFormatting', editor.keystrokeHandler.keystrokes[ defaultKeystroke ] );
+
+			editor.execCommand( 'applyFormatting' );
+
+			assert.areEqual( 'applyFormatting', editor.keystrokeHandler.keystrokes[ defaultKeystroke ] );
+		},
+
+		'test keystroke attached on format copy (normal) and detached on format apply with custom keystroke': function() {
+			var editor = this.editors.editor2;
+
+			bender.tools.selection.setWithHtml( editor, '<p>Copy <em>for{}mat</em></p>' );
+
+			assert.areEqual( 'pastetext', editor.keystrokeHandler.keystrokes[ defaultKeystroke ] );
+
+			editor.execCommand( 'copyFormatting' );
+
+			assert.areEqual( 'pastetext', editor.keystrokeHandler.keystrokes[ defaultKeystroke ] );
+			assert.areEqual( 'applyFormatting', editor.keystrokeHandler.keystrokes[ customKeystroke ] );
+
+			editor.execCommand( 'applyFormatting' );
+
+			assert.areEqual( 'pastetext', editor.keystrokeHandler.keystrokes[ defaultKeystroke ] );
+			assert.areEqual( undefined, editor.keystrokeHandler.keystrokes[ customKeystroke ] );
+		}
+	} );
+}() );

--- a/tests/plugins/copyformatting/manual/customkeystroke.md
+++ b/tests/plugins/copyformatting/manual/customkeystroke.md
@@ -22,4 +22,5 @@
 
 **Expected**
 
-* The keystrokes are not activating Copy Formatting functions.
+* The keystrokes are not activating Copy Formatting functions. If some content had been present
+in your clipboard it should be pasted as a plain text.


### PR DESCRIPTION
The fix introduces keystroke switching. The CF apply format keystroke is attached only when format is copied (copy formatting active). When format is applied (normal) or canceled (normal/sticky), the keystroke is restored to the default one.
The generic mechanism for keystroke switching was not introduced since we do not see any use for it in other places/plugins. The simpler approach with storing default command was implemented.

There is already a manual test covering this case, so there is no need for another one.

_Merge message proposal:_
The `Ctrl + Shift + V` shortcut works both with _paste as plain text_ and _apply format_ (copy formatting plugin), depending on the context.