### PR TITLE
Remove double slash from tableselection.css path

### DIFF
--- a/plugins/tableselection/plugin.js
+++ b/plugins/tableselection/plugin.js
@@ -917,7 +917,7 @@
 			insertRow = tabletools.insertRow;
 			insertColumn = tabletools.insertColumn;
 
-			CKEDITOR.document.appendStyleSheet( this.path + '/styles/tableselection.css' );
+			CKEDITOR.document.appendStyleSheet( this.path + 'styles/tableselection.css' );
 		},
 
 		init: function( editor ) {
@@ -928,7 +928,7 @@
 
 			// Add styles for fake visual selection.
 			if ( editor.addContentsCss ) {
-				editor.addContentsCss( this.path + '/styles/tableselection.css' );
+				editor.addContentsCss( this.path + 'styles/tableselection.css' );
 			}
 
 			editor.on( 'contentDom', function() {


### PR DESCRIPTION
## What is the purpose of this pull request?

Bug fix

this.path ends with a slash so the final path to tableselection.css contains a double slash. This can prevent the stylesheet from being loaded in some cases (e.g. when it is loaded from within a WebJar and not directly from the file system). Other plugins that use this.path (see a11yhelp, find, image2, link, liststyle, magicline, specialchar, table) don't prefix the path fragments appended to this.path with a slash.
