### PR TITLE
CSS boreder param parser.

### DIFF
--- a/core/tools.js
+++ b/core/tools.js
@@ -1627,6 +1627,21 @@
 					yellowgreen: '#9ACD32'
 				},
 
+				_borderStyle: [
+					'none',
+					'hidden',
+					'dotted',
+					'dashed',
+					'solid',
+					'double',
+					'groove',
+					'ridge',
+					'inset',
+					'outset'
+				],
+
+				_widthRegExp: /^(thin|medium|thick|[\+-]?\d+\.?\d*\S*)$/,
+
 				_rgbaRegExp: /rgba?\(\s*\d+%?\s*,\s*\d+%?\s*,\s*\d+%?\s*(?:,\s*[0-9.]+\s*)?\)/gi,
 
 				_hslaRegExp: /hsla?\(\s*[0-9.]+\s*,\s*\d+%\s*,\s*\d+%\s*(?:,\s*[0-9.]+\s*)?\)/gi,
@@ -1709,6 +1724,50 @@
 						ret.left = widths[ map[ 3 ] ];
 					}
 
+					return ret;
+				},
+
+				/**
+				 * Parses the `border` CSS property shorthand format.
+				 * This CSS properyty doesn't support inherit. (https://www.w3.org/TR/css3-background/#the-border-shorthands)
+				 *		console.log( CKEDITOR.tools.parse.border( '3px solid #ffeedd' ) );
+				 *		// Logs: { width: "3px", style: "solid", color: "#ffeedd", inherit: false }
+				 *
+				 * @param {String} value The `border` property value.
+				 * @returns {Object}
+				 * @returns {String} return.width border width.
+				 * @returns {String} return.style border-style attribute.
+				 * @returns {String} return.color border-color attribute.
+				 * @member CKEDITOR.tools.style.parse
+				 */
+				border: function( value ) {
+					var ret = {};
+					var input = value.split( /\s+/ );
+
+					CKEDITOR.tools.array.forEach( input, function( val ) {
+						if ( !ret.color ) {
+							var parseColor = CKEDITOR.tools.style.parse._findColor( val );
+							if ( parseColor.length ) {
+								ret.color = parseColor[ 0 ];
+								return;
+							}
+						}
+
+						if ( !ret.style ) {
+							if (  CKEDITOR.tools.indexOf( CKEDITOR.tools.style.parse._borderStyle, val ) !== -1 ) {
+								ret.style = val;
+								return;
+							}
+						}
+
+						if ( !ret.width ) {
+							if ( CKEDITOR.tools.style.parse._widthRegExp.test( val ) ) {
+								ret.width = val;
+								return;
+							}
+						}
+
+					} );
 					return ret;
 				},
 

--- a/core/tools.js
+++ b/core/tools.js
@@ -1730,7 +1730,7 @@
 				/**
 				 * Parses the `border` CSS property shorthand format.
 				 * This CSS properyty doesn't support inherit. (https://www.w3.org/TR/css3-background/#the-border-shorthands)
-				 *		console.log( CKEDITOR.tools.parse.border( '3px solid #ffeedd' ) );
+				 *		console.log( CKEDITOR.tools.style.parse.border( '3px solid #ffeedd' ) );
 				 *		// Logs: { width: "3px", style: "solid", color: "#ffeedd", inherit: false }
 				 *
 				 * @param {String} value The `border` property value.

--- a/tests/core/tools/style.js
+++ b/tests/core/tools/style.js
@@ -128,6 +128,34 @@
 
 		'test style.parse.margin docs sample': function() {
 			objectAssert.areEqual( { top: '3px', right: '0', bottom: '2', left: '0' }, CKEDITOR.tools.style.parse.margin( '3px 0 2' ) );
+		},
+
+		'test style.parse.border docs sample': function() {
+			objectAssert.areEqual( { width: '3px', style: 'solid', color: '#ffeedd' }, CKEDITOR.tools.style.parse.border( '3px solid #ffeedd' ) );
+		},
+
+		'test style.parse.border only with width': function() {
+			objectAssert.areEqual( { width: '0%' }, CKEDITOR.tools.style.parse.border( '0%' ) );
+		},
+
+		'test style.parse.border only with zero width': function() {
+			objectAssert.areEqual( { width: '0' }, CKEDITOR.tools.style.parse.border( '0' ) );
+		},
+
+		'test style.parse.border with width and style': function() {
+			objectAssert.areEqual( { width: '0%', style: 'groove' }, CKEDITOR.tools.style.parse.border( '0% groove' ) );
+		},
+
+		'test style.parse.border with mixed color and style': function() {
+			objectAssert.areEqual( { color: '#ff0000', style: 'dotted' }, CKEDITOR.tools.style.parse.border( '#ff0000 dotted' ) );
+		},
+
+		'test style.parse.border with mixed color, style and width': function() {
+			objectAssert.areEqual( { width: '7.5em', color: '#ff0000', style: 'dotted' }, CKEDITOR.tools.style.parse.border( '#ff0000 dotted 7.5em' ) );
+		},
+
+		'test style.parse.border with style only': function() {
+			objectAssert.areEqual( { style: 'dotted' }, CKEDITOR.tools.style.parse.border( 'dotted' ) );
 		}
 	} );
 } )();


### PR DESCRIPTION
## What is the purpose of this pull request?

New feature 

## Does your PR contain necessary tests?

All patches which change the editor code must include tests. You can always read more
on [PR testing](http://docs.ckeditor.com/#!/guide/dev_contributing_code-section-tests),
[how to set the testing environment](http://docs.ckeditor.com/#!/guide/dev_tests) and
[how to create tests](http://docs.ckeditor.com/#!/guide/dev_tests-section-creating-your-own-test)
in the official CKEditor documentation.

### This PR contains

- [X ] Unit tests
- [ ] Manual tests

## What changes did you make?

I added new function `border` to `CKEDITOR.tools.style.parse`. Now we can get nice object from CSS border attribute.

closes #616 