### PR TITLE
T/501 Allow opening dialog for an empty anchor

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -8,6 +8,7 @@ Fixed Issues:
 * [#545](https://github.com/ckeditor/ckeditor-dev/issues/545): [Edge] Fixed: Error thrown when pressing the Select All button in a [Source Mode](http://ckeditor.com/addon/sourcearea).
 * [#582](https://github.com/ckeditor/ckeditor-dev/issues/582): Fixed: Double slash in path to stylesheet needed by [Table Selection](http://ckeditor.com/addon/tableselection) plugin. Thanks to [Marius Dumitru Florea](https://github.com/mflorea)!
 * [#491](https://github.com/ckeditor/ckeditor-dev/issues/491): Fixed: Unnecessary dependency on [Editor Toolbar](http://ckeditor.com/addon/toolbar) plugin inside [Notification](http://ckeditor.com/addon/notification) plugin.
+* [#501](https://github.com/ckeditor/ckeditor-dev/issues/501): Fixed: Double click does not open dialog for modifying anchors inserted via [Link](http://ckeditor.com/addon/link) plugin.
 * [#9780](https://dev.ckeditor.com/ticket/9780): [IE8-9] Fixed: Clicking inside empty [read-only](http://docs.ckeditor.com/#!/api/CKEDITOR.editor-property-readOnly) editor throws an error.
 * [#16820](https://dev.ckeditor.com/ticket/16820): [IE10] Fixed: Clicking below single horizontal rule throws an error.
 

--- a/plugins/link/plugin.js
+++ b/plugins/link/plugin.js
@@ -95,11 +95,10 @@
 				// If the link has descendants and the last part of it is also a part of a word partially
 				// unlinked, clicked element may be a descendant of the link, not the link itself. (http://dev.ckeditor.com/ticket/11956)
 				// evt.data.element condition allows opening anchor dialog if the anchor is empty (#501).
-				var element = CKEDITOR.plugins.link.getSelectedLink( editor ) || evt.data.element.getAscendant( 'a', 1 ) || CKEDITOR.plugins.link.tryRestoreFakeAnchor( editor, evt.data.element );
+				var element = CKEDITOR.plugins.link.getSelectedLink( editor ) || evt.data.element.getAscendant( 'a', 1 ) || evt.data.element;
 
-				// if ( element && !element.isReadOnly() ) {
-				if ( element && !element.isReadOnly() ) {
-					if ( element.is( 'a' ) ) {
+				if ( element ) {
+					if ( element.is( 'a' ) && !element.isReadOnly() ) {
 						evt.data.dialog = ( element.getAttribute( 'name' ) && ( !element.getAttribute( 'href' ) || !element.getChildCount() ) ) ? 'anchor' : 'link';
 
 						// Pass the link to be selected along with event data.

--- a/plugins/link/plugin.js
+++ b/plugins/link/plugin.js
@@ -93,8 +93,8 @@
 
 			editor.on( 'doubleclick', function( evt ) {
 				// If the link has descendants and the last part of it is also a part of a word partially
-				// unlinked, clicked element may be a descendant of the link, not the link itself. (http://dev.ckeditor.com/ticket/11956)
-				// evt.data.element condition allows opening anchor dialog if the anchor is empty (#501).
+				// unlinked, clicked element may be a descendant of the link, not the link itself (http://dev.ckeditor.com/ticket/11956).
+				// The evt.data.element.getAscendant( 'img', 1 ) condition allows opening anchor dialog if the anchor is empty (#501).
 				var element = evt.data.element.getAscendant( 'a', 1 ) || evt.data.element.getAscendant( 'img', 1 );
 
 				if ( element && !element.isReadOnly() ) {

--- a/plugins/link/plugin.js
+++ b/plugins/link/plugin.js
@@ -94,8 +94,10 @@
 			editor.on( 'doubleclick', function( evt ) {
 				// If the link has descendants and the last part of it is also a part of a word partially
 				// unlinked, clicked element may be a descendant of the link, not the link itself. (http://dev.ckeditor.com/ticket/11956)
-				var element = CKEDITOR.plugins.link.getSelectedLink( editor ) || evt.data.element.getAscendant( 'a', 1 );
+				// evt.data.element condition allows opening anchor dialog if the anchor is empty (#501).
+				var element = CKEDITOR.plugins.link.getSelectedLink( editor ) || evt.data.element.getAscendant( 'a', 1 ) || CKEDITOR.plugins.link.tryRestoreFakeAnchor( editor, evt.data.element );
 
+				// if ( element && !element.isReadOnly() ) {
 				if ( element && !element.isReadOnly() ) {
 					if ( element.is( 'a' ) ) {
 						evt.data.dialog = ( element.getAttribute( 'name' ) && ( !element.getAttribute( 'href' ) || !element.getChildCount() ) ) ? 'anchor' : 'link';

--- a/plugins/link/plugin.js
+++ b/plugins/link/plugin.js
@@ -95,10 +95,10 @@
 				// If the link has descendants and the last part of it is also a part of a word partially
 				// unlinked, clicked element may be a descendant of the link, not the link itself. (http://dev.ckeditor.com/ticket/11956)
 				// evt.data.element condition allows opening anchor dialog if the anchor is empty (#501).
-				var element = CKEDITOR.plugins.link.getSelectedLink( editor ) || evt.data.element.getAscendant( 'a', 1 ) || evt.data.element;
+				var element = evt.data.element.getAscendant( 'a', 1 ) || evt.data.element.getAscendant( 'img', 1 );
 
-				if ( element ) {
-					if ( element.is( 'a' ) && !element.isReadOnly() ) {
+				if ( element && !element.isReadOnly() ) {
+					if ( element.is( 'a' ) ) {
 						evt.data.dialog = ( element.getAttribute( 'name' ) && ( !element.getAttribute( 'href' ) || !element.getChildCount() ) ) ? 'anchor' : 'link';
 
 						// Pass the link to be selected along with event data.

--- a/plugins/link/plugin.js
+++ b/plugins/link/plugin.js
@@ -95,7 +95,7 @@
 				// If the link has descendants and the last part of it is also a part of a word partially
 				// unlinked, clicked element may be a descendant of the link, not the link itself (http://dev.ckeditor.com/ticket/11956).
 				// The evt.data.element.getAscendant( 'img', 1 ) condition allows opening anchor dialog if the anchor is empty (#501).
-				var element = evt.data.element.getAscendant( 'a', 1 ) || evt.data.element.getAscendant( 'img', 1 );
+				var element = evt.data.element.getAscendant( { a: 1, img: 1 }, true );
 
 				if ( element && !element.isReadOnly() ) {
 					if ( element.is( 'a' ) ) {

--- a/tests/plugins/link/anchor.js
+++ b/tests/plugins/link/anchor.js
@@ -41,7 +41,7 @@
 
 				editor.on( 'dialogShow', function( evt ) {
 					resume( function() {
-						assert.areSame( evt.data._.name, 'anchor' );
+						assert.areSame( evt.data._.name, 'anchor', 'Anchor dialog has been opened.' );
 					} );
 				} );
 

--- a/tests/plugins/link/anchor.js
+++ b/tests/plugins/link/anchor.js
@@ -26,6 +26,31 @@
 					assert.isInnerHtmlMatching( '<p><a id="bar" name="bar"></a></p>', this.editor.getData() );
 				} );
 			} );
+		},
+
+		// #501
+		'test double-click on anchor is opening anchor dialog': function() {
+			var editor = this.editor,
+				bot = this.editorBot;
+
+			bot.setData( '<p><a name="foo" id="foo"></a></p>', function() {
+
+				var range = new CKEDITOR.dom.range( editor.document );
+				range.selectNodeContents( editor.editable().findOne( '[data-cke-real-element-type=anchor]' ) );
+				range.select();
+
+				editor.on( 'dialogShow', function( evt ) {
+					resume( function() {
+						assert.areSame( evt.data._.name, 'anchor' );
+					} );
+				} );
+
+				editor.fire( 'doubleclick', {
+					element: editor.editable().findOne( '[data-cke-real-element-type=anchor]' )
+				} );
+
+				wait();
+			} );
 		}
 	} );
 }() );

--- a/tests/plugins/link/link.js
+++ b/tests/plugins/link/link.js
@@ -546,6 +546,20 @@
 			editor.ui.get( 'Unlink' ).click( editor );
 
 			assert.areSame( '<p>I am<a href="http://foo"> an </a>in<a href="http://bar">sta</a>nce of ^<s>CKEditor</s>.</p>', bot.htmlWithSelection() );
+		},
+
+		// #501
+		'test double-click on anchor is opening anchor dialog': function() {
+			var bot = this.editorBot,
+				editor = bot.editor;
+
+			bot.setData( '<a id="anchor" name="anchor"></a>', function() {
+				editor.fire( 'doubleclick', {
+					element: editor.document.findOne( 'a' )
+				} );
+
+				assert.areSame( ( ( bot.dialog = 'anchor' ) ? true : false ), true );
+			} );
 		}
 	} );
 } )();

--- a/tests/plugins/link/link.js
+++ b/tests/plugins/link/link.js
@@ -546,20 +546,6 @@
 			editor.ui.get( 'Unlink' ).click( editor );
 
 			assert.areSame( '<p>I am<a href="http://foo"> an </a>in<a href="http://bar">sta</a>nce of ^<s>CKEditor</s>.</p>', bot.htmlWithSelection() );
-		},
-
-		// #501
-		'test double-click on anchor is opening anchor dialog': function() {
-			var bot = this.editorBot,
-				editor = bot.editor;
-
-			bot.setData( '<a id="anchor" name="anchor"></a>', function() {
-				editor.fire( 'doubleclick', {
-					element: editor.document.findOne( 'a' )
-				} );
-
-				assert.areSame( ( ( bot.dialog = 'anchor' ) ? true : false ), true );
-			} );
 		}
 	} );
 } )();

--- a/tests/plugins/link/manual/anchordialog.html
+++ b/tests/plugins/link/manual/anchordialog.html
@@ -1,0 +1,7 @@
+<div id="editor">
+	<p><a id="foo" name="foo"></a></p>
+</div>
+
+<script>
+	CKEDITOR.replace( 'editor' );
+</script>

--- a/tests/plugins/link/manual/anchordialog.md
+++ b/tests/plugins/link/manual/anchordialog.md
@@ -1,4 +1,4 @@
-@bender-tags: link, 4.7.2, 501, bug
+@bender-tags: link, 4.7.2, 501, bug, tc
 @bender-ui: collapsed
 @bender-ckeditor-plugins: link, toolbar, wysiwygarea
 

--- a/tests/plugins/link/manual/anchordialog.md
+++ b/tests/plugins/link/manual/anchordialog.md
@@ -1,0 +1,15 @@
+@bender-tags: link, 4.7.2, 501, bug
+@bender-ui: collapsed
+@bender-ckeditor-plugins: link, toolbar, wysiwygarea
+
+**Procedure:**
+
+1. Double-click on anchor.
+
+**Expected result:**
+
+Anchor dialog has been opened.
+
+**Unexpected result:**
+
+Nothing happend.

--- a/tests/plugins/link/manual/anchordialog.md
+++ b/tests/plugins/link/manual/anchordialog.md
@@ -12,4 +12,4 @@ Anchor dialog has been opened.
 
 **Unexpected result:**
 
-Nothing happend.
+Nothing happened.


### PR DESCRIPTION
## What is the purpose of this pull request?

Bug fix

## Does your PR contain necessary tests?

Yes

### This PR contains

- [X] Unit tests
- [X] Manual tests

## What changes did you make?

Add a new condition to element variable on double-click.

Closes #501 
