### PR TITLE
T/16982 Safari's clipboard API can be trusted

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -53,6 +53,7 @@ Other Changes:
 	* Fixed: The DOM Exception after click "Remove Language" on a selected word with enabled Language plugin in SCAYT.
 * [#16958](http://dev.ckeditor.com/ticket/16958): Switched default MathJax CDN provider from `cdn.mathjax.org` to [cdnjs](https://cdnjs.com/), due to closing of `cdn.mathjax.org` scheduled on April 30, 2017.
 * [#16954](http://dev.ckeditor.com/ticket/16954): Remove paste dialog.
+* [#16982](http://dev.ckeditor.com/ticket/16982): Latest Safari now supports enhanced clipboard API introduced in CKEditor 4.5.0.
 
 ## CKEditor 4.6.2
 

--- a/plugins/clipboard/plugin.js
+++ b/plugins/clipboard/plugin.js
@@ -1573,9 +1573,12 @@
 
 			// Because of a Firefox bug HTML data are not available in some cases (e.g. paste from Word), in such cases we
 			// need to use the pastebin (#13528, https://bugzilla.mozilla.org/show_bug.cgi?id=1183686).
-			// In newer Safari HTML data also should be available (#16982).
-			if ( ( CKEDITOR.env.gecko || CKEDITOR.env.safari ) &&
-				( dataTransfer.getData( 'text/html' ) || dataTransfer.getFilesCount() ) ) {
+			if ( CKEDITOR.env.gecko && ( dataTransfer.getData( 'text/html' ) || dataTransfer.getFilesCount() ) ) {
+				return true;
+			}
+
+			// Safari fixed clipboard in 10.1 (https://bugs.webkit.org/show_bug.cgi?id=19893) (#16982).
+			if ( CKEDITOR.env.safari && CKEDITOR.env.version >= 603 ) {
 				return true;
 			}
 

--- a/plugins/clipboard/plugin.js
+++ b/plugins/clipboard/plugin.js
@@ -1573,11 +1573,13 @@
 
 			// Because of a Firefox bug HTML data are not available in some cases (e.g. paste from Word), in such cases we
 			// need to use the pastebin (#13528, https://bugzilla.mozilla.org/show_bug.cgi?id=1183686).
-			if ( CKEDITOR.env.gecko && ( dataTransfer.getData( 'text/html' ) || dataTransfer.getFilesCount() ) ) {
+			// In newer Safari HTML data also should be available (#16982).
+			if ( ( CKEDITOR.env.gecko || CKEDITOR.env.safari ) &&
+				( dataTransfer.getData( 'text/html' ) || dataTransfer.getFilesCount() ) ) {
 				return true;
 			}
 
-			// In Safari and IE HTML data is not available though the Clipboard API.
+			// In older Safari and IE HTML data is not available though the Clipboard API.
 			// In Edge things are a bit messy at the moment -
 			// https://connect.microsoft.com/IE/feedback/details/1572456/edge-clipboard-api-text-html-content-messed-up-in-event-clipboarddata
 			// It is safer to use the paste bin in unknown cases.

--- a/tests/plugins/clipboard/paste.js
+++ b/tests/plugins/clipboard/paste.js
@@ -49,6 +49,8 @@
 		} );
 	}
 
+	var trustySafari = CKEDITOR.env.safari && CKEDITOR.env.version >= 603;
+
 	bender.test( {
 		setUp: function() {
 			// Force result data un-formatted.
@@ -1335,6 +1337,22 @@
 			assert.isTrue( canClipboardApiBeTrusted( dataTransfer ), 'Clipboard API should be used in Chrome.' );
 		},
 
+		'test canClipboardApiBeTrusted in Safari': function() {
+			if ( !trustySafari ) {
+				assert.ignore();
+			}
+
+			var canClipboardApiBeTrusted = CKEDITOR.plugins.clipboard.canClipboardApiBeTrusted,
+				nativeData = bender.tools.mockNativeDataTransfer();
+
+			nativeData.setData( 'text/html', '<b>foo</b>' );
+
+			var evt = { data: { $: { clipboardData: nativeData } } },
+				dataTransfer = CKEDITOR.plugins.clipboard.initPasteDataTransfer( evt );
+
+			assert.isTrue( canClipboardApiBeTrusted( dataTransfer ), 'Clipboard API should be marked as trusted.' );
+		},
+
 		'test canClipboardApiBeTrusted in Android Chrome (no dataTransfer support)': function() {
 			if ( !CKEDITOR.env.chrome ) {
 				assert.ignore();
@@ -1398,7 +1416,7 @@
 		},
 
 		'test canClipboardApiBeTrusted on other browser': function() {
-			if ( CKEDITOR.env.chrome || CKEDITOR.env.gecko || ( CKEDITOR.env.safari && CKEDITOR.env.version >= 603 ) ) {
+			if ( CKEDITOR.env.chrome || CKEDITOR.env.gecko || trustySafari ) {
 				assert.ignore();
 			}
 

--- a/tests/plugins/clipboard/paste.js
+++ b/tests/plugins/clipboard/paste.js
@@ -1398,7 +1398,7 @@
 		},
 
 		'test canClipboardApiBeTrusted on other browser': function() {
-			if ( CKEDITOR.env.chrome || CKEDITOR.env.gecko ) {
+			if ( CKEDITOR.env.chrome || CKEDITOR.env.gecko || ( CKEDITOR.env.safari && CKEDITOR.env.version >= 603 ) ) {
 				assert.ignore();
 			}
 


### PR DESCRIPTION
After enabling Clipboard API in Safari, all clipboard related tests are green and pasting seems to be working as usual.