### PR TITLE
Disable clipboard API for iOS Safari

### DIFF
--- a/plugins/clipboard/plugin.js
+++ b/plugins/clipboard/plugin.js
@@ -1578,7 +1578,8 @@
 			}
 
 			// Safari fixed clipboard in 10.1 (https://bugs.webkit.org/show_bug.cgi?id=19893) (#16982).
-			if ( CKEDITOR.env.safari && CKEDITOR.env.version >= 603 ) {
+			// However iOS version still doesn't work well enough (https://bugs.webkit.org/show_bug.cgi?id=19893#c34).
+			if ( CKEDITOR.env.safari && CKEDITOR.env.version >= 603 && !CKEDITOR.env.iOS ) {
 				return true;
 			}
 

--- a/tests/plugins/clipboard/paste.js
+++ b/tests/plugins/clipboard/paste.js
@@ -49,7 +49,7 @@
 		} );
 	}
 
-	var trustySafari = CKEDITOR.env.safari && CKEDITOR.env.version >= 603;
+	var trustySafari = CKEDITOR.env.safari && CKEDITOR.env.version >= 603 && !CKEDITOR.env.iOS;
 
 	bender.test( {
 		setUp: function() {


### PR DESCRIPTION
Disable clipboard API support for iOS Safari as it still is not implemented correctly.

Basically it still does not provide `text/html` type in the clipboardData, see https://bugs.webkit.org/show_bug.cgi?id=19893#c34.

This was causing clipboard not to work in the editor, and our multiple tests to fail.

Support for Safari was initially added in https://dev.ckeditor.com/ticket/16982 (87ff1a5046).