### PR TITLE
colorbutton plugin does not allow setting childRule

### DIFF
--- a/plugins/colorbutton/plugin.js
+++ b/plugins/colorbutton/plugin.js
@@ -231,15 +231,17 @@ CKEDITOR.plugins.add( 'colorbutton', {
 				if ( color ) {
 					var colorStyle = config[ 'colorButton_' + type + 'Style' ];
 
-					colorStyle.childRule = type == 'back' ?
-					function( element ) {
-						// It's better to apply background color as the innermost style. (http://dev.ckeditor.com/ticket/3599)
-						// Except for "unstylable elements". (http://dev.ckeditor.com/ticket/6103)
-						return isUnstylable( element );
-					} : function( element ) {
-						// Fore color style must be applied inside links instead of around it. (http://dev.ckeditor.com/ticket/4772,http://dev.ckeditor.com/ticket/6908)
-						return !( element.is( 'a' ) || element.getElementsByTag( 'a' ).count() ) || isUnstylable( element );
-					};
+					if ( !colorStyle.childRule ) {
+						colorStyle.childRule = type == 'back' ?
+							function( element ) {
+								// It's better to apply background color as the innermost style. (http://dev.ckeditor.com/ticket/3599)
+								// Except for "unstylable elements". (http://dev.ckeditor.com/ticket/6103)
+								return isUnstylable( element );
+							} : function( element ) {
+								// Fore color style must be applied inside links instead of around it. (http://dev.ckeditor.com/ticket/4772,http://dev.ckeditor.com/ticket/6908)
+								return !( element.is( 'a' ) || element.getElementsByTag( 'a' ).count() ) || isUnstylable( element );
+							};
+					}
 
 					editor.applyStyle( new CKEDITOR.style( colorStyle, { color: color } ) );
 				}

--- a/tests/plugins/colorbutton/manual/childRule.html
+++ b/tests/plugins/colorbutton/manual/childRule.html
@@ -1,0 +1,21 @@
+<div id="editor1">
+    <p>This is <strong>some text</strong></p>
+</div>
+
+<div id="editor2">
+    <p>This is <strong>some text</strong></p>
+</div>
+
+<script>
+  CKEDITOR.replace( 'editor1', {} );
+  CKEDITOR.replace( 'editor2', {
+    colorButton_foreStyle: {
+      element: 'span',
+      styles: { color: '#(color)' },
+      overrides: [{
+        element: 'font', attributes: { color: null },
+      }],
+      childRule: () => false,
+    }
+  } );
+</script>

--- a/tests/plugins/colorbutton/manual/childRule.md
+++ b/tests/plugins/colorbutton/manual/childRule.md
@@ -1,0 +1,25 @@
+@bender-tags: colorbutton, 4.7.0
+@bender-ui: collapsed
+@bender-ckeditor-plugins: wysiwygarea, toolbar, colorbutton, basicstyles
+
+### Scenario 1:
+
+1. Select the bold text in Editor 1.
+   Click *Text Color* button and select a color.
+	* **Expected**: The selected text gets the selected color.
+	* **Expected**: (Inspect Element) &lt;span style="color"&gt; wraps around &lt;strong&gt;
+1. Select the bold text in Editor 1.
+   Click *Background Color* button and select a color.
+	* **Expected**: The selected text gets the selected color.
+	* **Expected**: (Inspect Element) &lt;span style="color"&gt; wraps around &lt;strong&gt;
+
+### Scenario 2:
+
+1. Select the bold text in Editor 1.
+   Click *Text Color* button and select a color.
+	* **Expected**: The selected text gets the selected color.
+	* **Expected**: (Inspect Element) &lt;span style="color"&gt; is wrapped by &lt;strong&gt;
+1. Select the bold text in Editor 1.
+   Click *Background Color* button and select a color.
+	* **Expected**: The selected text gets the selected color.
+	* **Expected**: (Inspect Element) &lt;span style="color"&gt; is wrapped by &lt;strong&gt;


### PR DESCRIPTION
## What is the purpose of this pull request?

Other elements like coreStyles_bold and fontSize_style allow setting the childRule. For the colorButton plugin this is not possible because the plugin overwrites the childRule, no matter what.

## Does your PR contain necessary tests?

Unittest is not possible since the color style is directly set via the plugin's dialog.

### This PR contains

- [ ] Unit tests
- [X] Manual tests

## What changes did you make?

Added a condition around the childRule override. The childRule will only be set if it was not defined yet.
Also fixed codestyle for the changed piece of code.
