### PR TITLE
#17052 Error on scroll while selecting nested table

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -9,6 +9,7 @@ New Features:
 
 Fixed Issues:
 
+* [#493](https://github.com/ckeditor/ckeditor-dev/issues/493): Fixed: Selection started from a nested table causes an error in a browser while scrolling down.
 * [#415](https://github.com/ckeditor/ckeditor-dev/issues/415): Fixed: [Firefox] Enter key breaks table structure when pressed in a table selection.
 * [#457](https://github.com/ckeditor/ckeditor-dev/issues/457): Fixed: Error thrown when deleting content from the editor with no selection.
 * [#450](https://github.com/ckeditor/ckeditor-dev/issues/450): Fixed: [`CKEDITOR.filter`](http://docs.ckeditor.com/#!/api/CKEDITOR.filter) incorrectly transforms `margin` CSS property.

--- a/plugins/tableselection/plugin.js
+++ b/plugins/tableselection/plugin.js
@@ -198,7 +198,7 @@
 			return;
 		}
 
-		// We should check if the newly selected cell is still inside the same table (#17052).
+		// We should check if the newly selected cell is still inside the same table (http://dev.ckeditor.com/ticket/17052, #465).
 		if ( cell && fakeSelection.first.getAscendant( 'table' ).equals( cell.getAscendant( 'table' ) ) ) {
 			cells = getCellsBetween( fakeSelection.first, cell );
 

--- a/plugins/tableselection/plugin.js
+++ b/plugins/tableselection/plugin.js
@@ -198,7 +198,7 @@
 			return;
 		}
 
-		// We should check if the newly selected cell is still inside the same table (http://dev.ckeditor.com/ticket/17052, #465).
+		// We should check if the newly selected cell is still inside the same table (http://dev.ckeditor.com/ticket/17052, #493).
 		if ( cell && fakeSelection.first.getAscendant( 'table' ).equals( cell.getAscendant( 'table' ) ) ) {
 			cells = getCellsBetween( fakeSelection.first, cell );
 

--- a/plugins/tableselection/plugin.js
+++ b/plugins/tableselection/plugin.js
@@ -198,7 +198,8 @@
 			return;
 		}
 
-		if ( cell ) {
+		// We should check if the newly selected cell is still inside the same table (#17052).
+		if ( cell && fakeSelection.first.getAscendant( 'table' ).equals( cell.getAscendant( 'table' ) ) ) {
 			cells = getCellsBetween( fakeSelection.first, cell );
 
 			// The selection is inside one cell, so we should allow native selection,

--- a/tests/plugins/tableselection/_helpers/tableselection.js
+++ b/tests/plugins/tableselection/_helpers/tableselection.js
@@ -1,4 +1,4 @@
-/* exported tableSelectionHelpers, createPasteTestCase, doCommandTest */
+/* exported tableSelectionHelpers, createPasteTestCase, doCommandTest, mockMouseEventForCell, mockMouseSelection */
 
 ( function() {
 	'use strict';
@@ -159,5 +159,63 @@
 				}
 			}
 		} );
+	};
+
+	/**
+	 * @param {CKEDITOR.editor} editor Editor's instance.
+	 * @param {String} type Event's type.
+	 * @param {CKEDITOR.dom.element} cell Cell that is a target of the event.
+	 * @param {Function} callback
+	 */
+	window.mockMouseEventForCell = function( editor, type, cell, callback ) {
+
+		var host = editor.editable().isInline() ? editor.editable() : editor.document,
+			event = {
+				getTarget: function() {
+					return cell;
+				},
+
+				preventDefault: function() {
+					// noop
+				},
+
+				$: {
+					button: 0,
+
+					// We need these because on build version magicline plugin
+					// also listen on 'mousemove'.
+					clientX: 0,
+					clientY: 0
+				}
+			};
+
+		host.once( type, function() {
+			resume( callback );
+		} );
+
+		host.fire( type, event );
+		wait();
+	};
+
+	/**
+	 * @param {CKEDITOR.editor} editor Editor's instance.
+	 * @param {Array} cells Cells that should be selected. The first one is used as mousedown target,
+	 * the last as mousemove and mouseup target, others as mousemove targets.
+	 * @param {Function} callback
+	 */
+	window.mockMouseSelection = function( editor, cells, callback ) {
+		function handler() {
+			var cell = cells.shift();
+
+			if ( cells.length > 0 ) {
+				window.mockMouseEventForCell( editor, 'mousemove', cell, handler );
+			} else {
+				window.mockMouseEventForCell( editor, 'mousemove', cell, function() {
+					window.mockMouseEventForCell( editor, 'mouseup', cell, callback );
+				} );
+			}
+		}
+
+		window.mockMouseEventForCell( editor, 'mousedown', cells.shift(), handler );
 	};
 } )();

--- a/tests/plugins/tableselection/_helpers/tableselection.js
+++ b/tests/plugins/tableselection/_helpers/tableselection.js
@@ -161,7 +161,7 @@
 		} );
 	};
 
-	/**
+	/*
 	 * @param {CKEDITOR.editor} editor Editor's instance.
 	 * @param {String} type Event's type.
 	 * @param {CKEDITOR.dom.element} cell Cell that is a target of the event.
@@ -197,7 +197,7 @@
 		wait();
 	};
 
-	/**
+	/*
 	 * @param {CKEDITOR.editor} editor Editor's instance.
 	 * @param {Array} cells Cells that should be selected. The first one is used as mousedown target,
 	 * the last as mousemove and mouseup target, others as mousemove targets.

--- a/tests/plugins/tableselection/manual/nestedtablescroll.html
+++ b/tests/plugins/tableselection/manual/nestedtablescroll.html
@@ -1,19 +1,16 @@
 <div id="editor1">
-	<table border="1" cellpadding="1" cellspacing="1" style="width:500px">
-	<tbody>
+	<table border="1">
 		<tr>
 			<td>
-				<table border="1" cellpadding="1" cellspacing="1">
-					<tbody>
-						<tr>
-							<td>Cell 2.1.1</td>
-							<td>Cell 2.1.2</td>
-						</tr>
-						<tr>
-							<td>Cell 2.2.1</td>
-							<td>Cell 2.2.2</td>
-						</tr>
-					</tbody>
+				<table border="1">
+					<tr>
+						<td>Cell 2.1.1</td>
+						<td>Cell 2.1.2</td>
+					</tr>
+					<tr>
+						<td>Cell 2.2.1</td>
+						<td>Cell 2.2.2</td>
+					</tr>
 				</table>
 				<p>Cell 1.1.1</p>
 			</td>
@@ -27,8 +24,7 @@
 			<td>Cell 1.3.1</td>
 			<td>Cell 1.3.2</td>
 		</tr>
-	</tbody>
-</table>
+	</table>
 	<p>Some text</p>
 </div>
 

--- a/tests/plugins/tableselection/manual/nestedtablescroll.html
+++ b/tests/plugins/tableselection/manual/nestedtablescroll.html
@@ -1,0 +1,43 @@
+<div id="editor1">
+	<table border="1" cellpadding="1" cellspacing="1" style="width:500px">
+	<tbody>
+		<tr>
+			<td>
+				<table border="1" cellpadding="1" cellspacing="1">
+					<tbody>
+						<tr>
+							<td>Cell 2.1.1</td>
+							<td>Cell 2.1.2</td>
+						</tr>
+						<tr>
+							<td>Cell 2.2.1</td>
+							<td>Cell 2.2.2</td>
+						</tr>
+					</tbody>
+				</table>
+				<p>Cell 1.1.1</p>
+			</td>
+			<td>Cell 1.1.2</td>
+		</tr>
+		<tr>
+			<td>Cell 1.2.1</td>
+			<td>Cell 1.2.2</td>
+		</tr>
+		<tr>
+			<td>Cell 1.3.1</td>
+			<td>Cell 1.3.2</td>
+		</tr>
+	</tbody>
+</table>
+	<p>Some text</p>
+</div>
+
+<script>
+	if ( ( CKEDITOR.env.ie && CKEDITOR.env.version < 11 ) || bender.tools.env.mobile ) {
+		bender.ignore();
+	}
+
+	CKEDITOR.replace( 'editor1', {
+		height: 100
+	} );
+</script>

--- a/tests/plugins/tableselection/manual/nestedtablescroll.md
+++ b/tests/plugins/tableselection/manual/nestedtablescroll.md
@@ -8,6 +8,8 @@
 2. Select cells inside nested table.
 3. Without releasing mouse button, move pointer to the bottom edge of the editor to cause scrolling down to the end of the editor.
 
+**NOTE:** This issue could not be reproducible in IE and Edge due to https://developer.microsoft.com/en-us/microsoft-edge/platform/issues/12115046/
+
 **Expected result:**
 
 * Selection is contained inside nested table.

--- a/tests/plugins/tableselection/manual/nestedtablescroll.md
+++ b/tests/plugins/tableselection/manual/nestedtablescroll.md
@@ -8,11 +8,11 @@
 2. Select cells inside nested table.
 3. Without releasing mouse button, move pointer to the bottom edge of the editor to cause scrolling down to the end of the editor.
 
-**NOTE:** This issue could not be reproducible in IE and Edge due to https://developer.microsoft.com/en-us/microsoft-edge/platform/issues/12115046/
-
 **Expected result:**
 
 * Selection is contained inside nested table.
+* Editable gets scrolled.
+	* **Edge/IE** No scrolling occurs due to [#12115046](https://developer.microsoft.com/en-us/microsoft-edge/platform/issues/12115046/).
 * There are no errors in the console.
 
 **Unexpected result:**

--- a/tests/plugins/tableselection/manual/nestedtablescroll.md
+++ b/tests/plugins/tableselection/manual/nestedtablescroll.md
@@ -1,5 +1,5 @@
 @bender-ui: collapsed
-@bender-tags: tc, 17052, 4.7.1
+@bender-tags: tc, 17052, gh465, 4.7.1
 @bender-ckeditor-plugins: wysiwygarea, toolbar, tableselection
 
 **Procedure:**

--- a/tests/plugins/tableselection/manual/nestedtablescroll.md
+++ b/tests/plugins/tableselection/manual/nestedtablescroll.md
@@ -1,0 +1,18 @@
+@bender-ui: collapsed
+@bender-tags: tc, 17052, 4.7.1
+@bender-ckeditor-plugins: wysiwygarea, toolbar, tableselection
+
+**Procedure:**
+
+1. Open console.
+2. Select cells inside nested table.
+3. Without releasing mouse button, move pointer to the bottom edge of the editor to cause scrolling down to the end of the editor.
+
+**Expected result:**
+
+* Selection is contained inside nested table.
+* There are no errors in the console.
+
+**Unexpected result:**
+
+* There are errors in the console.

--- a/tests/plugins/tableselection/manual/nestedtablescroll.md
+++ b/tests/plugins/tableselection/manual/nestedtablescroll.md
@@ -1,5 +1,5 @@
 @bender-ui: collapsed
-@bender-tags: tc, 17052, gh465, 4.7.1
+@bender-tags: bug, trac17052, 465, 4.7.1
 @bender-ckeditor-plugins: wysiwygarea, toolbar, tableselection
 
 **Procedure:**

--- a/tests/plugins/tableselection/manual/nestedtablescroll.md
+++ b/tests/plugins/tableselection/manual/nestedtablescroll.md
@@ -1,5 +1,5 @@
 @bender-ui: collapsed
-@bender-tags: bug, trac17052, 465, 4.7.1
+@bender-tags: bug, trac17052, 493, 4.7.1
 @bender-ckeditor-plugins: wysiwygarea, toolbar, tableselection
 
 **Procedure:**

--- a/tests/plugins/tableselection/tableselection.html
+++ b/tests/plugins/tableselection/tableselection.html
@@ -22,4 +22,34 @@
 	</table>
 </textarea>
 
+<div id="nestedScroll">
+	<table border="1">
+		<tr>
+			<td>
+				<table border="1">
+					<tr>
+						<td>Cell 2.1.1</td>
+						<td>Cell 2.1.2</td>
+					</tr>
+					<tr>
+						<td>Cell 2.2.1</td>
+						<td>Cell 2.2.2</td>
+					</tr>
+				</table>
+				<p>Cell 1.1.1</p>
+			</td>
+			<td>Cell 1.1.2</td>
+		</tr>
+		<tr>
+			<td>Cell 1.2.1</td>
+			<td>Cell 1.2.2</td>
+		</tr>
+		<tr>
+			<td>Cell 1.3.1</td>
+			<td>Cell 1.3.2</td>
+		</tr>
+	</table>
+</div>
+
+
 <iframe id="focusIframe"></iframe>

--- a/tests/plugins/tableselection/tableselection.js
+++ b/tests/plugins/tableselection/tableselection.js
@@ -82,7 +82,7 @@
 			assert.areSame( 1,  editor.getSelection().isFake, 'Selection remains faked' );
 		},
 
-		'simulating merge cells from context menu ': function( editor ) {
+		'test simulating merge cells from context menu ': function( editor ) {
 			var selection = editor.getSelection(),
 				expected = '<table><tbody><tr><td>Cell 1.1</td><td rowspan="2">Cell 1.2<br />Cell 2.2</td>' +
 					'<td>Cell 1.3</td></tr><tr><td>Cell 2.1</td><td>Cell 2.3</td></tr></tbody></table>',
@@ -138,11 +138,9 @@
 		},
 
 		// #493
-		'simulating mouse events while scrolling and selecting cells in nested table': function( editor ) {
-			var cells;
-
+		'test simulating mouse events while scrolling and selecting cells in nested table': function( editor ) {
 			bender.tools.setHtmlWithSelection( editor, CKEDITOR.document.getById( 'nestedScroll' ).getHtml() );
-			cells = editor.editable().find( 'td' );
+			var cells = editor.editable().find( 'td' );
 
 			mockMouseSelection( editor, [ cells.getItem( 1 ), cells.getItem( 3 ), cells.getItem( 8 ) ], function() {
 				assert.pass();

--- a/tests/plugins/tableselection/tableselection.js
+++ b/tests/plugins/tableselection/tableselection.js
@@ -1,7 +1,7 @@
 /* bender-tags: tableselection */
 /* bender-ckeditor-plugins: tableselection */
 /* bender-include: _helpers/tableselection.js */
-/* global tableSelectionHelpers */
+/* global tableSelectionHelpers, mockMouseSelection */
 
 ( function() {
 	'use strict';
@@ -135,6 +135,18 @@
 			} );
 
 			wait();
+		},
+
+		// #493
+		'simulating mouse events while scrolling and selecting cells in nested table': function( editor ) {
+			var cells;
+
+			bender.tools.setHtmlWithSelection( editor, CKEDITOR.document.getById( 'nestedScroll' ).getHtml() );
+			cells = editor.editable().find( 'td' );
+
+			mockMouseSelection( editor, [ cells.getItem( 1 ), cells.getItem( 3 ), cells.getItem( 8 ) ], function() {
+				assert.pass();
+			} );
 		}
 	};
 


### PR DESCRIPTION
Issue was caused by the fact that mouse handler is fired also on `mousemove` and scrolling selects cell outside the nested table. Simple check if the newly selected cell is still inside the original table should do the trick.

Closes #493.