### PR TITLE
T/13729 Table: Insert Column before and After fails if a cell vertical split exist

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -14,6 +14,7 @@ Fixed Issues:
 * [#796](https://github.com/ckeditor/ckeditor-dev/issues/796): Fixed: List is pasted from OneNote in a reversed order.
 * [#834](https://github.com/ckeditor/ckeditor-dev/issues/834): [IE9-11] Fixed: Editor does not save selected state of radiobuttons inserted by [Form Elements](https://ckeditor.com/addon/forms) plugin.
 * [#704](https://github.com/ckeditor/ckeditor-dev/issues/704): [Edge] Fixed: Using `Ctrl/Cmd + Z` breaks widgets structure.
+* [#591](https://github.com/ckeditor/ckeditor-dev/issues/591): Fixed: Column is inserted in a wrong order inside table if any cell has a vertical split.
 
 ## CKEditor 4.7.3
 

--- a/plugins/tableselection/plugin.js
+++ b/plugins/tableselection/plugin.js
@@ -517,7 +517,7 @@
 			}
 		}
 
-		var startIndex = getCellColIndex( this.cells.first, true ),
+		var startIndex = getCellColIndex( this.cells.first ),
 			endIndex = getRealCellPosition( this.cells.last );
 
 		return CKEDITOR.tools.buildTableMap( this._getTable(), getRowIndex( this.rows.first ), startIndex,
@@ -657,7 +657,7 @@
 			var cellToReplace,
 				// Index of first selected cell, it needs to be reused later, to calculate the
 				// proper position of newly pasted cells.
-				startIndex = getCellColIndex( tableSel.cells.first, true ),
+				startIndex = getCellColIndex( tableSel.cells.first ),
 				selectedTable = tableSel._getTable(),
 				markers = {},
 				currentRow,

--- a/plugins/tabletools/plugin.js
+++ b/plugins/tabletools/plugin.js
@@ -230,14 +230,17 @@
 		return null;
 	}
 
-	function getCellColIndex( cell, isStart ) {
+	function getCellColIndex( cell ) {
 		var row = cell.getParent(),
 			rowCells = row.$.cells;
 
 		var colIndex = 0;
 		for ( var i = 0; i < rowCells.length; i++ ) {
 			var mapCell = rowCells[ i ];
-			colIndex += isStart ? 1 : mapCell.colSpan;
+
+			// Not always adding colSpan results in wrong position
+			// of newly inserted column. (#13729)
+			colIndex += mapCell.colSpan;
 			if ( mapCell == cell.$ )
 				break;
 		}
@@ -248,7 +251,7 @@
 	function getColumnsIndices( cells, isStart ) {
 		var retval = isStart ? Infinity : 0;
 		for ( var i = 0; i < cells.length; i++ ) {
-			var colIndex = getCellColIndex( cells[ i ], isStart );
+			var colIndex = getCellColIndex( cells[ i ] );
 			if ( isStart ? colIndex < retval : colIndex > retval )
 				retval = colIndex;
 		}

--- a/plugins/tabletools/plugin.js
+++ b/plugins/tabletools/plugin.js
@@ -239,7 +239,7 @@
 			var mapCell = rowCells[ i ];
 
 			// Not always adding colSpan results in wrong position
-			// of newly inserted column. (#13729)
+			// of newly inserted column. (#591) (http://dev.ckeditor.com/ticket/13729)
 			colIndex += mapCell.colSpan;
 			if ( mapCell == cell.$ )
 				break;

--- a/tests/plugins/tableselection/integrations/tabletools/tabletools.html
+++ b/tests/plugins/tableselection/integrations/tabletools/tabletools.html
@@ -412,6 +412,58 @@
 	</tr>
 	</tbody>
 </textarea>
+<textarea id="add-col-before-vertical-split">
+	<table>
+		<tbody>
+			<tr>
+				<td>1</td>
+				<td colspan="2">2</td>
+				<td>3</td>
+				<td>4</td>
+			</tr>
+			<tr>
+				<td>2</td>
+				<td></td>
+				<td></td>
+				<td></td>
+				<td></td>
+			</tr>
+			<tr>
+				<td>3</td>
+				<td colspan="2"></td>
+				<td></td>
+				<td></td>
+			</tr>
+		</tbody>
+	</table>
+	=>
+	<table>
+		<tbody>
+			<tr>
+				<td>1</td>
+				<td colspan="2">2</td>
+				<td>3</td>
+				<td>&nbsp;</td>
+				<td>4</td>
+			</tr>
+			<tr>
+				<td>2</td>
+				<td>&nbsp;</td>
+				<td>&nbsp;</td>
+				<td>&nbsp;</td>
+				<td>&nbsp;</td>
+				<td>&nbsp;</td>
+			</tr>
+			<tr>
+				<td>3</td>
+				<td colspan="2">&nbsp;</td>
+				<td>&nbsp;</td>
+				<td>&nbsp;</td>
+				<td>&nbsp;</td>
+			</tr>
+		</tbody>
+	</table>
+</textarea>
 
 <textarea id='add-col-after'>
 <table summary="X">

--- a/tests/plugins/tableselection/integrations/tabletools/tabletools.js
+++ b/tests/plugins/tableselection/integrations/tabletools/tabletools.js
@@ -41,6 +41,9 @@
 			doCommandTest( bot, 'columnInsertBefore', { 'case': 'add-col-before-4', cells: [ 1 ] } );
 			doCommandTest( bot, 'columnInsertBefore', { 'case': 'add-col-before-multi', cells: [ 0, 1 ] } );
 			doCommandTest( bot, 'columnInsertBefore', { 'case': 'add-col-before-multi2', cells: [ 1 ] } );
+
+			// #591
+			doCommandTest( bot, 'columnInsertBefore', { 'case': 'add-col-before-vertical-split', cells: [ 3 ] } );
 		},
 
 		'test insert col after': function( editor, bot ) {

--- a/tests/plugins/tableselection/integrations/tabletools/tabletools.js
+++ b/tests/plugins/tableselection/integrations/tabletools/tabletools.js
@@ -42,7 +42,7 @@
 			doCommandTest( bot, 'columnInsertBefore', { 'case': 'add-col-before-multi', cells: [ 0, 1 ] } );
 			doCommandTest( bot, 'columnInsertBefore', { 'case': 'add-col-before-multi2', cells: [ 1 ] } );
 
-			// #591
+			// (#591)
 			doCommandTest( bot, 'columnInsertBefore', { 'case': 'add-col-before-vertical-split', cells: [ 3 ] } );
 		},
 
@@ -96,8 +96,8 @@
 			doCommandTest( bot, 'cellDelete', { 'case': 'delete-nested-cells-3', cells: [ 1, 2, 3, 4 ], skipCheckingSelection: true } );
 		},
 
-		// (http://dev.ckeditor.com/ticket/10308, http://dev.ckeditor.com/ticket/11058)
-		// To reproduce http://dev.ckeditor.com/ticket/11058 we need 4 rows in the table.
+		// To reproduce http://dev.ckeditor.com/ticket/11058 we need 4 rows
+		// in the table (http://dev.ckeditor.com/ticket/10308, http://dev.ckeditor.com/ticket/11058).
 		'test remove row from middle row': function( editor, bot ) {
 			doCommandTest( bot, 'rowDelete', { 'case': 'delete-row-from-middle', cells: [ 1 ], skipCheckingSelection: true } );
 		},
@@ -142,7 +142,7 @@
 			assert.isTrue( expectedCells.getItem( 1 ).equals( selectedCells[ 1 ] ) );
 		},
 
-		// #tp-2217
+		// (#tp-2217)
 		'test getSelectedCells for nested table header cell': function( editor, bot ) {
 			var editable = editor.editable(),
 				table,

--- a/tests/plugins/tabletools/manual/insertcolumnverticalsplit.html
+++ b/tests/plugins/tabletools/manual/insertcolumnverticalsplit.html
@@ -1,0 +1,26 @@
+<div id="editor" contenteditable="true">
+	<table border="1" width="500">
+		<tr>
+			<td>1</td>
+			<td>2</td>
+			<td>3</td>
+			<td>4</td>
+		</tr>
+		<tr>
+			<td>2</td>
+			<td></td>
+			<td></td>
+			<td></td>
+		</tr>
+		<tr>
+			<td>3</td>
+			<td></td>
+			<td></td>
+			<td></td>
+		</tr>
+	</table>
+</div>
+
+<script>
+	CKEDITOR.replace( 'editor' );
+</script>

--- a/tests/plugins/tabletools/manual/insertcolumnverticalsplit.md
+++ b/tests/plugins/tabletools/manual/insertcolumnverticalsplit.md
@@ -1,4 +1,4 @@
-@bender-tags: 4.5.7, tc, tabletools, 13729
+@bender-tags: 4.8.0, bug, tabletools, trac13729, 591
 @bender-ui: collapsed
 @bender-ckeditor-plugins: wysiwygarea, toolbar, table, tabletools, contextmenu
 

--- a/tests/plugins/tabletools/manual/insertcolumnverticalsplit.md
+++ b/tests/plugins/tabletools/manual/insertcolumnverticalsplit.md
@@ -1,0 +1,8 @@
+@bender-tags: 4.5.7, tc, tabletools, 13729
+@bender-ui: collapsed
+@bender-ckeditor-plugins: wysiwygarea, toolbar, table, tabletools, contextmenu
+
+1. Make a vertical split in the cell 2,2.
+2. Right click in the first cell in 4. column to insert a new column before it.
+
+**Epected result:** A new column is inserted between 3rd and 4th column.

--- a/tests/plugins/tabletools/manual/insertcolumnverticalsplit.md
+++ b/tests/plugins/tabletools/manual/insertcolumnverticalsplit.md
@@ -5,4 +5,4 @@
 1. Make a vertical split in the cell 2,2.
 2. Right click in the first cell in 4. column to insert a new column before it.
 
-**Epected result:** A new column is inserted between 3rd and 4th column.
+**Expected result:** A new column is inserted between 3rd and 4th column.

--- a/tests/plugins/tabletools/tabletools.html
+++ b/tests/plugins/tabletools/tabletools.html
@@ -413,6 +413,59 @@
 	</tbody>
 </textarea>
 
+<textarea id="add-col-before-vertical-split">
+	<table>
+		<tbody>
+			<tr>
+				<td>1</td>
+				<td colspan="2">2</td>
+				<td>3</td>
+				<td>4^</td>
+			</tr>
+			<tr>
+				<td>2</td>
+				<td></td>
+				<td></td>
+				<td></td>
+				<td></td>
+			</tr>
+			<tr>
+				<td>3</td>
+				<td colspan="2"></td>
+				<td></td>
+				<td></td>
+			</tr>
+		</tbody>
+	</table>
+	=>
+	<table>
+		<tbody>
+			<tr>
+				<td>1</td>
+				<td colspan="2">2</td>
+				<td>3</td>
+				<td>&nbsp;</td>
+				<td>4</td>
+			</tr>
+			<tr>
+				<td>2</td>
+				<td>&nbsp;</td>
+				<td>&nbsp;</td>
+				<td>&nbsp;</td>
+				<td>&nbsp;</td>
+				<td>&nbsp;</td>
+			</tr>
+			<tr>
+				<td>3</td>
+				<td colspan="2">&nbsp;</td>
+				<td>&nbsp;</td>
+				<td>&nbsp;</td>
+				<td>&nbsp;</td>
+			</tr>
+		</tbody>
+	</table>
+</textarea>
+
 <textarea id='add-col-after'>
 <table summary="X">
 	<tbody>

--- a/tests/plugins/tabletools/tabletools.js
+++ b/tests/plugins/tabletools/tabletools.js
@@ -62,7 +62,7 @@
 			this.doTest( 'add-col-before-multi', 'columnInsertBefore' );
 			this.doTest( 'add-col-before-multi2', 'columnInsertBefore' );
 
-			// (#13729)
+			// (#591) (http://dev.ckeditor.com/ticket/13729)
 			this.doTest( 'add-col-before-vertical-split', 'columnInsertBefore' );
 		},
 

--- a/tests/plugins/tabletools/tabletools.js
+++ b/tests/plugins/tabletools/tabletools.js
@@ -61,6 +61,9 @@
 			this.doTest( 'add-col-before-4', 'columnInsertBefore' );
 			this.doTest( 'add-col-before-multi', 'columnInsertBefore' );
 			this.doTest( 'add-col-before-multi2', 'columnInsertBefore' );
+
+			// (#13729)
+			this.doTest( 'add-col-before-vertical-split', 'columnInsertBefore' );
 		},
 
 		'test insert col after': function() {


### PR DESCRIPTION
## What is the purpose of this pull request?

Bug fix

## Does your PR contain necessary tests?

All patches which change the editor code must include tests. You can always read more
on [PR testing](http://docs.ckeditor.com/#!/guide/dev_contributing_code-section-tests),
[how to set the testing environment](http://docs.ckeditor.com/#!/guide/dev_tests) and
[how to create tests](http://docs.ckeditor.com/#!/guide/dev_tests-section-creating-your-own-test)
in the official CKEditor documentation.

### This PR contains

- [x] Unit tests
- [x] Manual tests

## What changes did you make?

Closes #591.