### PR TITLE
T/16957 [PFW] Styles.inliner.inline does not take selectors specificity into account and duplicates rules.

### DIFF
--- a/plugins/pastefromword/filter/default.js
+++ b/plugins/pastefromword/filter/default.js
@@ -877,13 +877,19 @@
 						stylesObj.order = stylesObj.order.concat( parsedStyles.order );
 					}
 
-					// Sort all selectors so that all selectors containing classes are first (the order between
-					// class selectors is not modified) and then the rest of selectors.
+					// Sort all selectors so that all selectors containing classes are first and then the rest
+					// of the selectors. The order of the selectors with the same specificity is reversed
+					// so the most important will be applied first.
+					var orderCopy = stylesObj.order.slice();
 					stylesObj.order.sort( function( selector1, selector2 ) {
 						var value1 = isClassSelector( selector1 ) ? 1 : 0,
-							value2 = isClassSelector( selector2 ) ? 1 : 0;
+							value2 = isClassSelector( selector2 ) ? 1 : 0,
+							result = value2 - value1;
 
-						return value2 - value1;
+						// If the selectors have same specificity, the latter one should
+						// have higher priority (so goes first).
+						return result !== 0 ? result :
+							orderCopy.indexOf( selector2 ) - orderCopy.indexOf( selector1 );
 					} );
 
 					return stylesObj;
@@ -905,6 +911,8 @@
 						element = elements.getItem( i );
 
 						oldStyle = CKEDITOR.tools.parseCssText( element.getAttribute( 'style' ) );
+						// The styles are applied with decreasing priority so we do not want
+						// to overwrite the existing properties.
 						newStyle = CKEDITOR.tools.extend( {}, oldStyle, style );
 						element.setAttribute( 'style', CKEDITOR.tools.writeCssText( newStyle ) );
 					}

--- a/plugins/pastefromword/filter/default.js
+++ b/plugins/pastefromword/filter/default.js
@@ -832,6 +832,46 @@
 			},
 
 			/**
+			 * Sorts the given styles array. All rules containing class selectors will have lower indexes than the rest
+			 * of the rules. Selectors with the same priority will be sorted in a reverse order than in the input array.
+			 *
+			 * @param {Array} stylesArray Array of styles as returned from {@link CKEDITOR.plugins.pastefromword.inline#parse}.
+			 * @returns {Array} Sorted stylesArray.
+			 * @since 4.7.0
+			 * @private
+			 * @member CKEDITOR.plugins.pastefromword.styles.inliner
+			 */
+			sort: function( stylesArray ) {
+
+				// Returns comparison function which sorts all selectors in a way that class selectors are ordered
+				// before the rest of the selectors. The order of the selectors with the same specificity
+				// is reversed so that the most important will be applied first.
+				function getCompareFunction( styles ) {
+					var order = CKEDITOR.tools.array.map( styles, function( item ) {
+						return item.selector;
+					} );
+
+					return function( style1, style2 ) {
+						var value1 = isClassSelector( style1.selector ) ? 1 : 0,
+							value2 = isClassSelector( style2.selector ) ? 1 : 0,
+							result = value2 - value1;
+
+						// If the selectors have same specificity, the latter one should
+						// have higher priority (goes first).
+						return result !== 0 ? result :
+							order.indexOf( style2.selector ) - order.indexOf( style1.selector );
+					};
+				}
+
+				// True if given CSS selector contains a class selector.
+				function isClassSelector( selector ) {
+					return ( '' + selector ).indexOf( '.' ) !== -1;
+				}
+
+				return stylesArray.sort( getCompareFunction( stylesArray ) );
+			},
+
+			/**
 			 * Finds and inlines all the `style` elements in a given `html` string and returns a document, where
 			 * all the styles are inlined into appropriate elements.
 			 *
@@ -892,46 +932,6 @@
 				} );
 
 				return document;
-			},
-
-			/**
-			 * Sorts the given styles array. All rules containing class selectors will have lower indexes than the rest
-			 * of the rules. Selectors with the same priority will be sorted in a reverse order than in the input array.
-			 *
-			 * @param {Array} stylesArray Array of styles as returned from {@link CKEDITOR.plugins.pastefromword.inline#parse}.
-			 * @returns {Array} Sorted stylesArray.
-			 * @since 4.7.0
-			 * @private
-			 * @member CKEDITOR.plugins.pastefromword.styles.inliner
-			 */
-			sort: function( stylesArray ) {
-
-				// Returns comparison function which sorts all selectors in a way that class selectors are ordered
-				// before the rest of the selectors. The order of the selectors with the same specificity
-				// is reversed so that the most important will be applied first.
-				function getCompareFunction( styles ) {
-					var order = CKEDITOR.tools.array.map( styles, function( item ) {
-						return item.selector;
-					} );
-
-					return function( style1, style2 ) {
-						var value1 = isClassSelector( style1.selector ) ? 1 : 0,
-							value2 = isClassSelector( style2.selector ) ? 1 : 0,
-							result = value2 - value1;
-
-						// If the selectors have same specificity, the latter one should
-						// have higher priority (goes first).
-						return result !== 0 ? result :
-							order.indexOf( style2.selector ) - order.indexOf( style1.selector );
-					};
-				}
-
-				// True if given CSS selector contains a class selector.
-				function isClassSelector( selector ) {
-					return ( '' + selector ).indexOf( '.' ) !== -1;
-				}
-
-				return stylesArray.sort( getCompareFunction( stylesArray ) );
 			}
 		}
 	};

--- a/tests/plugins/pastefromword/generated/_fixtures/Table_text_attributes/Mixed/expected.html
+++ b/tests/plugins/pastefromword/generated/_fixtures/Table_text_attributes/Mixed/expected.html
@@ -68,11 +68,11 @@
 			</td>
 			<td style="height:26.25pt; vertical-align:bottom; white-space:nowrap; width:64pt">
 				<span style="font-size:11pt">
-					<span style="color:black">
-						<span style="font-weight:400">
-							<span style="font-style:normal">
-								<span style="text-decoration:none">
-									<span style="font-family:arial,sans-serif">family</span>
+					<span style="font-family:arial,sans-serif">
+						<span style="color:black">
+							<span style="font-weight:400">
+								<span style="font-style:normal">
+									<span style="text-decoration:none">family</span>
 								</span>
 							</span>
 						</span>
@@ -81,28 +81,28 @@
 			</td>
 			<td style="height:26.25pt; vertical-align:bottom; white-space:nowrap; width:48pt">
 				<span style="font-size:11pt">
-					<span style="color:black">
-						<strong>
+					<strong>
+						<span style="color:black">
 							<span style="font-style:normal">
 								<span style="text-decoration:none">
 									<span style="font-family:calibri,sans-serif">weight</span>
 								</span>
 							</span>
-						</strong>
-					</span>
+						</span>
+					</strong>
 				</span>
 			</td>
 			<td style="height:26.25pt; vertical-align:bottom; white-space:nowrap; width:82pt">
 				<span style="font-size:11pt">
-					<span style="color:black">
-						<span style="font-weight:400">
-							<em>
-								<u>
+					<em>
+						<u>
+							<span style="color:black">
+								<span style="font-weight:400">
 									<span style="font-family:calibri,sans-serif">style</span>
-								</u>
-							</em>
-						</span>
-					</span>
+								</span>
+							</span>
+						</u>
+					</em>
 				</span>
 			</td>
 			<td style="height:26.25pt; vertical-align:bottom; white-space:nowrap; width:48pt">
@@ -121,13 +121,13 @@
 			<td style="background-color:#92d050; height:26.25pt; vertical-align:bottom; white-space:nowrap; width:48pt">
 				<span style="font-size:16pt">
 					<span style="color:#00b050">
-						<span style="font-weight:400">
-							<em>
-								<span style="text-decoration:none">
-									<span style="font-family:times new roman,serif">all</span>
+						<em>
+							<span style="font-family:times new roman,serif">
+								<span style="font-weight:400">
+									<span style="text-decoration:none">all</span>
 								</span>
-							</em>
-						</span>
+							</span>
+						</em>
 					</span>
 				</span>
 			</td>
@@ -222,11 +222,11 @@
 			</td>
 			<td style="height:28.5pt; vertical-align:bottom; white-space:nowrap">
 				<span style="font-size:11pt">
-					<span style="color:black">
-						<span style="font-weight:400">
-							<span style="font-style:normal">
-								<span style="text-decoration:none">
-									<span style="font-family:times new roman,serif">family</span>
+					<span style="font-family:times new roman,serif">
+						<span style="color:black">
+							<span style="font-weight:400">
+								<span style="font-style:normal">
+									<span style="text-decoration:none">family</span>
 								</span>
 							</span>
 						</span>
@@ -271,15 +271,15 @@
 			</td>
 			<td style="height:28.5pt; vertical-align:bottom; white-space:nowrap">
 				<span style="font-size:11pt">
-					<span style="color:black">
-						<span style="font-weight:400">
-							<em>
-								<u>
+					<em>
+						<u>
+							<span style="color:black">
+								<span style="font-weight:400">
 									<span style="font-family:calibri,sans-serif">style</span>
-								</u>
-							</em>
-						</span>
-					</span>
+								</span>
+							</span>
+						</u>
+					</em>
 				</span>
 			</td>
 			<td style="height:28.5pt; vertical-align:bottom; white-space:nowrap">

--- a/tests/plugins/pastefromword/parsestyles.html
+++ b/tests/plugins/pastefromword/parsestyles.html
@@ -5,9 +5,12 @@
 	font-family:Calibri;}
 =>
 {
-	".MsoChpDefault": {
-		"font-family": "Calibri"
-	}
+	"styles": {
+		".MsoChpDefault": {
+			"font-family": "Calibri"
+		}
+	},
+	"order": [ ".MsoChpDefault" ]
 }
 </textarea>
 
@@ -21,9 +24,12 @@ p.MsoNormal, li.MsoNormal, div.MsoNormal {
 }
 =>
 {
-	"p.MsoNormal, li.MsoNormal, div.MsoNormal": {
+	"styles": {
+		"p.MsoNormal, li.MsoNormal, div.MsoNormal": {
 		"margin": "0cm 0cm 0.0001pt"
 	}
+	},
+	"order": [ "p.MsoNormal, li.MsoNormal, div.MsoNormal" ]
 }
 </textarea>
 
@@ -41,12 +47,15 @@ p.MsoNormal, li.MsoNormal, div.MsoNormal {
 }
 =>
 {
-	".MsoChpDefault": {
-		"font-family": "Calibri"
+	"styles": {
+		".MsoChpDefault": {
+			"font-family": "Calibri"
+		},
+		"p.MsoNormal, li.MsoNormal, div.MsoNormal": {
+			"margin": "0cm 0cm 0.0001pt"
+		}
 	},
-	"p.MsoNormal, li.MsoNormal, div.MsoNormal": {
-		"margin": "0cm 0cm 0.0001pt"
-	}
+	"order": [ ".MsoChpDefault", "p.MsoNormal, li.MsoNormal, div.MsoNormal" ]
 }
 </textarea>
 
@@ -57,7 +66,10 @@ p.MsoNormal, li.MsoNormal, div.MsoNormal
 	mso-style-parent:"";}
 =>
 {
-	"p.MsoNormal, li.MsoNormal, div.MsoNormal": {}
+	"styles": {
+		"p.MsoNormal, li.MsoNormal, div.MsoNormal": {}
+	},
+	"order": [ "p.MsoNormal, li.MsoNormal, div.MsoNormal" ]
 }
 </textarea>
 
@@ -74,9 +86,12 @@ p.MsoNormal, li.MsoNormal, div.MsoNormal
 	{margin:0cm;}
 =>
 {
-	"p.MsoNormal, li.MsoNormal, div.MsoNormal": {
+	"styles": {
+		"p.MsoNormal, li.MsoNormal, div.MsoNormal": {
 		"margin": "0cm"
 	}
+	},
+	"order": [ "p.MsoNormal, li.MsoNormal, div.MsoNormal" ]
 }
 </textarea>
 
@@ -92,9 +107,12 @@ p.MsoNormal, li.MsoNormal, div.MsoNormal
 	{margin:0cm;}
 =>
 {
-	"p.MsoNormal, li.MsoNormal, div.MsoNormal": {
+	"styles": {
+		"p.MsoNormal, li.MsoNormal, div.MsoNormal": {
 		"margin": "0cm"
 	}
+	},
+	"order": [ "p.MsoNormal, li.MsoNormal, div.MsoNormal" ]
 }
 </textarea>
 
@@ -199,4 +217,103 @@ p.MsoNormal, li.MsoNormal, div.MsoNormal
 {
 	"font-family": "Verdana"
 }
+</textarea>
+
+<textarea id="style-specificity">
+	<html>
+		<head>
+			<style>
+				.li1 {
+					background-color: #000;
+				}
+				.span1 {
+					color: #F00;
+				}
+				li {
+					background-color: #FFF;
+					color: #000;
+				}
+				span {
+					color: #FF0;
+					background-color: #00F;
+				}
+			</style>
+		</head>
+		<body>
+			<ul>
+				<li class="li1">
+					Foo<span class="span1">Bar</span>
+				</li>
+			</ul>
+		</body>
+	</html>
+=>
+	<ul>
+		<li class="li1" style="color:#000000;background-color:#000000;">
+			Foo<span class="span1" style="color:#FF0000;background-color:#0000FF;">Bar</span>
+		</li>
+	</ul>
+</textarea>
+
+<textarea id="style-specificity-multiple">
+	<html>
+		<head>
+			<style>
+				.li1 {
+					background-color: #000;
+				}
+				.span1 {
+					color: #F00;
+				}
+			</style>
+			<style>
+				li {
+					background-color: #FFF;
+					color: #000;
+				}
+				span {
+					color: #FF0;
+					background-color: #00F;
+				}
+			</style>
+		</head>
+		<body>
+			<ul>
+				<li class="li1">
+					Foo<span class="span1">Bar</span>
+				</li>
+			</ul>
+		</body>
+	</html>
+=>
+	<ul>
+		<li class="li1" style="color:#000000;background-color:#000000;">
+			Foo<span class="span1" style="color:#FF0000;background-color:#0000FF;">Bar</span>
+		</li>
+	</ul>
+</textarea>
+
+<textarea id="style-specificity-inline">
+	<html>
+		<head>
+			<style>
+				.li1 {
+					background-color: #000;
+				}
+				li {
+					background-color: #FFF;
+					color: #000;
+				}
+			</style>
+		</head>
+		<body>
+			<ul>
+				<li class="li1" style="background-color:#999">Foo</li>
+			</ul>
+		</body>
+	</html>
+=>
+	<ul>
+		<li class="li1" style="color:#000000;background-color:#999999;">Foo</li>
+	</ul>
 </textarea>

--- a/tests/plugins/pastefromword/parsestyles.html
+++ b/tests/plugins/pastefromword/parsestyles.html
@@ -317,3 +317,28 @@ p.MsoNormal, li.MsoNormal, div.MsoNormal
 		<li class="li1" style="color:#000000;background-color:#999999;">Foo</li>
 	</ul>
 </textarea>
+
+<textarea id="style-specificity-order">
+	<html>
+		<head>
+			<style>
+				.li1 {
+					background-color: #000;
+					color: #555;
+				}
+				.li2 {
+					background-color: #FFF;
+				}
+			</style>
+		</head>
+		<body>
+			<ul>
+				<li class="li1 li2">Foo</li>
+			</ul>
+		</body>
+	</html>
+=>
+	<ul>
+		<li class="li1 li2" style="color:#555555;background-color:#FFFFFF;">Foo</li>
+	</ul>
+</textarea>

--- a/tests/plugins/pastefromword/parsestyles.html
+++ b/tests/plugins/pastefromword/parsestyles.html
@@ -4,14 +4,12 @@
 	mso-default-props:yes;
 	font-family:Calibri;}
 =>
-{
+[ {
+	"selector": ".MsoChpDefault",
 	"styles": {
-		".MsoChpDefault": {
-			"font-family": "Calibri"
-		}
-	},
-	"order": [ ".MsoChpDefault" ]
-}
+		"font-family": "Calibri"
+	}
+} ]
 </textarea>
 
 <textarea id="styles2">
@@ -23,14 +21,12 @@ p.MsoNormal, li.MsoNormal, div.MsoNormal {
 	margin-bottom:.0001pt;
 }
 =>
-{
+[ {
+	"selector": "p.MsoNormal, li.MsoNormal, div.MsoNormal",
 	"styles": {
-		"p.MsoNormal, li.MsoNormal, div.MsoNormal": {
 		"margin": "0cm 0cm 0.0001pt"
 	}
-	},
-	"order": [ "p.MsoNormal, li.MsoNormal, div.MsoNormal" ]
-}
+} ]
 </textarea>
 
 <textarea id="multiple">
@@ -46,17 +42,17 @@ p.MsoNormal, li.MsoNormal, div.MsoNormal {
 	margin-bottom:.0001pt;
 }
 =>
-{
+[ {
+	"selector": ".MsoChpDefault",
 	"styles": {
-		".MsoChpDefault": {
-			"font-family": "Calibri"
-		},
-		"p.MsoNormal, li.MsoNormal, div.MsoNormal": {
-			"margin": "0cm 0cm 0.0001pt"
-		}
-	},
-	"order": [ ".MsoChpDefault", "p.MsoNormal, li.MsoNormal, div.MsoNormal" ]
-}
+		"font-family": "Calibri"
+	}
+}, {
+	"selector": "p.MsoNormal, li.MsoNormal, div.MsoNormal",
+	"styles": {
+		"margin": "0cm 0cm 0.0001pt"
+	}
+} ]
 </textarea>
 
 <textarea id="empty">
@@ -65,12 +61,10 @@ p.MsoNormal, li.MsoNormal, div.MsoNormal
 	mso-style-qformat:yes;
 	mso-style-parent:"";}
 =>
-{
-	"styles": {
-		"p.MsoNormal, li.MsoNormal, div.MsoNormal": {}
-	},
-	"order": [ "p.MsoNormal, li.MsoNormal, div.MsoNormal" ]
-}
+[ {
+	"selector": "p.MsoNormal, li.MsoNormal, div.MsoNormal",
+	"styles": { }
+} ]
 </textarea>
 
 <textarea id="font-face">
@@ -85,14 +79,12 @@ p.MsoNormal, li.MsoNormal, div.MsoNormal
 p.MsoNormal, li.MsoNormal, div.MsoNormal
 	{margin:0cm;}
 =>
-{
+[ {
+	"selector": "p.MsoNormal, li.MsoNormal, div.MsoNormal",
 	"styles": {
-		"p.MsoNormal, li.MsoNormal, div.MsoNormal": {
 		"margin": "0cm"
 	}
-	},
-	"order": [ "p.MsoNormal, li.MsoNormal, div.MsoNormal" ]
-}
+} ]
 </textarea>
 
 <textarea id="page">
@@ -106,14 +98,12 @@ p.MsoNormal, li.MsoNormal, div.MsoNormal
 p.MsoNormal, li.MsoNormal, div.MsoNormal
 	{margin:0cm;}
 =>
-{
+[ {
+	"selector": "p.MsoNormal, li.MsoNormal, div.MsoNormal",
 	"styles": {
-		"p.MsoNormal, li.MsoNormal, div.MsoNormal": {
 		"margin": "0cm"
 	}
-	},
-	"order": [ "p.MsoNormal, li.MsoNormal, div.MsoNormal" ]
-}
+} ]
 </textarea>
 
 <style id="real-style">

--- a/tests/plugins/pastefromword/parsestyles.js
+++ b/tests/plugins/pastefromword/parsestyles.js
@@ -50,14 +50,12 @@
 
 		'test parsing styles from real style element': function() {
 			var parseStyles = CKEDITOR.plugins.pastefromword.styles.inliner.parse,
-				expected = {
+				expected = [ {
+					selector: '.MsoChpDefault',
 					styles: {
-						'.MsoChpDefault': {
-							'font-family': 'Calibri'
-						}
-					},
-					order: [ '.MsoChpDefault' ]
-				};
+						'font-family': 'Calibri'
+					}
+				} ];
 
 			assert.beautified.js( JSON.stringify( expected ),
 				JSON.stringify( parseStyles( CKEDITOR.document.getById( 'real-style' ) ) ) );
@@ -65,17 +63,17 @@
 
 		'test parsing styles from a fake style element': function() {
 			var parseStyles = CKEDITOR.plugins.pastefromword.styles.inliner.parse,
-				expected = {
+				expected = [ {
+					selector: '.MsoChpDefault',
 					styles: {
-						'.MsoChpDefault': {
-							'font-family': 'Calibri'
-						},
-						'div a.foo, .bar': {
-							'text-decoration': 'underline'
-						}
-					},
-					order: [ '.MsoChpDefault', 'div a.foo, .bar' ]
-				};
+						'font-family': 'Calibri'
+					}
+				}, {
+					selector: 'div a.foo, .bar',
+					styles: {
+						'text-decoration': 'underline'
+					}
+				} ];
 
 			assert.beautified.js( JSON.stringify( expected ),
 				JSON.stringify( parseStyles( CKEDITOR.document.getById( 'fake-style' ) ) ) );

--- a/tests/plugins/pastefromword/parsestyles.js
+++ b/tests/plugins/pastefromword/parsestyles.js
@@ -95,6 +95,7 @@
 			testInlining( 'style-specificity' );
 			testInlining( 'style-specificity-multiple' );
 			testInlining( 'style-specificity-inline' );
+			testInlining( 'style-specificity-order' );
 		}
 	};
 

--- a/tests/plugins/pastefromword/parsestyles.js
+++ b/tests/plugins/pastefromword/parsestyles.js
@@ -51,9 +51,12 @@
 		'test parsing styles from real style element': function() {
 			var parseStyles = CKEDITOR.plugins.pastefromword.styles.inliner.parse,
 				expected = {
-					'.MsoChpDefault': {
-						'font-family': 'Calibri'
-					}
+					styles: {
+						'.MsoChpDefault': {
+							'font-family': 'Calibri'
+						}
+					},
+					order: [ '.MsoChpDefault' ]
 				};
 
 			assert.beautified.js( JSON.stringify( expected ),
@@ -63,12 +66,15 @@
 		'test parsing styles from a fake style element': function() {
 			var parseStyles = CKEDITOR.plugins.pastefromword.styles.inliner.parse,
 				expected = {
-					'.MsoChpDefault': {
-						'font-family': 'Calibri'
+					styles: {
+						'.MsoChpDefault': {
+							'font-family': 'Calibri'
+						},
+						'div a.foo, .bar': {
+							'text-decoration': 'underline'
+						}
 					},
-					'div a.foo, .bar': {
-						'text-decoration': 'underline'
-					}
+					order: [ '.MsoChpDefault', 'div a.foo, .bar' ]
 				};
 
 			assert.beautified.js( JSON.stringify( expected ),
@@ -83,6 +89,12 @@
 			testInlining( 'inline1' );
 			testInlining( 'inline2' );
 			testInlining( 'multiple-inline' );
+		},
+
+		'test parsing styles specificity': function() {
+			testInlining( 'style-specificity' );
+			testInlining( 'style-specificity-multiple' );
+			testInlining( 'style-specificity-inline' );
 		}
 	};
 


### PR DESCRIPTION
The fix keeps the order of the css rules when parsing. The rules containing class selectors have higher priority and are applied first.

The styles already existing on the element are not overwritten which means:
- inline styles are preserved
- styles with the highest priority are applied first

The second point above means that the styles inlining applies rules containing class selectors first in a reversed order (so the last on goes first) and then rest of the rules also in reversed order.

Please keep in mind that this solution is a minimalistic (almost) approach to solve this specific issue. There are some cases which are not covered (more complex selectors, rules with multiple selectors, etc), however as Excel or Word does not generate such styles it is sufficient.