### PR TITLE
Adding missing tags in manual tests

### DIFF
--- a/tests/plugins/enterkey/manual/noselection.md
+++ b/tests/plugins/enterkey/manual/noselection.md
@@ -1,4 +1,4 @@
-@bender-tags: 4.7.1, 478
+@bender-tags: 4.7.1, 478, tc, bug
 @bender-ui: collapsed
 @bender-ckeditor-plugins: wysiwygarea, toolbar, enterkey
 


### PR DESCRIPTION
## What is the purpose of this pull request?

task
## Does your PR contain necessary tests?

no. There is no such need.
### This PR contains

- [ ] Unit tests
- [ ] Manual tests

## What changes did you make?

add missing tags to manual test: `tests/plugins/enterkey/manual/noselection`

close #539 
