### PR TITLE
Enter modifies only first cell 

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -9,6 +9,7 @@ New Features:
 
 Fixed Issues:
 
+* [#415](https://github.com/ckeditor/ckeditor-dev/issues/415): Fixed: [Firefox] Enter key breaks table structure when pressed in a table selection.
 * [#457](https://github.com/ckeditor/ckeditor-dev/issues/457): Fixed: Error thrown when deleting content from the editor with no selection.
 * [#450](https://github.com/ckeditor/ckeditor-dev/issues/450): Fixed: [`CKEDITOR.filter`](http://docs.ckeditor.com/#!/api/CKEDITOR.filter) incorrectly transforms `margin` CSS property.
 

--- a/plugins/tableselection/plugin.js
+++ b/plugins/tableselection/plugin.js
@@ -853,7 +853,7 @@
 
 			function tableKeyPressListener( evt ) {
 				var selection = editor.getSelection(),
-					// Enter key also produces character, but Firefox doesn't think so (#415).
+					// Enter key also produces character, but Firefox doesn't think so (gh#415).
 					isCharKey = evt.data.$.charCode || ( evt.data.getKey() === 13 ),
 					ranges,
 					firstCell,

--- a/plugins/tableselection/plugin.js
+++ b/plugins/tableselection/plugin.js
@@ -853,12 +853,14 @@
 
 			function tableKeyPressListener( evt ) {
 				var selection = editor.getSelection(),
+					// Enter key also produces character, but Firefox doesn't think so (#415).
+					isCharKey = evt.data.$.charCode || ( evt.data.getKey() === 13 ),
 					ranges,
 					firstCell,
 					i;
 
 				// We must check if the event really did not produce any character as it's fired for all keys in Gecko.
-				if ( !selection || !selection.isInTable() || !selection.isFake || !evt.data.$.charCode ||
+				if ( !selection || !selection.isInTable() || !selection.isFake || !isCharKey ||
 					evt.data.getKeystroke() & CKEDITOR.CTRL ) {
 					return;
 				}

--- a/tests/plugins/tableselection/keyboard.html
+++ b/tests/plugins/tableselection/keyboard.html
@@ -228,3 +228,26 @@
 	</tbody>
 </table>
 </textarea>
+
+<textarea id="enterKey">
+<table>
+	<tr>
+		<td>a</td>
+		<td>b</td>
+		<td>c</td>
+		<td>d</td>
+	</tr>
+</table>
+
+=>
+<table>
+	<tbody>
+		<tr>
+			<td>^&nbsp;</td>
+			<td>&nbsp;</td>
+			<td>&nbsp;</td>
+			<td>&nbsp;</td>
+		</tr>
+	</tbody>
+</table>
+</textarea>

--- a/tests/plugins/tableselection/keyboard.js
+++ b/tests/plugins/tableselection/keyboard.js
@@ -172,6 +172,19 @@
 
 				bender.assert.beautified.html( expected, bot.htmlWithSelection() );
 			} );
+		},
+
+		// #415
+		'test enter key': function( editor, bot ) {
+			bender.tools.testInputOut( 'enterKey', function( source, expected ) {
+				bender.tools.setHtmlWithSelection( editor, source );
+
+				editor.getSelection().selectRanges( getRangesForCells( editor, [ 0, 1, 2, 3 ] ) );
+
+				editor.editable().fire( 'keypress', new CKEDITOR.dom.event( { keyCode: 13 } ) );
+
+				bender.assert.beautified.html( expected, bot.htmlWithSelection() );
+			} );
 		}
 	};
 

--- a/tests/plugins/tableselection/manual/enterkey.html
+++ b/tests/plugins/tableselection/manual/enterkey.html
@@ -1,0 +1,48 @@
+<div id="editor1">
+	<p>Some text</p>
+
+	<table border="1">
+		<tr>
+			<td>Cell 1.1</td>
+			<td>Cell 1.2</td>
+			<td>Cell 1.3</td>
+			<td>Cell 1.4</td>
+		</tr>
+		<tr>
+			<td>Cell 2.1</td>
+			<td>Cell 2.2</td>
+			<td>Cell 2.3</td>
+			<td>Cell 2.4</td>
+		</tr>
+		<tr>
+			<td>Cell 3.1</td>
+			<td>Cell 3.2</td>
+			<td>Cell 3.3</td>
+			<td>Cell 3.4</td>
+		</tr>
+		<tr>
+			<td>Cell 4.1</td>
+			<td>Cell 4.2</td>
+			<td>Cell 4.3</td>
+			<td>Cell 4.4</td>
+		</tr>
+		<tr>
+			<td>Cell 5.1</td>
+			<td>Cell 5.2</td>
+			<td>Cell 5.3</td>
+			<td>Cell 5.4</td>
+		</tr>
+	</table>
+
+	<p>Some text</p>
+</div>
+
+<script>
+	if ( !CKEDITOR.env.gecko ) {
+		bender.ignore();
+	}
+
+	CKEDITOR.replace( 'editor1', {
+		autoGrow_onStartup: true
+	} );
+</script>

--- a/tests/plugins/tableselection/manual/enterkey.md
+++ b/tests/plugins/tableselection/manual/enterkey.md
@@ -1,6 +1,6 @@
 @bender-ui: collapsed
 @bender-tags: tc, gh415, 4.7.1
-@bender-ckeditor-plugins: wysiwygarea, toolbar, tableselection, basicstyles, sourcearea, elementspath, undo, autogrow
+@bender-ckeditor-plugins: wysiwygarea, toolbar, tableselection, sourcearea, elementspath, undo
 
 **Procedure:**
 

--- a/tests/plugins/tableselection/manual/enterkey.md
+++ b/tests/plugins/tableselection/manual/enterkey.md
@@ -1,5 +1,5 @@
 @bender-ui: collapsed
-@bender-tags: tc, 415, 4.7.1
+@bender-tags: tc, gh415, 4.7.1
 @bender-ckeditor-plugins: wysiwygarea, toolbar, tableselection, basicstyles, sourcearea, elementspath, undo, autogrow
 
 **Procedure:**

--- a/tests/plugins/tableselection/manual/enterkey.md
+++ b/tests/plugins/tableselection/manual/enterkey.md
@@ -1,0 +1,13 @@
+@bender-ui: collapsed
+@bender-tags: tc, 415, 4.7.1
+@bender-ckeditor-plugins: wysiwygarea, toolbar, tableselection, basicstyles, sourcearea, elementspath, undo, autogrow
+
+**Procedure:**
+
+1. Select two or more table cells.
+2. Press <kbd>Enter</kbd>.
+
+**Expected result:**
+
+* Visual selection is discarded.
+* The new line is typed into the first selected table cell and collapsed selection is placed after it.


### PR DESCRIPTION
## What is the purpose of this pull request?

<!-- Bug fix / New feature / Typo fix / Other, please explain  -->
Bug fix, fixes #415.

## Does your PR contain necessary tests?

All patches which change the editor code must include tests. You can always read more
on [PR testing](http://docs.ckeditor.com/#!/guide/dev_contributing_code-section-tests),
[how to set the testing environment](http://docs.ckeditor.com/#!/guide/dev_tests) and
[how to create tests](http://docs.ckeditor.com/#!/guide/dev_tests-section-creating-your-own-test)
in the official CKEditor documentation.

### This PR contains

- [x] Unit tests
- [x] Manual tests

## What changes did you make?

It seems that Firefox treat <kbd>Enter</kbd> as the key that doesn't produce any character, so  `keyPressEvent.charCode` property is set to `0`. Explicitly checking if the <kbd>Enter</kbd> key is pressed seems to do the trick.
