### PR TITLE
Fixed issue tracker links in samples

### DIFF
--- a/samples/index.html
+++ b/samples/index.html
@@ -18,7 +18,7 @@ For licensing, see LICENSE.md or http://ckeditor.com/license
 	<div class="grid-container">
 		<ul class="navigation-a-left grid-width-70">
 			<li><a href="http://ckeditor.com">Project Homepage</a></li>
-			<li><a href="http://dev.ckeditor.com/">I found a bug</a></li>
+			<li><a href="https://github.com/ckeditor/ckeditor-dev/issues">I found a bug</a></li>
 			<li><a href="http://github.com/ckeditor/ckeditor-dev" class="icon-pos-right icon-navigation-a-github">Fork CKEditor on GitHub</a></li>
 		</ul>
 		<ul class="navigation-a-right grid-width-30">

--- a/samples/toolbarconfigurator/index.html
+++ b/samples/toolbarconfigurator/index.html
@@ -26,7 +26,7 @@ For licensing, see LICENSE.md or http://ckeditor.com/license
 	<div class="grid-container">
 		<ul class="navigation-a-left grid-width-70">
 			<li><a href="http://ckeditor.com">Project Homepage</a></li>
-			<li><a href="http://dev.ckeditor.com/">I found a bug</a></li>
+			<li><a href="https://github.com/ckeditor/ckeditor-dev/issues">I found a bug</a></li>
 			<li><a href="http://github.com/ckeditor/ckeditor-dev" class="icon-pos-right icon-navigation-a-github">Fork CKEditor on GitHub</a></li>
 		</ul>
 		<ul class="navigation-a-right grid-width-30">


### PR DESCRIPTION
Typo


1. Open `samples/index.html`.
1. See that "I found a bug" link points to the old tracker.