### PR TITLE
Disable tabletools manual tests on mobile env

### DIFF
--- a/tests/_benderjs/ckeditor/static/tools.js
+++ b/tests/_benderjs/ckeditor/static/tools.js
@@ -78,6 +78,16 @@
 			return bender.tools.fixHtml( html, stripLineBreaks );
 		},
 
+		env: {
+			/*
+			 * Tells whether current environment is running on a mobile browser.
+			 *
+			 * It's different from deprecated {@link CKEDITOR.env.mobile} in a way that we are just
+			 * interested in checking whether this is iOS or most popular Android env.
+			 */
+			mobile: CKEDITOR.env.iOS || navigator.userAgent.indexOf( 'Android' ) !== -1
+		},
+
 		fixHtml: function( html, stripLineBreaks, toLowerCase ) {
 			if ( toLowerCase !== false ) {
 				html = html.toLowerCase();
@@ -588,6 +598,8 @@
 		 * @deprecated Use {@link bender.tools.range#setWithHtml} instead.
 		 */
 		setHtmlWithRange: function( element, html, root ) {
+			var ranges = [];
+
 			root = root instanceof CKEDITOR.dom.document ?
 				root.getBody() : root || CKEDITOR.document.getBody();
 
@@ -617,9 +629,8 @@
 				element.setHtml( html );
 			}
 
-			var ranges = [],
-				// Walk prepared to traverse the inner dom tree of this element.
-				walkerRange = new CKEDITOR.dom.range( root );
+			// Walk prepared to traverse the inner dom tree of this element.
+			var walkerRange = new CKEDITOR.dom.range( root );
 
 			walkerRange.selectNodeContents( element );
 			var wallker = new CKEDITOR.dom.walker( walkerRange ),

--- a/tests/_benderjs/ckeditor/static/tools.js
+++ b/tests/_benderjs/ckeditor/static/tools.js
@@ -85,7 +85,7 @@
 			 * It's different from deprecated {@link CKEDITOR.env.mobile} in a way that we are just
 			 * interested in checking whether this is iOS or most popular Android env.
 			 */
-			mobile: CKEDITOR.env.iOS || navigator.userAgent.indexOf( 'Android' ) !== -1
+			mobile: CKEDITOR.env.iOS || navigator.userAgent.toLowerCase().indexOf( 'android' ) !== -1
 		},
 
 		fixHtml: function( html, stripLineBreaks, toLowerCase ) {

--- a/tests/plugins/tableselection/manual/blur.html
+++ b/tests/plugins/tableselection/manual/blur.html
@@ -80,7 +80,7 @@
 </div>
 
 <script>
-	if ( CKEDITOR.env.ie && CKEDITOR.env.version < 11 ) {
+	if ( ( CKEDITOR.env.ie && CKEDITOR.env.version < 11 ) || bender.tools.env.mobile ) {
 		bender.ignore();
 	}
 

--- a/tests/plugins/tableselection/manual/caption.html
+++ b/tests/plugins/tableselection/manual/caption.html
@@ -13,7 +13,7 @@
 </div>
 
 <script>
-	if ( CKEDITOR.env.ie && CKEDITOR.env.version < 11 ) {
+	if ( ( CKEDITOR.env.ie && CKEDITOR.env.version < 11 ) || bender.tools.env.mobile ) {
 		bender.ignore();
 	}
 

--- a/tests/plugins/tableselection/manual/cellbackground.html
+++ b/tests/plugins/tableselection/manual/cellbackground.html
@@ -12,7 +12,7 @@
 </div>
 
 <script>
-	if ( CKEDITOR.env.ie && CKEDITOR.env.version < 11 ) {
+	if ( ( CKEDITOR.env.ie && CKEDITOR.env.version < 11 ) || bender.tools.env.mobile ) {
 		bender.ignore();
 	}
 

--- a/tests/plugins/tableselection/manual/contextmenu.html
+++ b/tests/plugins/tableselection/manual/contextmenu.html
@@ -73,7 +73,7 @@
 </div>
 
 <script>
-	if ( CKEDITOR.env.ie && CKEDITOR.env.version < 11 ) {
+	if ( ( CKEDITOR.env.ie && CKEDITOR.env.version < 11 ) || bender.tools.env.mobile ) {
 		bender.ignore();
 	}
 

--- a/tests/plugins/tableselection/manual/drag.html
+++ b/tests/plugins/tableselection/manual/drag.html
@@ -22,7 +22,7 @@
 </div>
 
 <script>
-	if ( CKEDITOR.env.ie && CKEDITOR.env.version < 11 ) {
+	if ( ( CKEDITOR.env.ie && CKEDITOR.env.version < 11 ) || bender.tools.env.mobile ) {
 		bender.ignore();
 	}
 

--- a/tests/plugins/tableselection/manual/editortypes.html
+++ b/tests/plugins/tableselection/manual/editortypes.html
@@ -80,7 +80,7 @@
 </div>
 
 <script>
-	if ( CKEDITOR.env.ie && CKEDITOR.env.version < 11 ) {
+	if ( ( CKEDITOR.env.ie && CKEDITOR.env.version < 11 ) || bender.tools.env.mobile ) {
 		bender.ignore();
 	}
 

--- a/tests/plugins/tableselection/manual/enable.html
+++ b/tests/plugins/tableselection/manual/enable.html
@@ -79,7 +79,7 @@
 </div>
 
 <script>
-	if ( CKEDITOR.env.ie && CKEDITOR.env.version < 11 ) {
+	if ( ( CKEDITOR.env.ie && CKEDITOR.env.version < 11 ) || bender.tools.env.mobile ) {
 		bender.ignore();
 	}
 

--- a/tests/plugins/tableselection/manual/inlineeditor.html
+++ b/tests/plugins/tableselection/manual/inlineeditor.html
@@ -25,7 +25,7 @@
 </div>
 
 <script>
-	if ( CKEDITOR.env.ie && CKEDITOR.env.version < 11 ) {
+	if ( ( CKEDITOR.env.ie && CKEDITOR.env.version < 11 ) || bender.tools.env.mobile ) {
 		bender.ignore();
 	}
 

--- a/tests/plugins/tableselection/manual/integrations/basicstyles/basicstyles.html
+++ b/tests/plugins/tableselection/manual/integrations/basicstyles/basicstyles.html
@@ -38,7 +38,7 @@
 </div>
 
 <script>
-	if ( CKEDITOR.env.ie && CKEDITOR.env.version < 11 ) {
+	if ( ( CKEDITOR.env.ie && CKEDITOR.env.version < 11 ) || bender.tools.env.mobile ) {
 		bender.ignore();
 	}
 

--- a/tests/plugins/tableselection/manual/integrations/clipboard/clipboard.html
+++ b/tests/plugins/tableselection/manual/integrations/clipboard/clipboard.html
@@ -789,7 +789,7 @@
 </div>
 
 <script>
-	if ( CKEDITOR.env.ie && CKEDITOR.env.version < 11 ) {
+	if ( ( CKEDITOR.env.ie && CKEDITOR.env.version < 11 ) || bender.tools.env.mobile ) {
 		bender.ignore();
 	}
 

--- a/tests/plugins/tableselection/manual/integrations/clipboard/merge.html
+++ b/tests/plugins/tableselection/manual/integrations/clipboard/merge.html
@@ -38,7 +38,7 @@
 </div>
 
 <script>
-	if ( CKEDITOR.env.ie && CKEDITOR.env.version < 11 ) {
+	if ( ( CKEDITOR.env.ie && CKEDITOR.env.version < 11 ) || bender.tools.env.mobile ) {
 		bender.ignore();
 	}
 

--- a/tests/plugins/tableselection/manual/integrations/clipboard/mergeemptycell.html
+++ b/tests/plugins/tableselection/manual/integrations/clipboard/mergeemptycell.html
@@ -23,7 +23,7 @@
 </div>
 
 <script>
-	if ( CKEDITOR.env.ie && CKEDITOR.env.version < 11 ) {
+	if ( ( CKEDITOR.env.ie && CKEDITOR.env.version < 11 ) || bender.tools.env.mobile ) {
 		bender.ignore();
 	}
 

--- a/tests/plugins/tableselection/manual/integrations/clipboard/mixedcontent.html
+++ b/tests/plugins/tableselection/manual/integrations/clipboard/mixedcontent.html
@@ -436,7 +436,7 @@
 </div>
 
 <script>
-	if ( CKEDITOR.env.ie && CKEDITOR.env.version < 11 ) {
+	if ( ( CKEDITOR.env.ie && CKEDITOR.env.version < 11 ) || bender.tools.env.mobile ) {
 		bender.ignore();
 	}
 

--- a/tests/plugins/tableselection/manual/integrations/clipboard/nestedtable.html
+++ b/tests/plugins/tableselection/manual/integrations/clipboard/nestedtable.html
@@ -39,7 +39,7 @@
 </div>
 
 <script>
-	if ( CKEDITOR.env.ie && CKEDITOR.env.version < 11 ) {
+	if ( ( CKEDITOR.env.ie && CKEDITOR.env.version < 11 ) || bender.tools.env.mobile ) {
 		bender.ignore();
 	}
 

--- a/tests/plugins/tableselection/manual/integrations/clipboard/nestedtablemultiple.html
+++ b/tests/plugins/tableselection/manual/integrations/clipboard/nestedtablemultiple.html
@@ -36,7 +36,7 @@
 	</table>
 </div>
 <script>
-	if ( CKEDITOR.env.ie && CKEDITOR.env.version < 11 ) {
+	if ( ( CKEDITOR.env.ie && CKEDITOR.env.version < 11 ) || bender.tools.env.mobile ) {
 		bender.ignore();
 	}
 

--- a/tests/plugins/tableselection/manual/integrations/link/edit.html
+++ b/tests/plugins/tableselection/manual/integrations/link/edit.html
@@ -44,7 +44,7 @@
 </div>
 
 <script>
-	if ( CKEDITOR.env.ie && CKEDITOR.env.version < 11 ) {
+	if ( ( CKEDITOR.env.ie && CKEDITOR.env.version < 11 ) || bender.tools.env.mobile ) {
 		bender.ignore();
 	}
 

--- a/tests/plugins/tableselection/manual/integrations/link/link.html
+++ b/tests/plugins/tableselection/manual/integrations/link/link.html
@@ -80,7 +80,7 @@
 </div>
 
 <script>
-	if ( CKEDITOR.env.ie && CKEDITOR.env.version < 11 ) {
+	if ( ( CKEDITOR.env.ie && CKEDITOR.env.version < 11 ) || bender.tools.env.mobile ) {
 		bender.ignore();
 	}
 

--- a/tests/plugins/tableselection/manual/integrations/link/text.html
+++ b/tests/plugins/tableselection/manual/integrations/link/text.html
@@ -17,7 +17,7 @@
 </div>
 
 <script>
-	if ( CKEDITOR.env.ie && CKEDITOR.env.version < 11 ) {
+	if ( ( CKEDITOR.env.ie && CKEDITOR.env.version < 11 ) || bender.tools.env.mobile ) {
 		bender.ignore();
 	}
 

--- a/tests/plugins/tableselection/manual/integrations/selectall/selectall.html
+++ b/tests/plugins/tableselection/manual/integrations/selectall/selectall.html
@@ -80,7 +80,7 @@
 </div>
 
 <script>
-	if ( CKEDITOR.env.ie && CKEDITOR.env.version < 11 ) {
+	if ( ( CKEDITOR.env.ie && CKEDITOR.env.version < 11 ) || bender.tools.env.mobile ) {
 		bender.ignore();
 	}
 

--- a/tests/plugins/tableselection/manual/integrations/selectall/table.html
+++ b/tests/plugins/tableselection/manual/integrations/selectall/table.html
@@ -74,7 +74,7 @@
 </div>
 
 <script>
-	if ( CKEDITOR.env.ie && CKEDITOR.env.version < 11 ) {
+	if ( ( CKEDITOR.env.ie && CKEDITOR.env.version < 11 ) || bender.tools.env.mobile ) {
 		bender.ignore();
 	}
 

--- a/tests/plugins/tableselection/manual/integrations/tabletools/celldelete.html
+++ b/tests/plugins/tableselection/manual/integrations/tabletools/celldelete.html
@@ -80,7 +80,7 @@
 </div>
 
 <script>
-	if ( CKEDITOR.env.ie && CKEDITOR.env.version < 11 ) {
+	if ( ( CKEDITOR.env.ie && CKEDITOR.env.version < 11 ) || bender.tools.env.mobile ) {
 		bender.ignore();
 	}
 

--- a/tests/plugins/tableselection/manual/integrations/tabletools/cellmerge.html
+++ b/tests/plugins/tableselection/manual/integrations/tabletools/cellmerge.html
@@ -80,7 +80,7 @@
 </div>
 
 <script>
-	if ( CKEDITOR.env.ie && CKEDITOR.env.version < 11 ) {
+	if ( ( CKEDITOR.env.ie && CKEDITOR.env.version < 11 ) || bender.tools.env.mobile ) {
 		bender.ignore();
 	}
 

--- a/tests/plugins/tableselection/manual/integrations/tabletools/tabletools.html
+++ b/tests/plugins/tableselection/manual/integrations/tabletools/tabletools.html
@@ -79,7 +79,7 @@
 </div>
 
 <script>
-	if ( CKEDITOR.env.ie && CKEDITOR.env.version < 11 ) {
+	if ( ( CKEDITOR.env.ie && CKEDITOR.env.version < 11 ) || bender.tools.env.mobile ) {
 		bender.ignore();
 	}
 

--- a/tests/plugins/tableselection/manual/irregular.html
+++ b/tests/plugins/tableselection/manual/irregular.html
@@ -25,7 +25,7 @@
 </div>
 
 <script>
-	if ( CKEDITOR.env.ie && CKEDITOR.env.version < 11 ) {
+	if ( ( CKEDITOR.env.ie && CKEDITOR.env.version < 11 ) || bender.tools.env.mobile ) {
 		bender.ignore();
 	}
 

--- a/tests/plugins/tableselection/manual/keystrokes.html
+++ b/tests/plugins/tableselection/manual/keystrokes.html
@@ -38,7 +38,7 @@
 </div>
 
 <script>
-	if ( CKEDITOR.env.ie && CKEDITOR.env.version < 11 ) {
+	if ( ( CKEDITOR.env.ie && CKEDITOR.env.version < 11 ) || bender.tools.env.mobile ) {
 		bender.ignore();
 	}
 

--- a/tests/plugins/tableselection/manual/mouse.html
+++ b/tests/plugins/tableselection/manual/mouse.html
@@ -22,7 +22,7 @@
 </div>
 
 <script>
-	if ( CKEDITOR.env.ie && CKEDITOR.env.version < 11 ) {
+	if ( ( CKEDITOR.env.ie && CKEDITOR.env.version < 11 ) || bender.tools.env.mobile ) {
 		bender.ignore();
 	}
 

--- a/tests/plugins/tableselection/manual/native.html
+++ b/tests/plugins/tableselection/manual/native.html
@@ -71,7 +71,7 @@
 </div>
 
 <script>
-	if ( CKEDITOR.env.ie && CKEDITOR.env.version < 11 ) {
+	if ( ( CKEDITOR.env.ie && CKEDITOR.env.version < 11 ) || bender.tools.env.mobile ) {
 		bender.ignore();
 	}
 

--- a/tests/plugins/tableselection/manual/nestedheader.html
+++ b/tests/plugins/tableselection/manual/nestedheader.html
@@ -15,7 +15,7 @@
 </div>
 
 <script>
-	if ( CKEDITOR.env.ie && CKEDITOR.env.version < 11 ) {
+	if ( ( CKEDITOR.env.ie && CKEDITOR.env.version < 11 ) || bender.tools.env.mobile ) {
 		bender.ignore();
 	}
 

--- a/tests/plugins/tableselection/manual/nestedtable.html
+++ b/tests/plugins/tableselection/manual/nestedtable.html
@@ -32,7 +32,7 @@
 </div>
 
 <script>
-	if ( CKEDITOR.env.ie && CKEDITOR.env.version < 11 ) {
+	if ( ( CKEDITOR.env.ie && CKEDITOR.env.version < 11 ) || bender.tools.env.mobile ) {
 		bender.ignore();
 	}
 

--- a/tests/plugins/tableselection/manual/outsideeditor.html
+++ b/tests/plugins/tableselection/manual/outsideeditor.html
@@ -71,7 +71,7 @@
 </div>
 
 <script>
-	if ( CKEDITOR.env.ie && CKEDITOR.env.version < 11 ) {
+	if ( ( CKEDITOR.env.ie && CKEDITOR.env.version < 11 ) || bender.tools.env.mobile ) {
 		bender.ignore();
 	}
 

--- a/tests/plugins/tableselection/manual/outsidetable.html
+++ b/tests/plugins/tableselection/manual/outsidetable.html
@@ -71,7 +71,7 @@
 </div>
 
 <script>
-	if ( CKEDITOR.env.ie && CKEDITOR.env.version < 11 ) {
+	if ( ( CKEDITOR.env.ie && CKEDITOR.env.version < 11 ) || bender.tools.env.mobile ) {
 		bender.ignore();
 	}
 

--- a/tests/plugins/tableselection/manual/partialdelete.html
+++ b/tests/plugins/tableselection/manual/partialdelete.html
@@ -16,7 +16,7 @@
 </div>
 
 <script>
-	if ( CKEDITOR.env.ie && CKEDITOR.env.version < 11 ) {
+	if ( ( CKEDITOR.env.ie && CKEDITOR.env.version < 11 ) || bender.tools.env.mobile ) {
 		bender.ignore();
 	}
 

--- a/tests/plugins/tableselection/manual/selectionleak.html
+++ b/tests/plugins/tableselection/manual/selectionleak.html
@@ -19,7 +19,7 @@
 </div>
 
 <script>
-	if ( CKEDITOR.env.ie && CKEDITOR.env.version < 11 ) {
+	if ( ( CKEDITOR.env.ie && CKEDITOR.env.version < 11 ) || bender.tools.env.mobile ) {
 		bender.ignore();
 	}
 

--- a/tests/plugins/tableselection/manual/tableselection.html
+++ b/tests/plugins/tableselection/manual/tableselection.html
@@ -443,7 +443,7 @@
 </div>
 
 <script>
-	if ( CKEDITOR.env.ie && CKEDITOR.env.version < 11 ) {
+	if ( ( CKEDITOR.env.ie && CKEDITOR.env.version < 11 ) || bender.tools.env.mobile ) {
 		bender.ignore();
 	}
 

--- a/tests/plugins/tableselection/manual/widget.html
+++ b/tests/plugins/tableselection/manual/widget.html
@@ -3,7 +3,7 @@
 </div>
 
 <script>
-	if ( CKEDITOR.env.ie && CKEDITOR.env.version < 11 ) {
+	if ( ( CKEDITOR.env.ie && CKEDITOR.env.version < 11 ) || bender.tools.env.mobile ) {
 		bender.ignore();
 	}
 


### PR DESCRIPTION
To solve this issue I added a small helper variable to bender tools. I did not added it into `CKEDITOR` namespace as it is waaaay too simple for reliable check, but enough for our testing needs.