### PR TITLE
Font options are not toggleable any longer

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -6,6 +6,7 @@
 New Features:
 
 * [#607](https://github.com/ckeditor/ckeditor-dev/issues/607): Manually inserted hex color is prefixed with hash tag if needed. It ensures a valid hex color is used when setting table cell border or background color via [Color Dialog](http://ckeditor.com/addon/colordialog) window.
+* [#584](https://github.com/ckeditor/ckeditor-dev/issues/584): [Font size and Family](http://ckeditor.com/addon/font) and [Format](http://ckeditor.com/addon/format) drop-downs are not toggleable anymore. Default option to reset styles added.
 
 ## CKEditor 4.7.1
 

--- a/dev/langtool/meta/ckeditor.core/meta.txt
+++ b/dev/langtool/meta/ckeditor.core/meta.txt
@@ -81,4 +81,4 @@ common.keyboard.36 = Label for the "Home" key.
 common.keyboard.46 = Label for the "Delete" key.
 common.keyboard.224 = Label for the "Command" key.
 common.keyboardShortcut = ARIA message for keyboard shortcuts.
-common.optionDefault = "(Default)" option for drop-down menues of text styling, which removes specific style.
+common.optionDefault = Label for "(Default)" option in drop-down text-styling menus. Using such option restores default styling.

--- a/dev/langtool/meta/ckeditor.core/meta.txt
+++ b/dev/langtool/meta/ckeditor.core/meta.txt
@@ -81,3 +81,4 @@ common.keyboard.36 = Label for the "Home" key.
 common.keyboard.46 = Label for the "Delete" key.
 common.keyboard.224 = Label for the "Command" key.
 common.keyboardShortcut = ARIA message for keyboard shortcuts.
+common.optionDefault = "(Default)" option for drop-down menues of text styling, which removes specific style.

--- a/lang/af.js
+++ b/lang/af.js
@@ -112,6 +112,8 @@ CKEDITOR.lang[ 'af' ] = {
 		},
 
 		// Prepended to ARIA labels with shortcuts.
-		keyboardShortcut: 'Sleutel kombenasie'
+		keyboardShortcut: 'Sleutel kombenasie',
+
+		optionDefault: 'Default' // MISSING
 	}
 };

--- a/lang/ar.js
+++ b/lang/ar.js
@@ -112,6 +112,8 @@ CKEDITOR.lang[ 'ar' ] = {
 		},
 
 		// Prepended to ARIA labels with shortcuts.
-		keyboardShortcut: 'Keyboard shortcut' // MISSING
+		keyboardShortcut: 'Keyboard shortcut', // MISSING
+
+		optionDefault: 'Default' // MISSING
 	}
 };

--- a/lang/az.js
+++ b/lang/az.js
@@ -112,6 +112,8 @@ CKEDITOR.lang[ 'az' ] = {
 		},
 
 		// Prepended to ARIA labels with shortcuts.
-		keyboardShortcut: 'Qısayol düymələri'
+		keyboardShortcut: 'Qısayol düymələri',
+
+		optionDefault: 'Default' // MISSING
 	}
 };

--- a/lang/bg.js
+++ b/lang/bg.js
@@ -112,6 +112,8 @@ CKEDITOR.lang[ 'bg' ] = {
 		},
 
 		// Prepended to ARIA labels with shortcuts.
-		keyboardShortcut: 'Keyboard shortcut' // MISSING
+		keyboardShortcut: 'Keyboard shortcut', // MISSING
+
+		optionDefault: 'Default' // MISSING
 	}
 };

--- a/lang/bn.js
+++ b/lang/bn.js
@@ -112,6 +112,8 @@ CKEDITOR.lang[ 'bn' ] = {
 		},
 
 		// Prepended to ARIA labels with shortcuts.
-		keyboardShortcut: 'Keyboard shortcut' // MISSING
+		keyboardShortcut: 'Keyboard shortcut', // MISSING
+
+		optionDefault: 'Default' // MISSING
 	}
 };

--- a/lang/bs.js
+++ b/lang/bs.js
@@ -112,6 +112,8 @@ CKEDITOR.lang[ 'bs' ] = {
 		},
 
 		// Prepended to ARIA labels with shortcuts.
-		keyboardShortcut: 'Keyboard shortcut' // MISSING
+		keyboardShortcut: 'Keyboard shortcut', // MISSING
+
+		optionDefault: 'Default' // MISSING
 	}
 };

--- a/lang/ca.js
+++ b/lang/ca.js
@@ -112,6 +112,8 @@ CKEDITOR.lang[ 'ca' ] = {
 		},
 
 		// Prepended to ARIA labels with shortcuts.
-		keyboardShortcut: 'Keyboard shortcut' // MISSING
+		keyboardShortcut: 'Keyboard shortcut', // MISSING
+
+		optionDefault: 'Default' // MISSING
 	}
 };

--- a/lang/cs.js
+++ b/lang/cs.js
@@ -112,6 +112,8 @@ CKEDITOR.lang[ 'cs' ] = {
 		},
 
 		// Prepended to ARIA labels with shortcuts.
-		keyboardShortcut: 'Klávesová zkratka'
+		keyboardShortcut: 'Klávesová zkratka',
+
+		optionDefault: 'Default' // MISSING
 	}
 };

--- a/lang/cy.js
+++ b/lang/cy.js
@@ -112,6 +112,8 @@ CKEDITOR.lang[ 'cy' ] = {
 		},
 
 		// Prepended to ARIA labels with shortcuts.
-		keyboardShortcut: 'Keyboard shortcut' // MISSING
+		keyboardShortcut: 'Keyboard shortcut', // MISSING
+
+		optionDefault: 'Default' // MISSING
 	}
 };

--- a/lang/da.js
+++ b/lang/da.js
@@ -112,6 +112,8 @@ CKEDITOR.lang[ 'da' ] = {
 		},
 
 		// Prepended to ARIA labels with shortcuts.
-		keyboardShortcut: 'Tastatur genvej'
+		keyboardShortcut: 'Tastatur genvej',
+
+		optionDefault: 'Default' // MISSING
 	}
 };

--- a/lang/de-ch.js
+++ b/lang/de-ch.js
@@ -111,6 +111,8 @@ CKEDITOR.lang[ 'de-ch' ] = {
 		},
 
 		// Prepended to ARIA labels with shortcuts.
-		keyboardShortcut: 'Keyboard shortcut' // MISSING
+		keyboardShortcut: 'Keyboard shortcut', // MISSING
+
+		optionDefault: 'Default' // MISSING
 	}
 };

--- a/lang/de.js
+++ b/lang/de.js
@@ -112,6 +112,8 @@ CKEDITOR.lang[ 'de' ] = {
 		},
 
 		// Prepended to ARIA labels with shortcuts.
-		keyboardShortcut: 'Tastaturkürzel'
+		keyboardShortcut: 'Tastaturkürzel',
+
+		optionDefault: 'Default' // MISSING
 	}
 };

--- a/lang/el.js
+++ b/lang/el.js
@@ -112,6 +112,8 @@ CKEDITOR.lang[ 'el' ] = {
 		},
 
 		// Prepended to ARIA labels with shortcuts.
-		keyboardShortcut: 'Συντόμευση πληκτρολογίου'
+		keyboardShortcut: 'Συντόμευση πληκτρολογίου',
+
+		optionDefault: 'Default' // MISSING
 	}
 };

--- a/lang/en-au.js
+++ b/lang/en-au.js
@@ -112,6 +112,8 @@ CKEDITOR.lang[ 'en-au' ] = {
 		},
 
 		// Prepended to ARIA labels with shortcuts.
-		keyboardShortcut: 'Keyboard shortcut' // MISSING
+		keyboardShortcut: 'Keyboard shortcut', // MISSING
+
+		optionDefault: 'Default' // MISSING
 	}
 };

--- a/lang/en-ca.js
+++ b/lang/en-ca.js
@@ -112,6 +112,8 @@ CKEDITOR.lang[ 'en-ca' ] = {
 		},
 
 		// Prepended to ARIA labels with shortcuts.
-		keyboardShortcut: 'Keyboard shortcut' // MISSING
+		keyboardShortcut: 'Keyboard shortcut', // MISSING
+
+		optionDefault: 'Default' // MISSING
 	}
 };

--- a/lang/en-gb.js
+++ b/lang/en-gb.js
@@ -112,6 +112,8 @@ CKEDITOR.lang[ 'en-gb' ] = {
 		},
 
 		// Prepended to ARIA labels with shortcuts.
-		keyboardShortcut: 'Keyboard shortcut' // MISSING
+		keyboardShortcut: 'Keyboard shortcut', // MISSING
+
+		optionDefault: 'Default' // MISSING
 	}
 };

--- a/lang/en.js
+++ b/lang/en.js
@@ -112,6 +112,8 @@ CKEDITOR.lang[ 'en' ] = {
 		},
 
 		// Prepended to ARIA labels with shortcuts.
-		keyboardShortcut: 'Keyboard shortcut'
+		keyboardShortcut: 'Keyboard shortcut',
+
+		optionDefault: 'Default'
 	}
 };

--- a/lang/eo.js
+++ b/lang/eo.js
@@ -112,6 +112,8 @@ CKEDITOR.lang[ 'eo' ] = {
 		},
 
 		// Prepended to ARIA labels with shortcuts.
-		keyboardShortcut: 'Fulmoklavo'
+		keyboardShortcut: 'Fulmoklavo',
+
+		optionDefault: 'Default' // MISSING
 	}
 };

--- a/lang/es-mx.js
+++ b/lang/es-mx.js
@@ -3,7 +3,9 @@
  * For licensing, see LICENSE.md or http://ckeditor.com/license
  */
 
- // MISSING
+/**
+* @fileOverview 
+*/
 
 /**#@+
    @type String
@@ -109,6 +111,8 @@ CKEDITOR.lang[ 'es-mx' ] = {
 		},
 
 		// Prepended to ARIA labels with shortcuts.
-		keyboardShortcut: 'Atajo de teclado'
+		keyboardShortcut: 'Atajo de teclado',
+
+		optionDefault: 'Default' // MISSING
 	}
 };

--- a/lang/es.js
+++ b/lang/es.js
@@ -112,6 +112,8 @@ CKEDITOR.lang[ 'es' ] = {
 		},
 
 		// Prepended to ARIA labels with shortcuts.
-		keyboardShortcut: 'Keyboard shortcut' // MISSING
+		keyboardShortcut: 'Keyboard shortcut', // MISSING
+
+		optionDefault: 'Default' // MISSING
 	}
 };

--- a/lang/et.js
+++ b/lang/et.js
@@ -112,6 +112,8 @@ CKEDITOR.lang[ 'et' ] = {
 		},
 
 		// Prepended to ARIA labels with shortcuts.
-		keyboardShortcut: 'Keyboard shortcut' // MISSING
+		keyboardShortcut: 'Keyboard shortcut', // MISSING
+
+		optionDefault: 'Default' // MISSING
 	}
 };

--- a/lang/eu.js
+++ b/lang/eu.js
@@ -112,6 +112,8 @@ CKEDITOR.lang[ 'eu' ] = {
 		},
 
 		// Prepended to ARIA labels with shortcuts.
-		keyboardShortcut: 'Keyboard shortcut' // MISSING
+		keyboardShortcut: 'Keyboard shortcut', // MISSING
+
+		optionDefault: 'Default' // MISSING
 	}
 };

--- a/lang/fa.js
+++ b/lang/fa.js
@@ -112,6 +112,8 @@ CKEDITOR.lang[ 'fa' ] = {
 		},
 
 		// Prepended to ARIA labels with shortcuts.
-		keyboardShortcut: 'Keyboard shortcut' // MISSING
+		keyboardShortcut: 'Keyboard shortcut', // MISSING
+
+		optionDefault: 'Default' // MISSING
 	}
 };

--- a/lang/fi.js
+++ b/lang/fi.js
@@ -112,6 +112,8 @@ CKEDITOR.lang[ 'fi' ] = {
 		},
 
 		// Prepended to ARIA labels with shortcuts.
-		keyboardShortcut: 'Keyboard shortcut' // MISSING
+		keyboardShortcut: 'Keyboard shortcut', // MISSING
+
+		optionDefault: 'Default' // MISSING
 	}
 };

--- a/lang/fo.js
+++ b/lang/fo.js
@@ -112,6 +112,8 @@ CKEDITOR.lang[ 'fo' ] = {
 		},
 
 		// Prepended to ARIA labels with shortcuts.
-		keyboardShortcut: 'Keyboard shortcut' // MISSING
+		keyboardShortcut: 'Keyboard shortcut', // MISSING
+
+		optionDefault: 'Default' // MISSING
 	}
 };

--- a/lang/fr-ca.js
+++ b/lang/fr-ca.js
@@ -112,6 +112,8 @@ CKEDITOR.lang[ 'fr-ca' ] = {
 		},
 
 		// Prepended to ARIA labels with shortcuts.
-		keyboardShortcut: 'Keyboard shortcut' // MISSING
+		keyboardShortcut: 'Keyboard shortcut', // MISSING
+
+		optionDefault: 'Default' // MISSING
 	}
 };

--- a/lang/fr.js
+++ b/lang/fr.js
@@ -112,6 +112,8 @@ CKEDITOR.lang[ 'fr' ] = {
 		},
 
 		// Prepended to ARIA labels with shortcuts.
-		keyboardShortcut: 'Raccourci clavier'
+		keyboardShortcut: 'Raccourci clavier',
+
+		optionDefault: 'Default' // MISSING
 	}
 };

--- a/lang/gl.js
+++ b/lang/gl.js
@@ -112,6 +112,8 @@ CKEDITOR.lang[ 'gl' ] = {
 		},
 
 		// Prepended to ARIA labels with shortcuts.
-		keyboardShortcut: 'Atallo de teclado'
+		keyboardShortcut: 'Atallo de teclado',
+
+		optionDefault: 'Default' // MISSING
 	}
 };

--- a/lang/gu.js
+++ b/lang/gu.js
@@ -112,6 +112,8 @@ CKEDITOR.lang[ 'gu' ] = {
 		},
 
 		// Prepended to ARIA labels with shortcuts.
-		keyboardShortcut: 'Keyboard shortcut' // MISSING
+		keyboardShortcut: 'Keyboard shortcut', // MISSING
+
+		optionDefault: 'Default' // MISSING
 	}
 };

--- a/lang/he.js
+++ b/lang/he.js
@@ -112,6 +112,8 @@ CKEDITOR.lang[ 'he' ] = {
 		},
 
 		// Prepended to ARIA labels with shortcuts.
-		keyboardShortcut: 'Keyboard shortcut' // MISSING
+		keyboardShortcut: 'Keyboard shortcut', // MISSING
+
+		optionDefault: 'Default' // MISSING
 	}
 };

--- a/lang/hi.js
+++ b/lang/hi.js
@@ -112,6 +112,8 @@ CKEDITOR.lang[ 'hi' ] = {
 		},
 
 		// Prepended to ARIA labels with shortcuts.
-		keyboardShortcut: 'Keyboard shortcut' // MISSING
+		keyboardShortcut: 'Keyboard shortcut', // MISSING
+
+		optionDefault: 'Default' // MISSING
 	}
 };

--- a/lang/hr.js
+++ b/lang/hr.js
@@ -112,6 +112,8 @@ CKEDITOR.lang[ 'hr' ] = {
 		},
 
 		// Prepended to ARIA labels with shortcuts.
-		keyboardShortcut: 'Prečica na tipkovnici'
+		keyboardShortcut: 'Prečica na tipkovnici',
+
+		optionDefault: 'Default' // MISSING
 	}
 };

--- a/lang/hu.js
+++ b/lang/hu.js
@@ -112,6 +112,8 @@ CKEDITOR.lang[ 'hu' ] = {
 		},
 
 		// Prepended to ARIA labels with shortcuts.
-		keyboardShortcut: 'Gyorsbillentyű'
+		keyboardShortcut: 'Gyorsbillentyű',
+
+		optionDefault: 'Default' // MISSING
 	}
 };

--- a/lang/id.js
+++ b/lang/id.js
@@ -111,6 +111,8 @@ CKEDITOR.lang[ 'id' ] = {
 		},
 
 		// Prepended to ARIA labels with shortcuts.
-		keyboardShortcut: 'Pintasan Keyboard'
+		keyboardShortcut: 'Pintasan Keyboard',
+
+		optionDefault: 'Default' // MISSING
 	}
 };

--- a/lang/is.js
+++ b/lang/is.js
@@ -112,6 +112,8 @@ CKEDITOR.lang[ 'is' ] = {
 		},
 
 		// Prepended to ARIA labels with shortcuts.
-		keyboardShortcut: 'Keyboard shortcut' // MISSING
+		keyboardShortcut: 'Keyboard shortcut', // MISSING
+
+		optionDefault: 'Default' // MISSING
 	}
 };

--- a/lang/it.js
+++ b/lang/it.js
@@ -112,6 +112,8 @@ CKEDITOR.lang[ 'it' ] = {
 		},
 
 		// Prepended to ARIA labels with shortcuts.
-		keyboardShortcut: 'Scorciatoia da tastiera'
+		keyboardShortcut: 'Scorciatoia da tastiera',
+
+		optionDefault: 'Default' // MISSING
 	}
 };

--- a/lang/ja.js
+++ b/lang/ja.js
@@ -112,6 +112,8 @@ CKEDITOR.lang[ 'ja' ] = {
 		},
 
 		// Prepended to ARIA labels with shortcuts.
-		keyboardShortcut: 'キーボードショートカット'
+		keyboardShortcut: 'キーボードショートカット',
+
+		optionDefault: 'Default' // MISSING
 	}
 };

--- a/lang/ka.js
+++ b/lang/ka.js
@@ -112,6 +112,8 @@ CKEDITOR.lang[ 'ka' ] = {
 		},
 
 		// Prepended to ARIA labels with shortcuts.
-		keyboardShortcut: 'Keyboard shortcut' // MISSING
+		keyboardShortcut: 'Keyboard shortcut', // MISSING
+
+		optionDefault: 'Default' // MISSING
 	}
 };

--- a/lang/km.js
+++ b/lang/km.js
@@ -112,6 +112,8 @@ CKEDITOR.lang[ 'km' ] = {
 		},
 
 		// Prepended to ARIA labels with shortcuts.
-		keyboardShortcut: 'Keyboard shortcut' // MISSING
+		keyboardShortcut: 'Keyboard shortcut', // MISSING
+
+		optionDefault: 'Default' // MISSING
 	}
 };

--- a/lang/ko.js
+++ b/lang/ko.js
@@ -112,6 +112,8 @@ CKEDITOR.lang[ 'ko' ] = {
 		},
 
 		// Prepended to ARIA labels with shortcuts.
-		keyboardShortcut: '키보드 단축키'
+		keyboardShortcut: '키보드 단축키',
+
+		optionDefault: 'Default' // MISSING
 	}
 };

--- a/lang/ku.js
+++ b/lang/ku.js
@@ -111,6 +111,8 @@ CKEDITOR.lang[ 'ku' ] = {
 		},
 
 		// Prepended to ARIA labels with shortcuts.
-		keyboardShortcut: 'کورتبڕی تەختەکلیل'
+		keyboardShortcut: 'کورتبڕی تەختەکلیل',
+
+		optionDefault: 'Default' // MISSING
 	}
 };

--- a/lang/lt.js
+++ b/lang/lt.js
@@ -112,6 +112,8 @@ CKEDITOR.lang[ 'lt' ] = {
 		},
 
 		// Prepended to ARIA labels with shortcuts.
-		keyboardShortcut: 'Keyboard shortcut' // MISSING
+		keyboardShortcut: 'Keyboard shortcut', // MISSING
+
+		optionDefault: 'Default' // MISSING
 	}
 };

--- a/lang/lv.js
+++ b/lang/lv.js
@@ -112,6 +112,8 @@ CKEDITOR.lang[ 'lv' ] = {
 		},
 
 		// Prepended to ARIA labels with shortcuts.
-		keyboardShortcut: 'Keyboard shortcut' // MISSING
+		keyboardShortcut: 'Keyboard shortcut', // MISSING
+
+		optionDefault: 'Default' // MISSING
 	}
 };

--- a/lang/mk.js
+++ b/lang/mk.js
@@ -111,6 +111,8 @@ CKEDITOR.lang[ 'mk' ] = {
 		},
 
 		// Prepended to ARIA labels with shortcuts.
-		keyboardShortcut: 'Keyboard shortcut' // MISSING
+		keyboardShortcut: 'Keyboard shortcut', // MISSING
+
+		optionDefault: 'Default' // MISSING
 	}
 };

--- a/lang/mn.js
+++ b/lang/mn.js
@@ -112,6 +112,8 @@ CKEDITOR.lang[ 'mn' ] = {
 		},
 
 		// Prepended to ARIA labels with shortcuts.
-		keyboardShortcut: 'Keyboard shortcut' // MISSING
+		keyboardShortcut: 'Keyboard shortcut', // MISSING
+
+		optionDefault: 'Default' // MISSING
 	}
 };

--- a/lang/ms.js
+++ b/lang/ms.js
@@ -112,6 +112,8 @@ CKEDITOR.lang[ 'ms' ] = {
 		},
 
 		// Prepended to ARIA labels with shortcuts.
-		keyboardShortcut: 'Keyboard shortcut' // MISSING
+		keyboardShortcut: 'Keyboard shortcut', // MISSING
+
+		optionDefault: 'Default' // MISSING
 	}
 };

--- a/lang/nb.js
+++ b/lang/nb.js
@@ -112,6 +112,8 @@ CKEDITOR.lang[ 'nb' ] = {
 		},
 
 		// Prepended to ARIA labels with shortcuts.
-		keyboardShortcut: 'Tastatursnarvei'
+		keyboardShortcut: 'Tastatursnarvei',
+
+		optionDefault: 'Default' // MISSING
 	}
 };

--- a/lang/nl.js
+++ b/lang/nl.js
@@ -112,6 +112,8 @@ CKEDITOR.lang[ 'nl' ] = {
 		},
 
 		// Prepended to ARIA labels with shortcuts.
-		keyboardShortcut: 'Sneltoets'
+		keyboardShortcut: 'Sneltoets',
+
+		optionDefault: 'Default' // MISSING
 	}
 };

--- a/lang/no.js
+++ b/lang/no.js
@@ -112,6 +112,8 @@ CKEDITOR.lang[ 'no' ] = {
 		},
 
 		// Prepended to ARIA labels with shortcuts.
-		keyboardShortcut: 'Keyboard shortcut' // MISSING
+		keyboardShortcut: 'Keyboard shortcut', // MISSING
+
+		optionDefault: 'Default' // MISSING
 	}
 };

--- a/lang/oc.js
+++ b/lang/oc.js
@@ -112,6 +112,8 @@ CKEDITOR.lang[ 'oc' ] = {
 		},
 
 		// Prepended to ARIA labels with shortcuts.
-		keyboardShortcut: 'Acorchi de clavièr'
+		keyboardShortcut: 'Acorchi de clavièr',
+
+		optionDefault: 'Default' // MISSING
 	}
 };

--- a/lang/pl.js
+++ b/lang/pl.js
@@ -112,6 +112,8 @@ CKEDITOR.lang[ 'pl' ] = {
 		},
 
 		// Prepended to ARIA labels with shortcuts.
-		keyboardShortcut: 'Skrót klawiszowy'
+		keyboardShortcut: 'Skrót klawiszowy',
+
+		optionDefault: 'Default' // MISSING
 	}
 };

--- a/lang/pt-br.js
+++ b/lang/pt-br.js
@@ -111,6 +111,8 @@ CKEDITOR.lang[ 'pt-br' ] = {
 		},
 
 		// Prepended to ARIA labels with shortcuts.
-		keyboardShortcut: 'Atalho do teclado'
+		keyboardShortcut: 'Atalho do teclado',
+
+		optionDefault: 'Default' // MISSING
 	}
 };

--- a/lang/pt.js
+++ b/lang/pt.js
@@ -112,6 +112,8 @@ CKEDITOR.lang[ 'pt' ] = {
 		},
 
 		// Prepended to ARIA labels with shortcuts.
-		keyboardShortcut: 'Keyboard shortcut' // MISSING
+		keyboardShortcut: 'Keyboard shortcut', // MISSING
+
+		optionDefault: 'Default' // MISSING
 	}
 };

--- a/lang/ro.js
+++ b/lang/ro.js
@@ -112,6 +112,8 @@ CKEDITOR.lang[ 'ro' ] = {
 		},
 
 		// Prepended to ARIA labels with shortcuts.
-		keyboardShortcut: 'Keyboard shortcut' // MISSING
+		keyboardShortcut: 'Keyboard shortcut', // MISSING
+
+		optionDefault: 'Default' // MISSING
 	}
 };

--- a/lang/ru.js
+++ b/lang/ru.js
@@ -112,6 +112,8 @@ CKEDITOR.lang[ 'ru' ] = {
 		},
 
 		// Prepended to ARIA labels with shortcuts.
-		keyboardShortcut: 'Комбинация клавиш'
+		keyboardShortcut: 'Комбинация клавиш',
+
+		optionDefault: 'Default' // MISSING
 	}
 };

--- a/lang/si.js
+++ b/lang/si.js
@@ -111,6 +111,8 @@ CKEDITOR.lang[ 'si' ] = {
 		},
 
 		// Prepended to ARIA labels with shortcuts.
-		keyboardShortcut: 'Keyboard shortcut' // MISSING
+		keyboardShortcut: 'Keyboard shortcut', // MISSING
+
+		optionDefault: 'Default' // MISSING
 	}
 };

--- a/lang/sk.js
+++ b/lang/sk.js
@@ -112,6 +112,8 @@ CKEDITOR.lang[ 'sk' ] = {
 		},
 
 		// Prepended to ARIA labels with shortcuts.
-		keyboardShortcut: 'Klávesová skratka'
+		keyboardShortcut: 'Klávesová skratka',
+
+		optionDefault: 'Default' // MISSING
 	}
 };

--- a/lang/sl.js
+++ b/lang/sl.js
@@ -112,6 +112,8 @@ CKEDITOR.lang[ 'sl' ] = {
 		},
 
 		// Prepended to ARIA labels with shortcuts.
-		keyboardShortcut: 'Keyboard shortcut' // MISSING
+		keyboardShortcut: 'Keyboard shortcut', // MISSING
+
+		optionDefault: 'Default' // MISSING
 	}
 };

--- a/lang/sq.js
+++ b/lang/sq.js
@@ -111,6 +111,8 @@ CKEDITOR.lang[ 'sq' ] = {
 		},
 
 		// Prepended to ARIA labels with shortcuts.
-		keyboardShortcut: 'Keyboard shortcut' // MISSING
+		keyboardShortcut: 'Keyboard shortcut', // MISSING
+
+		optionDefault: 'Default' // MISSING
 	}
 };

--- a/lang/sr-latn.js
+++ b/lang/sr-latn.js
@@ -112,6 +112,8 @@ CKEDITOR.lang[ 'sr-latn' ] = {
 		},
 
 		// Prepended to ARIA labels with shortcuts.
-		keyboardShortcut: 'Keyboard shortcut' // MISSING
+		keyboardShortcut: 'Keyboard shortcut', // MISSING
+
+		optionDefault: 'Default' // MISSING
 	}
 };

--- a/lang/sr.js
+++ b/lang/sr.js
@@ -112,6 +112,8 @@ CKEDITOR.lang[ 'sr' ] = {
 		},
 
 		// Prepended to ARIA labels with shortcuts.
-		keyboardShortcut: 'Keyboard shortcut' // MISSING
+		keyboardShortcut: 'Keyboard shortcut', // MISSING
+
+		optionDefault: 'Default' // MISSING
 	}
 };

--- a/lang/sv.js
+++ b/lang/sv.js
@@ -111,6 +111,8 @@ CKEDITOR.lang[ 'sv' ] = {
 		},
 
 		// Prepended to ARIA labels with shortcuts.
-		keyboardShortcut: 'Kortkommando'
+		keyboardShortcut: 'Kortkommando',
+
+		optionDefault: 'Default' // MISSING
 	}
 };

--- a/lang/th.js
+++ b/lang/th.js
@@ -112,6 +112,8 @@ CKEDITOR.lang[ 'th' ] = {
 		},
 
 		// Prepended to ARIA labels with shortcuts.
-		keyboardShortcut: 'Keyboard shortcut' // MISSING
+		keyboardShortcut: 'Keyboard shortcut', // MISSING
+
+		optionDefault: 'Default' // MISSING
 	}
 };

--- a/lang/tr.js
+++ b/lang/tr.js
@@ -111,6 +111,8 @@ CKEDITOR.lang[ 'tr' ] = {
 		},
 
 		// Prepended to ARIA labels with shortcuts.
-		keyboardShortcut: 'Klavye Kısayolu'
+		keyboardShortcut: 'Klavye Kısayolu',
+
+		optionDefault: 'Default' // MISSING
 	}
 };

--- a/lang/tt.js
+++ b/lang/tt.js
@@ -112,6 +112,8 @@ CKEDITOR.lang[ 'tt' ] = {
 		},
 
 		// Prepended to ARIA labels with shortcuts.
-		keyboardShortcut: 'Keyboard shortcut' // MISSING
+		keyboardShortcut: 'Keyboard shortcut', // MISSING
+
+		optionDefault: 'Default' // MISSING
 	}
 };

--- a/lang/ug.js
+++ b/lang/ug.js
@@ -111,6 +111,8 @@ CKEDITOR.lang[ 'ug' ] = {
 		},
 
 		// Prepended to ARIA labels with shortcuts.
-		keyboardShortcut: 'Keyboard shortcut' // MISSING
+		keyboardShortcut: 'Keyboard shortcut', // MISSING
+
+		optionDefault: 'Default' // MISSING
 	}
 };

--- a/lang/uk.js
+++ b/lang/uk.js
@@ -112,6 +112,8 @@ CKEDITOR.lang[ 'uk' ] = {
 		},
 
 		// Prepended to ARIA labels with shortcuts.
-		keyboardShortcut: 'Keyboard shortcut' // MISSING
+		keyboardShortcut: 'Keyboard shortcut', // MISSING
+
+		optionDefault: 'Default' // MISSING
 	}
 };

--- a/lang/vi.js
+++ b/lang/vi.js
@@ -112,6 +112,8 @@ CKEDITOR.lang[ 'vi' ] = {
 		},
 
 		// Prepended to ARIA labels with shortcuts.
-		keyboardShortcut: 'Keyboard shortcut' // MISSING
+		keyboardShortcut: 'Keyboard shortcut', // MISSING
+
+		optionDefault: 'Default' // MISSING
 	}
 };

--- a/lang/zh-cn.js
+++ b/lang/zh-cn.js
@@ -112,6 +112,8 @@ CKEDITOR.lang[ 'zh-cn' ] = {
 		},
 
 		// Prepended to ARIA labels with shortcuts.
-		keyboardShortcut: '快捷键'
+		keyboardShortcut: '快捷键',
+
+		optionDefault: 'Default' // MISSING
 	}
 };

--- a/lang/zh.js
+++ b/lang/zh.js
@@ -112,6 +112,8 @@ CKEDITOR.lang[ 'zh' ] = {
 		},
 
 		// Prepended to ARIA labels with shortcuts.
-		keyboardShortcut: '鍵盤快捷鍵'
+		keyboardShortcut: '鍵盤快捷鍵',
+
+		optionDefault: 'Default' // MISSING
 	}
 };

--- a/plugins/font/plugin.js
+++ b/plugins/font/plugin.js
@@ -5,7 +5,6 @@
 
 ( function() {
 	function addCombo( editor, comboName, styleType, lang, entries, defaultLabel, styleDefinition, order ) {
-		// debugger;
 		var config = editor.config,
 			style = new CKEDITOR.style( styleDefinition );
 
@@ -94,7 +93,7 @@
 
 				this.startGroup( lang.panelTitle );
 
-				// Add (default) option as first element on the list.
+				// Add `(Default)` item as first element on the drop down list.
 				this.add( defaultValue, defaultText, defaultText );
 
 				for ( var i = 0; i < names.length; i++ ) {

--- a/plugins/font/plugin.js
+++ b/plugins/font/plugin.js
@@ -93,7 +93,7 @@
 
 				this.startGroup( lang.panelTitle );
 
-				// Add `(Default)` item as a first element on the drop down list.
+				// Add `(Default)` item as a first element on the drop-down list.
 				this.add( this.defaultValue, defaultText, defaultText );
 
 				for ( var i = 0; i < names.length; i++ ) {

--- a/plugins/font/plugin.js
+++ b/plugins/font/plugin.js
@@ -4,7 +4,7 @@
  */
 
 ( function() {
-	function addCombo( editor, comboName, styleType, lang, entries, defaultLabel, styleDefinition, order ) {
+	function addCombo( editor, comboName, styleType, lang, entries, defaultLabel, styleDefinition, order, twoStateList, clearFontAvailable ) {
 		var config = editor.config,
 			style = new CKEDITOR.style( styleDefinition );
 
@@ -89,9 +89,13 @@
 			init: function() {
 				this.startGroup( lang.panelTitle );
 
+				// Adding (clear) option to list.
+				if ( clearFontAvailable ) {
+					this.add( 'cke-clear', '<span>(clear)</span>', '(clear)' );
+				}
+
 				for ( var i = 0; i < names.length; i++ ) {
 					var name = names[ i ];
-
 					// Add the tag entry to the panel list.
 					this.add( name, styles[ name ].buildPreview(), name );
 				}
@@ -106,7 +110,7 @@
 
 				// When applying one style over another, first remove the previous one (http://dev.ckeditor.com/ticket/12403).
 				// NOTE: This is only a temporary fix. It will be moved to the styles system (http://dev.ckeditor.com/ticket/12687).
-				if ( previousValue && value != previousValue ) {
+				if ( previousValue && ( value != previousValue || value === 'cke-clear' ) ) {
 					var previousStyle = styles[ previousValue ],
 						range = editor.getSelection().getRanges()[ 0 ];
 
@@ -157,7 +161,9 @@
 					}
 				}
 
-				editor[ previousValue == value ? 'removeStyle' : 'applyStyle' ]( style );
+				if ( value !== 'cke-clear' ) {
+					editor[ twoStateList && previousValue == value ? 'removeStyle' : 'applyStyle' ]( style );
+				}
 
 				editor.fire( 'saveSnapshot' );
 			},
@@ -228,8 +234,8 @@
 		init: function( editor ) {
 			var config = editor.config;
 
-			addCombo( editor, 'Font', 'family', editor.lang.font, config.font_names, config.font_defaultLabel, config.font_style, 30 );
-			addCombo( editor, 'FontSize', 'size', editor.lang.font.fontSize, config.fontSize_sizes, config.fontSize_defaultLabel, config.fontSize_style, 40 );
+			addCombo( editor, 'Font', 'family', editor.lang.font, config.font_names, config.font_defaultLabel, config.font_style, 30, false, true );
+			addCombo( editor, 'FontSize', 'size', editor.lang.font.fontSize, config.fontSize_sizes, config.fontSize_defaultLabel, config.fontSize_style, 40, false, true );
 		}
 	} );
 } )();

--- a/plugins/font/plugin.js
+++ b/plugins/font/plugin.js
@@ -117,7 +117,8 @@
 					startBoundary,
 					endBoundary,
 					node,
-					bm;
+					bm,
+					defaultValue = 'cke-default';
 
 				// When applying one style over another, first remove the previous one (http://dev.ckeditor.com/ticket/12403).
 				// NOTE: This is only a temporary fix. It will be moved to the styles system (http://dev.ckeditor.com/ticket/12687).
@@ -170,13 +171,14 @@
 						editor.removeStyle( previousStyle );
 					}
 				}
-				if ( value === 'cke-default' && previousStyle ) {
-					editor.removeStyle( previousStyle );
-				} else if ( value !== 'cke-default' ) {
+
+				if ( value === defaultValue ) {
+					if ( previousStyle ) {
+						editor.removeStyle( previousStyle );
+					}
+				} else if ( value !== previousValue ) {
 					editor.applyStyle( style );
 				}
-
-				// editor[ previousValue == value ? 'removeStyle' : 'applyStyle' ]( style );
 
 				editor.fire( 'saveSnapshot' );
 			},

--- a/plugins/font/plugin.js
+++ b/plugins/font/plugin.js
@@ -90,7 +90,7 @@
 			init: function() {
 				var name,
 					defaultValue = 'cke-default',
-					defaultText = '(' + lang.optionDefault + ')';
+					defaultText = '(' + editor.lang.common.optionDefault + ')';
 
 				this.startGroup( lang.panelTitle );
 

--- a/plugins/font/plugin.js
+++ b/plugins/font/plugin.js
@@ -36,6 +36,7 @@
 			label: lang.label,
 			title: lang.panelTitle,
 			toolbar: 'styles,' + order,
+			defaultValue: 'cke-default',
 			allowedContent: style,
 			requiredContent: style,
 			contentTransformations: [
@@ -88,13 +89,12 @@
 
 			init: function() {
 				var name,
-					defaultValue = 'cke-default',
 					defaultText = '(' + editor.lang.common.optionDefault + ')';
 
 				this.startGroup( lang.panelTitle );
 
-				// Add `(Default)` item as first element on the drop down list.
-				this.add( defaultValue, defaultText, defaultText );
+				// Add `(Default)` item as a first element on the drop down list.
+				this.add( this.defaultValue, defaultText, defaultText );
 
 				for ( var i = 0; i < names.length; i++ ) {
 					name = names[ i ];
@@ -116,8 +116,7 @@
 					startBoundary,
 					endBoundary,
 					node,
-					bm,
-					defaultValue = 'cke-default';
+					bm;
 
 				// When applying one style over another, first remove the previous one (http://dev.ckeditor.com/ticket/12403).
 				// NOTE: This is only a temporary fix. It will be moved to the styles system (http://dev.ckeditor.com/ticket/12687).
@@ -171,7 +170,7 @@
 					}
 				}
 
-				if ( value === defaultValue ) {
+				if ( value === this.defaultValue ) {
 					if ( previousStyle ) {
 						editor.removeStyle( previousStyle );
 					}

--- a/plugins/format/plugin.js
+++ b/plugins/format/plugin.js
@@ -64,10 +64,13 @@ CKEDITOR.plugins.add( 'format', {
 				editor.focus();
 				editor.fire( 'saveSnapshot' );
 
-				var style = styles[ value ];
+				var style = styles[ value ],
+					elementPath = editor.elementPath();
 
-				// Always aply style, do not allow on toggle it by clicking on list item (#584).
-				editor.applyStyle( style );
+				// Always apply style, do not allow on toggle it by clicking on list item (#584).
+				if ( !style.checkActive( elementPath, editor ) ) {
+					editor.applyStyle( style );
+				}
 
 				// Save the undo snapshot after all changes are affected. (http://dev.ckeditor.com/ticket/4899)
 				setTimeout( function() {

--- a/plugins/format/plugin.js
+++ b/plugins/format/plugin.js
@@ -67,7 +67,7 @@ CKEDITOR.plugins.add( 'format', {
 				var style = styles[ value ],
 					elementPath = editor.elementPath();
 
-				// Always apply style, do not allow on toggle it by clicking on list item (#584).
+				// Always apply style, do not allow to toggle it by clicking on corresponding list item (#584).
 				if ( !style.checkActive( elementPath, editor ) ) {
 					editor.applyStyle( style );
 				}

--- a/plugins/format/plugin.js
+++ b/plugins/format/plugin.js
@@ -64,10 +64,10 @@ CKEDITOR.plugins.add( 'format', {
 				editor.focus();
 				editor.fire( 'saveSnapshot' );
 
-				var style = styles[ value ],
-					elementPath = editor.elementPath();
+				var style = styles[ value ];
 
-				editor[ style.checkActive( elementPath, editor ) ? 'removeStyle' : 'applyStyle' ]( style );
+				// Always aply style, do not allow on toggle it by clicking on list item (#584).
+				editor.applyStyle( style );
 
 				// Save the undo snapshot after all changes are affected. (http://dev.ckeditor.com/ticket/4899)
 				setTimeout( function() {

--- a/tests/plugins/font/font.js
+++ b/tests/plugins/font/font.js
@@ -35,8 +35,10 @@
 
 				this.wait( function() {
 					// Click again to exit the style.
+					// Since 4.8.0 2nd click into this same menu item do not unselect it.
+					// It is required to click into '(Default)' option to reset style (#584).
 					bot.combo( 'FontSize', function( combo ) {
-						combo.onClick( 48 );
+						combo.onClick( 'cke-default' );
 						this.wait( function() {
 							editor.insertText( 'bar' );
 							assert.isInnerHtmlMatching( '<p><span style="font-size:48px">foo</span>bar@</p>',

--- a/tests/plugins/font/font.js
+++ b/tests/plugins/font/font.js
@@ -222,7 +222,7 @@
 			this.assertCombo( 'Font', 'cke-default', false, bot, '<p>foo@</p>' );
 		},
 
-		'test reaaply this same font size twice': function() {
+		'test reapply this same font size twice': function() {
 			var bot = this.editorBot;
 			bender.tools.selection.setWithHtml( bot.editor, '<p>[foo]</p>' );
 
@@ -238,7 +238,7 @@
 
 		},
 
-		'test reaaply this same font family twice': function() {
+		'test reapply this same font family twice': function() {
 			var bot = this.editorBot;
 			bender.tools.selection.setWithHtml( bot.editor, '<p>[foo]</p>' );
 

--- a/tests/plugins/font/font.js
+++ b/tests/plugins/font/font.js
@@ -172,6 +172,43 @@
 				'<p>x<span style="font-size:12px"><em>foo</em></span><em><span style="font-size:24px">bar</span></em>x@</p>' );
 		},
 
+		// #584
+		'test remove font size from text': function() {
+			var bot = this.editorBot;
+			bender.tools.selection.setWithHtml( bot.editor, '<p><span style="font-size:12px">[foo]</span></p>' );
+			this.assertCombo( 'FontSize', 'cke-default', false, bot, '<p>foo@</p>' );
+		},
+
+		'test remove font family from text': function() {
+			var bot = this.editorBot;
+			bender.tools.selection.setWithHtml( bot.editor, '<p><span style="' + ffArial + '">[foo]</span></p>' );
+			this.assertCombo( 'Font', 'cke-default', false, bot, '<p>foo@</p>' );
+		},
+
+		'test remove font size partialy from text': function() {
+			var bot = this.editorBot;
+			bender.tools.selection.setWithHtml( bot.editor, '<p><span style="font-size:24px">[foo ]bar</span></p>' );
+			this.assertCombo( 'FontSize', 'cke-default', false, bot, '<p>foo <span style="font-size:24px">bar</span>@</p>' );
+		},
+
+		'test remove font family partially from text': function() {
+			var bot = this.editorBot;
+			bender.tools.selection.setWithHtml( bot.editor, '<p><span style="' + ffArial + '">[foo ]bar</span></p>' );
+			this.assertCombo( 'Font', 'cke-default', false, bot, '<p>foo <span style="' + ffArial + '">bar</span>@</p>' );
+		},
+
+		'test remove font size from unstyled text': function() {
+			var bot = this.editorBot;
+			bender.tools.selection.setWithHtml( bot.editor, '<p>[foo]</p>' );
+			this.assertCombo( 'FontSize', 'cke-default', false, bot, '<p>foo@</p>' );
+		},
+
+		'test remove font family from unstyled text': function() {
+			var bot = this.editorBot;
+			bender.tools.selection.setWithHtml( bot.editor, '<p>[foo]</p>' );
+			this.assertCombo( 'Font', 'cke-default', false, bot, '<p>foo@</p>' );
+		},
+
 		assertCombo: function( comboName, comboValue, collapsed, bot, resultHtml, callback ) {
 			bot.combo( comboName, function( combo ) {
 				combo.onClick( comboValue );

--- a/tests/plugins/font/font.js
+++ b/tests/plugins/font/font.js
@@ -48,8 +48,8 @@
 
 				this.wait( function() {
 					// Click again to exit the style.
-					// Since 4.8.0 2nd click into this same menu item do not unselect it.
-					// It is required to click into '(Default)' option to reset style (#584).
+					// Since 4.8.0, 2nd click on the same menu item does not unselect it.
+					// It is required to click on the '(Default)' option to reset style (#584).
 					bot.combo( 'FontSize', function( combo ) {
 						combo.onClick( 'cke-default' );
 						this.wait( function() {

--- a/tests/plugins/font/font.js
+++ b/tests/plugins/font/font.js
@@ -23,6 +23,19 @@
 			}
 		},
 
+		assertCombo: function( comboName, comboValue, collapsed, bot, resultHtml, callback ) {
+			bot.combo( comboName, function( combo ) {
+				combo.onClick( comboValue );
+
+				this.wait( function() {
+					// The empty span from collapsed selection is lost on FF and IE8, insert something to prevent that.
+					collapsed && bot.editor.insertText( 'bar' );
+					assert.isInnerHtmlMatching( resultHtml, bot.editor.editable().getHtml(), htmlMatchingOpts );
+					callback && callback( bot );
+				}, 0 );
+			} );
+		},
+
 		'test apply font size (collapsed selection)': function() {
 			var bot = this.editorBot,
 				editor = this.editor;
@@ -209,17 +222,36 @@
 			this.assertCombo( 'Font', 'cke-default', false, bot, '<p>foo@</p>' );
 		},
 
-		assertCombo: function( comboName, comboValue, collapsed, bot, resultHtml, callback ) {
-			bot.combo( comboName, function( combo ) {
-				combo.onClick( comboValue );
+		'test reaaply this same font size twice': function() {
+			var bot = this.editorBot;
+			bender.tools.selection.setWithHtml( bot.editor, '<p>[foo]</p>' );
 
+			bot.combo( 'FontSize', function( combo ) {
+				combo.onClick( 24 );
 				this.wait( function() {
-					// The empty span from collapsed selection is lost on FF and IE8, insert something to prevent that.
-					collapsed && bot.editor.insertText( 'bar' );
-					assert.isInnerHtmlMatching( resultHtml, bot.editor.editable().getHtml(), htmlMatchingOpts );
-					callback && callback( bot );
+					combo.onClick( 24 );
+					this.wait( function() {
+						assert.isInnerHtmlMatching( '<p><span style="font-size:24px">foo</span>@</p>', bot.editor.editable().getHtml(), htmlMatchingOpts );
+					}, 0 );
+				}, 0 );
+			} );
+
+		},
+
+		'test reaaply this same font family twice': function() {
+			var bot = this.editorBot;
+			bender.tools.selection.setWithHtml( bot.editor, '<p>[foo]</p>' );
+
+			bot.combo( 'Font', function( combo ) {
+				combo.onClick( 'Arial' );
+				this.wait( function() {
+					combo.onClick( 'Arial' );
+					this.wait( function() {
+						assert.isInnerHtmlMatching( '<p><span style="' + ffArial + '">foo</span>@</p>', bot.editor.editable().getHtml(), htmlMatchingOpts );
+					}, 0 );
 				}, 0 );
 			} );
 		}
+
 	} );
 } )();

--- a/tests/plugins/font/manual/preservestyle.html
+++ b/tests/plugins/font/manual/preservestyle.html
@@ -1,0 +1,7 @@
+<textarea name="ed" id="editor" cols="30" rows="10">
+	Hello world
+</textarea>
+
+<script>
+	CKEDITOR.replace( 'editor' );
+</script>

--- a/tests/plugins/font/manual/preservestyle.md
+++ b/tests/plugins/font/manual/preservestyle.md
@@ -3,6 +3,7 @@
 @bender-ckeditor-plugins: wysiwygarea, toolbar, font, elementspath, sourcearea
 
 Note: Perform below scenario for both `Font size` and `Font family` drop-downs.
+
 ----
 
 1. Select some text.

--- a/tests/plugins/font/manual/preservestyle.md
+++ b/tests/plugins/font/manual/preservestyle.md
@@ -1,6 +1,6 @@
 @bender-tags: 4.8.0, feature, tc
 @bender-ui: collapsed
-@bender-ckeditor-plugins: wysiwygarea, toolbar, font, elementspath
+@bender-ckeditor-plugins: wysiwygarea, toolbar, font, elementspath, sourcearea
 
 1. Select text
 1. Change `font size`

--- a/tests/plugins/font/manual/preservestyle.md
+++ b/tests/plugins/font/manual/preservestyle.md
@@ -2,15 +2,16 @@
 @bender-ui: collapsed
 @bender-ckeditor-plugins: wysiwygarea, toolbar, font, elementspath, sourcearea
 
+Note: Perform below scenario for both `Font size` and `Font family` drop-downs.
+----
+
 1. Select some text.
-1. Change `font size`, (e.g. `24`).
-1. Select this same text. So size on list has selected proper option.
+1. Change `Font size` (e.g. `24`).
+1. Select this same text.
+  * `Font size` drop-down shows size selected in a previous step.
 1. Select this same size once again (e.g. `24`).
-1. Text should preserve proper font size.
-1. Now select option `(Default)` to reset font size.
-1. Font size should reset to default one and `<span>` with font size style should disappear.
-1. Repeat those same steps for the `font name`.
+  * Selected text should preserve its font size.
+1. Select option `(Default)` to reset the `Font size`.
+  * `Font size` should reset to default one and `<span>` element with `Font size` style should disappear.
 
-**Expected:** Choosen font size/name will remain this same, after click into it. It still will be marked on dropdown menu and text preserve chosen style after reapplying it multiple times.
-
-**Unexpected:** Font size/name will be deselct and style dissapear from the text when clicked 2nd time.
+**Expected:** Choosen font size/name will remain the same, after click on its corresponding item in the drop-down menu. The item will remain marked as active. Selected text preserves chosen style after reapplying it multiple times.

--- a/tests/plugins/font/manual/preservestyle.md
+++ b/tests/plugins/font/manual/preservestyle.md
@@ -2,10 +2,10 @@
 @bender-ui: collapsed
 @bender-ckeditor-plugins: wysiwygarea, toolbar, font, elementspath, sourcearea
 
-1. Select text
-1. Change `font size`, (e.g. `24`)
+1. Select some text.
+1. Change `font size`, (e.g. `24`).
 1. Select this same text. So size on list has selected proper option.
-1. Select this same size once again (e.g. `24`)
+1. Select this same size once again (e.g. `24`).
 1. Text should preserve proper font size.
 1. Now select option `(Default)` to reset font size.
 1. Font size should reset to default one and `<span>` with font size style should disappear.

--- a/tests/plugins/font/manual/preservestyle.md
+++ b/tests/plugins/font/manual/preservestyle.md
@@ -1,0 +1,13 @@
+@bender-tags: 4.8.0, feature, tc
+@bender-ui: collapsed
+@bender-ckeditor-plugins: wysiwygarea, toolbar, font, elementspath
+
+1. Select text
+1. Change `font size`
+1. Select this same text, be sure that floating panel has selected previously chosen option
+1. Select this same option once again
+1. Repeat those steps for the `font name`.
+
+**Expected:** Font size/name will remain this same. It still will be marked on dropdown menu and applied to selected text.
+
+**Unexpected:** Font size/name will be deselct and style dissapear from the text.

--- a/tests/plugins/font/manual/preservestyle.md
+++ b/tests/plugins/font/manual/preservestyle.md
@@ -1,13 +1,16 @@
-@bender-tags: 4.8.0, feature, tc
+@bender-tags: 4.8.0, feature, 584
 @bender-ui: collapsed
 @bender-ckeditor-plugins: wysiwygarea, toolbar, font, elementspath, sourcearea
 
 1. Select text
-1. Change `font size`
-1. Select this same text, be sure that floating panel has selected previously chosen option
-1. Select this same option once again
-1. Repeat those steps for the `font name`.
+1. Change `font size`, (e.g. `24`)
+1. Select this same text. So size on list has selected proper option.
+1. Select this same size once again (e.g. `24`)
+1. Text should preserve proper font size.
+1. Now select option `(Default)` to reset font size.
+1. Font size should reset to default one and `<span>` with font size style should disappear.
+1. Repeat those same steps for the `font name`.
 
-**Expected:** Font size/name will remain this same. It still will be marked on dropdown menu and applied to selected text.
+**Expected:** Choosen font size/name will remain this same, after click into it. It still will be marked on dropdown menu and text preserve chosen style after reapplying it multiple times.
 
-**Unexpected:** Font size/name will be deselct and style dissapear from the text.
+**Unexpected:** Font size/name will be deselct and style dissapear from the text when clicked 2nd time.

--- a/tests/plugins/format/manual/preserveformatafterclick.html
+++ b/tests/plugins/format/manual/preserveformatafterclick.html
@@ -1,0 +1,7 @@
+<textarea name="ed" id="editor" cols="30" rows="10">
+	Hello world
+</textarea>
+
+<script>
+	CKEDITOR.replace( 'editor' );
+</script>

--- a/tests/plugins/format/manual/preserveformatafterclick.md
+++ b/tests/plugins/format/manual/preserveformatafterclick.md
@@ -1,0 +1,10 @@
+@bender-tags: 4.8.0, feature, 584
+@bender-ui: collapsed
+@bender-ckeditor-plugins: wysiwygarea, toolbar, format, elementspath, sourcearea
+
+1. Select text
+1. Try to apply multiple times this same format to one selection (different than normal).
+
+**Expected:** Choosen format should remain this same all the time.
+
+**Unexpected:** Text format toggle between styled and unstyled (Normal) one.

--- a/tests/plugins/format/manual/preserveformatafterclick.md
+++ b/tests/plugins/format/manual/preserveformatafterclick.md
@@ -2,9 +2,9 @@
 @bender-ui: collapsed
 @bender-ckeditor-plugins: wysiwygarea, toolbar, format, elementspath, sourcearea
 
-1. Select text
-1. Try to apply multiple times this same format to one selection (different than normal).
+1. Select text.
+1. Try to apply same format (other than Normal) multiple times.
 
-**Expected:** Choosen format should remain this same all the time.
+**Expected:** Choosen format should remain the same all the time.
 
-**Unexpected:** Text format toggle between styled and unstyled (Normal) one.
+**Unexpected:** Text format toggles between styled and unstyled (Normal) one.

--- a/tests/plugins/format/plugin.js
+++ b/tests/plugins/format/plugin.js
@@ -27,26 +27,21 @@ bender.test( {
 		assert.areSame( CKEDITOR.TRISTATE_DISABLED, combo._.state, 'check state disabled when not in context' );
 	},
 
-	// Drop down format menu should not have possibility to toggle option (#584).
-	'test apply format style twice': function() {
+	// Drop-down format menu should not be toggleable (#584).
+	'test apply format style to preformated text': function() {
 		var bot = this.editorBot,
 			editor = this.editor,
 			name = 'Format',
 			combo = editor.ui.get( name );
 
-		bot.setHtmlWithSelection( '<p>^foo</p>' );
-		// apply format 1st time
-		assert.areSame( CKEDITOR.TRISTATE_OFF, combo._.state, 'check state OFF' );
+		bot.setHtmlWithSelection( '<h1>f^oo</h1>' );
+
+		// Apply the same style format to element already styled.
+		assert.areSame( CKEDITOR.TRISTATE_OFF, combo.getState(), 'check state OFF' );
 		bot.combo( name, function( combo ) {
-			assert.areSame( CKEDITOR.TRISTATE_ON, combo._.state, 'check state ON when opened' );
+			assert.areSame( CKEDITOR.TRISTATE_ON, combo.getState(), 'check state ON when opened' );
 			combo.onClick( 'h1' );
-			assert.areSame( '<h1>^foo</h1>', bot.htmlWithSelection(), 'applied h1 block style' );
-			// apply format 2nd time
-			bot.combo( name, function( combo ) {
-				assert.areSame( CKEDITOR.TRISTATE_ON, combo._.state, 'check state ON when opened' );
-				combo.onClick( 'h1' );
-				assert.areSame( '<h1>^foo</h1>', bot.htmlWithSelection(), 'applied h1 block style' );
-			} );
+			assert.areSame( '<h1>f^oo</h1>', bot.htmlWithSelection(), 'applied h1 block style' );
 		} );
 	}
 

--- a/tests/plugins/format/plugin.js
+++ b/tests/plugins/format/plugin.js
@@ -29,19 +29,14 @@ bender.test( {
 
 	// Drop-down format menu should not be toggleable (#584).
 	'test apply format style to preformated text': function() {
-		var bot = this.editorBot,
-			editor = this.editor,
-			name = 'Format',
-			combo = editor.ui.get( name );
+		var bot = this.editorBot;
 
 		bot.setHtmlWithSelection( '<h1>f^oo</h1>' );
 
-		// Apply the same style format to element already styled.
-		assert.areSame( CKEDITOR.TRISTATE_OFF, combo.getState(), 'check state OFF' );
-		bot.combo( name, function( combo ) {
-			assert.areSame( CKEDITOR.TRISTATE_ON, combo.getState(), 'check state ON when opened' );
+		// Preserved h1 block style.
+		bot.combo( 'Format', function( combo ) {
 			combo.onClick( 'h1' );
-			assert.areSame( '<h1>f^oo</h1>', bot.htmlWithSelection(), 'applied h1 block style' );
+			assert.areSame( '<h1>f^oo</h1>', bot.htmlWithSelection() );
 		} );
 	}
 

--- a/tests/plugins/format/plugin.js
+++ b/tests/plugins/format/plugin.js
@@ -25,5 +25,29 @@ bender.test( {
 		bot.setHtmlWithSelection( '<fieldset><legend>^foo</legend><form>bar</form></fieldset>' );
 		var name = 'Format', combo = ed.ui.get( name );
 		assert.areSame( CKEDITOR.TRISTATE_DISABLED, combo._.state, 'check state disabled when not in context' );
+	},
+
+	// Drop down format menu should not have possibility to toggle option (#584).
+	'test apply format style twice': function() {
+		var bot = this.editorBot,
+			editor = this.editor,
+			name = 'Format',
+			combo = editor.ui.get( name );
+
+		bot.setHtmlWithSelection( '<p>^foo</p>' );
+		// apply format 1st time
+		assert.areSame( CKEDITOR.TRISTATE_OFF, combo._.state, 'check state OFF' );
+		bot.combo( name, function( combo ) {
+			assert.areSame( CKEDITOR.TRISTATE_ON, combo._.state, 'check state ON when opened' );
+			combo.onClick( 'h1' );
+			assert.areSame( '<h1>^foo</h1>', bot.htmlWithSelection(), 'applied h1 block style' );
+			// apply format 2nd time
+			bot.combo( name, function( combo ) {
+				assert.areSame( CKEDITOR.TRISTATE_ON, combo._.state, 'check state ON when opened' );
+				combo.onClick( 'h1' );
+				assert.areSame( '<h1>^foo</h1>', bot.htmlWithSelection(), 'applied h1 block style' );
+			} );
+		} );
 	}
+
 } );


### PR DESCRIPTION
## What is the purpose of this pull request?
New feature

## Does your PR contain necessary tests?
yes

### This PR contains
- [x] Unit tests
- [x] Manual tests

## What changes did you make?
- Disable possibility to toggle option on drop down list of: **font size**, **font family name**, **paragraph format**
- Add `(Default)` option to **font size** and **font family** name, which remove formating from selection
- Add new language entry with `Default` to `lang.common` file
- Fix one unit test which click twice into this same menu option and start to fail after change

close #584 
