### PR TITLE
Fixed failing widget tests on built version

### DIFF
--- a/tests/plugins/widget/dnd.js
+++ b/tests/plugins/widget/dnd.js
@@ -1,5 +1,6 @@
 /* bender-tags: widgetcore */
 /* bender-ckeditor-plugins: widget,undo,clipboard */
+/* bender-ckeditor-remove-plugins: tableselection */
 /* bender-include: _helpers/tools.js */
 /* global widgetTestsTools, lineutilsTestsTools */
 

--- a/tests/plugins/widget/undo.js
+++ b/tests/plugins/widget/undo.js
@@ -1,5 +1,6 @@
 /* bender-tags: widgetcore */
 /* bender-ckeditor-plugins: widget,undo,dialog,basicstyles,clipboard */
+/* bender-ckeditor-remove-plugins: tableselection */
 /* bender-include: _helpers/tools.js */
 /* global widgetTestsTools */
 

--- a/tests/plugins/widget/widgetselection.js
+++ b/tests/plugins/widget/widgetselection.js
@@ -1,5 +1,6 @@
 /* bender-tags: widgetcore */
 /* bender-ckeditor-plugins: widget,undo */
+/* bender-ckeditor-remove-plugins: tableselection */
 /* bender-include: _helpers/tools.js */
 /* global widgetTestsTools */
 


### PR DESCRIPTION
Tests are not adding evt.data or evt.data.target to simulated mouseup events, which is an artificial situation.

Fixes following tests:
* http://tests.ckeditor.dev:10470/tests/plugins/widget/dnd
* http://tests.ckeditor.dev:10470/tests/plugins/widget/undo
* http://tests.ckeditor.dev:10470/tests/plugins/widget/widgetselection