### PR TITLE
Fix for inline editors

### DIFF
--- a/plugins/tableselection/plugin.js
+++ b/plugins/tableselection/plugin.js
@@ -916,7 +916,9 @@
 			}
 
 			// Add styles for fake visual selection.
-			editor.addContentsCss( this.path + '/styles/tableselection.css' );
+			if ( editor.addContentsCss ) {
+				editor.addContentsCss( this.path + '/styles/tableselection.css' );
+			}
 
 			editor.on( 'contentDom', function() {
 				var editable = editor.editable(),

--- a/tests/plugins/tableselection/manual/inlineeditor.html
+++ b/tests/plugins/tableselection/manual/inlineeditor.html
@@ -1,0 +1,33 @@
+<h2>Inline editor</h2>
+<div id="editor" contenteditable="true">
+	<p>Some text</p>
+
+	<table border="1">
+		<tr>
+			<td>Cell 1.1.1</td>
+			<td>Cell 1.1.2</td>
+			<td>Cell 1.1.3</td>
+			<td>Cell 1.1.4</td>
+		</tr>
+		<tr>
+			<td>Cell 1.2.1</td>
+			<td>Cell 1.2.2</td>
+			<td>Cell 1.2.3</td>
+			<td>Cell 1.2.4</td>
+		</tr>
+		<tr>
+			<td>Cell 1.3.1</td>
+			<td>Cell 1.3.2</td>
+			<td>Cell 1.3.3</td>
+			<td>Cell 1.3.4</td>
+		</tr>
+	</table>
+</div>
+
+<script>
+	if ( CKEDITOR.env.ie && CKEDITOR.env.version < 11 ) {
+		bender.ignore();
+	}
+
+	CKEDITOR.inline( 'editor' );
+</script>

--- a/tests/plugins/tableselection/manual/inlineeditor.md
+++ b/tests/plugins/tableselection/manual/inlineeditor.md
@@ -1,0 +1,8 @@
+@bender-ui: collapsed
+@bender-tags: tc
+@bender-ckeditor-plugins: tableselection, floatingspace
+
+Check if inline editor is working correctly, especially:
+
+* there are no errors in console,
+* a toolbar is shown after clicking inside the editor

--- a/tests/plugins/tableselection/manual/inlineeditor.md
+++ b/tests/plugins/tableselection/manual/inlineeditor.md
@@ -1,8 +1,8 @@
 @bender-ui: collapsed
-@bender-tags: tc
+@bender-tags: tc, tp2351
 @bender-ckeditor-plugins: tableselection, floatingspace
 
 Check if inline editor is working correctly, especially:
 
-* there are no errors in console,
+* there are no errors in the console,
 * a toolbar is shown after clicking inside the editor


### PR DESCRIPTION
Tableselection plugin tries to add CSS to editor, however inline editors don't have this method. I've added a simple check to detect if we can use this method.