### PR TITLE
Update ballonpanel test condition to not run on iOS Safari.

### DIFF
--- a/tests/plugins/balloonpanel/positioning.inline.js
+++ b/tests/plugins/balloonpanel/positioning.inline.js
@@ -5,6 +5,10 @@
 
 ( function() {
 	'use strict';
+	// Iframes on Safari mobile cannot be scrolled. That's why method `_scrollViewport` quietly failed (#441).
+	if ( CKEDITOR.env.iOS && CKEDITOR.env.safari ) {
+		bender.ignore();
+	}
 
 	// We need to lie about view pane size. This is due running test from dashboard might have random, tiny size for
 	// the iframe, this will result with unpredictable balloon positioning. Not that it's relatively safe, because in


### PR DESCRIPTION
## What is the purpose of this pull request?

Bug fix

## Does your PR contain necessary tests?

No. PR correct existing tests.

### This PR contains

- [ ] Unit tests
- [ ] Manual tests

## What changes did you make?

Prevent of running test on mobile Safari.
Mobile safari do not allow on scrolling content of iframes. That's why unit test related to balloonpanell are not pass.
Situation is reported [here](https://bugs.webkit.org/show_bug.cgi?id=172854).

Close #441 