### PR TITLE
Fixed failing editor/getextractselectedhtml test on built version

### DIFF
--- a/tests/core/editor/getextractselectedhtml.js
+++ b/tests/core/editor/getextractselectedhtml.js
@@ -1,4 +1,5 @@
 /* bender-tags: editor,unit */
+/* bender-ckeditor-remove-plugins: tableselection */
 
 'use strict';
 


### PR DESCRIPTION
Reason for this test to fail was that build version contains by default table selection plugin, so while selecting it was also adding a custom markup to the cell (classes in particular). Thus tests were failing.

This test was failing only on Firefox (as these tests are ignored for other browsers).