### PR TITLE
Fix for getCommandKeystroke

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -18,6 +18,7 @@ Fixed Issues:
 * [#417](https://github.com/ckeditor/ckeditor-dev/issues/417): Fixed: [Table Resize](http://ckeditor.com/addon/tableresize) plugin throws an error when used with a table with only header or footer rows.
 * [#424](https://github.com/ckeditor/ckeditor-dev/issues/424): Fixed: Error thrown by [Tab Key Handling](http://ckeditor.com/addon/tab) and [Indent List](http://ckeditor.com/addon/indentlist) when pressing `Tab` with no selection in inline editor.
 * [#476](https://github.com/ckeditor/ckeditor-dev/issues/476): Fixed: Anchors inserted via [Link](http://ckeditor.com/addon/link) plugin on collapsed selection can't be edited.
+* [#523](https://github.com/ckeditor/ckeditor-dev/issues/523): Fixed: `editor.getCommandKeystroke` does not obtain correct keystroke.
 
 ## CKEditor 4.7
 

--- a/core/editor.js
+++ b/core/editor.js
@@ -1365,7 +1365,7 @@
 			var commandInstance = ( typeof command === 'string' ? this.getCommand( command ) : command );
 
 			if ( commandInstance ) {
-				var commandName = commandInstance && commandInstance.name,
+				var commandName = CKEDITOR.tools.object.findKey( this.commands, commandInstance ),
 					keystrokes = this.keystrokeHandler.keystrokes,
 					key;
 

--- a/core/tools.js
+++ b/core/tools.js
@@ -1854,11 +1854,11 @@
 		 */
 		object: {
 			/**
-			 * Return a first key from `obj` which has given value. If key cannot be find, `null` is returned.
+			 * Return a first key from `obj` which has given `value`.
 			 *
-			 * @param {Object} obj Object which key is looked for.
-			 * @param {Mixed} value Object's vlaue which key is looked for
-			 * @returns {String/null} Key string
+			 * @param {Object} obj Object which `key` is looked for.
+			 * @param {Mixed} value Object's `value` to be looked for.
+			 * @returns {String/null} Matched `key` or `null` if not found.
 			 * @member CKEDITOR.tools.object
 			 */
 

--- a/core/tools.js
+++ b/core/tools.js
@@ -1844,6 +1844,39 @@
 				}
 				return acc;
 			}
+		},
+
+		/**
+		 * A set of object helpers.
+		 *
+		 * @property {CKEDITOR.tools.object}
+		 * @member CKEDITOR.tools
+		 */
+		object: {
+			/**
+			 * Return a first key from `obj` which has given value. If key cannot be find, `null` is returned.
+			 *
+			 * @param {Object} obj Object which key is looked for.
+			 * @param {Mixed} value Object's vlaue which key is looked for
+			 * @returns {String/null} Key string
+			 * @member CKEDITOR.tools.object
+			 */
+
+			findKey: function( obj, value ) {
+				if ( typeof obj !== 'object' ) {
+					return null;
+				}
+
+				var key;
+
+				for ( key in obj ) {
+					if ( obj[ key ] === value ) {
+						return key;
+					}
+				}
+
+				return null;
+			}
 		}
 	};
 
@@ -1908,6 +1941,13 @@
 	 *
 	 * @since 4.6.1
 	 * @class CKEDITOR.tools.array
+	 */
+
+	/**
+	 * The namespace with helper functions and polyfills for objects.
+	 *
+	 * @since 4.7.2
+	 * @class CKEDITOR.tools.object
 	 */
 } )();
 

--- a/core/tools.js
+++ b/core/tools.js
@@ -1946,7 +1946,7 @@
 	/**
 	 * The namespace with helper functions and polyfills for objects.
 	 *
-	 * @since 4.7.2
+	 * @since 4.7.1
 	 * @class CKEDITOR.tools.object
 	 */
 } )();

--- a/tests/core/editor/keystrokehandler.js
+++ b/tests/core/editor/keystrokehandler.js
@@ -100,7 +100,7 @@ bender.test(
 	},
 
 	// #523
-	'test keystroke with capitall letters': function() {
+	'test keystroke with capital letters': function() {
 		var editor = this.editor,
 			keystrokes = editor.keystrokeHandler.keystrokes,
 			keystroke;

--- a/tests/core/editor/keystrokehandler.js
+++ b/tests/core/editor/keystrokehandler.js
@@ -5,8 +5,11 @@ bender.editor = true;
 
 var keyCombo1 = CKEDITOR.CTRL + 10,
 	keyCombo2 = CKEDITOR.ALT + 20,
+	keyCombo3 = CKEDITOR.SHIFT + CKEDITOR.ALT + 30,
 	command1 = 'command#1',
-	command2 = 'command#2';
+	command2 = 'command#2',
+	command3 = 'command#3WithCapitalLetters';
+
 
 bender.test(
 {
@@ -94,5 +97,26 @@ bender.test(
 	'test editor#getCommandKeystroke with empty name': function() {
 		var editor = this.editor;
 		assert.isNull( editor.getCommandKeystroke( '' ), 'Returned keystroke.' );
+	},
+
+	// #523
+	'test keystroke with capitall letters': function() {
+		var editor = this.editor,
+			keystrokes = editor.keystrokeHandler.keystrokes,
+			keystroke;
+
+		editor.addCommand( command3, {} );
+		editor.setKeystroke( keyCombo3, command3 );
+
+		assert.areEqual( command3, keystrokes[ keyCombo3 ] );
+
+		// Get by command instance.
+		keystroke = editor.getCommandKeystroke( editor.getCommand( command3 ) );
+		assert.areEqual( keyCombo3, keystroke, 'Keystrokes should be equal (command).' );
+
+		// Get by command name.
+		keystroke = editor.getCommandKeystroke( command3 );
+		assert.areEqual( keyCombo3, keystroke, 'Keystrokes should be equal (command name).' );
 	}
+
 } );

--- a/tests/core/tools/object.js
+++ b/tests/core/tools/object.js
@@ -1,0 +1,67 @@
+/* bender-tags: editor,unit */
+
+( function() {
+	'use strict';
+	bender.test( {
+		setUp: function() {
+			this.object = CKEDITOR.tools.object;
+		},
+
+		'test object.findKey': function() {
+			var inputObject = {
+				'a': 1,
+				'b': 'something',
+				'c': true
+			},
+			returned;
+
+			returned = this.object.findKey( inputObject, 1 );
+			assert.areSame( returned, 'a' );
+
+			returned = this.object.findKey( inputObject, 'something' );
+			assert.areSame( returned, 'b' );
+
+			returned = this.object.findKey( inputObject, true );
+			assert.areSame( returned, 'c' );
+
+		},
+
+		'test object.findKey for returning null': function() {
+			var inputObject = {
+				'a': 1
+			},
+			returned;
+
+			returned = this.object.findKey( 'notObject', 'a' );
+			assert.isNull( returned );
+
+			returned = this.object.findKey( inputObject, 'z' );
+			assert.isNull( returned );
+
+			returned = this.object.findKey( inputObject );
+			assert.isNull( returned );
+		},
+
+		'test object.findKeys for reference object\'s values': function() {
+			var example = function() {};
+			var innerArray = [ 1, 2, 3 ];
+			var innerObject = { 'a': 1, 'b': 2 };
+
+			var inputObject = {
+				'a': example,
+				'b': innerArray,
+				'c': innerObject
+			},
+			returned;
+
+			returned = this.object.findKey( inputObject, example );
+			assert.areSame( returned, 'a' );
+
+			returned = this.object.findKey( inputObject, innerArray );
+			assert.areSame( returned, 'b' );
+
+			returned = this.object.findKey( inputObject, innerObject );
+			assert.areSame( returned, 'c' );
+		}
+	} );
+} )();


### PR DESCRIPTION
## What is the purpose of this pull request?

Bug fix

## Does your PR contain necessary tests?

unit tests only
### This PR contains

- [x] Unit tests
- [ ] Manual tests

## What changes did you make?
- add new helper `CKEDITOR.tools.object.findKey()`
- fix `getCommandKeystroke` to return proper keystrokes

Close #523 