### PR TITLE
Removed JSON.stringify call so that PFW works in QM

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -19,6 +19,7 @@ Fixed Issues:
 * [#424](https://github.com/ckeditor/ckeditor-dev/issues/424): Fixed: Error thrown by [Tab Key Handling](http://ckeditor.com/addon/tab) and [Indent List](http://ckeditor.com/addon/indentlist) when pressing `Tab` with no selection in inline editor.
 * [#476](https://github.com/ckeditor/ckeditor-dev/issues/476): Fixed: Anchors inserted via [Link](http://ckeditor.com/addon/link) plugin on collapsed selection can't be edited.
 * [#523](https://github.com/ckeditor/ckeditor-dev/issues/523): Fixed: `editor.getCommandKeystroke` does not obtain correct keystroke.
+* [#534](https://github.com/ckeditor/ckeditor-dev/issues/534): [IE] Fixed: [Paste from Word](http://ckeditor.com/addon/pastefromword) does not work in Quirks Mode.
 
 ## CKEditor 4.7
 

--- a/plugins/pastefromword/filter/default.js
+++ b/plugins/pastefromword/filter/default.js
@@ -608,7 +608,7 @@
 				delete styles[ style ];
 			}
 
-			if ( JSON.stringify( styles ) !== '{}' ) {
+			if ( !CKEDITOR.tools.isEmpty( styles ) ) {
 				element.attributes.style = CKEDITOR.tools.writeCssText( styles );
 			} else {
 				delete element.attributes.style;

--- a/tests/plugins/pastefromword/manual/unorderedlist.html
+++ b/tests/plugins/pastefromword/manual/unorderedlist.html
@@ -1,0 +1,7 @@
+<textarea cols="80" id="editor1" name="editor1" rows="10">
+	<p>Paste here:</p>
+	<p></p>
+</textarea>
+<script>
+	CKEDITOR.replace( 'editor1' );
+</script>

--- a/tests/plugins/pastefromword/manual/unorderedlist.md
+++ b/tests/plugins/pastefromword/manual/unorderedlist.md
@@ -1,0 +1,19 @@
+@bender-tags: tc, bug, 4.7.1, 534, word
+@bender-ui: collapsed
+@bender-ckeditor-plugins: wysiwygarea, toolbar, undo, pastefromword, sourcearea, elementspath, newpage, list
+
+## Pasting list
+
+1. Open [`tests/plugins/pastefromword/generated/_fixtures/Unordered_list/Unordered_list.docx`](https://github.com/ckeditor/ckeditor-dev/blob/1fb8232af13c4d536277aaff2f9a9628c3a8bbf2/tests/plugins/pastefromword/generated/_fixtures/Unordered_list/Unordered_list.docx) file in Word.
+1. Select whole content.
+1. Copy to clipboard.
+1. Focus CKEditor.
+1. Paste.
+
+### Expected
+
+List gets pasted as a `ul` list (you can see it on elements path, or in source view).
+
+### Unexpected
+
+List gets pasted as set of paragraphs / error is thrown in the console.


### PR DESCRIPTION
## What is the purpose of this pull request?

Bug fix

## Does your PR contain necessary tests?

I did not add any unit tests as the change is covered by existing PFW unit tests.

### This PR contains

- [ ] Unit tests
- [x] Manual tests

## What changes did you make?

Replaced `JSON.stringify` call with Quirks-supported `CKEDITOR.tools.isEmpty` in PFW.

Closes #534.