### PR TITLE
Fixed contentscssgeturl test for CKEditor built version

### DIFF
--- a/tests/plugins/wysiwygarea/contentscssgeturl.js
+++ b/tests/plugins/wysiwygarea/contentscssgeturl.js
@@ -1,5 +1,5 @@
 /* bender-tags: editor,unit */
-/* bender-ckeditor-remove-plugins: copyformatting */
+/* bender-ckeditor-remove-plugins: copyformatting, tableselection */
 /* exported CKEDITOR_GETURL */
 
 // Load contents.css from assets directory and all other files a default way.


### PR DESCRIPTION
This PR fixes test http://tests.ckeditor.dev:1030/tests/plugins/wysiwygarea/contentscssgeturl in the built version.