### PR TITLE
Add filtering to paste handler in tableselection

### DIFF
--- a/plugins/tableselection/plugin.js
+++ b/plugins/tableselection/plugin.js
@@ -515,7 +515,9 @@
 
 		// Pasted value must be filtered using dataProcessor to strip all unsafe code
 		// before inserting it into temporary container.
-		tmpContainer.setHtml( dataProcessor.toHtml( evt.data.dataValue ) );
+		tmpContainer.setHtml( dataProcessor.toHtml( evt.data.dataValue ), {
+			fixForBody: false
+		} );
 		pastedTable = tmpContainer.findOne( 'table' );
 
 		if ( !selection.getRanges().length || !selection.isInTable() && !( boundarySelection = isBoundarySelection( selection ) ) ) {

--- a/plugins/tableselection/plugin.js
+++ b/plugins/tableselection/plugin.js
@@ -439,6 +439,7 @@
 
 	function fakeSelectionPasteHandler( evt ) {
 		var editor = evt.editor,
+			dataProcessor = editor.dataProcessor,
 			selection = editor.getSelection(),
 			tmpContainer = new CKEDITOR.dom.element( 'body' ),
 			newRowsCount = 0,
@@ -508,7 +509,13 @@
 			}
 		}
 
-		tmpContainer.setHtml( evt.data.dataValue );
+		if ( !dataProcessor ) {
+			dataProcessor = new CKEDITOR.htmlDataProcessor( editor );
+		}
+
+		// Pasted value must be filtered using dataProcessor to strip all unsafe code
+		// before inserting it into temporary container.
+		tmpContainer.setHtml( dataProcessor.toHtml( evt.data.dataValue ) );
 		pastedTable = tmpContainer.findOne( 'table' );
 
 		if ( !selection.getRanges().length || !selection.isInTable() && !( boundarySelection = isBoundarySelection( selection ) ) ) {

--- a/tests/plugins/tableselection/integrations/clipboard/xss.js
+++ b/tests/plugins/tableselection/integrations/clipboard/xss.js
@@ -1,4 +1,4 @@
-/* bender-tags: editor,unit */
+/* bender-tags: tableselection, clipboard */
 /* bender-ckeditor-plugins: tableselection */
 /* bender-include: ../../_helpers/tableselection.js */
 /* global tableSelectionHelpers */

--- a/tests/plugins/tableselection/integrations/clipboard/xss.js
+++ b/tests/plugins/tableselection/integrations/clipboard/xss.js
@@ -1,0 +1,44 @@
+/* bender-tags: editor,unit */
+/* bender-ckeditor-plugins: tableselection, image2 */
+/* bender-include: ../../_helpers/tableselection.js */
+/* global tableSelectionHelpers */
+
+( function() {
+	'use strict';
+
+	bender.editors = {
+		classic: {},
+		inline: {
+			creator: 'inline'
+		}
+	};
+
+	var tests = {
+		setUp: function() {
+			window.attack = sinon.spy();
+		},
+
+		tearDown: function() {
+			delete window.attack;
+		},
+
+		'test JS code is not executed on paste': function( editor ) {
+			bender.tools.setHtmlWithSelection( editor, '<p>foobar^</p>' );
+			bender.tools.emulatePaste( editor, '<img src="x" onerror="window.parent.attack();">' );
+
+			editor.once( 'afterPaste', function() {
+				resume( function() {
+					assert.areSame( 0, window.attack.callCount, 'Function was not invoked' );
+				} );
+			} );
+
+			wait();
+		}
+	};
+
+	tests = bender.tools.createTestsForEditors( CKEDITOR.tools.objectKeys( bender.editors ), tests );
+
+	tableSelectionHelpers.ignoreUnsupportedEnvironment( tests );
+
+	bender.test( tests );
+} )();

--- a/tests/plugins/tableselection/integrations/clipboard/xss.js
+++ b/tests/plugins/tableselection/integrations/clipboard/xss.js
@@ -1,5 +1,5 @@
 /* bender-tags: editor,unit */
-/* bender-ckeditor-plugins: tableselection, image2 */
+/* bender-ckeditor-plugins: tableselection */
 /* bender-include: ../../_helpers/tableselection.js */
 /* global tableSelectionHelpers */
 
@@ -7,9 +7,16 @@
 	'use strict';
 
 	bender.editors = {
-		classic: {},
+		classic: {
+			config: {
+				allowedContent: 'img[*]'
+			}
+		},
 		inline: {
-			creator: 'inline'
+			creator: 'inline',
+			config: {
+				allowedContent: 'img[*]'
+			}
 		}
 	};
 

--- a/tests/plugins/tableselection/manual/integrations/clipboard/xss.html
+++ b/tests/plugins/tableselection/manual/integrations/clipboard/xss.html
@@ -17,5 +17,7 @@
 		window.attack.armed = true;
 	}
 
-	CKEDITOR.replace( 'editor1' );
+	CKEDITOR.replace( 'editor1', {
+		allowedContent: 'img[*]'
+	} );
 </script>

--- a/tests/plugins/tableselection/manual/integrations/clipboard/xss.html
+++ b/tests/plugins/tableselection/manual/integrations/clipboard/xss.html
@@ -1,0 +1,21 @@
+<h2>Copy here…</h2>
+<img src="x" alt="Copy me!" onerror="window.parent.attack()">
+<div id="editor1">
+	<p>Paste here</p>
+</div>
+
+<script>
+	if ( CKEDITOR.env.ie && CKEDITOR.env.version < 11 ) {
+		bender.ignore();
+	}
+
+	window.attack = function() {
+		if ( window.attack.armed ) {
+			return alert( 'MEGA FAIL!' );
+		}
+
+		window.attack.armed = true;
+	}
+
+	CKEDITOR.replace( 'editor1' );
+</script>

--- a/tests/plugins/tableselection/manual/integrations/clipboard/xss.md
+++ b/tests/plugins/tableselection/manual/integrations/clipboard/xss.md
@@ -1,5 +1,5 @@
 @bender-ui: collapsed
-@bender-tags: tc, 18, 4.7.0
+@bender-tags: tc, 16755, 4.7.0, tp2348
 @bender-ckeditor-plugins: wysiwygarea, toolbar, tableselection, clipboard
 
 **Procedure:**

--- a/tests/plugins/tableselection/manual/integrations/clipboard/xss.md
+++ b/tests/plugins/tableselection/manual/integrations/clipboard/xss.md
@@ -1,6 +1,6 @@
 @bender-ui: collapsed
 @bender-tags: tc, 18, 4.7.0
-@bender-ckeditor-plugins: wysiwygarea, toolbar, tableselection, clipboard, image2
+@bender-ckeditor-plugins: wysiwygarea, toolbar, tableselection, clipboard
 
 **Procedure:**
 

--- a/tests/plugins/tableselection/manual/integrations/clipboard/xss.md
+++ b/tests/plugins/tableselection/manual/integrations/clipboard/xss.md
@@ -1,0 +1,17 @@
+@bender-ui: collapsed
+@bender-tags: tc, 18, 4.7.0
+@bender-ckeditor-plugins: wysiwygarea, toolbar, tableselection, clipboard, image2
+
+**Procedure:**
+
+1. Copy image with "Copy me!" alternative text.
+2. Paste it into the editor
+
+**Expected result:**
+
+No alert is shown.
+
+**Unexpected result:**
+
+"MEGA FAIL!" alert is shown.
+


### PR DESCRIPTION
Paste handler in tableselection plugin uses temporary container to handle pasted data. However it allows to paste unsafe HTML inside it. This PR adds appropriate filter.