### PR TITLE
Fixed: range#_find does not return boundary end element

### DIFF
--- a/core/dom/range.js
+++ b/core/dom/range.js
@@ -2885,7 +2885,7 @@ CKEDITOR.dom.range = function( root ) {
 					// It's not enough to get elements from common ancestor, because it migth contain too many matches.
 					// We need to ensure that returned items are between boundary points.
 					isStartGood = ( curItem.getPosition( boundaries.startNode ) & CKEDITOR.POSITION_FOLLOWING ) || boundaries.startNode.equals( curItem );
-					isEndGood = ( curItem.getPosition( boundaries.endNode ) & ( CKEDITOR.POSITION_PRECEDING + CKEDITOR.POSITION_IS_CONTAINED ) );
+					isEndGood = ( curItem.getPosition( boundaries.endNode ) & ( CKEDITOR.POSITION_PRECEDING + CKEDITOR.POSITION_IS_CONTAINED ) ) || boundaries.endNode.equals( curItem );
 
 					if ( isStartGood && isEndGood ) {
 						ret.push( curItem );

--- a/tests/core/dom/range/find.js
+++ b/tests/core/dom/range/find.js
@@ -30,6 +30,7 @@
 			assert.areSame( 'strong2', results[ 1 ].getId(), 'Id of a second matched element' );
 		},
 
+		// (#17022)
 		'test matching a contained node': function() {
 			var range = new CKEDITOR.dom.range( doc ),
 				strongsWrapper = doc.getById( 'strongs' ),

--- a/tests/core/dom/range/find.js
+++ b/tests/core/dom/range/find.js
@@ -30,6 +30,20 @@
 			assert.areSame( 'strong2', results[ 1 ].getId(), 'Id of a second matched element' );
 		},
 
+		'test matching a contained node': function() {
+			var range = new CKEDITOR.dom.range( doc ),
+				strongsWrapper = doc.getById( 'strongs' ),
+				results;
+
+			range.setStartBefore( strongsWrapper );
+			range.setEndAfter( strongsWrapper );
+			results = range._find( 'div' );
+
+			assert.isArray( results, 'Return object type' );
+			assert.areSame( 1, results.length, 'Result count' );
+			assert.areSame( 'strongs', results[ 0 ].getId(), 'Id of a first matched element' );
+		},
+
 		'test multiple matches in a spanned range': function() {
 			// This range will span across two div containers. As a result, common ancestor is the container that holds
 			// whole manual test HTML. There are more strongs in doc, so if scoping is wrong, more strongs than expected


### PR DESCRIPTION
Fix for [#17022](https://dev.ckeditor.com/ticket/17022).

This change doesn't deserve a changelog entry, since this method is marked as a private.