### PR TITLE
Paste from Word docs - missing member property.

### DIFF
--- a/plugins/pastefromword/filter/default.js
+++ b/plugins/pastefromword/filter/default.js
@@ -2060,6 +2060,7 @@
 		 * so that the list structure matches the content copied from Word.
 		 *
 		 * @param {CKEDITOR.htmlParser.element} element
+		 * @member CKEDITOR.plugins.pastefromword.heuristics
 		 * @private
 		 * */
 		correctLevelShift: function( element ) {
@@ -2095,6 +2096,7 @@
 		 *
 		 * @param {CKEDITOR.htmlParser.element} element
 		 * @returns {Boolean}
+		 * @member CKEDITOR.plugins.pastefromword.heuristics
 		 * @private
 		 */
 		isShifted: function( element ) {


### PR DESCRIPTION
Resulted in methods definiton leaking to global scope:
![image](https://cloud.githubusercontent.com/assets/1061942/25269181/d9f304e4-267b-11e7-842c-0d9ff3d39795.png)
