### PR TITLE
Updates to the image plugin to improve handling of percent-sized images

### DIFF
--- a/plugins/image/dialogs/image.js
+++ b/plugins/image/dialogs/image.js
@@ -727,10 +727,10 @@
 													if ( regexPercentSize.test( widthValue ) && regexPercentSize.test( heightValue ) ) {
 														var actualWidth = element.$.offsetWidth,
 
-														    widthPercentage = parseFloat( widthValue ),
-														    heightPercentage = parseFloat( heightValue ),
+															widthPercentage = parseFloat( widthValue ),
+															heightPercentage = parseFloat( heightValue ),
 
-														    aspectRatio = 1.0;
+															aspectRatio = 1.0;
 
 														if ( oImageOriginal.getCustomData( 'isReady' ) == 'true' )
 															aspectRatio = oImageOriginal.$.width / oImageOriginal.$.height;


### PR DESCRIPTION
We have a use of the `image` plugin that frequently inserts images with percentage widths. I've found the behaviour of the dialog to not entirely capture the way images with percentage widths fundamentally work. This PR addresses the issues I bumped into in the following ways:

* If a percentage is input into either `txtWidth` or `txtHeight`, the lock ratio is turned _on_ and the percentage value is copied to the other control.
* Setting a percentage height on an image in a container that doesn't have a defined height is a no-op, equivalent to `height: auto`, so the control will e.g. no longer emit `height: 50%;` when the width/height are set to `50%`.
* The preview area *does* have a fixed height, which resulted in the image appearing distorted, different from how it appears in the document after insertion. This code computes the appropriate height for the preview when the width is set to a percentage.
* The dialog has been updated to detect and properly re-load percentage width/height values when being re-opened on a previously-inserted image.

The code formatting in this codebase is very different from what I am accustomed to -- I have done my best to keep my newly-written code following the same style. Let me know if there are any style changes needed.