### PR TITLE
[#17020] Unit test for loosing focus in divarea editor

### DIFF
--- a/tests/core/focusmanager/lostfocus.html
+++ b/tests/core/focusmanager/lostfocus.html
@@ -1,0 +1,1 @@
+<input id="focusable" type="button" value="foo" />

--- a/tests/core/focusmanager/lostfocus.js
+++ b/tests/core/focusmanager/lostfocus.js
@@ -6,7 +6,7 @@ bender.editor = true;
 bender.test( {
 	'test lost focus in editor after click': function() {
 		// Test for checking if focusmanager reset ranges in divarea editor (bug introduced in https://dev.ckeditor.com/ticket/13446).
-		// It's necessary to keep focus in browser to get proper result of test. Focus in console or other window will cause test to
+		// It's necessary to keep focus in a browser to get proper result of test. Having focus in a console or other window will cause test to
 		// pass (https://dev.ckeditor.com/ticket/17020).
 
 		// Assert for IE8 returns different selection comparing to other browsers.
@@ -18,7 +18,7 @@ bender.test( {
 
 		var editor = this.editor;
 		editor.focus();
-		bender.tools.setHtmlWithSelection( editor, '<p>[foo] <strong>bar</strong></p>' );
+		bender.tools.selection.setWithHtml( editor, '<p>[foo] <strong>bar</strong></p>' );
 		CKEDITOR.document.getById( 'focusable' ).focus();
 		editor.getSelection().selectElement( editor.editable().findOne( 'strong' ) );
 		wait( function() {
@@ -30,6 +30,5 @@ bender.test( {
 					normalizeSelection: true
 				} );
 		}, 210 );
-
 	}
 } );

--- a/tests/core/focusmanager/lostfocus.js
+++ b/tests/core/focusmanager/lostfocus.js
@@ -8,7 +8,7 @@ bender.test( {
 		// Assert for IE8 returns different selection comparing to other browsers.
 		// IE8: <p>foo [<strong>bar]</strong></p>
 		// Others: <p>foo [<strong>bar</strong>]</p>
-		if ( CKEDITOR.env.ie && CKEDITOR.env.version <= 8 ) {
+		if ( CKEDITOR.env.ie && CKEDITOR.env.version <= 8 || CKEDITOR.env.safari ) {
 			assert.ignore();
 		}
 

--- a/tests/core/focusmanager/lostfocus.js
+++ b/tests/core/focusmanager/lostfocus.js
@@ -1,0 +1,26 @@
+/* bender-tags: editor,unit */
+/* bender-ckeditor-plugins: divarea */
+
+bender.editor = {
+	extraPlugins: 'divarea',
+	allowedContent: true
+};
+
+bender.test({
+	'test lost focus in editor after click': function() {
+		// #17020 - test for checking if focusmanager reset ranges in divarea editor (bug introduced in #13446).
+		// It's necessary to keep focus in browser to get proper result of test. Focus in console or other window will cause test to pass.
+		var editor = this.editor;
+		editor.focus();
+		bender.tools.setHtmlWithSelection( editor, '<p>[foo] <strong>bar</strong></p>' );
+		CKEDITOR.document.getById('focusable').focus();
+		var element = editor.editable().findOne('strong');
+		var selection = editor.getSelection();
+		selection.selectElement(element);
+
+		wait( function() {
+			assert.areSame('Range', editor.window.$.getSelection().type );
+		}, 200);
+
+	}
+});

--- a/tests/core/focusmanager/lostfocus.js
+++ b/tests/core/focusmanager/lostfocus.js
@@ -1,29 +1,26 @@
 /* bender-tags: editor,unit */
 /* bender-ckeditor-plugins: divarea */
 
-bender.editor = {
-	extraPlugins: 'divarea',
-	allowedContent: true
-};
+bender.editor = {};
 
-bender.test({
+bender.test( {
 	'test lost focus in editor after click': function() {
-		// #17020 - test for checking if focusmanager reset ranges in divarea editor (bug introduced in #13446).
+		// Ticket: https://dev.ckeditor.com/ticket/17020
+		// Test for checking if focusmanager reset ranges in divarea editor (bug introduced in https://dev.ckeditor.com/ticket/13446).
 		// It's necessary to keep focus in browser to get proper result of test. Focus in console or other window will cause test to pass.
 		var editor = this.editor;
 		editor.focus();
 		bender.tools.setHtmlWithSelection( editor, '<p>[foo] <strong>bar</strong></p>' );
-		CKEDITOR.document.getById('focusable').focus();
-		var element = editor.editable().findOne('strong');
+		CKEDITOR.document.getById( 'focusable' ).focus();
 		var selection = editor.getSelection();
-		selection.selectElement(element);
+		selection.selectElement( editor.editable().findOne( 'strong' ) );
 		wait( function() {
 			// refresh selection
 			var sel = editor.getSelection();
-			sel.unlock();
 			sel.reset();
-			assert.isInnerHtmlMatching( '<p>foo [<strong>bar</strong>]@</p>', bender.tools.range.getWithHtml( editor.editable(), sel.getRanges()[0] ) );
-		}, 210);
+			assert.isInnerHtmlMatching( '<p>foo [<strong>bar</strong>]@</p>',
+					bender.tools.range.getWithHtml( editor.editable(), sel.getRanges()[ 0 ] ) );
+		}, 210 );
 
 	}
-});
+} );

--- a/tests/core/focusmanager/lostfocus.js
+++ b/tests/core/focusmanager/lostfocus.js
@@ -17,10 +17,13 @@ bender.test({
 		var element = editor.editable().findOne('strong');
 		var selection = editor.getSelection();
 		selection.selectElement(element);
-
 		wait( function() {
-			assert.areSame('Range', editor.window.$.getSelection().type );
-		}, 200);
+			// refresh selection
+			var sel = editor.getSelection();
+			sel.unlock();
+			sel.reset();
+			assert.isInnerHtmlMatching( '<p>foo [<strong>bar</strong>]@</p>', bender.tools.range.getWithHtml( editor.editable(), sel.getRanges()[0] ) );
+		}, 210);
 
 	}
 });

--- a/tests/core/focusmanager/lostfocus.js
+++ b/tests/core/focusmanager/lostfocus.js
@@ -5,13 +5,9 @@ bender.editor = true;
 
 bender.test( {
 	'test lost focus in editor after click': function() {
-		// Test for checking if focusmanager reset ranges in divarea editor (bug introduced in https://dev.ckeditor.com/ticket/13446).
-		// It's necessary to keep focus in a browser to get proper result of test. Having focus in a console or other window will cause test to
-		// pass (https://dev.ckeditor.com/ticket/17020).
-
 		// Assert for IE8 returns different selection comparing to other browsers.
-		// Normal browser <p>foo [<strong>bar</strong>]</p>
 		// IE8: <p>foo [<strong>bar]</strong></p>
+		// Others: <p>foo [<strong>bar</strong>]</p>
 		if ( CKEDITOR.env.ie && CKEDITOR.env.version <= 8 ) {
 			assert.ignore();
 		}

--- a/tests/core/focusmanager/lostfocus.js
+++ b/tests/core/focusmanager/lostfocus.js
@@ -1,30 +1,29 @@
 /* bender-tags: editor,unit */
 /* bender-ckeditor-plugins: divarea */
 
-// Assert for IE8 returns different selection comparing to other browsers.
-// Normal browser <p>foo [<strong>bar</strong>]</p>
-// IE8: <p>foo [<strong>bar]</strong></p>
-if ( CKEDITOR.env.ie && CKEDITOR.env.version <= 8 ) {
-	bender.ignore();
-}
-
-bender.editor = {};
+bender.editor = true;
 
 bender.test( {
 	'test lost focus in editor after click': function() {
 		// Test for checking if focusmanager reset ranges in divarea editor (bug introduced in https://dev.ckeditor.com/ticket/13446).
 		// It's necessary to keep focus in browser to get proper result of test. Focus in console or other window will cause test to
 		// pass (https://dev.ckeditor.com/ticket/17020).
+
+		// Assert for IE8 returns different selection comparing to other browsers.
+		// Normal browser <p>foo [<strong>bar</strong>]</p>
+		// IE8: <p>foo [<strong>bar]</strong></p>
+		if ( CKEDITOR.env.ie && CKEDITOR.env.version <= 8 ) {
+			assert.ignore();
+		}
+
 		var editor = this.editor;
 		editor.focus();
 		bender.tools.setHtmlWithSelection( editor, '<p>[foo] <strong>bar</strong></p>' );
 		CKEDITOR.document.getById( 'focusable' ).focus();
-		var selection = editor.getSelection();
-		selection.selectElement( editor.editable().findOne( 'strong' ) );
+		editor.getSelection().selectElement( editor.editable().findOne( 'strong' ) );
 		wait( function() {
 			// Refresh selection.
-			var sel = editor.getSelection();
-			sel.reset();
+			editor.getSelection().reset();
 			assert.isInnerHtmlMatching( '<p>foo [<strong>bar</strong>]@</p>',
 				bender.tools.selection.getWithHtml( editor ), {
 					compareSelection: true,

--- a/tests/core/focusmanager/lostfocus.js
+++ b/tests/core/focusmanager/lostfocus.js
@@ -1,6 +1,13 @@
 /* bender-tags: editor,unit */
 /* bender-ckeditor-plugins: divarea */
 
+// Assert for IE8 returns different selection comparing to other browsers.
+// Normal browser <p>foo [<strong>bar</strong>]</p>
+// IE8: <p>foo [<strong>bar]</strong></p>
+if ( CKEDITOR.env.ie && CKEDITOR.env.version <= 8 ) {
+	bender.ignore();
+}
+
 bender.editor = {};
 
 bender.test( {
@@ -19,7 +26,10 @@ bender.test( {
 			var sel = editor.getSelection();
 			sel.reset();
 			assert.isInnerHtmlMatching( '<p>foo [<strong>bar</strong>]@</p>',
-				bender.tools.range.getWithHtml( editor.editable(), sel.getRanges()[ 0 ] ) );
+				bender.tools.selection.getWithHtml( editor ), {
+					compareSelection: true,
+					normalizeSelection: true
+				} );
 		}, 210 );
 
 	}

--- a/tests/core/focusmanager/lostfocus.js
+++ b/tests/core/focusmanager/lostfocus.js
@@ -5,9 +5,9 @@ bender.editor = {};
 
 bender.test( {
 	'test lost focus in editor after click': function() {
-		// Ticket: https://dev.ckeditor.com/ticket/17020
 		// Test for checking if focusmanager reset ranges in divarea editor (bug introduced in https://dev.ckeditor.com/ticket/13446).
-		// It's necessary to keep focus in browser to get proper result of test. Focus in console or other window will cause test to pass.
+		// It's necessary to keep focus in browser to get proper result of test. Focus in console or other window will cause test to
+		// pass (https://dev.ckeditor.com/ticket/17020).
 		var editor = this.editor;
 		editor.focus();
 		bender.tools.setHtmlWithSelection( editor, '<p>[foo] <strong>bar</strong></p>' );
@@ -15,11 +15,11 @@ bender.test( {
 		var selection = editor.getSelection();
 		selection.selectElement( editor.editable().findOne( 'strong' ) );
 		wait( function() {
-			// refresh selection
+			// Refresh selection.
 			var sel = editor.getSelection();
 			sel.reset();
 			assert.isInnerHtmlMatching( '<p>foo [<strong>bar</strong>]@</p>',
-					bender.tools.range.getWithHtml( editor.editable(), sel.getRanges()[ 0 ] ) );
+				bender.tools.range.getWithHtml( editor.editable(), sel.getRanges()[ 0 ] ) );
 		}, 210 );
 
 	}


### PR DESCRIPTION
Added unit test for loosing focus in divarea editor. Problem exist in **4.6.2**.
It seems that change introduced in 13446 843720475bc05426f2c147e79f04d4cda1091dce break divarea editor.
Unit test require to have focus in view port of the browser.