### PR TITLE
Fixed failing selection built test for IE/Edge

### DIFF
--- a/tests/core/selection/selection.js
+++ b/tests/core/selection/selection.js
@@ -671,6 +671,7 @@ bender.test( {
 		}
 
 		this.editor.editable().fire( 'keydown', {
+			$: {},
 			preventDefault: preventSpy,
 			getKeystroke: function() {},
 			getKey: function() {}
@@ -689,6 +690,7 @@ bender.test( {
 			'<span contenteditable="true">^bar</span></span>' );
 
 		this.editor.editable().fire( 'keydown', {
+			$: {},
 			preventDefault: preventSpy,
 			getKeystroke: function() {},
 			getKey: function() {}


### PR DESCRIPTION
This test was failing on built version, because there was undo plugin used, [which checks for modifier keys on native event object](https://github.com/cksource/ckeditor-dev/blob/576dc67/plugins/undo/plugin.js#L1242). It make sense to mimic native evt object in the test.