### PR TITLE
Fixed failing keystrokes/keystrokes test for the built version

### DIFF
--- a/tests/core/editable/keystrokes/keystrokes.js
+++ b/tests/core/editable/keystrokes/keystrokes.js
@@ -1,4 +1,5 @@
 /* bender-tags: editor,unit */
+/* bender-ckeditor-remove-plugins: tableselection */
 
 bender.editor = {
 	config: {


### PR DESCRIPTION
These tests were created for "regular" table selection and do not result with our improved selection.