### PR TITLE
t/17010 [API] Range#shrink method should allow for skipping bogus BR elements

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -15,6 +15,7 @@ New Features:
 * [#16818](http://dev.ckeditor.com/ticket/16818): Added table cell height parsing in the [Paste from Word](http://ckeditor.com/addon/pastefromword) plugin.
 * [#16850](http://dev.ckeditor.com/ticket/16850): Added a new [`config.enableContextMenu`](http://docs.ckeditor.com/#!/api/CKEDITOR.config-cfg-enableContextMenu) configuration option for enabling and disabling the [context menu](http://ckeditor.com/addon/contextmenu).
 * [#16937](http://dev.ckeditor.com/ticket/16937): The `command` parameter in [CKEDITOR.editor.getCommandKeystroke](http://docs.ckeditor.dev/#!/api/CKEDITOR.editor-method-getCommandKeystroke) now also accepts a command name as an argument.
+* [#17010](http://dev.ckeditor.com/ticket/17010): The [CKEDITOR.dom.range.shrink](http://docs.ckeditor.com/#!/api/CKEDITOR.dom.range-method-shrink) now allows for skipping bogus `br` elements.
 
 Fixed Issues:
 

--- a/core/dom/range.js
+++ b/core/dom/range.js
@@ -1786,7 +1786,7 @@ CKEDITOR.dom.range = function( root ) {
 
 				var currentElement;
 				walker.guard = function( node, movingOut ) {
-					// Skipping bogus before other cases (#tp2245).
+					// Skipping bogus before other cases (#17010, #tp2245).
 					if ( skipBogus && isBogus( node ) ) {
 						return true;
 					}

--- a/core/dom/range.js
+++ b/core/dom/range.js
@@ -1725,9 +1725,12 @@ CKEDITOR.dom.range = function( root ) {
 		 *     node, range remains if there's no text nodes on boundaries at all.
 		 *
 		 * @param {Boolean} [selectContents=false] Whether result range anchors at the inner OR outer boundary of the node.
-		 * @param {Boolean} [shrinkOnBlockBoundary=true] Whether block boundary should be included in shrinked range.
-		 * @param {Boolean} [skipBogus=false] Wheter bogus `<br>` elements should be ignored while `mode` is set to
-		 * {@link CKEDITOR#SHRINK_TEXT}. This parameter was added in 4.7.0.
+		 * @param {Boolean/Object} [options=true] If this parameter is of a boolean type, it's treated as
+		 * `options.shrinkOnBlockBoundary`. This parameter was added in 4.7.0.
+		 * @param {Boolean} [options.shrinkOnBlockBoundary=true] Whether block boundary should be included in
+		 * shrinked range.
+		 * @param {Boolean} [options.skipBogus=false] Whether bogus `<br>` elements should be ignored while
+		 * `mode` is set to {@link CKEDITOR#SHRINK_TEXT}. This option was added in 4.7.0.
 		 */
 		shrink: function( mode, selectContents, options ) {
 			var shrinkOnBlockBoundary = typeof options === 'boolean' ? options :

--- a/core/dom/range.js
+++ b/core/dom/range.js
@@ -1729,7 +1729,11 @@ CKEDITOR.dom.range = function( root ) {
 		 * @param {Boolean} [skipBogus=false] Wheter bogus `<br>` elements should be ignored while `mode` is set to
 		 * {@link CKEDITOR#SHRINK_TEXT}. This parameter was added in 4.7.0.
 		 */
-		shrink: function( mode, selectContents, shrinkOnBlockBoundary, skipBogus ) {
+		shrink: function( mode, selectContents, options ) {
+			var shrinkOnBlockBoundary = typeof options === 'boolean' ? options :
+				( options && typeof options.shrinkOnBlockBoundary === 'boolean' ? options.shrinkOnBlockBoundary : true ),
+				skipBogus = options && options.skipBogus;
+
 			// Unable to shrink a collapsed range.
 			if ( !this.collapsed ) {
 				mode = mode || CKEDITOR.SHRINK_TEXT;

--- a/core/dom/range.js
+++ b/core/dom/range.js
@@ -1726,7 +1726,7 @@ CKEDITOR.dom.range = function( root ) {
 		 *
 		 * @param {Boolean} selectContents Whether result range anchors at the inner OR outer boundary of the node.
 		 */
-		shrink: function( mode, selectContents, shrinkOnBlockBoundary ) {
+		shrink: function( mode, selectContents, shrinkOnBlockBoundary, skipBogus ) {
 			// Unable to shrink a collapsed range.
 			if ( !this.collapsed ) {
 				mode = mode || CKEDITOR.SHRINK_TEXT;
@@ -1767,7 +1767,8 @@ CKEDITOR.dom.range = function( root ) {
 				}
 
 				var walker = new CKEDITOR.dom.walker( walkerRange ),
-					isBookmark = CKEDITOR.dom.walker.bookmark();
+					isBookmark = CKEDITOR.dom.walker.bookmark(),
+					isBogus = CKEDITOR.dom.walker.bogus();
 
 				walker.evaluator = function( node ) {
 					return node.type == ( mode == CKEDITOR.SHRINK_ELEMENT ? CKEDITOR.NODE_ELEMENT : CKEDITOR.NODE_TEXT );
@@ -1775,6 +1776,11 @@ CKEDITOR.dom.range = function( root ) {
 
 				var currentElement;
 				walker.guard = function( node, movingOut ) {
+					// Skipping bogus before other cases (#tp2245).
+					if ( skipBogus && isBogus( node ) ) {
+						return true;
+					}
+
 					if ( isBookmark( node ) )
 						return true;
 

--- a/core/dom/range.js
+++ b/core/dom/range.js
@@ -1724,7 +1724,10 @@ CKEDITOR.dom.range = function( root ) {
 		 * * {@link CKEDITOR#SHRINK_TEXT} - Shrink the range boudaries to anchor by the side of enclosed text
 		 *     node, range remains if there's no text nodes on boundaries at all.
 		 *
-		 * @param {Boolean} selectContents Whether result range anchors at the inner OR outer boundary of the node.
+		 * @param {Boolean} [selectContents=false] Whether result range anchors at the inner OR outer boundary of the node.
+		 * @param {Boolean} [shrinkOnBlockBoundary=true] Whether block boundary should be included in shrinked range.
+		 * @param {Boolean} [skipBogus=false] Wheter bogus `<br>` elements should be ignored while `mode` is set to
+		 * {@link CKEDITOR#SHRINK_TEXT}. This parameter was added in 4.7.0.
 		 */
 		shrink: function( mode, selectContents, shrinkOnBlockBoundary, skipBogus ) {
 			// Unable to shrink a collapsed range.

--- a/core/dom/range.js
+++ b/core/dom/range.js
@@ -1786,7 +1786,7 @@ CKEDITOR.dom.range = function( root ) {
 
 				var currentElement;
 				walker.guard = function( node, movingOut ) {
-					// Skipping bogus before other cases (#17010, #tp2245).
+					// Skipping bogus before other cases (#17010).
 					if ( skipBogus && isBogus( node ) ) {
 						return true;
 					}

--- a/tests/core/dom/range/shrink.html
+++ b/tests/core/dom/range/shrink.html
@@ -5,4 +5,11 @@
 	<p id="_ShrinkP4"> Test <b id="_ShrinkB4">shrink <i id="_ShrinkI4"><img /></i>element</b>.</p>
 	<p id="_P1">some text <i id="_I2">and</i><b id="_B2"><a id="_L1" href="javascript:void(0)">a link</a></b></p>
 </div>
+<textarea id="bogus_table">
+	<table>
+		<tr>
+			[<td>Cell 1.1<br></td>]
+		</tr>
+	</table>
+</textarea>
 <div id="editable_playground" contenteditable="true"></div>

--- a/tests/core/dom/range/shrink.js
+++ b/tests/core/dom/range/shrink.js
@@ -327,7 +327,7 @@
 			assert.areSame( source, bender.tools.getHtmlWithRanges( ct, new CKEDITOR.dom.rangeList( [ range ] ) ) );
 		},
 
-		// #tp2245
+		// (#17010)
 		'test shrink with skipBogus param - SHRINK_TEXT': function() {
 			var ct = doc.getById( 'editable_playground' ),
 				source = CKEDITOR.document.getById( 'bogus_table' ).getValue(),
@@ -337,7 +337,7 @@
 			assert.areSame( 'Cell 1.1', range.cloneContents().getHtml() );
 		},
 
-		// #tp2245
+		// (#17010)
 		'test shrink with skipBogus param - SHRINK_ELEMENT': function() {
 			var ct = doc.getById( 'editable_playground' ),
 				source = CKEDITOR.document.getById( 'bogus_table' ).getValue(),

--- a/tests/core/dom/range/shrink.js
+++ b/tests/core/dom/range/shrink.js
@@ -333,7 +333,7 @@
 				source = CKEDITOR.document.getById( 'bogus_table' ).getValue(),
 				range = bender.tools.setHtmlWithRange( ct, source )[ 0 ];
 
-			range.shrink( CKEDITOR.SHRINK_TEXT, false, true, true );
+			range.shrink( CKEDITOR.SHRINK_TEXT, false, { skipBogus: true } );
 			assert.areSame( 'Cell 1.1', range.cloneContents().getHtml() );
 		},
 
@@ -344,7 +344,7 @@
 				range = bender.tools.setHtmlWithRange( ct, source )[ 0 ],
 				cell = ct.findOne( 'td' );
 
-			range.shrink( CKEDITOR.SHRINK_ELEMENT, false, true, true );
+			range.shrink( CKEDITOR.SHRINK_ELEMENT, false, { skipBogus: true } );
 			assert.areSame( cell.getOuterHtml(), range.cloneContents().getHtml() );
 		}
 	};

--- a/tests/core/dom/range/shrink.js
+++ b/tests/core/dom/range/shrink.js
@@ -325,6 +325,27 @@
 			var range = bender.tools.setHtmlWithRange( ct, source )[ 0 ];
 			range.shrink( CKEDITOR.SHRINK_TEXT );
 			assert.areSame( source, bender.tools.getHtmlWithRanges( ct, new CKEDITOR.dom.rangeList( [ range ] ) ) );
+		},
+
+		// #tp2245
+		'test shrink with skipBogus param - SHRINK_TEXT': function() {
+			var ct = doc.getById( 'editable_playground' ),
+				source = CKEDITOR.document.getById( 'bogus_table' ).getValue(),
+				range = bender.tools.setHtmlWithRange( ct, source )[ 0 ];
+
+			range.shrink( CKEDITOR.SHRINK_TEXT, false, true, true );
+			assert.areSame( 'Cell 1.1', range.cloneContents().getHtml() );
+		},
+
+		// #tp2245
+		'test shrink with skipBogus param - SHRINK_ELEMENT': function() {
+			var ct = doc.getById( 'editable_playground' ),
+				source = CKEDITOR.document.getById( 'bogus_table' ).getValue(),
+				range = bender.tools.setHtmlWithRange( ct, source )[ 0 ],
+				cell = ct.findOne( 'td' );
+
+			range.shrink( CKEDITOR.SHRINK_ELEMENT, false, true, true );
+			assert.areSame( cell.getOuterHtml(), range.cloneContents().getHtml() );
 		}
 	};
 


### PR DESCRIPTION
This PR adds third parameter to `CKEDITOR.dom.range`, `options`, which groups two options for the method:

* `shrinkOnBlockBoundary`
* `skipBogus`

For the compatibility if `options` is passed a boolean, then it's treated as `options.shrinkOnBlockBoundary`.