### PR TITLE
Fixed tests affected by tabletools in the built version

### DIFF
--- a/plugins/tableselection/plugin.js
+++ b/plugins/tableselection/plugin.js
@@ -761,7 +761,7 @@
 							targetNode = targetNode.getPreviousSourceNode( false, CKEDITOR.NODE_ELEMENT, boundaryTable );
 						}
 
-						if ( !targetNode && !endNode.is( 'table' ) && endNode.getNext() ) {
+						if ( !targetNode && endNode && endNode.is && !endNode.is( 'table' ) && endNode.getNext() ) {
 							// Special case: say we were removing the first row, so there are no more tds before, check if there's a cell after removed row.
 							targetNode = endNode.getNext().findOne( 'td, th' );
 							// In that particular case we want to select beginning.

--- a/tests/plugins/tableselection/integrations/clipboard/pastenested.js
+++ b/tests/plugins/tableselection/integrations/clipboard/pastenested.js
@@ -1,5 +1,6 @@
 /* bender-tags: editor,unit */
 /* bender-ckeditor-plugins: tableselection */
+/* bender-ckeditor-remove-plugins: dialogadvtab */
 /* bender-include: ../../_helpers/tableselection.js */
 /* global createPasteTestCase */
 

--- a/tests/plugins/tableselection/integrations/core/style.js
+++ b/tests/plugins/tableselection/integrations/core/style.js
@@ -1,5 +1,6 @@
 /* bender-tags: editor,unit */
 /* bender-ckeditor-plugins: entities,dialog,tabletools,clipboard,toolbar,tableselection */
+/* bender-ckeditor-remove-plugins: basicstyles */
 /* bender-include: ../../_helpers/tableselection.js */
 /* global tableSelectionHelpers */
 

--- a/tests/plugins/wysiwygarea/contentscss.js
+++ b/tests/plugins/wysiwygarea/contentscss.js
@@ -1,5 +1,5 @@
 /* bender-tags: editor,unit */
-/* bender-ckeditor-remove-plugins: copyformatting */
+/* bender-ckeditor-remove-plugins: copyformatting,tableselection */
 
 ( function() {
 	'use strict';


### PR DESCRIPTION
Some simply were failing because of ACF transformations, the other was failing because tabletools was adding an extra CSS file. Also added extra safety check, which was failing in one of the tests.

Fixes tests:
* http://tests.ckeditor.dev:10470/tests/plugins/wysiwygarea/contentscss
* http://tests.ckeditor.dev:10470/tests/plugins/tableselection/integrations/clipboard/pastenested
* http://tests.ckeditor.dev:1030/tests/plugins/tableselection/integrations/core/style