### PR TITLE
Tableresize plugin: fire change event

### DIFF
--- a/plugins/tableresize/plugin.js
+++ b/plugins/tableresize/plugin.js
@@ -214,6 +214,7 @@
 			var table = pillar.table;
 			setTimeout( function() {
 				table.removeCustomData( '_cke_table_pillars' );
+				editor.fire( 'change' );
 			}, 0 );
 
 			document.removeListener( 'dragstart', cancel );


### PR DESCRIPTION
Fire the change event after drag is completed. If you would do a save action after every change, the resize action would not trigger a change.