### PR TITLE
T/16960 Fix paste message in other locales

### DIFF
--- a/dev/langtool/meta/ckeditor.plugin-clipboard/meta.txt
+++ b/dev/langtool/meta/ckeditor.plugin-clipboard/meta.txt
@@ -6,4 +6,4 @@ copyError = A notification message shown when browser is blocking copying, and u
 cut = Toolbar button tooltip for the Cut feature.
 cutError = A notification message shown when browser is blocking cutting, and user should use the keyboard instead. %1 sequence is replaced with a keystroke that, when pressed, will perform the action.
 paste = Toolbar button tooltip for the Paste feature.
-pasteMsg = A notification message shown when browser is blocking pasting, and user should use the keyboard instead. %1 sequence is replaced with a keystroke that, when pressed, will perform the action.
+pasteDefaultMsg = A notification message shown when browser is blocking pasting, and user should use the keyboard instead. %1 sequence is replaced with a keystroke that, when pressed, will perform the action.

--- a/dev/langtool/meta/ckeditor.plugin-clipboard/meta.txt
+++ b/dev/langtool/meta/ckeditor.plugin-clipboard/meta.txt
@@ -6,4 +6,4 @@ copyError = A notification message shown when browser is blocking copying, and u
 cut = Toolbar button tooltip for the Cut feature.
 cutError = A notification message shown when browser is blocking cutting, and user should use the keyboard instead. %1 sequence is replaced with a keystroke that, when pressed, will perform the action.
 paste = Toolbar button tooltip for the Paste feature.
-pasteDefaultMsg = A notification message shown when browser is blocking pasting, and user should use the keyboard instead. %1 sequence is replaced with a keystroke that, when pressed, will perform the action.
+pasteNotification = A notification message shown when browser is blocking pasting, and user should use the keyboard instead. %1 sequence is replaced with a keystroke that, when pressed, will perform the action.

--- a/dev/langtool/meta/ckeditor.plugin-pastetext/meta.txt
+++ b/dev/langtool/meta/ckeditor.plugin-pastetext/meta.txt
@@ -2,4 +2,4 @@
 # For licensing, see LICENSE.md or http://ckeditor.com/license
 
 button = Toolbar button tooltip for the Paste as Plain Text feature.
-pasteMsg = A notification message shown when browser is blocking pasting, and user should use the keyboard instead. %1 sequence is replaced with a keystroke that, when pressed, will perform the action.
+pasteNotification = A notification message shown when browser is blocking pasting, and user should use the keyboard instead. %1 sequence is replaced with a keystroke that, when pressed, will perform the action.

--- a/plugins/clipboard/lang/af.js
+++ b/plugins/clipboard/lang/af.js
@@ -8,5 +8,5 @@ CKEDITOR.plugins.setLang( 'clipboard', 'af', {
 	cut: 'Knip',
 	cutError: 'U blaaier se sekuriteitsinstelling belet die outomatiese knip-aksie. Gebruik die sleutelbordkombinasie (Ctrl/Cmd+X).',
 	paste: 'Plak',
-	pasteMsg: 'Plak die teks in die volgende teks-area met die sleutelbordkombinasie (<STRONG>Ctrl/Cmd+V</STRONG>) en druk <STRONG>OK</STRONG>.'
+	pasteDefaultMsg: 'Your browser doesn\'t allow you to paste this way. Press %1 to paste.' // MISSING
 } );

--- a/plugins/clipboard/lang/af.js
+++ b/plugins/clipboard/lang/af.js
@@ -8,5 +8,5 @@ CKEDITOR.plugins.setLang( 'clipboard', 'af', {
 	cut: 'Knip',
 	cutError: 'U blaaier se sekuriteitsinstelling belet die outomatiese knip-aksie. Gebruik die sleutelbordkombinasie (Ctrl/Cmd+X).',
 	paste: 'Plak',
-	pasteDefaultMsg: 'Your browser doesn\'t allow you to paste this way. Press %1 to paste.' // MISSING
+	pasteNotification: 'Your browser doesn\'t allow you to paste this way. Press %1 to paste.' // MISSING
 } );

--- a/plugins/clipboard/lang/ar.js
+++ b/plugins/clipboard/lang/ar.js
@@ -8,5 +8,5 @@ CKEDITOR.plugins.setLang( 'clipboard', 'ar', {
 	cut: 'قص',
 	cutError: 'الإعدادات الأمنية للمتصفح الذي تستخدمه تمنع القص التلقائي. فضلاً إستخدم لوحة المفاتيح لفعل ذلك (Ctrl/Cmd+X).',
 	paste: 'لصق',
-	pasteDefaultMsg: 'Your browser doesn\'t allow you to paste this way. Press %1 to paste.' // MISSING
+	pasteNotification: 'Your browser doesn\'t allow you to paste this way. Press %1 to paste.' // MISSING
 } );

--- a/plugins/clipboard/lang/ar.js
+++ b/plugins/clipboard/lang/ar.js
@@ -8,5 +8,5 @@ CKEDITOR.plugins.setLang( 'clipboard', 'ar', {
 	cut: 'قص',
 	cutError: 'الإعدادات الأمنية للمتصفح الذي تستخدمه تمنع القص التلقائي. فضلاً إستخدم لوحة المفاتيح لفعل ذلك (Ctrl/Cmd+X).',
 	paste: 'لصق',
-	pasteMsg: 'الصق داخل الصندوق بإستخدام زرائر (<STRONG>Ctrl/Cmd+V</STRONG>) في لوحة المفاتيح، ثم اضغط زر  <STRONG>موافق</STRONG>.'
+	pasteDefaultMsg: 'Your browser doesn\'t allow you to paste this way. Press %1 to paste.' // MISSING
 } );

--- a/plugins/clipboard/lang/az.js
+++ b/plugins/clipboard/lang/az.js
@@ -8,5 +8,5 @@ CKEDITOR.plugins.setLang( 'clipboard', 'az', {
 	cut: 'Kəs',
 	cutError: 'Avtomatik kəsmə mümkün deyil. Ctrl+X basın.',
 	paste: 'Əlavə et',
-	pasteMsg: 'Bu sahəyə əlavə edin (<strong>Ctrl+V</strong>)'
+	pasteDefaultMsg: 'Your browser doesn\'t allow you to paste this way. Press %1 to paste.' // MISSING
 } );

--- a/plugins/clipboard/lang/az.js
+++ b/plugins/clipboard/lang/az.js
@@ -8,5 +8,5 @@ CKEDITOR.plugins.setLang( 'clipboard', 'az', {
 	cut: 'Kəs',
 	cutError: 'Avtomatik kəsmə mümkün deyil. Ctrl+X basın.',
 	paste: 'Əlavə et',
-	pasteDefaultMsg: 'Your browser doesn\'t allow you to paste this way. Press %1 to paste.' // MISSING
+	pasteNotification: 'Your browser doesn\'t allow you to paste this way. Press %1 to paste.' // MISSING
 } );

--- a/plugins/clipboard/lang/bg.js
+++ b/plugins/clipboard/lang/bg.js
@@ -8,5 +8,5 @@ CKEDITOR.plugins.setLang( 'clipboard', 'bg', {
 	cut: 'Отрежи',
 	cutError: 'Настройките за сигурност на Вашия браузър не позволяват на редактора автоматично да изъплни действията за отрязване. Моля ползвайте клавиатурните команди за целта (ctrl+x).',
 	paste: 'Вмъкни',
-	pasteMsg: 'Вмъкнете тук съдъжанието с клавиатуарата (<STRONG>Ctrl/Cmd+V</STRONG>) и натиснете <STRONG>OK</STRONG>.'
+	pasteDefaultMsg: 'Your browser doesn\'t allow you to paste this way. Press %1 to paste.' // MISSING
 } );

--- a/plugins/clipboard/lang/bg.js
+++ b/plugins/clipboard/lang/bg.js
@@ -8,5 +8,5 @@ CKEDITOR.plugins.setLang( 'clipboard', 'bg', {
 	cut: 'Отрежи',
 	cutError: 'Настройките за сигурност на Вашия браузър не позволяват на редактора автоматично да изъплни действията за отрязване. Моля ползвайте клавиатурните команди за целта (ctrl+x).',
 	paste: 'Вмъкни',
-	pasteDefaultMsg: 'Your browser doesn\'t allow you to paste this way. Press %1 to paste.' // MISSING
+	pasteNotification: 'Your browser doesn\'t allow you to paste this way. Press %1 to paste.' // MISSING
 } );

--- a/plugins/clipboard/lang/bn.js
+++ b/plugins/clipboard/lang/bn.js
@@ -8,5 +8,5 @@ CKEDITOR.plugins.setLang( 'clipboard', 'bn', {
 	cut: 'কাট',
 	cutError: 'আপনার ব্রাউজারের সুরক্ষা সেটিংস এডিটরকে অটোমেটিক কাট করার অনুমতি দেয়নি। দয়া করে এই কাজের জন্য কিবোর্ড ব্যবহার করুন (Ctrl/Cmd+X)।',
 	paste: 'পেস্ট',
-	pasteDefaultMsg: 'Your browser doesn\'t allow you to paste this way. Press %1 to paste.' // MISSING
+	pasteNotification: 'Your browser doesn\'t allow you to paste this way. Press %1 to paste.' // MISSING
 } );

--- a/plugins/clipboard/lang/bn.js
+++ b/plugins/clipboard/lang/bn.js
@@ -8,5 +8,5 @@ CKEDITOR.plugins.setLang( 'clipboard', 'bn', {
 	cut: 'কাট',
 	cutError: 'আপনার ব্রাউজারের সুরক্ষা সেটিংস এডিটরকে অটোমেটিক কাট করার অনুমতি দেয়নি। দয়া করে এই কাজের জন্য কিবোর্ড ব্যবহার করুন (Ctrl/Cmd+X)।',
 	paste: 'পেস্ট',
-	pasteMsg: 'অনুগ্রহ করে নীচের বাক্সে কিবোর্ড ব্যবহার করে (<STRONG>Ctrl/Cmd+V</STRONG>) পেস্ট করুন এবং <STRONG>OK</STRONG> চাপ দিন'
+	pasteDefaultMsg: 'Your browser doesn\'t allow you to paste this way. Press %1 to paste.' // MISSING
 } );

--- a/plugins/clipboard/lang/bs.js
+++ b/plugins/clipboard/lang/bs.js
@@ -8,5 +8,5 @@ CKEDITOR.plugins.setLang( 'clipboard', 'bs', {
 	cut: 'Izreži',
 	cutError: 'Sigurnosne postavke vašeg pretraživaèa ne dozvoljavaju operacije automatskog rezanja. Molimo koristite kraticu na tastaturi (Ctrl/Cmd+X).',
 	paste: 'Zalijepi',
-	pasteMsg: 'Your browser doesn\'t allow you to paste this way. Press %1 to paste.' // MISSING
+	pasteDefaultMsg: 'Your browser doesn\'t allow you to paste this way. Press %1 to paste.' // MISSING
 } );

--- a/plugins/clipboard/lang/bs.js
+++ b/plugins/clipboard/lang/bs.js
@@ -8,5 +8,5 @@ CKEDITOR.plugins.setLang( 'clipboard', 'bs', {
 	cut: 'Izreži',
 	cutError: 'Sigurnosne postavke vašeg pretraživaèa ne dozvoljavaju operacije automatskog rezanja. Molimo koristite kraticu na tastaturi (Ctrl/Cmd+X).',
 	paste: 'Zalijepi',
-	pasteDefaultMsg: 'Your browser doesn\'t allow you to paste this way. Press %1 to paste.' // MISSING
+	pasteNotification: 'Your browser doesn\'t allow you to paste this way. Press %1 to paste.' // MISSING
 } );

--- a/plugins/clipboard/lang/ca.js
+++ b/plugins/clipboard/lang/ca.js
@@ -8,5 +8,5 @@ CKEDITOR.plugins.setLang( 'clipboard', 'ca', {
 	cut: 'Retallar',
 	cutError: 'La configuració de seguretat del vostre navegador no permet executar automàticament les operacions de retallar. Si us plau, utilitzeu el teclat (Ctrl/Cmd+X).',
 	paste: 'Enganxar',
-	pasteDefaultMsg: 'Your browser doesn\'t allow you to paste this way. Press %1 to paste.' // MISSING
+	pasteNotification: 'Your browser doesn\'t allow you to paste this way. Press %1 to paste.' // MISSING
 } );

--- a/plugins/clipboard/lang/ca.js
+++ b/plugins/clipboard/lang/ca.js
@@ -8,5 +8,5 @@ CKEDITOR.plugins.setLang( 'clipboard', 'ca', {
 	cut: 'Retallar',
 	cutError: 'La configuració de seguretat del vostre navegador no permet executar automàticament les operacions de retallar. Si us plau, utilitzeu el teclat (Ctrl/Cmd+X).',
 	paste: 'Enganxar',
-	pasteMsg: 'Si us plau, enganxi dins del següent camp utilitzant el teclat (<strong>Ctrl/Cmd+V</strong>) i premi OK.'
+	pasteDefaultMsg: 'Your browser doesn\'t allow you to paste this way. Press %1 to paste.' // MISSING
 } );

--- a/plugins/clipboard/lang/cs.js
+++ b/plugins/clipboard/lang/cs.js
@@ -8,5 +8,5 @@ CKEDITOR.plugins.setLang( 'clipboard', 'cs', {
 	cut: 'Vyjmout',
 	cutError: 'Bezpečnostní nastavení vašeho prohlížeče nedovolují editoru spustit funkci pro vyjmutí zvoleného textu do schránky. Prosím vyjměte zvolený text do schránky pomocí klávesnice (Ctrl/Cmd+X).',
 	paste: 'Vložit',
-	pasteDefaultMsg: 'Your browser doesn\'t allow you to paste this way. Press %1 to paste.' // MISSING
+	pasteNotification: 'Your browser doesn\'t allow you to paste this way. Press %1 to paste.' // MISSING
 } );

--- a/plugins/clipboard/lang/cs.js
+++ b/plugins/clipboard/lang/cs.js
@@ -8,5 +8,5 @@ CKEDITOR.plugins.setLang( 'clipboard', 'cs', {
 	cut: 'Vyjmout',
 	cutError: 'Bezpečnostní nastavení vašeho prohlížeče nedovolují editoru spustit funkci pro vyjmutí zvoleného textu do schránky. Prosím vyjměte zvolený text do schránky pomocí klávesnice (Ctrl/Cmd+X).',
 	paste: 'Vložit',
-	pasteMsg: 'Do následujícího pole vložte požadovaný obsah pomocí klávesnice (<STRONG>Ctrl/Cmd+V</STRONG>) a stiskněte <STRONG>OK</STRONG>.'
+	pasteDefaultMsg: 'Your browser doesn\'t allow you to paste this way. Press %1 to paste.' // MISSING
 } );

--- a/plugins/clipboard/lang/cy.js
+++ b/plugins/clipboard/lang/cy.js
@@ -8,5 +8,5 @@ CKEDITOR.plugins.setLang( 'clipboard', 'cy', {
 	cut: 'Torri',
 	cutError: 'Nid yw gosodiadau diogelwch eich porwr yn caniatàu\'r golygydd i gynnal \'gweithredoedd torri\' yn awtomatig. Defnyddiwch y bysellfwrdd (Ctrl/Cmd+X).',
 	paste: 'Gludo',
-	pasteDefaultMsg: 'Your browser doesn\'t allow you to paste this way. Press %1 to paste.' // MISSING
+	pasteNotification: 'Your browser doesn\'t allow you to paste this way. Press %1 to paste.' // MISSING
 } );

--- a/plugins/clipboard/lang/cy.js
+++ b/plugins/clipboard/lang/cy.js
@@ -8,5 +8,5 @@ CKEDITOR.plugins.setLang( 'clipboard', 'cy', {
 	cut: 'Torri',
 	cutError: 'Nid yw gosodiadau diogelwch eich porwr yn caniatàu\'r golygydd i gynnal \'gweithredoedd torri\' yn awtomatig. Defnyddiwch y bysellfwrdd (Ctrl/Cmd+X).',
 	paste: 'Gludo',
-	pasteMsg: 'Gludwch i mewn i\'r blwch canlynol gan ddefnyddio\'r bysellfwrdd (<strong>Ctrl/Cmd+V</strong>) a phwyso <strong>Iawn</strong>.'
+	pasteDefaultMsg: 'Your browser doesn\'t allow you to paste this way. Press %1 to paste.' // MISSING
 } );

--- a/plugins/clipboard/lang/da.js
+++ b/plugins/clipboard/lang/da.js
@@ -8,5 +8,5 @@ CKEDITOR.plugins.setLang( 'clipboard', 'da', {
 	cut: 'Klip',
 	cutError: 'Din browsers sikkerhedsindstillinger tillader ikke editoren at få automatisk adgang til udklipsholderen.<br><br>Brug i stedet tastaturet til at klippe teksten (Ctrl/Cmd+X).',
 	paste: 'Indsæt',
-	pasteDefaultMsg: 'Your browser doesn\'t allow you to paste this way. Press %1 to paste.' // MISSING
+	pasteNotification: 'Your browser doesn\'t allow you to paste this way. Press %1 to paste.' // MISSING
 } );

--- a/plugins/clipboard/lang/da.js
+++ b/plugins/clipboard/lang/da.js
@@ -8,5 +8,5 @@ CKEDITOR.plugins.setLang( 'clipboard', 'da', {
 	cut: 'Klip',
 	cutError: 'Din browsers sikkerhedsindstillinger tillader ikke editoren at få automatisk adgang til udklipsholderen.<br><br>Brug i stedet tastaturet til at klippe teksten (Ctrl/Cmd+X).',
 	paste: 'Indsæt',
-	pasteMsg: 'Indsæt i feltet herunder (<STRONG>Ctrl/Cmd+V</STRONG>) og klik på <STRONG>OK</STRONG>.'
+	pasteDefaultMsg: 'Your browser doesn\'t allow you to paste this way. Press %1 to paste.' // MISSING
 } );

--- a/plugins/clipboard/lang/de-ch.js
+++ b/plugins/clipboard/lang/de-ch.js
@@ -8,5 +8,5 @@ CKEDITOR.plugins.setLang( 'clipboard', 'de-ch', {
 	cut: 'Ausschneiden',
 	cutError: 'Die Sicherheitseinstellungen Ihres Browsers lassen es nicht zu, den Text automatisch auszuschneiden. Bitte benutzen Sie die System-Zwischenablage über STRG-X (ausschneiden) und STRG-V (einfügen).',
 	paste: 'Einfügen',
-	pasteMsg: 'Bitte fügen Sie den Text in der folgenden Box über die Tastatur (mit <STRONG>Strg+V</STRONG>) ein und bestätigen Sie mit <STRONG>OK</STRONG>.'
+	pasteDefaultMsg: 'Your browser doesn\'t allow you to paste this way. Press %1 to paste.' // MISSING
 } );

--- a/plugins/clipboard/lang/de-ch.js
+++ b/plugins/clipboard/lang/de-ch.js
@@ -8,5 +8,5 @@ CKEDITOR.plugins.setLang( 'clipboard', 'de-ch', {
 	cut: 'Ausschneiden',
 	cutError: 'Die Sicherheitseinstellungen Ihres Browsers lassen es nicht zu, den Text automatisch auszuschneiden. Bitte benutzen Sie die System-Zwischenablage über STRG-X (ausschneiden) und STRG-V (einfügen).',
 	paste: 'Einfügen',
-	pasteDefaultMsg: 'Your browser doesn\'t allow you to paste this way. Press %1 to paste.' // MISSING
+	pasteNotification: 'Your browser doesn\'t allow you to paste this way. Press %1 to paste.' // MISSING
 } );

--- a/plugins/clipboard/lang/de.js
+++ b/plugins/clipboard/lang/de.js
@@ -8,5 +8,5 @@ CKEDITOR.plugins.setLang( 'clipboard', 'de', {
 	cut: 'Ausschneiden',
 	cutError: 'Die Sicherheitseinstellungen Ihres Browsers lassen es nicht zu, den Text automatisch auszuschneiden. Bitte benutzen Sie die System-Zwischenablage über STRG-X (ausschneiden) und STRG-V (einfügen).',
 	paste: 'Einfügen',
-	pasteDefaultMsg: 'Your browser doesn\'t allow you to paste this way. Press %1 to paste.' // MISSING
+	pasteNotification: 'Your browser doesn\'t allow you to paste this way. Press %1 to paste.' // MISSING
 } );

--- a/plugins/clipboard/lang/de.js
+++ b/plugins/clipboard/lang/de.js
@@ -8,5 +8,5 @@ CKEDITOR.plugins.setLang( 'clipboard', 'de', {
 	cut: 'Ausschneiden',
 	cutError: 'Die Sicherheitseinstellungen Ihres Browsers lassen es nicht zu, den Text automatisch auszuschneiden. Bitte benutzen Sie die System-Zwischenablage über STRG-X (ausschneiden) und STRG-V (einfügen).',
 	paste: 'Einfügen',
-	pasteMsg: 'Bitte fügen Sie den Text in der folgenden Box über die Tastatur (mit <STRONG>Strg+V</STRONG>) ein und bestätigen Sie mit <STRONG>OK</STRONG>.'
+	pasteDefaultMsg: 'Your browser doesn\'t allow you to paste this way. Press %1 to paste.' // MISSING
 } );

--- a/plugins/clipboard/lang/el.js
+++ b/plugins/clipboard/lang/el.js
@@ -8,5 +8,5 @@ CKEDITOR.plugins.setLang( 'clipboard', 'el', {
 	cut: 'Αποκοπή',
 	cutError: 'Οι ρυθμίσεις ασφαλείας του περιηγητή σας δεν επιτρέπουν την επιλεγμένη εργασία αποκοπής. Παρακαλώ χρησιμοποιείστε το πληκτρολόγιο (Ctrl/Cmd+X).',
 	paste: 'Επικόλληση',
-	pasteDefaultMsg: 'Your browser doesn\'t allow you to paste this way. Press %1 to paste.' // MISSING
+	pasteNotification: 'Your browser doesn\'t allow you to paste this way. Press %1 to paste.' // MISSING
 } );

--- a/plugins/clipboard/lang/el.js
+++ b/plugins/clipboard/lang/el.js
@@ -8,5 +8,5 @@ CKEDITOR.plugins.setLang( 'clipboard', 'el', {
 	cut: 'Αποκοπή',
 	cutError: 'Οι ρυθμίσεις ασφαλείας του περιηγητή σας δεν επιτρέπουν την επιλεγμένη εργασία αποκοπής. Παρακαλώ χρησιμοποιείστε το πληκτρολόγιο (Ctrl/Cmd+X).',
 	paste: 'Επικόλληση',
-	pasteMsg: 'Παρακαλώ επικολλήστε στο ακόλουθο κουτί χρησιμοποιώντας το πληκτρολόγιο (<strong>Ctrl/Cmd+V</strong>) και πατήστε OK.'
+	pasteDefaultMsg: 'Your browser doesn\'t allow you to paste this way. Press %1 to paste.' // MISSING
 } );

--- a/plugins/clipboard/lang/en-au.js
+++ b/plugins/clipboard/lang/en-au.js
@@ -8,5 +8,5 @@ CKEDITOR.plugins.setLang( 'clipboard', 'en-au', {
 	cut: 'Cut',
 	cutError: 'Your browser security settings don\'t permit the editor to automatically execute cutting operations. Please use the keyboard for that (Ctrl/Cmd+X).',
 	paste: 'Paste',
-	pasteDefaultMsg: 'Your browser doesn\'t allow you to paste this way. Press %1 to paste.' // MISSING
+	pasteNotification: 'Your browser doesn\'t allow you to paste this way. Press %1 to paste.' // MISSING
 } );

--- a/plugins/clipboard/lang/en-au.js
+++ b/plugins/clipboard/lang/en-au.js
@@ -8,5 +8,5 @@ CKEDITOR.plugins.setLang( 'clipboard', 'en-au', {
 	cut: 'Cut',
 	cutError: 'Your browser security settings don\'t permit the editor to automatically execute cutting operations. Please use the keyboard for that (Ctrl/Cmd+X).',
 	paste: 'Paste',
-	pasteMsg: 'Please paste inside the following box using the keyboard (<strong>Ctrl/Cmd+V</strong>) and hit OK'
+	pasteDefaultMsg: 'Your browser doesn\'t allow you to paste this way. Press %1 to paste.' // MISSING
 } );

--- a/plugins/clipboard/lang/en-ca.js
+++ b/plugins/clipboard/lang/en-ca.js
@@ -8,5 +8,5 @@ CKEDITOR.plugins.setLang( 'clipboard', 'en-ca', {
 	cut: 'Cut',
 	cutError: 'Your browser security settings don\'t permit the editor to automatically execute cutting operations. Please use the keyboard for that (Ctrl/Cmd+X).',
 	paste: 'Paste',
-	pasteDefaultMsg: 'Your browser doesn\'t allow you to paste this way. Press %1 to paste.' // MISSING
+	pasteNotification: 'Your browser doesn\'t allow you to paste this way. Press %1 to paste.' // MISSING
 } );

--- a/plugins/clipboard/lang/en-ca.js
+++ b/plugins/clipboard/lang/en-ca.js
@@ -8,5 +8,5 @@ CKEDITOR.plugins.setLang( 'clipboard', 'en-ca', {
 	cut: 'Cut',
 	cutError: 'Your browser security settings don\'t permit the editor to automatically execute cutting operations. Please use the keyboard for that (Ctrl/Cmd+X).',
 	paste: 'Paste',
-	pasteMsg: 'Please paste inside the following box using the keyboard (<strong>Ctrl/Cmd+V</strong>) and hit OK'
+	pasteDefaultMsg: 'Your browser doesn\'t allow you to paste this way. Press %1 to paste.' // MISSING
 } );

--- a/plugins/clipboard/lang/en-gb.js
+++ b/plugins/clipboard/lang/en-gb.js
@@ -8,5 +8,5 @@ CKEDITOR.plugins.setLang( 'clipboard', 'en-gb', {
 	cut: 'Cut',
 	cutError: 'Your browser security settings don\'t permit the editor to automatically execute cutting operations. Please use the keyboard for that (Ctrl/Cmd+X).',
 	paste: 'Paste',
-	pasteMsg: 'Please paste inside the following box using the keyboard (<strong>Ctrl/Cmd+V</strong>) and hit OK'
+	pasteDefaultMsg: 'Your browser doesn\'t allow you to paste this way. Press %1 to paste.' // MISSING
 } );

--- a/plugins/clipboard/lang/en-gb.js
+++ b/plugins/clipboard/lang/en-gb.js
@@ -8,5 +8,5 @@ CKEDITOR.plugins.setLang( 'clipboard', 'en-gb', {
 	cut: 'Cut',
 	cutError: 'Your browser security settings don\'t permit the editor to automatically execute cutting operations. Please use the keyboard for that (Ctrl/Cmd+X).',
 	paste: 'Paste',
-	pasteDefaultMsg: 'Your browser doesn\'t allow you to paste this way. Press %1 to paste.' // MISSING
+	pasteNotification: 'Your browser doesn\'t allow you to paste this way. Press %1 to paste.' // MISSING
 } );

--- a/plugins/clipboard/lang/en.js
+++ b/plugins/clipboard/lang/en.js
@@ -8,5 +8,5 @@ CKEDITOR.plugins.setLang( 'clipboard', 'en', {
 	cut: 'Cut',
 	cutError: 'Your browser security settings don\'t permit the editor to automatically execute cutting operations. Please use the keyboard for that (Ctrl/Cmd+X).',
 	paste: 'Paste',
-	pasteDefaultMsg: 'Your browser doesn\'t allow you to paste this way. Press %1 to paste.'
+	pasteNotification: 'Your browser doesn\'t allow you to paste this way. Press %1 to paste.'
 } );

--- a/plugins/clipboard/lang/en.js
+++ b/plugins/clipboard/lang/en.js
@@ -8,5 +8,5 @@ CKEDITOR.plugins.setLang( 'clipboard', 'en', {
 	cut: 'Cut',
 	cutError: 'Your browser security settings don\'t permit the editor to automatically execute cutting operations. Please use the keyboard for that (Ctrl/Cmd+X).',
 	paste: 'Paste',
-	pasteMsg: 'Your browser doesn\'t allow you to paste this way. Press %1 to paste.'
+	pasteDefaultMsg: 'Your browser doesn\'t allow you to paste this way. Press %1 to paste.'
 } );

--- a/plugins/clipboard/lang/eo.js
+++ b/plugins/clipboard/lang/eo.js
@@ -8,5 +8,5 @@ CKEDITOR.plugins.setLang( 'clipboard', 'eo', {
 	cut: 'Eltondi',
 	cutError: 'La sekurecagordo de via TTT-legilo ne permesas, ke la redaktilo faras eltondajn operaciojn. Bonvolu uzi la klavaron por tio (Ctrl/Cmd-X).',
 	paste: 'Interglui',
-	pasteDefaultMsg: 'Your browser doesn\'t allow you to paste this way. Press %1 to paste.' // MISSING
+	pasteNotification: 'Your browser doesn\'t allow you to paste this way. Press %1 to paste.' // MISSING
 } );

--- a/plugins/clipboard/lang/eo.js
+++ b/plugins/clipboard/lang/eo.js
@@ -8,5 +8,5 @@ CKEDITOR.plugins.setLang( 'clipboard', 'eo', {
 	cut: 'Eltondi',
 	cutError: 'La sekurecagordo de via TTT-legilo ne permesas, ke la redaktilo faras eltondajn operaciojn. Bonvolu uzi la klavaron por tio (Ctrl/Cmd-X).',
 	paste: 'Interglui',
-	pasteMsg: 'Bonvolu glui la tekston en la jenan areon per uzado de la klavaro (<strong>Ctrl/Cmd+V</strong>) kaj premu OK'
+	pasteDefaultMsg: 'Your browser doesn\'t allow you to paste this way. Press %1 to paste.' // MISSING
 } );

--- a/plugins/clipboard/lang/es.js
+++ b/plugins/clipboard/lang/es.js
@@ -8,5 +8,5 @@ CKEDITOR.plugins.setLang( 'clipboard', 'es', {
 	cut: 'Cortar',
 	cutError: 'La configuración de seguridad de este navegador no permite la ejecución automática de operaciones de cortado.\r\nPor favor use el teclado (Ctrl/Cmd+X).',
 	paste: 'Pegar',
-	pasteDefaultMsg: 'Your browser doesn\'t allow you to paste this way. Press %1 to paste.' // MISSING
+	pasteNotification: 'Your browser doesn\'t allow you to paste this way. Press %1 to paste.' // MISSING
 } );

--- a/plugins/clipboard/lang/es.js
+++ b/plugins/clipboard/lang/es.js
@@ -8,5 +8,5 @@ CKEDITOR.plugins.setLang( 'clipboard', 'es', {
 	cut: 'Cortar',
 	cutError: 'La configuración de seguridad de este navegador no permite la ejecución automática de operaciones de cortado.\r\nPor favor use el teclado (Ctrl/Cmd+X).',
 	paste: 'Pegar',
-	pasteMsg: 'Por favor pegue dentro del cuadro utilizando el teclado (<STRONG>Ctrl/Cmd+V</STRONG>);\r\nluego presione <STRONG>Aceptar</STRONG>.'
+	pasteDefaultMsg: 'Your browser doesn\'t allow you to paste this way. Press %1 to paste.' // MISSING
 } );

--- a/plugins/clipboard/lang/et.js
+++ b/plugins/clipboard/lang/et.js
@@ -8,5 +8,5 @@ CKEDITOR.plugins.setLang( 'clipboard', 'et', {
 	cut: 'Lõika',
 	cutError: 'Sinu veebisirvija turvaseaded ei luba redaktoril automaatselt lõigata. Palun kasutage selleks klaviatuuri klahvikombinatsiooni (Ctrl/Cmd+X).',
 	paste: 'Aseta',
-	pasteMsg: 'Palun aseta tekst järgnevasse kasti kasutades klaviatuuri klahvikombinatsiooni (<STRONG>Ctrl/Cmd+V</STRONG>) ja vajuta seejärel <STRONG>OK</STRONG>.'
+	pasteDefaultMsg: 'Your browser doesn\'t allow you to paste this way. Press %1 to paste.' // MISSING
 } );

--- a/plugins/clipboard/lang/et.js
+++ b/plugins/clipboard/lang/et.js
@@ -8,5 +8,5 @@ CKEDITOR.plugins.setLang( 'clipboard', 'et', {
 	cut: 'Lõika',
 	cutError: 'Sinu veebisirvija turvaseaded ei luba redaktoril automaatselt lõigata. Palun kasutage selleks klaviatuuri klahvikombinatsiooni (Ctrl/Cmd+X).',
 	paste: 'Aseta',
-	pasteDefaultMsg: 'Your browser doesn\'t allow you to paste this way. Press %1 to paste.' // MISSING
+	pasteNotification: 'Your browser doesn\'t allow you to paste this way. Press %1 to paste.' // MISSING
 } );

--- a/plugins/clipboard/lang/eu.js
+++ b/plugins/clipboard/lang/eu.js
@@ -8,5 +8,5 @@ CKEDITOR.plugins.setLang( 'clipboard', 'eu', {
 	cut: 'Ebaki',
 	cutError: 'Zure web nabigatzailearen segurtasun ezarpenek ez dute baimentzen testuak automatikoki moztea. Mesedez teklatua erabil ezazu (Ctrl/Cmd+X).',
 	paste: 'Itsatsi',
-	pasteMsg: 'Mesedez teklatua erabiliz (<strong>Ctrl/Cmd+V</strong>) ondorengo eremuan testua itsatsi eta sakatu <strong>Ados</strong>.'
+	pasteDefaultMsg: 'Your browser doesn\'t allow you to paste this way. Press %1 to paste.' // MISSING
 } );

--- a/plugins/clipboard/lang/eu.js
+++ b/plugins/clipboard/lang/eu.js
@@ -8,5 +8,5 @@ CKEDITOR.plugins.setLang( 'clipboard', 'eu', {
 	cut: 'Ebaki',
 	cutError: 'Zure web nabigatzailearen segurtasun ezarpenek ez dute baimentzen testuak automatikoki moztea. Mesedez teklatua erabil ezazu (Ctrl/Cmd+X).',
 	paste: 'Itsatsi',
-	pasteDefaultMsg: 'Your browser doesn\'t allow you to paste this way. Press %1 to paste.' // MISSING
+	pasteNotification: 'Your browser doesn\'t allow you to paste this way. Press %1 to paste.' // MISSING
 } );

--- a/plugins/clipboard/lang/fa.js
+++ b/plugins/clipboard/lang/fa.js
@@ -8,5 +8,5 @@ CKEDITOR.plugins.setLang( 'clipboard', 'fa', {
 	cut: 'برش',
 	cutError: 'تنظیمات امنیتی مرورگر شما اجازه نمیدهد که ویرایشگر به طور خودکار عملکردهای برش را انجام دهد. لطفا با دکمههای صفحه کلید این کار را انجام دهید (Ctrl/Cmd+X).',
 	paste: 'چسباندن',
-	pasteMsg: 'لطفا متن را با کلیدهای (<STRONG>Ctrl/Cmd+V</STRONG>) در این جعبهٴ متنی بچسبانید و <STRONG>پذیرش</STRONG> را بزنید.'
+	pasteDefaultMsg: 'Your browser doesn\'t allow you to paste this way. Press %1 to paste.' // MISSING
 } );

--- a/plugins/clipboard/lang/fa.js
+++ b/plugins/clipboard/lang/fa.js
@@ -8,5 +8,5 @@ CKEDITOR.plugins.setLang( 'clipboard', 'fa', {
 	cut: 'برش',
 	cutError: 'تنظیمات امنیتی مرورگر شما اجازه نمیدهد که ویرایشگر به طور خودکار عملکردهای برش را انجام دهد. لطفا با دکمههای صفحه کلید این کار را انجام دهید (Ctrl/Cmd+X).',
 	paste: 'چسباندن',
-	pasteDefaultMsg: 'Your browser doesn\'t allow you to paste this way. Press %1 to paste.' // MISSING
+	pasteNotification: 'Your browser doesn\'t allow you to paste this way. Press %1 to paste.' // MISSING
 } );

--- a/plugins/clipboard/lang/fi.js
+++ b/plugins/clipboard/lang/fi.js
@@ -8,5 +8,5 @@ CKEDITOR.plugins.setLang( 'clipboard', 'fi', {
 	cut: 'Leikkaa',
 	cutError: 'Selaimesi turva-asetukset eivät salli editorin toteuttaa leikkaamista. Käytä näppäimistöä leikkaamiseen (Ctrl+X).',
 	paste: 'Liitä',
-	pasteDefaultMsg: 'Your browser doesn\'t allow you to paste this way. Press %1 to paste.' // MISSING
+	pasteNotification: 'Your browser doesn\'t allow you to paste this way. Press %1 to paste.' // MISSING
 } );

--- a/plugins/clipboard/lang/fi.js
+++ b/plugins/clipboard/lang/fi.js
@@ -8,5 +8,5 @@ CKEDITOR.plugins.setLang( 'clipboard', 'fi', {
 	cut: 'Leikkaa',
 	cutError: 'Selaimesi turva-asetukset eivät salli editorin toteuttaa leikkaamista. Käytä näppäimistöä leikkaamiseen (Ctrl+X).',
 	paste: 'Liitä',
-	pasteMsg: 'Liitä painamalla (<STRONG>Ctrl+V</STRONG>) ja painamalla <STRONG>OK</STRONG>.'
+	pasteDefaultMsg: 'Your browser doesn\'t allow you to paste this way. Press %1 to paste.' // MISSING
 } );

--- a/plugins/clipboard/lang/fo.js
+++ b/plugins/clipboard/lang/fo.js
@@ -8,5 +8,5 @@ CKEDITOR.plugins.setLang( 'clipboard', 'fo', {
 	cut: 'Kvett',
 	cutError: 'Trygdaruppseting alnótskagans forðar tekstviðgeranum í at kvetta tekstin. Vinarliga nýt knappaborðið til at kvetta tekstin (Ctrl/Cmd+X).',
 	paste: 'Innrita',
-	pasteDefaultMsg: 'Your browser doesn\'t allow you to paste this way. Press %1 to paste.' // MISSING
+	pasteNotification: 'Your browser doesn\'t allow you to paste this way. Press %1 to paste.' // MISSING
 } );

--- a/plugins/clipboard/lang/fo.js
+++ b/plugins/clipboard/lang/fo.js
@@ -8,5 +8,5 @@ CKEDITOR.plugins.setLang( 'clipboard', 'fo', {
 	cut: 'Kvett',
 	cutError: 'Trygdaruppseting alnótskagans forðar tekstviðgeranum í at kvetta tekstin. Vinarliga nýt knappaborðið til at kvetta tekstin (Ctrl/Cmd+X).',
 	paste: 'Innrita',
-	pasteMsg: 'Vinarliga koyr tekstin í hendan rútin við knappaborðinum (<strong>Ctrl/Cmd+V</strong>) og klikk á <strong>Góðtak</strong>.'
+	pasteDefaultMsg: 'Your browser doesn\'t allow you to paste this way. Press %1 to paste.' // MISSING
 } );

--- a/plugins/clipboard/lang/fr-ca.js
+++ b/plugins/clipboard/lang/fr-ca.js
@@ -8,5 +8,5 @@ CKEDITOR.plugins.setLang( 'clipboard', 'fr-ca', {
 	cut: 'Couper',
 	cutError: 'Les paramètres de sécurité de votre navigateur empêchent l\'éditeur de couper automatiquement vos données. Veuillez utiliser les équivalents claviers (Ctrl/Cmd+X).',
 	paste: 'Coller',
-	pasteDefaultMsg: 'Your browser doesn\'t allow you to paste this way. Press %1 to paste.' // MISSING
+	pasteNotification: 'Your browser doesn\'t allow you to paste this way. Press %1 to paste.' // MISSING
 } );

--- a/plugins/clipboard/lang/fr-ca.js
+++ b/plugins/clipboard/lang/fr-ca.js
@@ -8,5 +8,5 @@ CKEDITOR.plugins.setLang( 'clipboard', 'fr-ca', {
 	cut: 'Couper',
 	cutError: 'Les paramètres de sécurité de votre navigateur empêchent l\'éditeur de couper automatiquement vos données. Veuillez utiliser les équivalents claviers (Ctrl/Cmd+X).',
 	paste: 'Coller',
-	pasteMsg: 'Veuillez coller dans la zone ci-dessous en utilisant le clavier (<STRONG>Ctrl/Cmd+V</STRONG>) et appuyer sur <STRONG>OK</STRONG>.'
+	pasteDefaultMsg: 'Your browser doesn\'t allow you to paste this way. Press %1 to paste.' // MISSING
 } );

--- a/plugins/clipboard/lang/fr.js
+++ b/plugins/clipboard/lang/fr.js
@@ -8,5 +8,5 @@ CKEDITOR.plugins.setLang( 'clipboard', 'fr', {
 	cut: 'Couper',
 	cutError: 'Les paramètres de sécurité de votre navigateur n\'autorisent pas l\'éditeur à exécuter automatiquement l\'opération « Couper ». Veuillez utiliser le raccourci clavier à cet effet (Ctrl/Cmd+X).',
 	paste: 'Coller',
-	pasteDefaultMsg: 'Your browser doesn\'t allow you to paste this way. Press %1 to paste.' // MISSING
+	pasteNotification: 'Your browser doesn\'t allow you to paste this way. Press %1 to paste.' // MISSING
 } );

--- a/plugins/clipboard/lang/fr.js
+++ b/plugins/clipboard/lang/fr.js
@@ -8,5 +8,5 @@ CKEDITOR.plugins.setLang( 'clipboard', 'fr', {
 	cut: 'Couper',
 	cutError: 'Les paramètres de sécurité de votre navigateur n\'autorisent pas l\'éditeur à exécuter automatiquement l\'opération « Couper ». Veuillez utiliser le raccourci clavier à cet effet (Ctrl/Cmd+X).',
 	paste: 'Coller',
-	pasteMsg: 'Veuillez coller le texte dans la zone suivante en utilisant le raccourci clavier (<strong>Ctrl/Cmd+V</strong>) et cliquez sur OK.'
+	pasteDefaultMsg: 'Your browser doesn\'t allow you to paste this way. Press %1 to paste.' // MISSING
 } );

--- a/plugins/clipboard/lang/gl.js
+++ b/plugins/clipboard/lang/gl.js
@@ -8,5 +8,5 @@ CKEDITOR.plugins.setLang( 'clipboard', 'gl', {
 	cut: 'Cortar',
 	cutError: 'Os axustes de seguranza do seu navegador non permiten que o editor realice automaticamente as tarefas de corte. Use o teclado para iso (Ctrl/Cmd+X).',
 	paste: 'Pegar',
-	pasteMsg: 'Pegue dentro do seguinte cadro usando o teclado (<STRONG>Ctrl/Cmd+V</STRONG>) e prema en Aceptar'
+	pasteDefaultMsg: 'Your browser doesn\'t allow you to paste this way. Press %1 to paste.' // MISSING
 } );

--- a/plugins/clipboard/lang/gl.js
+++ b/plugins/clipboard/lang/gl.js
@@ -8,5 +8,5 @@ CKEDITOR.plugins.setLang( 'clipboard', 'gl', {
 	cut: 'Cortar',
 	cutError: 'Os axustes de seguranza do seu navegador non permiten que o editor realice automaticamente as tarefas de corte. Use o teclado para iso (Ctrl/Cmd+X).',
 	paste: 'Pegar',
-	pasteDefaultMsg: 'Your browser doesn\'t allow you to paste this way. Press %1 to paste.' // MISSING
+	pasteNotification: 'Your browser doesn\'t allow you to paste this way. Press %1 to paste.' // MISSING
 } );

--- a/plugins/clipboard/lang/gu.js
+++ b/plugins/clipboard/lang/gu.js
@@ -8,5 +8,5 @@ CKEDITOR.plugins.setLang( 'clipboard', 'gu', {
 	cut: 'કાપવું',
 	cutError: 'તમારા બ્રાઉઝર ની સુરક્ષિત સેટિંગસ કટ કરવાની પરવાનગી નથી આપતી. (Ctrl/Cmd+X) નો ઉપયોગ કરો.',
 	paste: 'પેસ્ટ',
-	pasteMsg: 'Ctrl/Cmd+V નો પ્રયોગ કરી પેસ્ટ કરો'
+	pasteDefaultMsg: 'Your browser doesn\'t allow you to paste this way. Press %1 to paste.' // MISSING
 } );

--- a/plugins/clipboard/lang/gu.js
+++ b/plugins/clipboard/lang/gu.js
@@ -8,5 +8,5 @@ CKEDITOR.plugins.setLang( 'clipboard', 'gu', {
 	cut: 'કાપવું',
 	cutError: 'તમારા બ્રાઉઝર ની સુરક્ષિત સેટિંગસ કટ કરવાની પરવાનગી નથી આપતી. (Ctrl/Cmd+X) નો ઉપયોગ કરો.',
 	paste: 'પેસ્ટ',
-	pasteDefaultMsg: 'Your browser doesn\'t allow you to paste this way. Press %1 to paste.' // MISSING
+	pasteNotification: 'Your browser doesn\'t allow you to paste this way. Press %1 to paste.' // MISSING
 } );

--- a/plugins/clipboard/lang/he.js
+++ b/plugins/clipboard/lang/he.js
@@ -8,5 +8,5 @@ CKEDITOR.plugins.setLang( 'clipboard', 'he', {
 	cut: 'גזירה',
 	cutError: 'הגדרות האבטחה בדפדפן שלך לא מאפשרות לעורך לבצע פעולות גזירה אוטומטיות. יש להשתמש במקלדת לשם כך (Ctrl/Cmd+X).',
 	paste: 'הדבקה',
-	pasteMsg: 'נא להדביק בתוך הקופסה באמצעות (<b>Ctrl/Cmd+V</b>) וללחוץ על <b>אישור</b>.'
+	pasteDefaultMsg: 'Your browser doesn\'t allow you to paste this way. Press %1 to paste.' // MISSING
 } );

--- a/plugins/clipboard/lang/he.js
+++ b/plugins/clipboard/lang/he.js
@@ -8,5 +8,5 @@ CKEDITOR.plugins.setLang( 'clipboard', 'he', {
 	cut: 'גזירה',
 	cutError: 'הגדרות האבטחה בדפדפן שלך לא מאפשרות לעורך לבצע פעולות גזירה אוטומטיות. יש להשתמש במקלדת לשם כך (Ctrl/Cmd+X).',
 	paste: 'הדבקה',
-	pasteDefaultMsg: 'Your browser doesn\'t allow you to paste this way. Press %1 to paste.' // MISSING
+	pasteNotification: 'Your browser doesn\'t allow you to paste this way. Press %1 to paste.' // MISSING
 } );

--- a/plugins/clipboard/lang/hi.js
+++ b/plugins/clipboard/lang/hi.js
@@ -8,5 +8,5 @@ CKEDITOR.plugins.setLang( 'clipboard', 'hi', {
 	cut: 'कट',
 	cutError: 'आपके ब्राउज़र की सुरक्षा सॅटिन्ग्स ने कट करने की अनुमति नहीं प्रदान की है। (Ctrl/Cmd+X) का प्रयोग करें।',
 	paste: 'पेस्ट',
-	pasteDefaultMsg: 'Your browser doesn\'t allow you to paste this way. Press %1 to paste.' // MISSING
+	pasteNotification: 'Your browser doesn\'t allow you to paste this way. Press %1 to paste.' // MISSING
 } );

--- a/plugins/clipboard/lang/hi.js
+++ b/plugins/clipboard/lang/hi.js
@@ -8,5 +8,5 @@ CKEDITOR.plugins.setLang( 'clipboard', 'hi', {
 	cut: 'कट',
 	cutError: 'आपके ब्राउज़र की सुरक्षा सॅटिन्ग्स ने कट करने की अनुमति नहीं प्रदान की है। (Ctrl/Cmd+X) का प्रयोग करें।',
 	paste: 'पेस्ट',
-	pasteMsg: 'Ctrl/Cmd+V का प्रयोग करके पेस्ट करें और ठीक है करें.'
+	pasteDefaultMsg: 'Your browser doesn\'t allow you to paste this way. Press %1 to paste.' // MISSING
 } );

--- a/plugins/clipboard/lang/hr.js
+++ b/plugins/clipboard/lang/hr.js
@@ -8,5 +8,5 @@ CKEDITOR.plugins.setLang( 'clipboard', 'hr', {
 	cut: 'Izreži',
 	cutError: 'Sigurnosne postavke Vašeg pretraživača ne dozvoljavaju operacije automatskog izrezivanja. Molimo koristite kraticu na tipkovnici (Ctrl/Cmd+X).',
 	paste: 'Zalijepi',
-	pasteDefaultMsg: 'Your browser doesn\'t allow you to paste this way. Press %1 to paste.' // MISSING
+	pasteNotification: 'Your browser doesn\'t allow you to paste this way. Press %1 to paste.' // MISSING
 } );

--- a/plugins/clipboard/lang/hr.js
+++ b/plugins/clipboard/lang/hr.js
@@ -8,5 +8,5 @@ CKEDITOR.plugins.setLang( 'clipboard', 'hr', {
 	cut: 'Izreži',
 	cutError: 'Sigurnosne postavke Vašeg pretraživača ne dozvoljavaju operacije automatskog izrezivanja. Molimo koristite kraticu na tipkovnici (Ctrl/Cmd+X).',
 	paste: 'Zalijepi',
-	pasteMsg: 'Molimo zaljepite unutar doljnjeg okvira koristeći tipkovnicu (<STRONG>Ctrl/Cmd+V</STRONG>) i kliknite <STRONG>OK</STRONG>.'
+	pasteDefaultMsg: 'Your browser doesn\'t allow you to paste this way. Press %1 to paste.' // MISSING
 } );

--- a/plugins/clipboard/lang/hu.js
+++ b/plugins/clipboard/lang/hu.js
@@ -8,5 +8,5 @@ CKEDITOR.plugins.setLang( 'clipboard', 'hu', {
 	cut: 'Kivágás',
 	cutError: 'A böngésző biztonsági beállításai nem engedélyezik a szerkesztőnek, hogy végrehajtsa a kivágás műveletet. Használja az alábbi billentyűkombinációt (Ctrl/Cmd+X).',
 	paste: 'Beillesztés',
-	pasteDefaultMsg: 'Your browser doesn\'t allow you to paste this way. Press %1 to paste.' // MISSING
+	pasteNotification: 'Your browser doesn\'t allow you to paste this way. Press %1 to paste.' // MISSING
 } );

--- a/plugins/clipboard/lang/hu.js
+++ b/plugins/clipboard/lang/hu.js
@@ -8,5 +8,5 @@ CKEDITOR.plugins.setLang( 'clipboard', 'hu', {
 	cut: 'Kivágás',
 	cutError: 'A böngésző biztonsági beállításai nem engedélyezik a szerkesztőnek, hogy végrehajtsa a kivágás műveletet. Használja az alábbi billentyűkombinációt (Ctrl/Cmd+X).',
 	paste: 'Beillesztés',
-	pasteMsg: 'Másolja be az alábbi mezőbe a <STRONG>Ctrl/Cmd+V</STRONG> billentyűk lenyomásával, majd nyomjon <STRONG>Rendben</STRONG>-t.'
+	pasteDefaultMsg: 'Your browser doesn\'t allow you to paste this way. Press %1 to paste.' // MISSING
 } );

--- a/plugins/clipboard/lang/id.js
+++ b/plugins/clipboard/lang/id.js
@@ -8,5 +8,5 @@ CKEDITOR.plugins.setLang( 'clipboard', 'id', {
 	cut: 'Potong',
 	cutError: 'Your browser security settings don\'t permit the editor to automatically execute cutting operations. Please use the keyboard for that (Ctrl/Cmd+X).', // MISSING
 	paste: 'Tempel',
-	pasteDefaultMsg: 'Your browser doesn\'t allow you to paste this way. Press %1 to paste.' // MISSING
+	pasteNotification: 'Your browser doesn\'t allow you to paste this way. Press %1 to paste.' // MISSING
 } );

--- a/plugins/clipboard/lang/id.js
+++ b/plugins/clipboard/lang/id.js
@@ -8,5 +8,5 @@ CKEDITOR.plugins.setLang( 'clipboard', 'id', {
 	cut: 'Potong',
 	cutError: 'Your browser security settings don\'t permit the editor to automatically execute cutting operations. Please use the keyboard for that (Ctrl/Cmd+X).', // MISSING
 	paste: 'Tempel',
-	pasteMsg: 'Your browser doesn\'t allow you to paste this way. Press %1 to paste.' // MISSING
+	pasteDefaultMsg: 'Your browser doesn\'t allow you to paste this way. Press %1 to paste.' // MISSING
 } );

--- a/plugins/clipboard/lang/is.js
+++ b/plugins/clipboard/lang/is.js
@@ -8,5 +8,5 @@ CKEDITOR.plugins.setLang( 'clipboard', 'is', {
 	cut: 'Klippa',
 	cutError: 'Öryggisstillingar vafrans þíns leyfa ekki klippingu texta með músaraðgerð. Notaðu lyklaborðið í klippa (Ctrl/Cmd+X).',
 	paste: 'Líma',
-	pasteDefaultMsg: 'Your browser doesn\'t allow you to paste this way. Press %1 to paste.' // MISSING
+	pasteNotification: 'Your browser doesn\'t allow you to paste this way. Press %1 to paste.' // MISSING
 } );

--- a/plugins/clipboard/lang/is.js
+++ b/plugins/clipboard/lang/is.js
@@ -8,5 +8,5 @@ CKEDITOR.plugins.setLang( 'clipboard', 'is', {
 	cut: 'Klippa',
 	cutError: 'Öryggisstillingar vafrans þíns leyfa ekki klippingu texta með músaraðgerð. Notaðu lyklaborðið í klippa (Ctrl/Cmd+X).',
 	paste: 'Líma',
-	pasteMsg: 'Límdu í svæðið hér að neðan og (<STRONG>Ctrl/Cmd+V</STRONG>) og smelltu á <STRONG>OK</STRONG>.'
+	pasteDefaultMsg: 'Your browser doesn\'t allow you to paste this way. Press %1 to paste.' // MISSING
 } );

--- a/plugins/clipboard/lang/it.js
+++ b/plugins/clipboard/lang/it.js
@@ -8,5 +8,5 @@ CKEDITOR.plugins.setLang( 'clipboard', 'it', {
 	cut: 'Taglia',
 	cutError: 'Le impostazioni di sicurezza del browser non permettono di tagliare automaticamente il testo. Usa la tastiera (Ctrl/Cmd+X).',
 	paste: 'Incolla',
-	pasteMsg: 'Incolla il testo all\'interno dell\'area sottostante usando la scorciatoia di tastiere (<STRONG>Ctrl/Cmd+V</STRONG>) e premi <STRONG>OK</STRONG>.'
+	pasteDefaultMsg: 'Your browser doesn\'t allow you to paste this way. Press %1 to paste.' // MISSING
 } );

--- a/plugins/clipboard/lang/it.js
+++ b/plugins/clipboard/lang/it.js
@@ -8,5 +8,5 @@ CKEDITOR.plugins.setLang( 'clipboard', 'it', {
 	cut: 'Taglia',
 	cutError: 'Le impostazioni di sicurezza del browser non permettono di tagliare automaticamente il testo. Usa la tastiera (Ctrl/Cmd+X).',
 	paste: 'Incolla',
-	pasteDefaultMsg: 'Your browser doesn\'t allow you to paste this way. Press %1 to paste.' // MISSING
+	pasteNotification: 'Your browser doesn\'t allow you to paste this way. Press %1 to paste.' // MISSING
 } );

--- a/plugins/clipboard/lang/ja.js
+++ b/plugins/clipboard/lang/ja.js
@@ -8,5 +8,5 @@ CKEDITOR.plugins.setLang( 'clipboard', 'ja', {
 	cut: '切り取り',
 	cutError: 'ブラウザーのセキュリティ設定によりエディタの切り取り操作を自動で実行することができません。実行するには手動でキーボードの(Ctrl/Cmd+X)を使用してください。',
 	paste: '貼り付け',
-	pasteDefaultMsg: 'Your browser doesn\'t allow you to paste this way. Press %1 to paste.' // MISSING
+	pasteNotification: 'Your browser doesn\'t allow you to paste this way. Press %1 to paste.' // MISSING
 } );

--- a/plugins/clipboard/lang/ja.js
+++ b/plugins/clipboard/lang/ja.js
@@ -8,5 +8,5 @@ CKEDITOR.plugins.setLang( 'clipboard', 'ja', {
 	cut: '切り取り',
 	cutError: 'ブラウザーのセキュリティ設定によりエディタの切り取り操作を自動で実行することができません。実行するには手動でキーボードの(Ctrl/Cmd+X)を使用してください。',
 	paste: '貼り付け',
-	pasteMsg: 'キーボード(<STRONG>Ctrl/Cmd+V</STRONG>)を使用して、次の入力エリア内で貼り付けて、<STRONG>OK</STRONG>を押してください。'
+	pasteDefaultMsg: 'Your browser doesn\'t allow you to paste this way. Press %1 to paste.' // MISSING
 } );

--- a/plugins/clipboard/lang/ka.js
+++ b/plugins/clipboard/lang/ka.js
@@ -8,5 +8,5 @@ CKEDITOR.plugins.setLang( 'clipboard', 'ka', {
 	cut: 'ამოჭრა',
 	cutError: 'თქვენი ბროუზერის უსაფრთხოების პარამეტრები არ იძლევა ამოჭრის ოპერაციის ავტომატურად განხორციელების საშუალებას. გამოიყენეთ კლავიატურა ამისთვის (Ctrl/Cmd+X).',
 	paste: 'ჩასმა',
-	pasteMsg: 'ჩასვით ამ არის შიგნით კლავიატურის გამოყენებით (<strong>Ctrl/Cmd+V</strong>) და დააჭირეთ OK-ს'
+	pasteDefaultMsg: 'Your browser doesn\'t allow you to paste this way. Press %1 to paste.' // MISSING
 } );

--- a/plugins/clipboard/lang/ka.js
+++ b/plugins/clipboard/lang/ka.js
@@ -8,5 +8,5 @@ CKEDITOR.plugins.setLang( 'clipboard', 'ka', {
 	cut: 'ამოჭრა',
 	cutError: 'თქვენი ბროუზერის უსაფრთხოების პარამეტრები არ იძლევა ამოჭრის ოპერაციის ავტომატურად განხორციელების საშუალებას. გამოიყენეთ კლავიატურა ამისთვის (Ctrl/Cmd+X).',
 	paste: 'ჩასმა',
-	pasteDefaultMsg: 'Your browser doesn\'t allow you to paste this way. Press %1 to paste.' // MISSING
+	pasteNotification: 'Your browser doesn\'t allow you to paste this way. Press %1 to paste.' // MISSING
 } );

--- a/plugins/clipboard/lang/km.js
+++ b/plugins/clipboard/lang/km.js
@@ -8,5 +8,5 @@ CKEDITOR.plugins.setLang( 'clipboard', 'km', {
 	cut: 'កាត់យក',
 	cutError: 'ការកំណត់សុវត្ថភាពរបស់កម្មវិធីរុករករបស់លោកអ្នក នេះ​មិនអាចធ្វើកម្មវិធីតាក់តែងអត្ថបទ កាត់អត្ថបទយកដោយស្វ័យប្រវត្តបានឡើយ ។ សូមប្រើប្រាស់បន្សំ ឃីដូចនេះ  (Ctrl/Cmd+X) ។',
 	paste: 'បិទ​ភ្ជាប់',
-	pasteMsg: 'សូមចំលងអត្ថបទទៅដាក់ក្នុងប្រអប់ដូចខាងក្រោមដោយប្រើប្រាស់ ឃី ​(<STRONG>Ctrl/Cmd+V</STRONG>) ហើយចុច <STRONG>OK</STRONG> ។'
+	pasteDefaultMsg: 'Your browser doesn\'t allow you to paste this way. Press %1 to paste.' // MISSING
 } );

--- a/plugins/clipboard/lang/km.js
+++ b/plugins/clipboard/lang/km.js
@@ -8,5 +8,5 @@ CKEDITOR.plugins.setLang( 'clipboard', 'km', {
 	cut: 'កាត់យក',
 	cutError: 'ការកំណត់សុវត្ថភាពរបស់កម្មវិធីរុករករបស់លោកអ្នក នេះ​មិនអាចធ្វើកម្មវិធីតាក់តែងអត្ថបទ កាត់អត្ថបទយកដោយស្វ័យប្រវត្តបានឡើយ ។ សូមប្រើប្រាស់បន្សំ ឃីដូចនេះ  (Ctrl/Cmd+X) ។',
 	paste: 'បិទ​ភ្ជាប់',
-	pasteDefaultMsg: 'Your browser doesn\'t allow you to paste this way. Press %1 to paste.' // MISSING
+	pasteNotification: 'Your browser doesn\'t allow you to paste this way. Press %1 to paste.' // MISSING
 } );

--- a/plugins/clipboard/lang/ko.js
+++ b/plugins/clipboard/lang/ko.js
@@ -8,5 +8,5 @@ CKEDITOR.plugins.setLang( 'clipboard', 'ko', {
 	cut: '잘라내기',
 	cutError: '브라우저의 보안설정 때문에 잘라내기 기능을 실행할 수 없습니다. 키보드(Ctrl/Cmd+X)를 이용해서 잘라내기 하십시오',
 	paste: '붙여넣기',
-	pasteMsg: '키보드(<strong>Ctrl/Cmd+V</strong>)를 이용해서 상자안에 붙여넣고 <strong>확인</strong> 를 누르세요.'
+	pasteDefaultMsg: 'Your browser doesn\'t allow you to paste this way. Press %1 to paste.' // MISSING
 } );

--- a/plugins/clipboard/lang/ko.js
+++ b/plugins/clipboard/lang/ko.js
@@ -8,5 +8,5 @@ CKEDITOR.plugins.setLang( 'clipboard', 'ko', {
 	cut: '잘라내기',
 	cutError: '브라우저의 보안설정 때문에 잘라내기 기능을 실행할 수 없습니다. 키보드(Ctrl/Cmd+X)를 이용해서 잘라내기 하십시오',
 	paste: '붙여넣기',
-	pasteDefaultMsg: 'Your browser doesn\'t allow you to paste this way. Press %1 to paste.' // MISSING
+	pasteNotification: 'Your browser doesn\'t allow you to paste this way. Press %1 to paste.' // MISSING
 } );

--- a/plugins/clipboard/lang/ku.js
+++ b/plugins/clipboard/lang/ku.js
@@ -8,5 +8,5 @@ CKEDITOR.plugins.setLang( 'clipboard', 'ku', {
 	cut: 'بڕین',
 	cutError: 'پارێزی وێبگەڕەکەت ڕێگەنادات بە سەرنووسەکە لەبڕینی خۆکارانە. تکایە لەبری ئەمە ئەم فەرمانە بەکاربهێنە بەداگرتنی کلیلی (Ctrl/Cmd+X).',
 	paste: 'لکاندن',
-	pasteDefaultMsg: 'Your browser doesn\'t allow you to paste this way. Press %1 to paste.' // MISSING
+	pasteNotification: 'Your browser doesn\'t allow you to paste this way. Press %1 to paste.' // MISSING
 } );

--- a/plugins/clipboard/lang/ku.js
+++ b/plugins/clipboard/lang/ku.js
@@ -8,5 +8,5 @@ CKEDITOR.plugins.setLang( 'clipboard', 'ku', {
 	cut: 'بڕین',
 	cutError: 'پارێزی وێبگەڕەکەت ڕێگەنادات بە سەرنووسەکە لەبڕینی خۆکارانە. تکایە لەبری ئەمە ئەم فەرمانە بەکاربهێنە بەداگرتنی کلیلی (Ctrl/Cmd+X).',
 	paste: 'لکاندن',
-	pasteMsg: 'تکایە بیلکێنە لەناوەوەی ئەم سنوقە لەڕێی تەختەکلیلەکەت بە بەکارهێنانی کلیلی (<STRONG>Ctrl/Cmd+V</STRONG>) دووای کلیکی باشە بکە.'
+	pasteDefaultMsg: 'Your browser doesn\'t allow you to paste this way. Press %1 to paste.' // MISSING
 } );

--- a/plugins/clipboard/lang/lt.js
+++ b/plugins/clipboard/lang/lt.js
@@ -8,5 +8,5 @@ CKEDITOR.plugins.setLang( 'clipboard', 'lt', {
 	cut: 'Iškirpti',
 	cutError: 'Jūsų naršyklės saugumo nustatymai neleidžia redaktoriui automatiškai įvykdyti iškirpimo operacijų. Tam prašome naudoti klaviatūrą (Ctrl/Cmd+X).',
 	paste: 'Įdėti',
-	pasteMsg: 'Žemiau esančiame įvedimo lauke įdėkite tekstą, naudodami klaviatūrą (<STRONG>Ctrl/Cmd+V</STRONG>) ir paspauskite mygtuką <STRONG>OK</STRONG>.'
+	pasteDefaultMsg: 'Your browser doesn\'t allow you to paste this way. Press %1 to paste.' // MISSING
 } );

--- a/plugins/clipboard/lang/lt.js
+++ b/plugins/clipboard/lang/lt.js
@@ -8,5 +8,5 @@ CKEDITOR.plugins.setLang( 'clipboard', 'lt', {
 	cut: 'Iškirpti',
 	cutError: 'Jūsų naršyklės saugumo nustatymai neleidžia redaktoriui automatiškai įvykdyti iškirpimo operacijų. Tam prašome naudoti klaviatūrą (Ctrl/Cmd+X).',
 	paste: 'Įdėti',
-	pasteDefaultMsg: 'Your browser doesn\'t allow you to paste this way. Press %1 to paste.' // MISSING
+	pasteNotification: 'Your browser doesn\'t allow you to paste this way. Press %1 to paste.' // MISSING
 } );

--- a/plugins/clipboard/lang/lv.js
+++ b/plugins/clipboard/lang/lv.js
@@ -8,5 +8,5 @@ CKEDITOR.plugins.setLang( 'clipboard', 'lv', {
 	cut: 'Izgriezt',
 	cutError: 'Jūsu pārlūkprogrammas drošības iestatījumi nepieļauj redaktoram automātiski veikt izgriezšanas darbību.  Lūdzu, izmantojiet (Ctrl/Cmd+X), lai veiktu šo darbību.',
 	paste: 'Ielīmēt',
-	pasteDefaultMsg: 'Your browser doesn\'t allow you to paste this way. Press %1 to paste.' // MISSING
+	pasteNotification: 'Your browser doesn\'t allow you to paste this way. Press %1 to paste.' // MISSING
 } );

--- a/plugins/clipboard/lang/lv.js
+++ b/plugins/clipboard/lang/lv.js
@@ -8,5 +8,5 @@ CKEDITOR.plugins.setLang( 'clipboard', 'lv', {
 	cut: 'Izgriezt',
 	cutError: 'Jūsu pārlūkprogrammas drošības iestatījumi nepieļauj redaktoram automātiski veikt izgriezšanas darbību.  Lūdzu, izmantojiet (Ctrl/Cmd+X), lai veiktu šo darbību.',
 	paste: 'Ielīmēt',
-	pasteMsg: 'Lūdzu, ievietojiet tekstu šajā laukumā, izmantojot klaviatūru (<STRONG>Ctrl/Cmd+V</STRONG>) un apstipriniet ar <STRONG>Darīts!</STRONG>.'
+	pasteDefaultMsg: 'Your browser doesn\'t allow you to paste this way. Press %1 to paste.' // MISSING
 } );

--- a/plugins/clipboard/lang/mk.js
+++ b/plugins/clipboard/lang/mk.js
@@ -8,5 +8,5 @@ CKEDITOR.plugins.setLang( 'clipboard', 'mk', {
 	cut: 'Исечи (Cut)',
 	cutError: 'Опциите за безбедност на вашиот прелистувач не дозволуваат уредувачот автоматски да изврши сечење. Ве молиме употребете ја тастатурата. (Ctrl/Cmd+C)',
 	paste: 'Залепи (Paste)',
-	pasteMsg: 'Ве молиме да залепите во следниот квадрат користејќи ја тастатурата (<string>Ctrl/Cmd+V</string>) и да притиснете OK'
+	pasteDefaultMsg: 'Your browser doesn\'t allow you to paste this way. Press %1 to paste.' // MISSING
 } );

--- a/plugins/clipboard/lang/mk.js
+++ b/plugins/clipboard/lang/mk.js
@@ -8,5 +8,5 @@ CKEDITOR.plugins.setLang( 'clipboard', 'mk', {
 	cut: 'Исечи (Cut)',
 	cutError: 'Опциите за безбедност на вашиот прелистувач не дозволуваат уредувачот автоматски да изврши сечење. Ве молиме употребете ја тастатурата. (Ctrl/Cmd+C)',
 	paste: 'Залепи (Paste)',
-	pasteDefaultMsg: 'Your browser doesn\'t allow you to paste this way. Press %1 to paste.' // MISSING
+	pasteNotification: 'Your browser doesn\'t allow you to paste this way. Press %1 to paste.' // MISSING
 } );

--- a/plugins/clipboard/lang/mn.js
+++ b/plugins/clipboard/lang/mn.js
@@ -8,5 +8,5 @@ CKEDITOR.plugins.setLang( 'clipboard', 'mn', {
 	cut: 'Хайчлах',
 	cutError: 'Таны browser-ын хамгаалалтын тохиргоо editor-д автоматаар хайчлах үйлдэлийг зөвшөөрөхгүй байна. (Ctrl/Cmd+X) товчны хослолыг ашиглана уу.',
 	paste: 'Буулгах',
-	pasteMsg: '(<strong>Ctrl/Cmd+V</strong>) товчийг ашиглан paste хийнэ үү. Мөн <strong>OK</strong> дар.'
+	pasteDefaultMsg: 'Your browser doesn\'t allow you to paste this way. Press %1 to paste.' // MISSING
 } );

--- a/plugins/clipboard/lang/mn.js
+++ b/plugins/clipboard/lang/mn.js
@@ -8,5 +8,5 @@ CKEDITOR.plugins.setLang( 'clipboard', 'mn', {
 	cut: 'Хайчлах',
 	cutError: 'Таны browser-ын хамгаалалтын тохиргоо editor-д автоматаар хайчлах үйлдэлийг зөвшөөрөхгүй байна. (Ctrl/Cmd+X) товчны хослолыг ашиглана уу.',
 	paste: 'Буулгах',
-	pasteDefaultMsg: 'Your browser doesn\'t allow you to paste this way. Press %1 to paste.' // MISSING
+	pasteNotification: 'Your browser doesn\'t allow you to paste this way. Press %1 to paste.' // MISSING
 } );

--- a/plugins/clipboard/lang/ms.js
+++ b/plugins/clipboard/lang/ms.js
@@ -8,5 +8,5 @@ CKEDITOR.plugins.setLang( 'clipboard', 'ms', {
 	cut: 'Potong',
 	cutError: 'Keselamatan perisian browser anda tidak membenarkan operasi suntingan text/imej. Sila gunakan papan kekunci (Ctrl/Cmd+X).',
 	paste: 'Tampal',
-	pasteDefaultMsg: 'Your browser doesn\'t allow you to paste this way. Press %1 to paste.' // MISSING
+	pasteNotification: 'Your browser doesn\'t allow you to paste this way. Press %1 to paste.' // MISSING
 } );

--- a/plugins/clipboard/lang/ms.js
+++ b/plugins/clipboard/lang/ms.js
@@ -8,5 +8,5 @@ CKEDITOR.plugins.setLang( 'clipboard', 'ms', {
 	cut: 'Potong',
 	cutError: 'Keselamatan perisian browser anda tidak membenarkan operasi suntingan text/imej. Sila gunakan papan kekunci (Ctrl/Cmd+X).',
 	paste: 'Tampal',
-	pasteMsg: 'Your browser doesn\'t allow you to paste this way. Press %1 to paste.' // MISSING
+	pasteDefaultMsg: 'Your browser doesn\'t allow you to paste this way. Press %1 to paste.' // MISSING
 } );

--- a/plugins/clipboard/lang/nb.js
+++ b/plugins/clipboard/lang/nb.js
@@ -8,5 +8,5 @@ CKEDITOR.plugins.setLang( 'clipboard', 'nb', {
 	cut: 'Klipp ut',
 	cutError: 'Din nettlesers sikkerhetsinstillinger tillater ikke automatisk utklipping av tekst. Vennligst bruk tastatursnarveien (Ctrl/Cmd+X).',
 	paste: 'Lim inn',
-	pasteDefaultMsg: 'Your browser doesn\'t allow you to paste this way. Press %1 to paste.' // MISSING
+	pasteNotification: 'Your browser doesn\'t allow you to paste this way. Press %1 to paste.' // MISSING
 } );

--- a/plugins/clipboard/lang/nb.js
+++ b/plugins/clipboard/lang/nb.js
@@ -8,5 +8,5 @@ CKEDITOR.plugins.setLang( 'clipboard', 'nb', {
 	cut: 'Klipp ut',
 	cutError: 'Din nettlesers sikkerhetsinstillinger tillater ikke automatisk utklipping av tekst. Vennligst bruk tastatursnarveien (Ctrl/Cmd+X).',
 	paste: 'Lim inn',
-	pasteMsg: 'Vennligst lim inn i følgende boks med tastaturet (<strong>Ctrl/Cmd+V</strong>) og trykk <strong>OK</strong>.'
+	pasteDefaultMsg: 'Your browser doesn\'t allow you to paste this way. Press %1 to paste.' // MISSING
 } );

--- a/plugins/clipboard/lang/nl.js
+++ b/plugins/clipboard/lang/nl.js
@@ -8,5 +8,5 @@ CKEDITOR.plugins.setLang( 'clipboard', 'nl', {
 	cut: 'Knippen',
 	cutError: 'De beveiligingsinstelling van de browser verhinderen het automatisch knippen. Gebruik de sneltoets Ctrl/Cmd+X van het toetsenbord.',
 	paste: 'Plakken',
-	pasteMsg: 'Plak de tekst in het volgende vak gebruikmakend van uw toetsenbord (<strong>Ctrl/Cmd+V</strong>) en klik op OK.'
+	pasteDefaultMsg: 'Your browser doesn\'t allow you to paste this way. Press %1 to paste.' // MISSING
 } );

--- a/plugins/clipboard/lang/nl.js
+++ b/plugins/clipboard/lang/nl.js
@@ -8,5 +8,5 @@ CKEDITOR.plugins.setLang( 'clipboard', 'nl', {
 	cut: 'Knippen',
 	cutError: 'De beveiligingsinstelling van de browser verhinderen het automatisch knippen. Gebruik de sneltoets Ctrl/Cmd+X van het toetsenbord.',
 	paste: 'Plakken',
-	pasteDefaultMsg: 'Your browser doesn\'t allow you to paste this way. Press %1 to paste.' // MISSING
+	pasteNotification: 'Your browser doesn\'t allow you to paste this way. Press %1 to paste.' // MISSING
 } );

--- a/plugins/clipboard/lang/no.js
+++ b/plugins/clipboard/lang/no.js
@@ -8,5 +8,5 @@ CKEDITOR.plugins.setLang( 'clipboard', 'no', {
 	cut: 'Klipp ut',
 	cutError: 'Din nettlesers sikkerhetsinstillinger tillater ikke automatisk utklipping av tekst. Vennligst bruk snarveien (Ctrl/Cmd+X).',
 	paste: 'Lim inn',
-	pasteMsg: 'Vennligst lim inn i følgende boks med tastaturet (<STRONG>Ctrl/Cmd+V</STRONG>) og trykk <STRONG>OK</STRONG>.'
+	pasteDefaultMsg: 'Your browser doesn\'t allow you to paste this way. Press %1 to paste.' // MISSING
 } );

--- a/plugins/clipboard/lang/no.js
+++ b/plugins/clipboard/lang/no.js
@@ -8,5 +8,5 @@ CKEDITOR.plugins.setLang( 'clipboard', 'no', {
 	cut: 'Klipp ut',
 	cutError: 'Din nettlesers sikkerhetsinstillinger tillater ikke automatisk utklipping av tekst. Vennligst bruk snarveien (Ctrl/Cmd+X).',
 	paste: 'Lim inn',
-	pasteDefaultMsg: 'Your browser doesn\'t allow you to paste this way. Press %1 to paste.' // MISSING
+	pasteNotification: 'Your browser doesn\'t allow you to paste this way. Press %1 to paste.' // MISSING
 } );

--- a/plugins/clipboard/lang/oc.js
+++ b/plugins/clipboard/lang/oc.js
@@ -8,5 +8,5 @@ CKEDITOR.plugins.setLang( 'clipboard', 'oc', {
 	cut: 'Talhar',
 	cutError: 'Los paramètres de seguretat de vòstre navigador autorizan pas l\'editor a executar automaticament l\'operacion « Talhar ». Utilizatz l\'acorchi de clavièr a aqueste efièit (Ctrl/Cmd+X).',
 	paste: 'Pegar',
-	pasteMsg: 'Pegatz lo tèxte dins la zòna seguenta en utilizant l\'acorchi de clavièr (<strong>Ctrl/Cmd+V</strong>) e clicatz sus D\'acòrdi.'
+	pasteDefaultMsg: 'Your browser doesn\'t allow you to paste this way. Press %1 to paste.' // MISSING
 } );

--- a/plugins/clipboard/lang/oc.js
+++ b/plugins/clipboard/lang/oc.js
@@ -8,5 +8,5 @@ CKEDITOR.plugins.setLang( 'clipboard', 'oc', {
 	cut: 'Talhar',
 	cutError: 'Los paramètres de seguretat de vòstre navigador autorizan pas l\'editor a executar automaticament l\'operacion « Talhar ». Utilizatz l\'acorchi de clavièr a aqueste efièit (Ctrl/Cmd+X).',
 	paste: 'Pegar',
-	pasteDefaultMsg: 'Your browser doesn\'t allow you to paste this way. Press %1 to paste.' // MISSING
+	pasteNotification: 'Your browser doesn\'t allow you to paste this way. Press %1 to paste.' // MISSING
 } );

--- a/plugins/clipboard/lang/pl.js
+++ b/plugins/clipboard/lang/pl.js
@@ -8,5 +8,5 @@ CKEDITOR.plugins.setLang( 'clipboard', 'pl', {
 	cut: 'Wytnij',
 	cutError: 'Ustawienia bezpieczeństwa Twojej przeglądarki nie pozwalają na automatyczne wycinanie tekstu. Użyj skrótu klawiszowego Ctrl/Cmd+X.',
 	paste: 'Wklej',
-	pasteMsg: 'Wklej tekst w poniższym polu, używając skrótu klawiaturowego (<STRONG>Ctrl/Cmd+V</STRONG>), i kliknij <STRONG>OK</STRONG>.'
+	pasteDefaultMsg: 'Your browser doesn\'t allow you to paste this way. Press %1 to paste.' // MISSING
 } );

--- a/plugins/clipboard/lang/pl.js
+++ b/plugins/clipboard/lang/pl.js
@@ -8,5 +8,5 @@ CKEDITOR.plugins.setLang( 'clipboard', 'pl', {
 	cut: 'Wytnij',
 	cutError: 'Ustawienia bezpieczeństwa Twojej przeglądarki nie pozwalają na automatyczne wycinanie tekstu. Użyj skrótu klawiszowego Ctrl/Cmd+X.',
 	paste: 'Wklej',
-	pasteDefaultMsg: 'Your browser doesn\'t allow you to paste this way. Press %1 to paste.' // MISSING
+	pasteNotification: 'Your browser doesn\'t allow you to paste this way. Press %1 to paste.' // MISSING
 } );

--- a/plugins/clipboard/lang/pt-br.js
+++ b/plugins/clipboard/lang/pt-br.js
@@ -8,5 +8,5 @@ CKEDITOR.plugins.setLang( 'clipboard', 'pt-br', {
 	cut: 'Recortar',
 	cutError: 'As configurações de segurança do seu navegador não permitem que o editor execute operações de recortar automaticamente. Por favor, utilize o teclado para recortar (Ctrl/Cmd+X).',
 	paste: 'Colar',
-	pasteDefaultMsg: 'Your browser doesn\'t allow you to paste this way. Press %1 to paste.' // MISSING
+	pasteNotification: 'Your browser doesn\'t allow you to paste this way. Press %1 to paste.' // MISSING
 } );

--- a/plugins/clipboard/lang/pt-br.js
+++ b/plugins/clipboard/lang/pt-br.js
@@ -8,5 +8,5 @@ CKEDITOR.plugins.setLang( 'clipboard', 'pt-br', {
 	cut: 'Recortar',
 	cutError: 'As configurações de segurança do seu navegador não permitem que o editor execute operações de recortar automaticamente. Por favor, utilize o teclado para recortar (Ctrl/Cmd+X).',
 	paste: 'Colar',
-	pasteMsg: 'Transfira o link usado na caixa usando o teclado com (<STRONG>Ctrl/Cmd+V</STRONG>) e <STRONG>OK</STRONG>.'
+	pasteDefaultMsg: 'Your browser doesn\'t allow you to paste this way. Press %1 to paste.' // MISSING
 } );

--- a/plugins/clipboard/lang/pt.js
+++ b/plugins/clipboard/lang/pt.js
@@ -8,5 +8,5 @@ CKEDITOR.plugins.setLang( 'clipboard', 'pt', {
 	cut: 'Cortar',
 	cutError: 'A configuração de segurança do navegador não permite a execução automática de operações de cortar. Por favor use o teclado (Ctrl/Cmd+X).',
 	paste: 'Colar',
-	pasteMsg: 'Por favor, cole dentro da seguinte caixa usando o teclado (<STRONG>Ctrl/Cmd+V</STRONG>) e carregue em <STRONG>OK</STRONG>.'
+	pasteDefaultMsg: 'Your browser doesn\'t allow you to paste this way. Press %1 to paste.' // MISSING
 } );

--- a/plugins/clipboard/lang/pt.js
+++ b/plugins/clipboard/lang/pt.js
@@ -8,5 +8,5 @@ CKEDITOR.plugins.setLang( 'clipboard', 'pt', {
 	cut: 'Cortar',
 	cutError: 'A configuração de segurança do navegador não permite a execução automática de operações de cortar. Por favor use o teclado (Ctrl/Cmd+X).',
 	paste: 'Colar',
-	pasteDefaultMsg: 'Your browser doesn\'t allow you to paste this way. Press %1 to paste.' // MISSING
+	pasteNotification: 'Your browser doesn\'t allow you to paste this way. Press %1 to paste.' // MISSING
 } );

--- a/plugins/clipboard/lang/ro.js
+++ b/plugins/clipboard/lang/ro.js
@@ -8,5 +8,5 @@ CKEDITOR.plugins.setLang( 'clipboard', 'ro', {
 	cut: 'Taie',
 	cutError: 'Setările de securitate ale navigatorului (browser) pe care îl folosiţi nu permit editorului să execute automat operaţiunea de tăiere. Vă rugăm folosiţi tastatura (Ctrl/Cmd+X).',
 	paste: 'Adaugă',
-	pasteDefaultMsg: 'Your browser doesn\'t allow you to paste this way. Press %1 to paste.' // MISSING
+	pasteNotification: 'Your browser doesn\'t allow you to paste this way. Press %1 to paste.' // MISSING
 } );

--- a/plugins/clipboard/lang/ro.js
+++ b/plugins/clipboard/lang/ro.js
@@ -8,5 +8,5 @@ CKEDITOR.plugins.setLang( 'clipboard', 'ro', {
 	cut: 'Taie',
 	cutError: 'Setările de securitate ale navigatorului (browser) pe care îl folosiţi nu permit editorului să execute automat operaţiunea de tăiere. Vă rugăm folosiţi tastatura (Ctrl/Cmd+X).',
 	paste: 'Adaugă',
-	pasteMsg: 'Vă rugăm adăugaţi în căsuţa următoare folosind tastatura (<strong>Ctrl/Cmd+V</strong>) şi apăsaţi OK'
+	pasteDefaultMsg: 'Your browser doesn\'t allow you to paste this way. Press %1 to paste.' // MISSING
 } );

--- a/plugins/clipboard/lang/ru.js
+++ b/plugins/clipboard/lang/ru.js
@@ -8,5 +8,5 @@ CKEDITOR.plugins.setLang( 'clipboard', 'ru', {
 	cut: 'Вырезать',
 	cutError: 'Настройки безопасности вашего браузера не разрешают редактору выполнять операции по вырезке текста. Пожалуйста, используйте для этого клавиатуру (Ctrl/Cmd+X).',
 	paste: 'Вставить',
-	pasteMsg: 'Пожалуйста, вставьте текст в зону ниже, используя клавиатуру (<strong>Ctrl/Cmd+V</strong>) и нажмите кнопку "OK".'
+	pasteDefaultMsg: 'Your browser doesn\'t allow you to paste this way. Press %1 to paste.' // MISSING
 } );

--- a/plugins/clipboard/lang/ru.js
+++ b/plugins/clipboard/lang/ru.js
@@ -8,5 +8,5 @@ CKEDITOR.plugins.setLang( 'clipboard', 'ru', {
 	cut: 'Вырезать',
 	cutError: 'Настройки безопасности вашего браузера не разрешают редактору выполнять операции по вырезке текста. Пожалуйста, используйте для этого клавиатуру (Ctrl/Cmd+X).',
 	paste: 'Вставить',
-	pasteDefaultMsg: 'Your browser doesn\'t allow you to paste this way. Press %1 to paste.' // MISSING
+	pasteNotification: 'Your browser doesn\'t allow you to paste this way. Press %1 to paste.' // MISSING
 } );

--- a/plugins/clipboard/lang/si.js
+++ b/plugins/clipboard/lang/si.js
@@ -8,5 +8,5 @@ CKEDITOR.plugins.setLang( 'clipboard', 'si', {
 	cut: 'කපාගන්න',
 	cutError: 'Your browser security settings don\'t permit the editor to automatically execute cutting operations. Please use the keyboard for that (Ctrl/Cmd+X).', // MISSING
 	paste: 'අලවන්න',
-	pasteMsg: 'Your browser doesn\'t allow you to paste this way. Press %1 to paste.' // MISSING
+	pasteDefaultMsg: 'Your browser doesn\'t allow you to paste this way. Press %1 to paste.' // MISSING
 } );

--- a/plugins/clipboard/lang/si.js
+++ b/plugins/clipboard/lang/si.js
@@ -8,5 +8,5 @@ CKEDITOR.plugins.setLang( 'clipboard', 'si', {
 	cut: 'කපාගන්න',
 	cutError: 'Your browser security settings don\'t permit the editor to automatically execute cutting operations. Please use the keyboard for that (Ctrl/Cmd+X).', // MISSING
 	paste: 'අලවන්න',
-	pasteDefaultMsg: 'Your browser doesn\'t allow you to paste this way. Press %1 to paste.' // MISSING
+	pasteNotification: 'Your browser doesn\'t allow you to paste this way. Press %1 to paste.' // MISSING
 } );

--- a/plugins/clipboard/lang/sk.js
+++ b/plugins/clipboard/lang/sk.js
@@ -8,5 +8,5 @@ CKEDITOR.plugins.setLang( 'clipboard', 'sk', {
 	cut: 'Vystrihnúť',
 	cutError: 'Bezpečnostné nastavenia vášho prehliadača nedovoľujú editoru automaticky spustiť operáciu vystrihnutia. Použite na to klávesnicu (Ctrl/Cmd+X).',
 	paste: 'Vložiť',
-	pasteDefaultMsg: 'Your browser doesn\'t allow you to paste this way. Press %1 to paste.' // MISSING
+	pasteNotification: 'Your browser doesn\'t allow you to paste this way. Press %1 to paste.' // MISSING
 } );

--- a/plugins/clipboard/lang/sk.js
+++ b/plugins/clipboard/lang/sk.js
@@ -8,5 +8,5 @@ CKEDITOR.plugins.setLang( 'clipboard', 'sk', {
 	cut: 'Vystrihnúť',
 	cutError: 'Bezpečnostné nastavenia vášho prehliadača nedovoľujú editoru automaticky spustiť operáciu vystrihnutia. Použite na to klávesnicu (Ctrl/Cmd+X).',
 	paste: 'Vložiť',
-	pasteMsg: 'Použitím klávesnice (<STRONG>Ctrl/Cmd+V</STRONG>) vložte text do rámčeka a stlačte OK.'
+	pasteDefaultMsg: 'Your browser doesn\'t allow you to paste this way. Press %1 to paste.' // MISSING
 } );

--- a/plugins/clipboard/lang/sl.js
+++ b/plugins/clipboard/lang/sl.js
@@ -8,5 +8,5 @@ CKEDITOR.plugins.setLang( 'clipboard', 'sl', {
 	cut: 'Izreži',
 	cutError: 'Varnostne nastavitve brskalnika ne dopuščajo samodejnega izrezovanja. Uporabite kombinacijo tipk na tipkovnici (Ctrl/Cmd+X).',
 	paste: 'Prilepi',
-	pasteDefaultMsg: 'Your browser doesn\'t allow you to paste this way. Press %1 to paste.' // MISSING
+	pasteNotification: 'Your browser doesn\'t allow you to paste this way. Press %1 to paste.' // MISSING
 } );

--- a/plugins/clipboard/lang/sl.js
+++ b/plugins/clipboard/lang/sl.js
@@ -8,5 +8,5 @@ CKEDITOR.plugins.setLang( 'clipboard', 'sl', {
 	cut: 'Izreži',
 	cutError: 'Varnostne nastavitve brskalnika ne dopuščajo samodejnega izrezovanja. Uporabite kombinacijo tipk na tipkovnici (Ctrl/Cmd+X).',
 	paste: 'Prilepi',
-	pasteMsg: 'Prosimo, prilepite v sleči okvir s pomočjo tipkovnice (<strong>Ctrl/Cmd+V</strong>) in pritisnite V redu.'
+	pasteDefaultMsg: 'Your browser doesn\'t allow you to paste this way. Press %1 to paste.' // MISSING
 } );

--- a/plugins/clipboard/lang/sq.js
+++ b/plugins/clipboard/lang/sq.js
@@ -8,5 +8,5 @@ CKEDITOR.plugins.setLang( 'clipboard', 'sq', {
 	cut: 'Preje',
 	cutError: 'Të dhënat e sigurisë së shfletuesit tuaj nuk lejojnë që redaktuesi automatikisht të kryej veprimin e prerjes. Ju lutemi shfrytëzoni tastierën për këtë veprim (Ctrl/Cmd+X).',
 	paste: 'Hidhe',
-	pasteMsg: 'Ju lutemi hidhni brenda kutizës në vijim duke shfrytëzuar tastierën (<strong>Ctrl/Cmd+V</strong>) dhe shtypni Mirë.'
+	pasteDefaultMsg: 'Your browser doesn\'t allow you to paste this way. Press %1 to paste.' // MISSING
 } );

--- a/plugins/clipboard/lang/sq.js
+++ b/plugins/clipboard/lang/sq.js
@@ -8,5 +8,5 @@ CKEDITOR.plugins.setLang( 'clipboard', 'sq', {
 	cut: 'Preje',
 	cutError: 'Të dhënat e sigurisë së shfletuesit tuaj nuk lejojnë që redaktuesi automatikisht të kryej veprimin e prerjes. Ju lutemi shfrytëzoni tastierën për këtë veprim (Ctrl/Cmd+X).',
 	paste: 'Hidhe',
-	pasteDefaultMsg: 'Your browser doesn\'t allow you to paste this way. Press %1 to paste.' // MISSING
+	pasteNotification: 'Your browser doesn\'t allow you to paste this way. Press %1 to paste.' // MISSING
 } );

--- a/plugins/clipboard/lang/sr-latn.js
+++ b/plugins/clipboard/lang/sr-latn.js
@@ -8,5 +8,5 @@ CKEDITOR.plugins.setLang( 'clipboard', 'sr-latn', {
 	cut: 'Iseci',
 	cutError: 'Sigurnosna podešavanja Vašeg pretraživača ne dozvoljavaju operacije automatskog isecanja teksta. Molimo Vas da koristite prečicu sa tastature (Ctrl/Cmd+X).',
 	paste: 'Zalepi',
-	pasteMsg: 'Molimo Vas da zalepite unutar donje povrine koristeći tastaturnu prečicu (<STRONG>Ctrl/Cmd+V</STRONG>) i da pritisnete <STRONG>OK</STRONG>.'
+	pasteDefaultMsg: 'Your browser doesn\'t allow you to paste this way. Press %1 to paste.' // MISSING
 } );

--- a/plugins/clipboard/lang/sr-latn.js
+++ b/plugins/clipboard/lang/sr-latn.js
@@ -8,5 +8,5 @@ CKEDITOR.plugins.setLang( 'clipboard', 'sr-latn', {
 	cut: 'Iseci',
 	cutError: 'Sigurnosna podešavanja Vašeg pretraživača ne dozvoljavaju operacije automatskog isecanja teksta. Molimo Vas da koristite prečicu sa tastature (Ctrl/Cmd+X).',
 	paste: 'Zalepi',
-	pasteDefaultMsg: 'Your browser doesn\'t allow you to paste this way. Press %1 to paste.' // MISSING
+	pasteNotification: 'Your browser doesn\'t allow you to paste this way. Press %1 to paste.' // MISSING
 } );

--- a/plugins/clipboard/lang/sr.js
+++ b/plugins/clipboard/lang/sr.js
@@ -8,5 +8,5 @@ CKEDITOR.plugins.setLang( 'clipboard', 'sr', {
 	cut: 'Исеци',
 	cutError: 'Сигурносна подешавања Вашег претраживача не дозвољавају операције аутоматског исецања текста. Молимо Вас да користите пречицу са тастатуре (Ctrl/Cmd+X).',
 	paste: 'Залепи',
-	pasteDefaultMsg: 'Your browser doesn\'t allow you to paste this way. Press %1 to paste.' // MISSING
+	pasteNotification: 'Your browser doesn\'t allow you to paste this way. Press %1 to paste.' // MISSING
 } );

--- a/plugins/clipboard/lang/sr.js
+++ b/plugins/clipboard/lang/sr.js
@@ -8,5 +8,5 @@ CKEDITOR.plugins.setLang( 'clipboard', 'sr', {
 	cut: 'Исеци',
 	cutError: 'Сигурносна подешавања Вашег претраживача не дозвољавају операције аутоматског исецања текста. Молимо Вас да користите пречицу са тастатуре (Ctrl/Cmd+X).',
 	paste: 'Залепи',
-	pasteMsg: 'Молимо Вас да залепите унутар доње површине користећи тастатурну пречицу (<STRONG>Ctrl/Cmd+V</STRONG>) и да притиснете <STRONG>OK</STRONG>.'
+	pasteDefaultMsg: 'Your browser doesn\'t allow you to paste this way. Press %1 to paste.' // MISSING
 } );

--- a/plugins/clipboard/lang/sv.js
+++ b/plugins/clipboard/lang/sv.js
@@ -8,5 +8,5 @@ CKEDITOR.plugins.setLang( 'clipboard', 'sv', {
 	cut: 'Klipp ut',
 	cutError: 'Säkerhetsinställningar i Er webbläsare tillåter inte åtgärden klipp ut. Använd (Ctrl/Cmd+X) istället.',
 	paste: 'Klistra in',
-	pasteDefaultMsg: 'Your browser doesn\'t allow you to paste this way. Press %1 to paste.' // MISSING
+	pasteNotification: 'Your browser doesn\'t allow you to paste this way. Press %1 to paste.' // MISSING
 } );

--- a/plugins/clipboard/lang/sv.js
+++ b/plugins/clipboard/lang/sv.js
@@ -8,5 +8,5 @@ CKEDITOR.plugins.setLang( 'clipboard', 'sv', {
 	cut: 'Klipp ut',
 	cutError: 'Säkerhetsinställningar i Er webbläsare tillåter inte åtgärden klipp ut. Använd (Ctrl/Cmd+X) istället.',
 	paste: 'Klistra in',
-	pasteMsg: 'Var god och klistra in Er text i rutan nedan genom att använda (<strong>Ctrl/Cmd+V</strong>) klicka sen på OK.'
+	pasteDefaultMsg: 'Your browser doesn\'t allow you to paste this way. Press %1 to paste.' // MISSING
 } );

--- a/plugins/clipboard/lang/th.js
+++ b/plugins/clipboard/lang/th.js
@@ -8,5 +8,5 @@ CKEDITOR.plugins.setLang( 'clipboard', 'th', {
 	cut: 'ตัด',
 	cutError: 'ไม่สามารถตัดข้อความที่เลือกไว้ได้เนื่องจากการกำหนดค่าระดับความปลอดภัย. กรุณาใช้ปุ่มลัดเพื่อวางข้อความแทน (กดปุ่ม Ctrl/Cmd และตัว X พร้อมกัน).',
 	paste: 'วาง',
-	pasteDefaultMsg: 'Your browser doesn\'t allow you to paste this way. Press %1 to paste.' // MISSING
+	pasteNotification: 'Your browser doesn\'t allow you to paste this way. Press %1 to paste.' // MISSING
 } );

--- a/plugins/clipboard/lang/th.js
+++ b/plugins/clipboard/lang/th.js
@@ -8,5 +8,5 @@ CKEDITOR.plugins.setLang( 'clipboard', 'th', {
 	cut: 'ตัด',
 	cutError: 'ไม่สามารถตัดข้อความที่เลือกไว้ได้เนื่องจากการกำหนดค่าระดับความปลอดภัย. กรุณาใช้ปุ่มลัดเพื่อวางข้อความแทน (กดปุ่ม Ctrl/Cmd และตัว X พร้อมกัน).',
 	paste: 'วาง',
-	pasteMsg: 'กรุณาใช้คีย์บอร์ดเท่านั้น โดยกดปุ๋ม (<strong>Ctrl/Cmd และ V</strong>)พร้อมๆกัน และกด <strong>OK</strong>.'
+	pasteDefaultMsg: 'Your browser doesn\'t allow you to paste this way. Press %1 to paste.' // MISSING
 } );

--- a/plugins/clipboard/lang/tr.js
+++ b/plugins/clipboard/lang/tr.js
@@ -8,5 +8,5 @@ CKEDITOR.plugins.setLang( 'clipboard', 'tr', {
 	cut: 'Kes',
 	cutError: 'Gezgin yazılımınızın güvenlik ayarları düzenleyicinin otomatik kesme işlemine izin vermiyor. İşlem için (Ctrl/Cmd+X) tuşlarını kullanın.',
 	paste: 'Yapıştır',
-	pasteMsg: 'Lütfen aşağıdaki kutunun içine yapıştırın. (<STRONG>Ctrl/Cmd+V</STRONG>) ve <STRONG>Tamam</STRONG> butonunu tıklayın.'
+	pasteDefaultMsg: 'Your browser doesn\'t allow you to paste this way. Press %1 to paste.' // MISSING
 } );

--- a/plugins/clipboard/lang/tr.js
+++ b/plugins/clipboard/lang/tr.js
@@ -8,5 +8,5 @@ CKEDITOR.plugins.setLang( 'clipboard', 'tr', {
 	cut: 'Kes',
 	cutError: 'Gezgin yazılımınızın güvenlik ayarları düzenleyicinin otomatik kesme işlemine izin vermiyor. İşlem için (Ctrl/Cmd+X) tuşlarını kullanın.',
 	paste: 'Yapıştır',
-	pasteDefaultMsg: 'Your browser doesn\'t allow you to paste this way. Press %1 to paste.' // MISSING
+	pasteNotification: 'Your browser doesn\'t allow you to paste this way. Press %1 to paste.' // MISSING
 } );

--- a/plugins/clipboard/lang/tt.js
+++ b/plugins/clipboard/lang/tt.js
@@ -8,5 +8,5 @@ CKEDITOR.plugins.setLang( 'clipboard', 'tt', {
 	cut: 'Кисеп алу',
 	cutError: 'Браузерыгызның иминлек үзлекләре автоматик рәвештә күчермәләү үтәүне тыя. Тиз төймәләрне (Ctrl/Cmd+C) кулланыгыз.',
 	paste: 'Өстәү',
-	pasteDefaultMsg: 'Your browser doesn\'t allow you to paste this way. Press %1 to paste.' // MISSING
+	pasteNotification: 'Your browser doesn\'t allow you to paste this way. Press %1 to paste.' // MISSING
 } );

--- a/plugins/clipboard/lang/tt.js
+++ b/plugins/clipboard/lang/tt.js
@@ -8,5 +8,5 @@ CKEDITOR.plugins.setLang( 'clipboard', 'tt', {
 	cut: 'Кисеп алу',
 	cutError: 'Браузерыгызның иминлек үзлекләре автоматик рәвештә күчермәләү үтәүне тыя. Тиз төймәләрне (Ctrl/Cmd+C) кулланыгыз.',
 	paste: 'Өстәү',
-	pasteMsg: 'Your browser doesn\'t allow you to paste this way. Press %1 to paste.' // MISSING
+	pasteDefaultMsg: 'Your browser doesn\'t allow you to paste this way. Press %1 to paste.' // MISSING
 } );

--- a/plugins/clipboard/lang/ug.js
+++ b/plugins/clipboard/lang/ug.js
@@ -8,5 +8,5 @@ CKEDITOR.plugins.setLang( 'clipboard', 'ug', {
 	cut: 'كەس',
 	cutError: 'تور كۆرگۈڭىزنىڭ بىخەتەرلىك تەڭشىكى تەھرىرلىگۈچنىڭ كەس مەشغۇلاتىنى ئۆزلۈكىدىن ئىجرا قىلىشىغا يول قويمايدۇ، ھەرپتاختا تېز كۇنۇپكا (Ctrl/Cmd+X) ئارقىلىق تاماملاڭ',
 	paste: 'چاپلا',
-	pasteDefaultMsg: 'Your browser doesn\'t allow you to paste this way. Press %1 to paste.' // MISSING
+	pasteNotification: 'Your browser doesn\'t allow you to paste this way. Press %1 to paste.' // MISSING
 } );

--- a/plugins/clipboard/lang/ug.js
+++ b/plugins/clipboard/lang/ug.js
@@ -8,5 +8,5 @@ CKEDITOR.plugins.setLang( 'clipboard', 'ug', {
 	cut: 'كەس',
 	cutError: 'تور كۆرگۈڭىزنىڭ بىخەتەرلىك تەڭشىكى تەھرىرلىگۈچنىڭ كەس مەشغۇلاتىنى ئۆزلۈكىدىن ئىجرا قىلىشىغا يول قويمايدۇ، ھەرپتاختا تېز كۇنۇپكا (Ctrl/Cmd+X) ئارقىلىق تاماملاڭ',
 	paste: 'چاپلا',
-	pasteMsg: 'ھەرپتاختا تېز كۇنۇپكا (<STRONG>Ctrl/Cmd+V</STRONG>) نى ئىشلىتىپ مەزمۇننى تۆۋەندىكى رامكىغا كۆچۈرۈڭ، ئاندىن <STRONG>جەزملە</STRONG>نى بېسىڭ'
+	pasteDefaultMsg: 'Your browser doesn\'t allow you to paste this way. Press %1 to paste.' // MISSING
 } );

--- a/plugins/clipboard/lang/uk.js
+++ b/plugins/clipboard/lang/uk.js
@@ -8,5 +8,5 @@ CKEDITOR.plugins.setLang( 'clipboard', 'uk', {
 	cut: 'Вирізати',
 	cutError: 'Налаштування безпеки Вашого браузера не дозволяють редактору автоматично виконувати операції вирізування. Будь ласка, використовуйте клавіатуру для цього (Ctrl/Cmd+X)',
 	paste: 'Вставити',
-	pasteMsg: 'Будь ласка, вставте інформацію з буфера обміну в цю область, користуючись комбінацією клавіш (<STRONG>Ctrl/Cmd+V</STRONG>), та натисніть <STRONG>OK</STRONG>.'
+	pasteDefaultMsg: 'Your browser doesn\'t allow you to paste this way. Press %1 to paste.' // MISSING
 } );

--- a/plugins/clipboard/lang/uk.js
+++ b/plugins/clipboard/lang/uk.js
@@ -8,5 +8,5 @@ CKEDITOR.plugins.setLang( 'clipboard', 'uk', {
 	cut: 'Вирізати',
 	cutError: 'Налаштування безпеки Вашого браузера не дозволяють редактору автоматично виконувати операції вирізування. Будь ласка, використовуйте клавіатуру для цього (Ctrl/Cmd+X)',
 	paste: 'Вставити',
-	pasteDefaultMsg: 'Your browser doesn\'t allow you to paste this way. Press %1 to paste.' // MISSING
+	pasteNotification: 'Your browser doesn\'t allow you to paste this way. Press %1 to paste.' // MISSING
 } );

--- a/plugins/clipboard/lang/vi.js
+++ b/plugins/clipboard/lang/vi.js
@@ -8,5 +8,5 @@ CKEDITOR.plugins.setLang( 'clipboard', 'vi', {
 	cut: 'Cắt',
 	cutError: 'Các thiết lập bảo mật của trình duyệt không cho phép trình biên tập tự động thực thi lệnh cắt. Hãy sử dụng bàn phím cho lệnh này (Ctrl/Cmd+X).',
 	paste: 'Dán',
-	pasteMsg: 'Hãy dán nội dung vào trong khung bên dưới, sử dụng tổ hợp phím (<STRONG>Ctrl/Cmd+V</STRONG>) và nhấn vào nút <STRONG>Đồng ý</STRONG>.'
+	pasteDefaultMsg: 'Your browser doesn\'t allow you to paste this way. Press %1 to paste.' // MISSING
 } );

--- a/plugins/clipboard/lang/vi.js
+++ b/plugins/clipboard/lang/vi.js
@@ -8,5 +8,5 @@ CKEDITOR.plugins.setLang( 'clipboard', 'vi', {
 	cut: 'Cắt',
 	cutError: 'Các thiết lập bảo mật của trình duyệt không cho phép trình biên tập tự động thực thi lệnh cắt. Hãy sử dụng bàn phím cho lệnh này (Ctrl/Cmd+X).',
 	paste: 'Dán',
-	pasteDefaultMsg: 'Your browser doesn\'t allow you to paste this way. Press %1 to paste.' // MISSING
+	pasteNotification: 'Your browser doesn\'t allow you to paste this way. Press %1 to paste.' // MISSING
 } );

--- a/plugins/clipboard/lang/zh-cn.js
+++ b/plugins/clipboard/lang/zh-cn.js
@@ -8,5 +8,5 @@ CKEDITOR.plugins.setLang( 'clipboard', 'zh-cn', {
 	cut: '剪切',
 	cutError: '您的浏览器安全设置不允许编辑器自动执行剪切操作，请使用键盘快捷键(Ctrl/Cmd+X)来完成。',
 	paste: '粘贴',
-	pasteMsg: '请使用键盘快捷键(<STRONG>Ctrl/Cmd+V</STRONG>)把内容粘贴到下面的方框里，再按 <STRONG>确定</STRONG>'
+	pasteDefaultMsg: 'Your browser doesn\'t allow you to paste this way. Press %1 to paste.' // MISSING
 } );

--- a/plugins/clipboard/lang/zh-cn.js
+++ b/plugins/clipboard/lang/zh-cn.js
@@ -8,5 +8,5 @@ CKEDITOR.plugins.setLang( 'clipboard', 'zh-cn', {
 	cut: '剪切',
 	cutError: '您的浏览器安全设置不允许编辑器自动执行剪切操作，请使用键盘快捷键(Ctrl/Cmd+X)来完成。',
 	paste: '粘贴',
-	pasteDefaultMsg: 'Your browser doesn\'t allow you to paste this way. Press %1 to paste.' // MISSING
+	pasteNotification: 'Your browser doesn\'t allow you to paste this way. Press %1 to paste.' // MISSING
 } );

--- a/plugins/clipboard/lang/zh.js
+++ b/plugins/clipboard/lang/zh.js
@@ -8,5 +8,5 @@ CKEDITOR.plugins.setLang( 'clipboard', 'zh', {
 	cut: '剪下',
 	cutError: '瀏覽器的安全性設定不允許編輯器自動執行剪下動作。請使用鏐盤快捷鍵 (Ctrl/Cmd+X) 剪下。',
 	paste: '貼上',
-	pasteDefaultMsg: 'Your browser doesn\'t allow you to paste this way. Press %1 to paste.' // MISSING
+	pasteNotification: 'Your browser doesn\'t allow you to paste this way. Press %1 to paste.' // MISSING
 } );

--- a/plugins/clipboard/lang/zh.js
+++ b/plugins/clipboard/lang/zh.js
@@ -8,5 +8,5 @@ CKEDITOR.plugins.setLang( 'clipboard', 'zh', {
 	cut: '剪下',
 	cutError: '瀏覽器的安全性設定不允許編輯器自動執行剪下動作。請使用鏐盤快捷鍵 (Ctrl/Cmd+X) 剪下。',
 	paste: '貼上',
-	pasteMsg: '請使用鍵盤快捷鍵 (<strong>Ctrl/Cmd+V</strong>) 貼到下方區域中並按下「確定」。'
+	pasteDefaultMsg: 'Your browser doesn\'t allow you to paste this way. Press %1 to paste.' // MISSING
 } );

--- a/plugins/clipboard/plugin.js
+++ b/plugins/clipboard/plugin.js
@@ -706,7 +706,7 @@
 						forcedType = data.type,
 						keystroke = CKEDITOR.tools.keystrokeToString( editor.lang.common.keyboard,
 							editor.getCommandKeystroke( this ) ),
-						msg = typeof notification === 'string' ? notification : editor.lang.clipboard.pasteDefaultMsg
+						msg = typeof notification === 'string' ? notification : editor.lang.clipboard.pasteNotification
 							.replace( /%1/, '<kbd aria-label="' + keystroke.aria + '">' + keystroke.display + '</kbd>' ),
 						pastedContent = typeof data === 'string' ? data : data.dataValue;
 

--- a/plugins/clipboard/plugin.js
+++ b/plugins/clipboard/plugin.js
@@ -706,7 +706,7 @@
 						forcedType = data.type,
 						keystroke = CKEDITOR.tools.keystrokeToString( editor.lang.common.keyboard,
 							editor.getCommandKeystroke( this ) ),
-						msg = typeof notification === 'string' ? notification : editor.lang.clipboard.pasteMsg
+						msg = typeof notification === 'string' ? notification : editor.lang.clipboard.pasteDefaultMsg
 							.replace( /%1/, '<kbd aria-label="' + keystroke.aria + '">' + keystroke.display + '</kbd>' ),
 						pastedContent = typeof data === 'string' ? data : data.dataValue;
 

--- a/plugins/pastetext/lang/af.js
+++ b/plugins/pastetext/lang/af.js
@@ -4,5 +4,5 @@ For licensing, see LICENSE.md or http://ckeditor.com/license
 */
 CKEDITOR.plugins.setLang( 'pastetext', 'af', {
 	button: 'Plak as eenvoudige teks',
-	pasteMsg: 'Your browser doesn\'t allow you to paste plain text this way. Press %1 to paste.' // MISSING
+	pasteNotification: 'Your browser doesn\'t allow you to paste plain text this way. Press %1 to paste.' // MISSING
 } );

--- a/plugins/pastetext/lang/ar.js
+++ b/plugins/pastetext/lang/ar.js
@@ -4,5 +4,5 @@ For licensing, see LICENSE.md or http://ckeditor.com/license
 */
 CKEDITOR.plugins.setLang( 'pastetext', 'ar', {
 	button: 'لصق كنص بسيط',
-	pasteMsg: 'Your browser doesn\'t allow you to paste plain text this way. Press %1 to paste.' // MISSING
+	pasteNotification: 'Your browser doesn\'t allow you to paste plain text this way. Press %1 to paste.' // MISSING
 } );

--- a/plugins/pastetext/lang/az.js
+++ b/plugins/pastetext/lang/az.js
@@ -4,5 +4,5 @@ For licensing, see LICENSE.md or http://ckeditor.com/license
 */
 CKEDITOR.plugins.setLang( 'pastetext', 'az', {
 	button: 'Yalnız mətni saxla',
-	pasteMsg: 'Your browser doesn\'t allow you to paste plain text this way. Press %1 to paste.' // MISSING
+	pasteNotification: 'Your browser doesn\'t allow you to paste plain text this way. Press %1 to paste.' // MISSING
 } );

--- a/plugins/pastetext/lang/bg.js
+++ b/plugins/pastetext/lang/bg.js
@@ -4,5 +4,5 @@ For licensing, see LICENSE.md or http://ckeditor.com/license
 */
 CKEDITOR.plugins.setLang( 'pastetext', 'bg', {
 	button: 'Вмъкни като чист текст',
-	pasteMsg: 'Your browser doesn\'t allow you to paste plain text this way. Press %1 to paste.' // MISSING
+	pasteNotification: 'Your browser doesn\'t allow you to paste plain text this way. Press %1 to paste.' // MISSING
 } );

--- a/plugins/pastetext/lang/bn.js
+++ b/plugins/pastetext/lang/bn.js
@@ -4,5 +4,5 @@ For licensing, see LICENSE.md or http://ckeditor.com/license
 */
 CKEDITOR.plugins.setLang( 'pastetext', 'bn', {
 	button: 'সাধারণ টেক্সট হিসেবে পেইস্ট করি',
-	pasteMsg: 'Your browser doesn\'t allow you to paste plain text this way. Press %1 to paste.' // MISSING
+	pasteNotification: 'Your browser doesn\'t allow you to paste plain text this way. Press %1 to paste.' // MISSING
 } );

--- a/plugins/pastetext/lang/bs.js
+++ b/plugins/pastetext/lang/bs.js
@@ -4,5 +4,5 @@ For licensing, see LICENSE.md or http://ckeditor.com/license
 */
 CKEDITOR.plugins.setLang( 'pastetext', 'bs', {
 	button: 'Zalijepi kao obièan tekst',
-	pasteMsg: 'Your browser doesn\'t allow you to paste plain text this way. Press %1 to paste.' // MISSING
+	pasteNotification: 'Your browser doesn\'t allow you to paste plain text this way. Press %1 to paste.' // MISSING
 } );

--- a/plugins/pastetext/lang/ca.js
+++ b/plugins/pastetext/lang/ca.js
@@ -4,5 +4,5 @@ For licensing, see LICENSE.md or http://ckeditor.com/license
 */
 CKEDITOR.plugins.setLang( 'pastetext', 'ca', {
 	button: 'Enganxa com a text no formatat',
-	pasteMsg: 'Your browser doesn\'t allow you to paste plain text this way. Press %1 to paste.' // MISSING
+	pasteNotification: 'Your browser doesn\'t allow you to paste plain text this way. Press %1 to paste.' // MISSING
 } );

--- a/plugins/pastetext/lang/cs.js
+++ b/plugins/pastetext/lang/cs.js
@@ -4,5 +4,5 @@ For licensing, see LICENSE.md or http://ckeditor.com/license
 */
 CKEDITOR.plugins.setLang( 'pastetext', 'cs', {
 	button: 'Vložit jako čistý text',
-	pasteMsg: 'Your browser doesn\'t allow you to paste plain text this way. Press %1 to paste.' // MISSING
+	pasteNotification: 'Your browser doesn\'t allow you to paste plain text this way. Press %1 to paste.' // MISSING
 } );

--- a/plugins/pastetext/lang/cy.js
+++ b/plugins/pastetext/lang/cy.js
@@ -4,5 +4,5 @@ For licensing, see LICENSE.md or http://ckeditor.com/license
 */
 CKEDITOR.plugins.setLang( 'pastetext', 'cy', {
 	button: 'Gludo fel testun plaen',
-	pasteMsg: 'Your browser doesn\'t allow you to paste plain text this way. Press %1 to paste.' // MISSING
+	pasteNotification: 'Your browser doesn\'t allow you to paste plain text this way. Press %1 to paste.' // MISSING
 } );

--- a/plugins/pastetext/lang/da.js
+++ b/plugins/pastetext/lang/da.js
@@ -4,5 +4,5 @@ For licensing, see LICENSE.md or http://ckeditor.com/license
 */
 CKEDITOR.plugins.setLang( 'pastetext', 'da', {
 	button: 'Indsæt som ikke-formateret tekst',
-	pasteMsg: 'Your browser doesn\'t allow you to paste plain text this way. Press %1 to paste.' // MISSING
+	pasteNotification: 'Your browser doesn\'t allow you to paste plain text this way. Press %1 to paste.' // MISSING
 } );

--- a/plugins/pastetext/lang/de-ch.js
+++ b/plugins/pastetext/lang/de-ch.js
@@ -4,5 +4,5 @@ For licensing, see LICENSE.md or http://ckeditor.com/license
 */
 CKEDITOR.plugins.setLang( 'pastetext', 'de-ch', {
 	button: 'Als Klartext einfügen',
-	pasteMsg: 'Your browser doesn\'t allow you to paste plain text this way. Press %1 to paste.' // MISSING
+	pasteNotification: 'Your browser doesn\'t allow you to paste plain text this way. Press %1 to paste.' // MISSING
 } );

--- a/plugins/pastetext/lang/de.js
+++ b/plugins/pastetext/lang/de.js
@@ -4,5 +4,5 @@ For licensing, see LICENSE.md or http://ckeditor.com/license
 */
 CKEDITOR.plugins.setLang( 'pastetext', 'de', {
 	button: 'Als Klartext einfügen',
-	pasteMsg: 'Your browser doesn\'t allow you to paste plain text this way. Press %1 to paste.' // MISSING
+	pasteNotification: 'Your browser doesn\'t allow you to paste plain text this way. Press %1 to paste.' // MISSING
 } );

--- a/plugins/pastetext/lang/el.js
+++ b/plugins/pastetext/lang/el.js
@@ -4,5 +4,5 @@ For licensing, see LICENSE.md or http://ckeditor.com/license
 */
 CKEDITOR.plugins.setLang( 'pastetext', 'el', {
 	button: 'Επικόλληση ως απλό κείμενο',
-	pasteMsg: 'Your browser doesn\'t allow you to paste plain text this way. Press %1 to paste.' // MISSING
+	pasteNotification: 'Your browser doesn\'t allow you to paste plain text this way. Press %1 to paste.' // MISSING
 } );

--- a/plugins/pastetext/lang/en-au.js
+++ b/plugins/pastetext/lang/en-au.js
@@ -4,5 +4,5 @@ For licensing, see LICENSE.md or http://ckeditor.com/license
 */
 CKEDITOR.plugins.setLang( 'pastetext', 'en-au', {
 	button: 'Paste as plain text',
-	pasteMsg: 'Your browser doesn\'t allow you to paste plain text this way. Press %1 to paste.' // MISSING
+	pasteNotification: 'Your browser doesn\'t allow you to paste plain text this way. Press %1 to paste.' // MISSING
 } );

--- a/plugins/pastetext/lang/en-ca.js
+++ b/plugins/pastetext/lang/en-ca.js
@@ -4,5 +4,5 @@ For licensing, see LICENSE.md or http://ckeditor.com/license
 */
 CKEDITOR.plugins.setLang( 'pastetext', 'en-ca', {
 	button: 'Paste as plain text',
-	pasteMsg: 'Your browser doesn\'t allow you to paste plain text this way. Press %1 to paste.' // MISSING
+	pasteNotification: 'Your browser doesn\'t allow you to paste plain text this way. Press %1 to paste.' // MISSING
 } );

--- a/plugins/pastetext/lang/en-gb.js
+++ b/plugins/pastetext/lang/en-gb.js
@@ -4,5 +4,5 @@ For licensing, see LICENSE.md or http://ckeditor.com/license
 */
 CKEDITOR.plugins.setLang( 'pastetext', 'en-gb', {
 	button: 'Paste as plain text',
-	pasteMsg: 'Your browser doesn\'t allow you to paste plain text this way. Press %1 to paste.' // MISSING
+	pasteNotification: 'Your browser doesn\'t allow you to paste plain text this way. Press %1 to paste.' // MISSING
 } );

--- a/plugins/pastetext/lang/en.js
+++ b/plugins/pastetext/lang/en.js
@@ -4,5 +4,5 @@ For licensing, see LICENSE.md or http://ckeditor.com/license
 */
 CKEDITOR.plugins.setLang( 'pastetext', 'en', {
 	button: 'Paste as plain text',
-	pasteMsg: 'Your browser doesn\'t allow you to paste plain text this way. Press %1 to paste.'
+	pasteNotification: 'Your browser doesn\'t allow you to paste plain text this way. Press %1 to paste.'
 } );

--- a/plugins/pastetext/lang/eo.js
+++ b/plugins/pastetext/lang/eo.js
@@ -4,5 +4,5 @@ For licensing, see LICENSE.md or http://ckeditor.com/license
 */
 CKEDITOR.plugins.setLang( 'pastetext', 'eo', {
 	button: 'Interglui kiel platan tekston',
-	pasteMsg: 'Your browser doesn\'t allow you to paste plain text this way. Press %1 to paste.' // MISSING
+	pasteNotification: 'Your browser doesn\'t allow you to paste plain text this way. Press %1 to paste.' // MISSING
 } );

--- a/plugins/pastetext/lang/es.js
+++ b/plugins/pastetext/lang/es.js
@@ -4,5 +4,5 @@ For licensing, see LICENSE.md or http://ckeditor.com/license
 */
 CKEDITOR.plugins.setLang( 'pastetext', 'es', {
 	button: 'Pegar como Texto Plano',
-	pasteMsg: 'Your browser doesn\'t allow you to paste plain text this way. Press %1 to paste.' // MISSING
+	pasteNotification: 'Your browser doesn\'t allow you to paste plain text this way. Press %1 to paste.' // MISSING
 } );

--- a/plugins/pastetext/lang/et.js
+++ b/plugins/pastetext/lang/et.js
@@ -4,5 +4,5 @@ For licensing, see LICENSE.md or http://ckeditor.com/license
 */
 CKEDITOR.plugins.setLang( 'pastetext', 'et', {
 	button: 'Asetamine tavalise tekstina',
-	pasteMsg: 'Your browser doesn\'t allow you to paste plain text this way. Press %1 to paste.' // MISSING
+	pasteNotification: 'Your browser doesn\'t allow you to paste plain text this way. Press %1 to paste.' // MISSING
 } );

--- a/plugins/pastetext/lang/eu.js
+++ b/plugins/pastetext/lang/eu.js
@@ -4,5 +4,5 @@ For licensing, see LICENSE.md or http://ckeditor.com/license
 */
 CKEDITOR.plugins.setLang( 'pastetext', 'eu', {
 	button: 'Itsatsi testu arrunta bezala',
-	pasteMsg: 'Your browser doesn\'t allow you to paste plain text this way. Press %1 to paste.' // MISSING
+	pasteNotification: 'Your browser doesn\'t allow you to paste plain text this way. Press %1 to paste.' // MISSING
 } );

--- a/plugins/pastetext/lang/fa.js
+++ b/plugins/pastetext/lang/fa.js
@@ -4,5 +4,5 @@ For licensing, see LICENSE.md or http://ckeditor.com/license
 */
 CKEDITOR.plugins.setLang( 'pastetext', 'fa', {
 	button: 'چسباندن به عنوان متن ساده',
-	pasteMsg: 'Your browser doesn\'t allow you to paste plain text this way. Press %1 to paste.' // MISSING
+	pasteNotification: 'Your browser doesn\'t allow you to paste plain text this way. Press %1 to paste.' // MISSING
 } );

--- a/plugins/pastetext/lang/fi.js
+++ b/plugins/pastetext/lang/fi.js
@@ -4,5 +4,5 @@ For licensing, see LICENSE.md or http://ckeditor.com/license
 */
 CKEDITOR.plugins.setLang( 'pastetext', 'fi', {
 	button: 'Liitä tekstinä',
-	pasteMsg: 'Your browser doesn\'t allow you to paste plain text this way. Press %1 to paste.' // MISSING
+	pasteNotification: 'Your browser doesn\'t allow you to paste plain text this way. Press %1 to paste.' // MISSING
 } );

--- a/plugins/pastetext/lang/fo.js
+++ b/plugins/pastetext/lang/fo.js
@@ -4,5 +4,5 @@ For licensing, see LICENSE.md or http://ckeditor.com/license
 */
 CKEDITOR.plugins.setLang( 'pastetext', 'fo', {
 	button: 'Innrita som reinan tekst',
-	pasteMsg: 'Your browser doesn\'t allow you to paste plain text this way. Press %1 to paste.' // MISSING
+	pasteNotification: 'Your browser doesn\'t allow you to paste plain text this way. Press %1 to paste.' // MISSING
 } );

--- a/plugins/pastetext/lang/fr-ca.js
+++ b/plugins/pastetext/lang/fr-ca.js
@@ -4,5 +4,5 @@ For licensing, see LICENSE.md or http://ckeditor.com/license
 */
 CKEDITOR.plugins.setLang( 'pastetext', 'fr-ca', {
 	button: 'Coller comme texte',
-	pasteMsg: 'Your browser doesn\'t allow you to paste plain text this way. Press %1 to paste.' // MISSING
+	pasteNotification: 'Your browser doesn\'t allow you to paste plain text this way. Press %1 to paste.' // MISSING
 } );

--- a/plugins/pastetext/lang/fr.js
+++ b/plugins/pastetext/lang/fr.js
@@ -4,5 +4,5 @@ For licensing, see LICENSE.md or http://ckeditor.com/license
 */
 CKEDITOR.plugins.setLang( 'pastetext', 'fr', {
 	button: 'Coller comme texte brut',
-	pasteMsg: 'Your browser doesn\'t allow you to paste plain text this way. Press %1 to paste.' // MISSING
+	pasteNotification: 'Your browser doesn\'t allow you to paste plain text this way. Press %1 to paste.' // MISSING
 } );

--- a/plugins/pastetext/lang/gl.js
+++ b/plugins/pastetext/lang/gl.js
@@ -4,5 +4,5 @@ For licensing, see LICENSE.md or http://ckeditor.com/license
 */
 CKEDITOR.plugins.setLang( 'pastetext', 'gl', {
 	button: 'Pegar como texto simple',
-	pasteMsg: 'Your browser doesn\'t allow you to paste plain text this way. Press %1 to paste.' // MISSING
+	pasteNotification: 'Your browser doesn\'t allow you to paste plain text this way. Press %1 to paste.' // MISSING
 } );

--- a/plugins/pastetext/lang/gu.js
+++ b/plugins/pastetext/lang/gu.js
@@ -4,5 +4,5 @@ For licensing, see LICENSE.md or http://ckeditor.com/license
 */
 CKEDITOR.plugins.setLang( 'pastetext', 'gu', {
 	button: 'પેસ્ટ (ટેક્સ્ટ)',
-	pasteMsg: 'Your browser doesn\'t allow you to paste plain text this way. Press %1 to paste.' // MISSING
+	pasteNotification: 'Your browser doesn\'t allow you to paste plain text this way. Press %1 to paste.' // MISSING
 } );

--- a/plugins/pastetext/lang/he.js
+++ b/plugins/pastetext/lang/he.js
@@ -4,5 +4,5 @@ For licensing, see LICENSE.md or http://ckeditor.com/license
 */
 CKEDITOR.plugins.setLang( 'pastetext', 'he', {
 	button: 'הדבקה כטקסט פשוט',
-	pasteMsg: 'Your browser doesn\'t allow you to paste plain text this way. Press %1 to paste.' // MISSING
+	pasteNotification: 'Your browser doesn\'t allow you to paste plain text this way. Press %1 to paste.' // MISSING
 } );

--- a/plugins/pastetext/lang/hi.js
+++ b/plugins/pastetext/lang/hi.js
@@ -4,5 +4,5 @@ For licensing, see LICENSE.md or http://ckeditor.com/license
 */
 CKEDITOR.plugins.setLang( 'pastetext', 'hi', {
 	button: 'पेस्ट (सादा टॅक्स्ट)',
-	pasteMsg: 'Your browser doesn\'t allow you to paste plain text this way. Press %1 to paste.' // MISSING
+	pasteNotification: 'Your browser doesn\'t allow you to paste plain text this way. Press %1 to paste.' // MISSING
 } );

--- a/plugins/pastetext/lang/hr.js
+++ b/plugins/pastetext/lang/hr.js
@@ -4,5 +4,5 @@ For licensing, see LICENSE.md or http://ckeditor.com/license
 */
 CKEDITOR.plugins.setLang( 'pastetext', 'hr', {
 	button: 'Zalijepi kao čisti tekst',
-	pasteMsg: 'Your browser doesn\'t allow you to paste plain text this way. Press %1 to paste.' // MISSING
+	pasteNotification: 'Your browser doesn\'t allow you to paste plain text this way. Press %1 to paste.' // MISSING
 } );

--- a/plugins/pastetext/lang/hu.js
+++ b/plugins/pastetext/lang/hu.js
@@ -4,5 +4,5 @@ For licensing, see LICENSE.md or http://ckeditor.com/license
 */
 CKEDITOR.plugins.setLang( 'pastetext', 'hu', {
 	button: 'Beillesztés formázatlan szövegként',
-	pasteMsg: 'Your browser doesn\'t allow you to paste plain text this way. Press %1 to paste.' // MISSING
+	pasteNotification: 'Your browser doesn\'t allow you to paste plain text this way. Press %1 to paste.' // MISSING
 } );

--- a/plugins/pastetext/lang/id.js
+++ b/plugins/pastetext/lang/id.js
@@ -4,5 +4,5 @@ For licensing, see LICENSE.md or http://ckeditor.com/license
 */
 CKEDITOR.plugins.setLang( 'pastetext', 'id', {
 	button: 'Tempel sebagai teks polos',
-	pasteMsg: 'Your browser doesn\'t allow you to paste plain text this way. Press %1 to paste.' // MISSING
+	pasteNotification: 'Your browser doesn\'t allow you to paste plain text this way. Press %1 to paste.' // MISSING
 } );

--- a/plugins/pastetext/lang/is.js
+++ b/plugins/pastetext/lang/is.js
@@ -4,5 +4,5 @@ For licensing, see LICENSE.md or http://ckeditor.com/license
 */
 CKEDITOR.plugins.setLang( 'pastetext', 'is', {
 	button: 'Líma sem ósniðinn texta',
-	pasteMsg: 'Your browser doesn\'t allow you to paste plain text this way. Press %1 to paste.' // MISSING
+	pasteNotification: 'Your browser doesn\'t allow you to paste plain text this way. Press %1 to paste.' // MISSING
 } );

--- a/plugins/pastetext/lang/it.js
+++ b/plugins/pastetext/lang/it.js
@@ -4,5 +4,5 @@ For licensing, see LICENSE.md or http://ckeditor.com/license
 */
 CKEDITOR.plugins.setLang( 'pastetext', 'it', {
 	button: 'Incolla come testo semplice',
-	pasteMsg: 'Your browser doesn\'t allow you to paste plain text this way. Press %1 to paste.' // MISSING
+	pasteNotification: 'Your browser doesn\'t allow you to paste plain text this way. Press %1 to paste.' // MISSING
 } );

--- a/plugins/pastetext/lang/ja.js
+++ b/plugins/pastetext/lang/ja.js
@@ -4,5 +4,5 @@ For licensing, see LICENSE.md or http://ckeditor.com/license
 */
 CKEDITOR.plugins.setLang( 'pastetext', 'ja', {
 	button: 'プレーンテキストとして貼り付け',
-	pasteMsg: 'Your browser doesn\'t allow you to paste plain text this way. Press %1 to paste.' // MISSING
+	pasteNotification: 'Your browser doesn\'t allow you to paste plain text this way. Press %1 to paste.' // MISSING
 } );

--- a/plugins/pastetext/lang/ka.js
+++ b/plugins/pastetext/lang/ka.js
@@ -4,5 +4,5 @@ For licensing, see LICENSE.md or http://ckeditor.com/license
 */
 CKEDITOR.plugins.setLang( 'pastetext', 'ka', {
 	button: 'მხოლოდ ტექსტის ჩასმა',
-	pasteMsg: 'Your browser doesn\'t allow you to paste plain text this way. Press %1 to paste.' // MISSING
+	pasteNotification: 'Your browser doesn\'t allow you to paste plain text this way. Press %1 to paste.' // MISSING
 } );

--- a/plugins/pastetext/lang/km.js
+++ b/plugins/pastetext/lang/km.js
@@ -4,5 +4,5 @@ For licensing, see LICENSE.md or http://ckeditor.com/license
 */
 CKEDITOR.plugins.setLang( 'pastetext', 'km', {
 	button: 'បិទ​ភ្ជាប់​ជា​អត្ថបទ​ធម្មតា',
-	pasteMsg: 'Your browser doesn\'t allow you to paste plain text this way. Press %1 to paste.' // MISSING
+	pasteNotification: 'Your browser doesn\'t allow you to paste plain text this way. Press %1 to paste.' // MISSING
 } );

--- a/plugins/pastetext/lang/ko.js
+++ b/plugins/pastetext/lang/ko.js
@@ -4,5 +4,5 @@ For licensing, see LICENSE.md or http://ckeditor.com/license
 */
 CKEDITOR.plugins.setLang( 'pastetext', 'ko', {
 	button: '텍스트로 붙여넣기',
-	pasteMsg: 'Your browser doesn\'t allow you to paste plain text this way. Press %1 to paste.' // MISSING
+	pasteNotification: 'Your browser doesn\'t allow you to paste plain text this way. Press %1 to paste.' // MISSING
 } );

--- a/plugins/pastetext/lang/ku.js
+++ b/plugins/pastetext/lang/ku.js
@@ -4,5 +4,5 @@ For licensing, see LICENSE.md or http://ckeditor.com/license
 */
 CKEDITOR.plugins.setLang( 'pastetext', 'ku', {
 	button: 'لکاندنی وەك دەقی ڕوون',
-	pasteMsg: 'Your browser doesn\'t allow you to paste plain text this way. Press %1 to paste.' // MISSING
+	pasteNotification: 'Your browser doesn\'t allow you to paste plain text this way. Press %1 to paste.' // MISSING
 } );

--- a/plugins/pastetext/lang/lt.js
+++ b/plugins/pastetext/lang/lt.js
@@ -4,5 +4,5 @@ For licensing, see LICENSE.md or http://ckeditor.com/license
 */
 CKEDITOR.plugins.setLang( 'pastetext', 'lt', {
 	button: 'Įdėti kaip gryną tekstą',
-	pasteMsg: 'Your browser doesn\'t allow you to paste plain text this way. Press %1 to paste.' // MISSING
+	pasteNotification: 'Your browser doesn\'t allow you to paste plain text this way. Press %1 to paste.' // MISSING
 } );

--- a/plugins/pastetext/lang/lv.js
+++ b/plugins/pastetext/lang/lv.js
@@ -4,5 +4,5 @@ For licensing, see LICENSE.md or http://ckeditor.com/license
 */
 CKEDITOR.plugins.setLang( 'pastetext', 'lv', {
 	button: 'Ievietot kā vienkāršu tekstu',
-	pasteMsg: 'Your browser doesn\'t allow you to paste plain text this way. Press %1 to paste.' // MISSING
+	pasteNotification: 'Your browser doesn\'t allow you to paste plain text this way. Press %1 to paste.' // MISSING
 } );

--- a/plugins/pastetext/lang/mk.js
+++ b/plugins/pastetext/lang/mk.js
@@ -4,5 +4,5 @@ For licensing, see LICENSE.md or http://ckeditor.com/license
 */
 CKEDITOR.plugins.setLang( 'pastetext', 'mk', {
 	button: 'Paste as plain text', // MISSING
-	pasteMsg: 'Your browser doesn\'t allow you to paste plain text this way. Press %1 to paste.' // MISSING
+	pasteNotification: 'Your browser doesn\'t allow you to paste plain text this way. Press %1 to paste.' // MISSING
 } );

--- a/plugins/pastetext/lang/mn.js
+++ b/plugins/pastetext/lang/mn.js
@@ -4,5 +4,5 @@ For licensing, see LICENSE.md or http://ckeditor.com/license
 */
 CKEDITOR.plugins.setLang( 'pastetext', 'mn', {
 	button: 'Энгийн бичвэрээр буулгах',
-	pasteMsg: 'Your browser doesn\'t allow you to paste plain text this way. Press %1 to paste.' // MISSING
+	pasteNotification: 'Your browser doesn\'t allow you to paste plain text this way. Press %1 to paste.' // MISSING
 } );

--- a/plugins/pastetext/lang/ms.js
+++ b/plugins/pastetext/lang/ms.js
@@ -4,5 +4,5 @@ For licensing, see LICENSE.md or http://ckeditor.com/license
 */
 CKEDITOR.plugins.setLang( 'pastetext', 'ms', {
 	button: 'Tampal sebagai text biasa',
-	pasteMsg: 'Your browser doesn\'t allow you to paste plain text this way. Press %1 to paste.' // MISSING
+	pasteNotification: 'Your browser doesn\'t allow you to paste plain text this way. Press %1 to paste.' // MISSING
 } );

--- a/plugins/pastetext/lang/nb.js
+++ b/plugins/pastetext/lang/nb.js
@@ -4,5 +4,5 @@ For licensing, see LICENSE.md or http://ckeditor.com/license
 */
 CKEDITOR.plugins.setLang( 'pastetext', 'nb', {
 	button: 'Lim inn som ren tekst',
-	pasteMsg: 'Your browser doesn\'t allow you to paste plain text this way. Press %1 to paste.' // MISSING
+	pasteNotification: 'Your browser doesn\'t allow you to paste plain text this way. Press %1 to paste.' // MISSING
 } );

--- a/plugins/pastetext/lang/nl.js
+++ b/plugins/pastetext/lang/nl.js
@@ -4,5 +4,5 @@ For licensing, see LICENSE.md or http://ckeditor.com/license
 */
 CKEDITOR.plugins.setLang( 'pastetext', 'nl', {
 	button: 'Plakken als platte tekst',
-	pasteMsg: 'Your browser doesn\'t allow you to paste plain text this way. Press %1 to paste.' // MISSING
+	pasteNotification: 'Your browser doesn\'t allow you to paste plain text this way. Press %1 to paste.' // MISSING
 } );

--- a/plugins/pastetext/lang/no.js
+++ b/plugins/pastetext/lang/no.js
@@ -4,5 +4,5 @@ For licensing, see LICENSE.md or http://ckeditor.com/license
 */
 CKEDITOR.plugins.setLang( 'pastetext', 'no', {
 	button: 'Lim inn som ren tekst',
-	pasteMsg: 'Your browser doesn\'t allow you to paste plain text this way. Press %1 to paste.' // MISSING
+	pasteNotification: 'Your browser doesn\'t allow you to paste plain text this way. Press %1 to paste.' // MISSING
 } );

--- a/plugins/pastetext/lang/oc.js
+++ b/plugins/pastetext/lang/oc.js
@@ -4,5 +4,5 @@ For licensing, see LICENSE.md or http://ckeditor.com/license
 */
 CKEDITOR.plugins.setLang( 'pastetext', 'oc', {
 	button: 'Pegar coma tèxte brut',
-	pasteMsg: 'Your browser doesn\'t allow you to paste plain text this way. Press %1 to paste.' // MISSING
+	pasteNotification: 'Your browser doesn\'t allow you to paste plain text this way. Press %1 to paste.' // MISSING
 } );

--- a/plugins/pastetext/lang/pl.js
+++ b/plugins/pastetext/lang/pl.js
@@ -4,5 +4,5 @@ For licensing, see LICENSE.md or http://ckeditor.com/license
 */
 CKEDITOR.plugins.setLang( 'pastetext', 'pl', {
 	button: 'Wklej jako czysty tekst',
-	pasteMsg: 'Your browser doesn\'t allow you to paste plain text this way. Press %1 to paste.' // MISSING
+	pasteNotification: 'Your browser doesn\'t allow you to paste plain text this way. Press %1 to paste.' // MISSING
 } );

--- a/plugins/pastetext/lang/pt-br.js
+++ b/plugins/pastetext/lang/pt-br.js
@@ -4,5 +4,5 @@ For licensing, see LICENSE.md or http://ckeditor.com/license
 */
 CKEDITOR.plugins.setLang( 'pastetext', 'pt-br', {
 	button: 'Colar como Texto sem Formatação',
-	pasteMsg: 'Your browser doesn\'t allow you to paste plain text this way. Press %1 to paste.' // MISSING
+	pasteNotification: 'Your browser doesn\'t allow you to paste plain text this way. Press %1 to paste.' // MISSING
 } );

--- a/plugins/pastetext/lang/pt.js
+++ b/plugins/pastetext/lang/pt.js
@@ -4,5 +4,5 @@ For licensing, see LICENSE.md or http://ckeditor.com/license
 */
 CKEDITOR.plugins.setLang( 'pastetext', 'pt', {
 	button: 'Colar como texto simples',
-	pasteMsg: 'Your browser doesn\'t allow you to paste plain text this way. Press %1 to paste.' // MISSING
+	pasteNotification: 'Your browser doesn\'t allow you to paste plain text this way. Press %1 to paste.' // MISSING
 } );

--- a/plugins/pastetext/lang/ro.js
+++ b/plugins/pastetext/lang/ro.js
@@ -4,5 +4,5 @@ For licensing, see LICENSE.md or http://ckeditor.com/license
 */
 CKEDITOR.plugins.setLang( 'pastetext', 'ro', {
 	button: 'Adaugă ca text simplu (Plain Text)',
-	pasteMsg: 'Your browser doesn\'t allow you to paste plain text this way. Press %1 to paste.' // MISSING
+	pasteNotification: 'Your browser doesn\'t allow you to paste plain text this way. Press %1 to paste.' // MISSING
 } );

--- a/plugins/pastetext/lang/ru.js
+++ b/plugins/pastetext/lang/ru.js
@@ -4,5 +4,5 @@ For licensing, see LICENSE.md or http://ckeditor.com/license
 */
 CKEDITOR.plugins.setLang( 'pastetext', 'ru', {
 	button: 'Вставить только текст',
-	pasteMsg: 'Your browser doesn\'t allow you to paste plain text this way. Press %1 to paste.' // MISSING
+	pasteNotification: 'Your browser doesn\'t allow you to paste plain text this way. Press %1 to paste.' // MISSING
 } );

--- a/plugins/pastetext/lang/si.js
+++ b/plugins/pastetext/lang/si.js
@@ -4,5 +4,5 @@ For licensing, see LICENSE.md or http://ckeditor.com/license
 */
 CKEDITOR.plugins.setLang( 'pastetext', 'si', {
 	button: 'සාමාන්‍ය අක්ෂර ලෙස අලවන්න',
-	pasteMsg: 'Your browser doesn\'t allow you to paste plain text this way. Press %1 to paste.' // MISSING
+	pasteNotification: 'Your browser doesn\'t allow you to paste plain text this way. Press %1 to paste.' // MISSING
 } );

--- a/plugins/pastetext/lang/sk.js
+++ b/plugins/pastetext/lang/sk.js
@@ -4,5 +4,5 @@ For licensing, see LICENSE.md or http://ckeditor.com/license
 */
 CKEDITOR.plugins.setLang( 'pastetext', 'sk', {
 	button: 'Vložiť ako čistý text',
-	pasteMsg: 'Your browser doesn\'t allow you to paste plain text this way. Press %1 to paste.' // MISSING
+	pasteNotification: 'Your browser doesn\'t allow you to paste plain text this way. Press %1 to paste.' // MISSING
 } );

--- a/plugins/pastetext/lang/sl.js
+++ b/plugins/pastetext/lang/sl.js
@@ -4,5 +4,5 @@ For licensing, see LICENSE.md or http://ckeditor.com/license
 */
 CKEDITOR.plugins.setLang( 'pastetext', 'sl', {
 	button: 'Prilepi kot golo besedilo',
-	pasteMsg: 'Your browser doesn\'t allow you to paste plain text this way. Press %1 to paste.' // MISSING
+	pasteNotification: 'Your browser doesn\'t allow you to paste plain text this way. Press %1 to paste.' // MISSING
 } );

--- a/plugins/pastetext/lang/sq.js
+++ b/plugins/pastetext/lang/sq.js
@@ -4,5 +4,5 @@ For licensing, see LICENSE.md or http://ckeditor.com/license
 */
 CKEDITOR.plugins.setLang( 'pastetext', 'sq', {
 	button: 'Hidhe si tekst të thjeshtë',
-	pasteMsg: 'Your browser doesn\'t allow you to paste plain text this way. Press %1 to paste.' // MISSING
+	pasteNotification: 'Your browser doesn\'t allow you to paste plain text this way. Press %1 to paste.' // MISSING
 } );

--- a/plugins/pastetext/lang/sr-latn.js
+++ b/plugins/pastetext/lang/sr-latn.js
@@ -4,5 +4,5 @@ For licensing, see LICENSE.md or http://ckeditor.com/license
 */
 CKEDITOR.plugins.setLang( 'pastetext', 'sr-latn', {
 	button: 'Zalepi kao čist tekst',
-	pasteMsg: 'Your browser doesn\'t allow you to paste plain text this way. Press %1 to paste.' // MISSING
+	pasteNotification: 'Your browser doesn\'t allow you to paste plain text this way. Press %1 to paste.' // MISSING
 } );

--- a/plugins/pastetext/lang/sr.js
+++ b/plugins/pastetext/lang/sr.js
@@ -4,5 +4,5 @@ For licensing, see LICENSE.md or http://ckeditor.com/license
 */
 CKEDITOR.plugins.setLang( 'pastetext', 'sr', {
 	button: 'Залепи као чист текст',
-	pasteMsg: 'Your browser doesn\'t allow you to paste plain text this way. Press %1 to paste.' // MISSING
+	pasteNotification: 'Your browser doesn\'t allow you to paste plain text this way. Press %1 to paste.' // MISSING
 } );

--- a/plugins/pastetext/lang/sv.js
+++ b/plugins/pastetext/lang/sv.js
@@ -4,5 +4,5 @@ For licensing, see LICENSE.md or http://ckeditor.com/license
 */
 CKEDITOR.plugins.setLang( 'pastetext', 'sv', {
 	button: 'Klistra in som vanlig text',
-	pasteMsg: 'Your browser doesn\'t allow you to paste plain text this way. Press %1 to paste.' // MISSING
+	pasteNotification: 'Your browser doesn\'t allow you to paste plain text this way. Press %1 to paste.' // MISSING
 } );

--- a/plugins/pastetext/lang/th.js
+++ b/plugins/pastetext/lang/th.js
@@ -4,5 +4,5 @@ For licensing, see LICENSE.md or http://ckeditor.com/license
 */
 CKEDITOR.plugins.setLang( 'pastetext', 'th', {
 	button: 'วางแบบตัวอักษรธรรมดา',
-	pasteMsg: 'Your browser doesn\'t allow you to paste plain text this way. Press %1 to paste.' // MISSING
+	pasteNotification: 'Your browser doesn\'t allow you to paste plain text this way. Press %1 to paste.' // MISSING
 } );

--- a/plugins/pastetext/lang/tr.js
+++ b/plugins/pastetext/lang/tr.js
@@ -4,5 +4,5 @@ For licensing, see LICENSE.md or http://ckeditor.com/license
 */
 CKEDITOR.plugins.setLang( 'pastetext', 'tr', {
 	button: 'Düz Metin Olarak Yapıştır',
-	pasteMsg: 'Your browser doesn\'t allow you to paste plain text this way. Press %1 to paste.' // MISSING
+	pasteNotification: 'Your browser doesn\'t allow you to paste plain text this way. Press %1 to paste.' // MISSING
 } );

--- a/plugins/pastetext/lang/tt.js
+++ b/plugins/pastetext/lang/tt.js
@@ -4,5 +4,5 @@ For licensing, see LICENSE.md or http://ckeditor.com/license
 */
 CKEDITOR.plugins.setLang( 'pastetext', 'tt', {
 	button: 'Форматлаусыз текст өстәү',
-	pasteMsg: 'Your browser doesn\'t allow you to paste plain text this way. Press %1 to paste.' // MISSING
+	pasteNotification: 'Your browser doesn\'t allow you to paste plain text this way. Press %1 to paste.' // MISSING
 } );

--- a/plugins/pastetext/lang/ug.js
+++ b/plugins/pastetext/lang/ug.js
@@ -4,5 +4,5 @@ For licensing, see LICENSE.md or http://ckeditor.com/license
 */
 CKEDITOR.plugins.setLang( 'pastetext', 'ug', {
 	button: 'پىچىمى يوق تېكىست سۈپىتىدە چاپلا',
-	pasteMsg: 'Your browser doesn\'t allow you to paste plain text this way. Press %1 to paste.' // MISSING
+	pasteNotification: 'Your browser doesn\'t allow you to paste plain text this way. Press %1 to paste.' // MISSING
 } );

--- a/plugins/pastetext/lang/uk.js
+++ b/plugins/pastetext/lang/uk.js
@@ -4,5 +4,5 @@ For licensing, see LICENSE.md or http://ckeditor.com/license
 */
 CKEDITOR.plugins.setLang( 'pastetext', 'uk', {
 	button: 'Вставити тільки текст',
-	pasteMsg: 'Your browser doesn\'t allow you to paste plain text this way. Press %1 to paste.' // MISSING
+	pasteNotification: 'Your browser doesn\'t allow you to paste plain text this way. Press %1 to paste.' // MISSING
 } );

--- a/plugins/pastetext/lang/vi.js
+++ b/plugins/pastetext/lang/vi.js
@@ -4,5 +4,5 @@ For licensing, see LICENSE.md or http://ckeditor.com/license
 */
 CKEDITOR.plugins.setLang( 'pastetext', 'vi', {
 	button: 'Dán theo định dạng văn bản thuần',
-	pasteMsg: 'Your browser doesn\'t allow you to paste plain text this way. Press %1 to paste.' // MISSING
+	pasteNotification: 'Your browser doesn\'t allow you to paste plain text this way. Press %1 to paste.' // MISSING
 } );

--- a/plugins/pastetext/lang/zh-cn.js
+++ b/plugins/pastetext/lang/zh-cn.js
@@ -4,5 +4,5 @@ For licensing, see LICENSE.md or http://ckeditor.com/license
 */
 CKEDITOR.plugins.setLang( 'pastetext', 'zh-cn', {
 	button: '粘贴为无格式文本',
-	pasteMsg: 'Your browser doesn\'t allow you to paste plain text this way. Press %1 to paste.' // MISSING
+	pasteNotification: 'Your browser doesn\'t allow you to paste plain text this way. Press %1 to paste.' // MISSING
 } );

--- a/plugins/pastetext/lang/zh.js
+++ b/plugins/pastetext/lang/zh.js
@@ -4,5 +4,5 @@ For licensing, see LICENSE.md or http://ckeditor.com/license
 */
 CKEDITOR.plugins.setLang( 'pastetext', 'zh', {
 	button: '貼成純文字',
-	pasteMsg: 'Your browser doesn\'t allow you to paste plain text this way. Press %1 to paste.' // MISSING
+	pasteNotification: 'Your browser doesn\'t allow you to paste plain text this way. Press %1 to paste.' // MISSING
 } );

--- a/plugins/pastetext/plugin.js
+++ b/plugins/pastetext/plugin.js
@@ -35,7 +35,7 @@
 					editor.getCommandKeystroke( CKEDITOR.env.ie ? editor.commands.paste : this ) ),
 				notification = ( data && typeof data.notification !== 'undefined' ) ? data.notification :
 					!data || !data.from || ( data.from === 'keystrokeHandler' && CKEDITOR.env.ie ),
-				msg = ( notification && typeof notification === 'string' ) ? notification : lang.pastetext.pasteMsg
+				msg = ( notification && typeof notification === 'string' ) ? notification : lang.pastetext.pasteNotification
 					.replace( /%1/, '<kbd aria-label="' + keyInfo.aria + '">' + keyInfo.display + '</kbd>' );
 
 			editor.execCommand( 'paste', {

--- a/tests/plugins/clipboard/_helpers/pasting.js
+++ b/tests/plugins/clipboard/_helpers/pasting.js
@@ -169,7 +169,7 @@ function testResetScenario( editor, queue ) {
 function getDefaultNotification( editor, command, keyInfo ) {
 	var keystroke = keyInfo || CKEDITOR.tools.keystrokeToString( editor.lang.common.keyboard,
 		editor.getCommandKeystroke( editor.commands[ command ] ) ),
-		msg = editor.lang[ command === 'paste' ? 'clipboard' : command ].pasteMsg
+		msg = editor.lang[ command === 'paste' ? 'clipboard' : command ].pasteDefaultMsg
 			.replace( /%1/, '<kbd aria-label="' + keystroke.aria + '">' + keystroke.display + '</kbd>' );
 
 	return msg;

--- a/tests/plugins/clipboard/_helpers/pasting.js
+++ b/tests/plugins/clipboard/_helpers/pasting.js
@@ -169,7 +169,7 @@ function testResetScenario( editor, queue ) {
 function getDefaultNotification( editor, command, keyInfo ) {
 	var keystroke = keyInfo || CKEDITOR.tools.keystrokeToString( editor.lang.common.keyboard,
 		editor.getCommandKeystroke( editor.commands[ command ] ) ),
-		msg = editor.lang[ command === 'paste' ? 'clipboard' : command ].pasteDefaultMsg
+		msg = ( command === 'paste' ? editor.lang.clipboard.pasteDefaultMsg : editor.lang[ command ].pasteMsg )
 			.replace( /%1/, '<kbd aria-label="' + keystroke.aria + '">' + keystroke.display + '</kbd>' );
 
 	return msg;

--- a/tests/plugins/clipboard/_helpers/pasting.js
+++ b/tests/plugins/clipboard/_helpers/pasting.js
@@ -169,7 +169,7 @@ function testResetScenario( editor, queue ) {
 function getDefaultNotification( editor, command, keyInfo ) {
 	var keystroke = keyInfo || CKEDITOR.tools.keystrokeToString( editor.lang.common.keyboard,
 		editor.getCommandKeystroke( editor.commands[ command ] ) ),
-		msg = ( command === 'paste' ? editor.lang.clipboard.pasteDefaultMsg : editor.lang[ command ].pasteMsg )
+		msg = editor.lang[ command === 'paste' ? 'clipboard' : command ].pasteNotification
 			.replace( /%1/, '<kbd aria-label="' + keystroke.aria + '">' + keystroke.display + '</kbd>' );
 
 	return msg;


### PR DESCRIPTION
Renamed the lang entry from `pasteMsg` to `pasteDefaultMsg`.