### PR TITLE
Failing test Object word2013 datatransfer (Edge, Safari).

### DIFF
--- a/tests/plugins/pastefromword/generated/generic.js
+++ b/tests/plugins/pastefromword/generated/generic.js
@@ -57,8 +57,8 @@
 			}
 		},
 		customFilters: [
-			pfwTools.filters.span,
-			pfwTools.filters.style
+			pfwTools.filters.style,
+			pfwTools.filters.span
 		],
 		ignoreAll: CKEDITOR.env.ie && CKEDITOR.env.version <= 11
 	} ) );

--- a/tests/plugins/pastefromword/generated/generic.js
+++ b/tests/plugins/pastefromword/generated/generic.js
@@ -35,6 +35,7 @@
 			'Image': true,
 			'Italic': true,
 			'Link': true,
+			'Object': [ 'word2013' ],
 			'Only_paragraphs': true,
 			'Ordered_list': true,
 			'Ordered_list_multiple': true,
@@ -46,8 +47,14 @@
 			'Underline': true,
 			'Unordered_list': true,
 			'Table_alignment': true,
-			'Table_vertical_alignment': true,
-			'Object': [ 'word2013' ]
+			'Table_vertical_alignment': true
+		},
+		testData: {
+			_should: {
+				ignore: {
+					'test Object word2013 datatransfer': CKEDITOR.env.edge
+				}
+			}
 		},
 		customFilters: [
 			pfwTools.filters.span,


### PR DESCRIPTION
**For Edge I just ignored the tests as Edge still do not use datatransfer.**

**For Safari it was a little more interesting:**

The test failed because of the reversed order of the spans with font-family styles:
![image](https://cloud.githubusercontent.com/assets/1061942/25945698/314db96a-3648-11e7-8398-218aa510c1aa.png)

In the [generated/generic tests two custom filters are used](https://github.com/ckeditor/ckeditor-dev/blob/4cacb998a8ff0093ed9b9e5deffeb5bae0270c58/tests/plugins/pastefromword/generated/generic.js#L52) to make html output consistent:

* [pfwTools.filters.span](https://github.com/ckeditor/ckeditor-dev/blob/4cacb998a8ff0093ed9b9e5deffeb5bae0270c58/tests/plugins/pastefromword/generated/_helpers/pfwTools.js#L20)
* [pfwTools.filters.style](https://github.com/ckeditor/ckeditor-dev/blob/4cacb998a8ff0093ed9b9e5deffeb5bae0270c58/tests/plugins/pastefromword/generated/_helpers/pfwTools.js#L94)

The `span` one sorts _stacked_ styling `span` elements (sorts by the length of the style attribute) so it is always consistent. The `style` one just takes care of correct quoting of fonts in `font-family` style.

In this case [the inline style](https://github.com/ckeditor/ckeditor-dev/blob/4cacb998a8ff0093ed9b9e5deffeb5bae0270c58/tests/plugins/pastefromword/generated/_fixtures/Object/word2013/datatransfer.html#L785) `style='font-family:"Verdana",sans-serif;` becomes `style=\"font-family:&quot;verdana&quot;,sans-serif\"` when parsed by Safari. So when it is compared to the other font-family style span (`style="font-family:times new roman,serif"`) it is put before because it is longer. It happens only for test when sorting filter is used.

So the style filter should be used first (it takes care of inconsistent quoting) and then the span filter which sorts styling spans. Not the other way around as it was before. This was quite entertaining issue :)


