### PR TITLE
Removed unnecessary line in template docs

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -21,5 +21,3 @@ in the official CKEditor documentation.
 ## What changes did you make?
 
 *Give an overview…*
-
-**Thank you for contributing!**


### PR DESCRIPTION
The reason is we want to keep it as short as possible.