### PR TITLE
Corrections in clipboard/manual/buttons test

### DIFF
--- a/tests/plugins/clipboard/manual/buttons.md
+++ b/tests/plugins/clipboard/manual/buttons.md
@@ -31,4 +31,4 @@ The same as above.
 
 **IE (not Edge):** A security alert may be displayed &ndash; confirm it. After confirming the content should be pasted.
 
-**Other browsers:** The paste dialog should be displyed.
+**Other browsers:** Notification is shown, with instructions on how to paste.

--- a/tests/plugins/clipboard/manual/buttons.md
+++ b/tests/plugins/clipboard/manual/buttons.md
@@ -8,7 +8,7 @@
 
 #### Expected result:
 
-**Chrome, Edge, Opera:** Selected text should be copied into clipboard and pasted into editor. Notifications should be opened for copy and paste.
+**Chrome, Edge, Opera, Firefox, Safari (desktop):** Selected text should be copied into clipboard and pasted into editor. Notifications should be opened for copy and paste.
 
 **IE:** A security alert may be displayed &ndash; confirm it. After confirming it everything should be the same as in Chrome.
 


### PR DESCRIPTION
Now Firefox and Safari (desktop only) also supports clipboard api allowing for copy and cut.