### PR TITLE
Check if document.createTextRange exists for IE in 'select all' plugin.

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -5,6 +5,7 @@
 
 Fixed Issues:
 
+* [#545](https://github.com/ckeditor/ckeditor-dev/issues/545): [Edge] Fixed: Error thrown when pressing the Select All button in a [Source Mode](http://ckeditor.com/addon/sourcearea).
 * [#582](https://github.com/ckeditor/ckeditor-dev/issues/582): Fixed: Double slash in path to stylesheet needed by [Table Selection](http://ckeditor.com/addon/tableselection) plugin. Thanks to [Marius Dumitru Florea](https://github.com/mflorea)!
 * [#9780](https://dev.ckeditor.com/ticket/9780): [IE8-9] Fixed: Clicking inside empty [read-only](http://docs.ckeditor.com/#!/api/CKEDITOR.editor-property-readOnly) editor throws an error.
 * [#16820](https://dev.ckeditor.com/ticket/16820): [IE10] Fixed: Clicking below single horizontal rule throws an error.

--- a/plugins/selectall/plugin.js
+++ b/plugins/selectall/plugin.js
@@ -24,9 +24,9 @@
 					if ( editable.is( 'textarea' ) ) {
 						var textarea = editable.$;
 
-						if ( CKEDITOR.env.ie )
+						if ( CKEDITOR.env.ie && document.createTextRange ) {
 							textarea.createTextRange().execCommand( 'SelectAll' );
-						else {
+						} else {
 							textarea.selectionStart = 0;
 							textarea.selectionEnd = textarea.value.length;
 						}

--- a/plugins/selectall/plugin.js
+++ b/plugins/selectall/plugin.js
@@ -24,7 +24,7 @@
 					if ( editable.is( 'textarea' ) ) {
 						var textarea = editable.$;
 
-						if ( CKEDITOR.env.ie && document.createTextRange ) {
+						if ( CKEDITOR.env.ie && textarea.createTextRange ) {
 							textarea.createTextRange().execCommand( 'SelectAll' );
 						} else {
 							textarea.selectionStart = 0;

--- a/tests/plugins/selectall/manual/selectall.html
+++ b/tests/plugins/selectall/manual/selectall.html
@@ -1,0 +1,15 @@
+<h2>Classic editor</h2>
+
+<div id="editor1">
+	<p>Some text</p>
+
+	<p>Some text2</p>
+</div>
+
+<script>
+	if ( ( CKEDITOR.env.ie && CKEDITOR.env.version < 11 ) || bender.tools.env.mobile ) {
+		bender.ignore();
+	}
+
+	CKEDITOR.replace( 'editor1' );
+</script>

--- a/tests/plugins/selectall/manual/selectall.html
+++ b/tests/plugins/selectall/manual/selectall.html
@@ -7,7 +7,7 @@
 </div>
 
 <script>
-	if ( ( CKEDITOR.env.ie && CKEDITOR.env.version < 11 ) || bender.tools.env.mobile ) {
+	if ( !CKEDITOR.env.edge || bender.tools.env.mobile ) {
 		bender.ignore();
 	}
 

--- a/tests/plugins/selectall/manual/selectall.md
+++ b/tests/plugins/selectall/manual/selectall.md
@@ -1,0 +1,12 @@
+@bender-ui: collapsed
+@bender-tags: tc, 545, 2564, 4.7.1, bug
+@bender-ckeditor-plugins: wysiwygarea, selectall, sourcearea, toolbar
+
+**Procedure:**
+
+1. Change view to source code
+2. click `select all` button
+
+**Expected result:**
+
+* The whole code should be selected

--- a/tests/plugins/selectall/manual/selectall.md
+++ b/tests/plugins/selectall/manual/selectall.md
@@ -1,12 +1,12 @@
 @bender-ui: collapsed
-@bender-tags: tc, 545, 2564, 4.7.1, bug
+@bender-tags: tc, 545, 4.7.1, bug
 @bender-ckeditor-plugins: wysiwygarea, selectall, sourcearea, toolbar
 
 **Procedure:**
 
-1. Change view to source code
-2. click `select all` button
+1. Change view to source mode.
+2. Click `select all` button.
 
 **Expected result:**
 
-* The whole code should be selected
+* The whole content should be selected.

--- a/tests/plugins/selectall/manual/selectall.md
+++ b/tests/plugins/selectall/manual/selectall.md
@@ -1,5 +1,5 @@
 @bender-ui: collapsed
-@bender-tags: tc, 545, 4.7.1, bug
+@bender-tags: tc, 545, 4.7.2, bug
 @bender-ckeditor-plugins: wysiwygarea, selectall, sourcearea, toolbar
 
 **Procedure:**

--- a/tests/plugins/selectall/selectall.js
+++ b/tests/plugins/selectall/selectall.js
@@ -1,5 +1,5 @@
 /* bender-tags: selection */
-/* bender-ckeditor-plugins: selectall,sourcearea */
+/* bender-ckeditor-plugins: wysiwygarea,selectall,sourcearea */
 
 ( function() {
 	'use strict';
@@ -48,17 +48,31 @@
 		},
 
 		'test selectall in source view': function() {
-			var editor = this.editors.editorFramed;
+			var eventsRecorder;
+			bender.editorBot.create( {
+				name: 'testall_source_editor',
+				startupData: '<p>foo</p><p>bar</p>',
+				config: {
+					startupMode: 'source',
+					on: {
+						pluginsLoaded: function() {
+							eventsRecorder = bender.tools.recordEvents( this, [ 'beforeSetMode', 'beforeModeUnload', 'mode' ] );
+						}
+					}
+				}
+			}, function( bot ) {
+				var editor = bot.editor;
+				editor.execCommand( 'selectAll' );
 
-			editor.setData( '<p>foo</p><p>bar</p>' );
-			editor.setMode('source');
-			
-			editor.execCommand( 'selectAll' );
-			console.log(CKEDITOR.document.getActive().$.selectionEnd);
-			
-			assert.areSame(CKEDITOR.document.getActive().$.selectionStart, 0);
-			assert.areSame(CKEDITOR.document.getActive().$.selectionEnd, 20)
-			editor.setMode('wysiwyg');
+				eventsRecorder.assert( [ 'beforeSetMode', 'mode' ] );
+				assert.areSame( 'source', editor.mode, 'editor.mode' );
+				if ( CKEDITOR.env.ie && CKEDITOR.env.version <= 8 ) {
+					assert.areSame( document.selection.createRange().text.length, 20 );
+				} else {
+					assert.areSame( CKEDITOR.document.getActive().$.selectionStart, 0 );
+					assert.areSame( CKEDITOR.document.getActive().$.selectionEnd, 20 );
+				}
+			} );
 		}
 	} );
 

--- a/tests/plugins/selectall/selectall.js
+++ b/tests/plugins/selectall/selectall.js
@@ -1,5 +1,5 @@
 /* bender-tags: selection */
-/* bender-ckeditor-plugins: selectall */
+/* bender-ckeditor-plugins: selectall,sourcearea */
 
 ( function() {
 	'use strict';
@@ -45,6 +45,20 @@
 				acceptableResults,
 				bender.tools.html.prepareInnerHtmlForComparison( bender.tools.selection.getWithHtml( editor ), htmlMatchingOpts )
 			);
+		},
+
+		'test selectall in source view': function() {
+			var editor = this.editors.editorFramed;
+
+			editor.setData( '<p>foo</p><p>bar</p>' );
+			editor.setMode('source');
+			
+			editor.execCommand( 'selectAll' );
+			console.log(CKEDITOR.document.getActive().$.selectionEnd);
+			
+			assert.areSame(CKEDITOR.document.getActive().$.selectionStart, 0);
+			assert.areSame(CKEDITOR.document.getActive().$.selectionEnd, 20)
+			editor.setMode('wysiwyg');
 		}
 	} );
 

--- a/tests/plugins/selectall/selectall.js
+++ b/tests/plugins/selectall/selectall.js
@@ -19,6 +19,13 @@
 		editorInline: {
 			creator: 'inline',
 			name: 'test_editor_inline'
+		},
+		editorSource: {
+			name: 'test_source_mode',
+			startupData: '<p>foo</p><p>bar</p>',
+			config: {
+				startupMode: 'source'
+			}
 		}
 	};
 
@@ -48,31 +55,17 @@
 		},
 
 		'test selectall in source view': function() {
-			var eventsRecorder;
-			bender.editorBot.create( {
-				name: 'testall_source_editor',
-				startupData: '<p>foo</p><p>bar</p>',
-				config: {
-					startupMode: 'source',
-					on: {
-						pluginsLoaded: function() {
-							eventsRecorder = bender.tools.recordEvents( this, [ 'beforeSetMode', 'beforeModeUnload', 'mode' ] );
-						}
-					}
-				}
-			}, function( bot ) {
-				var editor = bot.editor;
-				editor.execCommand( 'selectAll' );
+			var editor = this.editors.editorSource;
 
-				eventsRecorder.assert( [ 'beforeSetMode', 'mode' ] );
-				assert.areSame( 'source', editor.mode, 'editor.mode' );
-				if ( CKEDITOR.env.ie && CKEDITOR.env.version <= 8 ) {
-					assert.areSame( document.selection.createRange().text.length, 20 );
-				} else {
-					assert.areSame( CKEDITOR.document.getActive().$.selectionStart, 0 );
-					assert.areSame( CKEDITOR.document.getActive().$.selectionEnd, 20 );
-				}
-			} );
+			editor.execCommand( 'selectAll' );
+
+			assert.areSame( 'source', editor.mode, 'editor.mode' );
+			if ( CKEDITOR.env.ie && CKEDITOR.env.version <= 8 ) {
+				assert.areSame( document.selection.createRange().text.length, 20 );
+			} else {
+				assert.areSame( CKEDITOR.document.getActive().$.selectionStart, 0 );
+				assert.areSame( CKEDITOR.document.getActive().$.selectionEnd, 20 );
+			}
 		}
 	} );
 


### PR DESCRIPTION
## What is the purpose of this pull request?

<!-- Bug fix / New feature / Typo fix / Other, please explain  -->
Bug fix
## Does your PR contain necessary tests?

`selectall` plugin test already exists.

### This PR contains

- [X] Unit tests
- [X] Manual tests

## What changes did you make?

selectall plugin is now checking if `createTextRange` method exists in IE.

Closes #545 