### PR TITLE
T/17027 Commands event data should be initialized as an empty object

### DIFF
--- a/core/editor.js
+++ b/core/editor.js
@@ -1573,7 +1573,7 @@ CKEDITOR.ELEMENT_MODE_INLINE = 3;
  * @member CKEDITOR.config
  */
 
- /**
+/**
  * Customizes the {@link CKEDITOR.editor#title human-readable title} of this editor. This title is displayed in
  * tooltips and impacts various [accessibility aspects](#!/guide/dev_a11y-section-announcing-the-editor-on-the-page),
  * e.g. it is commonly used by screen readers for distinguishing editor instances and for navigation.

--- a/core/editor.js
+++ b/core/editor.js
@@ -886,7 +886,8 @@
 		 *		editorInstance.execCommand( 'bold' );
 		 *
 		 * @param {String} commandName The indentifier name of the command.
-		 * @param {Object} [data] The data to be passed to the command.
+		 * @param {Object} [data] The data to be passed to the command. If nothing is passed,
+		 * the empty object will be used from 4.7.0.
 		 * @returns {Boolean} `true` if the command was executed
 		 * successfully, otherwise `false`.
 		 * @see CKEDITOR.editor#addCommand
@@ -896,7 +897,7 @@
 
 			var eventData = {
 				name: commandName,
-				commandData: data,
+				commandData: data || {},
 				command: command
 			};
 

--- a/core/editor.js
+++ b/core/editor.js
@@ -885,7 +885,7 @@
 		 *
 		 *		editorInstance.execCommand( 'bold' );
 		 *
-		 * @param {String} commandName The indentifier name of the command.
+		 * @param {String} commandName The identifier name of the command.
 		 * @param {Object} [data] The data to be passed to the command. If nothing is passed,
 		 * the empty object will be used from 4.7.0.
 		 * @returns {Boolean} `true` if the command was executed

--- a/core/editor.js
+++ b/core/editor.js
@@ -886,10 +886,9 @@
 		 *		editorInstance.execCommand( 'bold' );
 		 *
 		 * @param {String} commandName The identifier name of the command.
-		 * @param {Object} [data] The data to be passed to the command. If nothing is passed,
-		 * the empty object will be used from 4.7.0.
-		 * @returns {Boolean} `true` if the command was executed
-		 * successfully, otherwise `false`.
+		 * @param {Object} [data] The data to be passed to the command. It defaults to
+		 * an empty object starting from 4.7.0.
+		 * @returns {Boolean} `true` if the command was executed successfully, `false` otherwise.
 		 * @see CKEDITOR.editor#addCommand
 		 */
 		execCommand: function( commandName, data ) {

--- a/tests/core/command/events.js
+++ b/tests/core/command/events.js
@@ -34,6 +34,28 @@
 
 			this.editor.execCommand( 'mockupCommand' );
 			assert.isTrue( cmdCalled, 'Command should be called' );
+		},
+
+		// #17027
+		'test default event data value': function() {
+			var beforeExecData;
+
+			this.editor.once( 'beforeCommandExec', function( evt ) {
+				beforeExecData = evt.data.commandData;
+
+				assert.isObject( beforeExecData, 'Event data is initialized as an empty object.' );
+			}, null, null, 1 );
+
+			this.editor.once( 'afterCommandExec', function( evt ) {
+				assert.areSame( beforeExecData, evt.data.commandData, 'The same object is passed to afterCommandExec.' );
+			}, null, null, 1 );
+
+			this.editor.addCommand( 'dataFlow', {
+				exec: function() {
+				}
+			} );
+
+			this.editor.execCommand( 'dataFlow' );
 		}
 	} );
 } )();

--- a/tests/core/command/events.js
+++ b/tests/core/command/events.js
@@ -43,15 +43,16 @@
 			this.editor.once( 'beforeCommandExec', function( evt ) {
 				beforeExecData = evt.data.commandData;
 
-				assert.isObject( beforeExecData, 'Event data is initialized as an empty object.' );
-			}, null, null, 1 );
+				assert.isObject( beforeExecData, 'Event data is initialized as an empty object' );
+			} );
 
 			this.editor.once( 'afterCommandExec', function( evt ) {
-				assert.areSame( beforeExecData, evt.data.commandData, 'The same object is passed to afterCommandExec.' );
-			}, null, null, 1 );
+				assert.areSame( beforeExecData, evt.data.commandData, 'The same object is passed to afterCommandExec' );
+			} );
 
 			this.editor.addCommand( 'dataFlow', {
-				exec: function() {
+				exec: function( editor, data ) {
+					assert.areSame( beforeExecData, data, 'Same object is given as data' );
 				}
 			} );
 


### PR DESCRIPTION
Currently if command is not passed an object as a second argument, it fall backs to undefined, causing the unability to pass anything from command to afterCommandExec event.

This change is intended to introduce empty object as a default value for command's event data.