### PR TITLE
Update Benderjs to 0.4.2

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -58,6 +58,7 @@ Other Changes:
 * [#16958](http://dev.ckeditor.com/ticket/16958): Switched the default MathJax CDN provider for the [Mathematical Formulas](http://ckeditor.com/addon/mathjax) plugin from `cdn.mathjax.org` to [cdnjs](https://cdnjs.com/), due to closing of `cdn.mathjax.org` scheduled for April 30, 2017.
 * [#16954](http://dev.ckeditor.com/ticket/16954): Removed the paste dialog.
 * [#16982](http://dev.ckeditor.com/ticket/16982): Latest Safari now supports enhanced clipboard API introduced in CKEditor 4.5.0.
+* [#17025](http://dev.ckeditor.com/ticket/17025): Upgraded [Bender.js](https://github.com/benderjs/benderjs) to 0.4.2.
 
 ## CKEditor 4.6.2
 

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
 	"description": "The development version of CKEditor - JavaScript WYSIWYG web text editor.",
 	"devDependencies": {
 		"benderjs-coverage": "^0.2.1",
-		"benderjs": "^0.4.1",
+		"benderjs": "^0.4.2",
 		"benderjs-jquery": "^0.3.0",
 		"benderjs-sinon": "^0.3.1",
 		"benderjs-yui": "^0.3.2",


### PR DESCRIPTION
This PR updates Bender so that it works correctly with Node 7.x.

Issue [#17025](http://dev.ckeditor.com/ticket/17025) on Trac.