### PR TITLE
T/16920 Widget plugins not using dialog as a direct dependency

### DIFF
--- a/plugins/sourcedialog/plugin.js
+++ b/plugins/sourcedialog/plugin.js
@@ -7,6 +7,7 @@ CKEDITOR.plugins.add( 'sourcedialog', {
 	// jscs:disable maximumLineLength
 	lang: 'af,ar,az,bg,bn,bs,ca,cs,cy,da,de,de-ch,el,en,en-au,en-ca,en-gb,eo,es,et,eu,fa,fi,fo,fr,fr-ca,gl,gu,he,hi,hr,hu,id,is,it,ja,ka,km,ko,ku,lt,lv,mn,ms,nb,nl,no,oc,pl,pt,pt-br,ro,ru,si,sk,sl,sq,sr,sr-latn,sv,th,tr,tt,ug,uk,vi,zh,zh-cn', // %REMOVE_LINE_CORE%
 	// jscs:enable maximumLineLength
+	requires: 'dialog',
 	icons: 'sourcedialog,sourcedialog-rtl', // %REMOVE_LINE_CORE%
 	hidpi: true, // %REMOVE_LINE_CORE%
 

--- a/plugins/widget/dev/assets/simplebox/plugin.js
+++ b/plugins/widget/dev/assets/simplebox/plugin.js
@@ -3,7 +3,7 @@
 // Register the plugin within the editor.
 CKEDITOR.plugins.add( 'simplebox', {
 	// This plugin requires the Widgets System defined in the 'widget' plugin.
-	requires: 'widget',
+	requires: 'widget,dialog',
 
 	// Register the icon used for the toolbar button. It must be the same
 	// as the name of the widget.


### PR DESCRIPTION
I checked all the plugins by checking which ones utilizes dialog API `CKEDITOR.dialog`, depends on `widget` or has its own dialogs.
Then all the plugins which somehow depends on dialogs, but do not have `dialog` plugin as a dependency were run with CKEditor on minimal config (with `toolbar` and `wysiwygarea` plugins) to check if it is needed (basically, those were the two plugins I made changes in).

_Merge message proposal:_
Fixed missing dialog dependencies in dialog dependent plugins.