### PR TITLE
Method tools.style.parse#background should return an object

### DIFF
--- a/core/tools.js
+++ b/core/tools.js
@@ -1648,7 +1648,7 @@
 				 */
 				background: function( value ) {
 					var ret = {},
-						colors = [];
+						colors;
 
 					colors = this._findColor( value );
 

--- a/core/tools.js
+++ b/core/tools.js
@@ -1647,7 +1647,7 @@
 				 * @member CKEDITOR.tools.style.parse
 				 */
 				background: function( value ) {
-					var ret = [],
+					var ret = {},
 						colors = [];
 
 					colors = this._findColor( value );

--- a/tests/core/tools/style.js
+++ b/tests/core/tools/style.js
@@ -8,6 +8,14 @@
 			this.parse = CKEDITOR.tools.style.parse;
 		},
 
+		'test style.parse.background return type': function() {
+			var ret = this.parse.background( 'red url(foo.bar)' );
+
+			assert.isObject( ret, 'Type returned' );
+			// Array is also an object, so it needs some extra checking.
+			assert.areNotSame( Array, ret.constructor, 'Returned value constructor' );
+		},
+
 		'test style.parse.background single background': function() {
 			var ret = this.parse.background( 'red url(foo.bar) no-repeat' );
 


### PR DESCRIPTION
Fix for [#16972](http://dev.ckeditor.com/ticket/16972).

This method should return an object, [as described in our API docs](http://docs.ckeditor.com/#!/api/CKEDITOR.tools.style.parse-method-background).