### PR TITLE
Improved aspect ratio matching in switchLockRatio function

### DIFF
--- a/plugins/image/dialogs/image.js
+++ b/plugins/image/dialogs/image.js
@@ -116,14 +116,22 @@
 						if ( !dialog.userlockRatio && oImageOriginal.getCustomData( 'isReady' ) == 'true' ) {
 							var width = dialog.getValueOf( 'info', 'txtWidth' ),
 								height = dialog.getValueOf( 'info', 'txtHeight' ),
-								originalRatio = oImageOriginal.$.width * 1000 / oImageOriginal.$.height,
-								thisRatio = width * 1000 / height;
+								originalRatio = oImageOriginal.$.width / oImageOriginal.$.height,
+								thisRatio = width / height;
 							dialog.lockRatio = false; // Default: unlock ratio
 
 							if ( !width && !height )
 								dialog.lockRatio = true;
 							else if ( !isNaN( originalRatio ) && !isNaN( thisRatio ) ) {
-								if ( Math.round( originalRatio ) == Math.round( thisRatio ) )
+								var ratioComparison = originalRatio / thisRatio;
+
+								// Ensure that we have the larger ratio value divided by the smaller ratio value, to simplify
+								// testing for the desired tolerance.
+								if ( ratioComparison < 1.0 )
+									ratioComparison = 1.0 / ratioComparison;
+
+								// Check that the ratios are within 2% of one another.
+								if ( ratioComparison < 1.02 )
 									dialog.lockRatio = true;
 							}
 						}


### PR DESCRIPTION
In the `image` dialog, there is a function `switchLockRatio` which can receive a parameter `'check'` to indicate that it should try to automatically determine whether the current width/height are the result of previously having the ratio locked. However, the way this calculation is done is "too precise". For instance, if the image is 1800x1200 pixels, and the user resizes it to 500x333, the current calculation will not see 500x333 as being "the same" aspect ratio as 1800x1200. The way the calculation currently works is, the aspect ratio is scaled by 1,000 and then rounded off, which is the same as keeping three decimals. With four decimals, 1800x1200 produces an aspect ratio of 1.500, while 500x333 produces an aspect ratio of 1.502 (1.5015015...).

I think a more appropriate cutoff is 2%, rather than 0.1%. This PR restructures the code to make it much simpler/more intuitive to tune the cutoff, and tunes it to 2% (1.02).