### PR TITLE
Remove config.tableImprovements

### DIFF
--- a/core/selection.js
+++ b/core/selection.js
@@ -1981,7 +1981,7 @@
 			}
 
 			// Handle special case - fake selection of table cells.
-			if ( editor && editor.config.tableImprovements && isTableSelection( ranges ) && !isSelectingTable ) {
+			if ( editor && editor.plugins.tableselection && isTableSelection( ranges ) && !isSelectingTable ) {
 				performFakeTableSelection.call( this, ranges );
 				return;
 			}

--- a/core/selection.js
+++ b/core/selection.js
@@ -1981,7 +1981,10 @@
 			}
 
 			// Handle special case - fake selection of table cells.
-			if ( editor && editor.plugins.tableselection && isTableSelection( ranges ) && !isSelectingTable ) {
+			if ( editor && editor.plugins.tableselection &&
+				CKEDITOR.plugins.tableselection.isSupportedEnvironment &&
+				isTableSelection( ranges ) && !isSelectingTable
+			) {
 				performFakeTableSelection.call( this, ranges );
 				return;
 			}

--- a/plugins/tableselection/plugin.js
+++ b/plugins/tableselection/plugin.js
@@ -910,13 +910,8 @@
 		},
 
 		init: function( editor ) {
-			// Allow overwriting the native table selection with our custom one.
-			if ( !editor.config.tableImprovements ) {
-				return;
-			}
-
+			// Disable unsupported browsers.
 			if ( !CKEDITOR.plugins.tableselection.isSupportedEnvironment ) {
-				editor.config.tableImprovements = false;
 				return;
 			}
 
@@ -973,18 +968,4 @@
 			} );
 		}
 	} );
-
-	/**
-	 * Indicates if table improvements features (overwriting native table selection,
-	 * introducing multiple ranges for table cells and handling pasting of multiple ranges
-	 * containing table cells) are enabled.
-	 *
-	 *		// Disable table improvements.
-	 *		config.tableImprovements = false
-	 *
-	 * @since 4.7.0
-	 * @cfg {Boolean} [tableImprovements=true]
-	 * @member CKEDITOR.config
-	 */
-	CKEDITOR.config.tableImprovements = true;
 }() );

--- a/tests/core/style/applyremove.js
+++ b/tests/core/style/applyremove.js
@@ -6,7 +6,7 @@
 
 	bender.editor = {
 		config: {
-			tableImprovements: false
+			removePlugins: 'tableselection'
 		}
 	};
 

--- a/tests/plugins/tableselection/integrations/core/getextractselectedhtml.js
+++ b/tests/plugins/tableselection/integrations/core/getextractselectedhtml.js
@@ -7,16 +7,9 @@
 	'use strict';
 
 	bender.editors = {
-		classic: {
-			config: {
-				tableImprovements: true
-			}
-		},
+		classic: {},
 
 		inline: {
-			config: {
-				tableImprovements: true
-			},
 			creator: 'inline'
 		}
 	};

--- a/tests/plugins/tableselection/integrations/core/style.js
+++ b/tests/plugins/tableselection/integrations/core/style.js
@@ -8,16 +8,12 @@
 
 	bender.editors = {
 		classic: {
-			config: {
-				tableImprovements: true
-			}
+			config: {}
 		},
 
 		inline: {
 			creator: 'inline',
-			config: {
-				tableImprovements: true
-			}
+			config: {}
 		}
 	};
 

--- a/tests/plugins/tableselection/integrations/tabletools/tabletools.js
+++ b/tests/plugins/tableselection/integrations/tabletools/tabletools.js
@@ -8,16 +8,12 @@
 
 	bender.editors = {
 		classic: {
-			config: {
-				tableImprovements: true
-			},
+			config: {},
 			allowedForTests: 'table[width];td[id]'
 		},
 
 		inline: {
-			config: {
-				tableImprovements: true
-			},
+			config: {},
 			allowedForTests: 'table[width];td[id]',
 			creator: 'inline'
 		}

--- a/tests/plugins/tableselection/manual/enable.html
+++ b/tests/plugins/tableselection/manual/enable.html
@@ -88,6 +88,6 @@
 	} );
 	CKEDITOR.replace( 'editor2', {
 		autoGrow_onStartup: true,
-		tableImprovements: false
+		removePlugins: 'tableselection'
 	} );
 </script>

--- a/tests/plugins/tableselection/manual/enable.md
+++ b/tests/plugins/tableselection/manual/enable.md
@@ -1,6 +1,6 @@
 @bender-ui: collapsed
 @bender-tags: tc, 18
-@bender-ckeditor-plugins: wysiwygarea, toolbar, tableselection, autogrow
+@bender-ckeditor-plugins: wysiwygarea, toolbar, table, tableselection, autogrow
 
 Try to select more than one cell in both of editors.
 

--- a/tests/plugins/tableselection/manual/integrations/tabletools/tabletools.html
+++ b/tests/plugins/tableselection/manual/integrations/tabletools/tabletools.html
@@ -88,6 +88,6 @@
 	} );
 	CKEDITOR.replace( 'editor2', {
 		autoGrow_onStartup: true,
-		tableImprovements: false
+		removePlugins: 'tableselection'
 	} );
 </script>

--- a/tests/plugins/tableselection/table.js
+++ b/tests/plugins/tableselection/table.js
@@ -230,46 +230,6 @@
 			clearTableSelection( editor.editable() );
 		},
 
-		'Switching off fake table selection': function() {
-			var editor = this.editor,
-				selection = editor.getSelection(),
-				initialRev = selection.rev,
-				realSelection,
-				ranges;
-
-			editor.config.tableImprovements = false;
-			bender.tools.setHtmlWithSelection( editor, CKEDITOR.document.getById( 'simpleTable' ).getHtml() );
-
-			ranges = getRangesForCells( editor, editor.editable().findOne( 'table' ), [ 1 ] );
-
-			selection.selectRanges( ranges );
-
-			assert.isFalse( !!selection.isFake, 'isFake is not set' );
-			assert.isTrue( selection.isInTable(), 'isInTable is true' );
-			assert.isTrue( selection.rev > initialRev, 'Next rev' );
-			assert.isNotNull( selection.getNative(), 'getNative() is not null' );
-			assert.isNotNull( selection.getSelectedText(), 'getSelectedText() should not be null' );
-
-			// In Safari the selection is inside the cell.
-			if ( isQuirkyEnv ) {
-				assert.areSame( CKEDITOR.SELECTION_TEXT, selection.getType(), 'Text type selection' );
-			} else {
-				assert.areSame( CKEDITOR.SELECTION_ELEMENT, selection.getType(), 'Element type selection' );
-				assert.isTrue( ranges[ 0 ].getEnclosedNode().equals( selection.getSelectedElement() ),
-					'Selected element equals to the first selected cell' );
-			}
-
-			realSelection = editor.getSelection( 1 );
-
-			if ( !isQuirkyEnv ) {
-				assert.isTrue( ranges[ 0 ].getEnclosedNode().equals( realSelection.getSelectedElement() ),
-					'Real selected element equals to the first selected cell' );
-			}
-
-			editor.config.tableImprovements = true;
-			clearTableSelection( editor.editable() );
-		},
-
 		'Reset fake-selection': function() {
 			var editor = this.editor,
 				selection = editor.getSelection(),

--- a/tests/plugins/tabletools/tabletools.js
+++ b/tests/plugins/tabletools/tabletools.js
@@ -6,7 +6,7 @@
 
 	bender.editor = {
 		config: {
-			tableImprovements: false
+			removePlugins: 'tableselection'
 		},
 		allowedForTests: 'table[width];td[id]'
 	};


### PR DESCRIPTION
Since we extracted table selection into a separate plugin, we can now safely remove this config variable.

Now the proper way to disable table selection is simply by removing tableselection plugin.