### PR TITLE
`cloneContents` properly return document fragment

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -17,6 +17,7 @@ Fixed Issues:
 * [#501](https://github.com/ckeditor/ckeditor-dev/issues/501): Fixed: Double click does not open dialog for modifying anchors inserted via [Link](http://ckeditor.com/addon/link) plugin.
 * [#9780](https://dev.ckeditor.com/ticket/9780): [IE8-9] Fixed: Clicking inside empty [read-only](http://docs.ckeditor.com/#!/api/CKEDITOR.editor-property-readOnly) editor throws an error.
 * [#16820](https://dev.ckeditor.com/ticket/16820): [IE10] Fixed: Clicking below single horizontal rule throws an error.
+* [#426](https://github.com/ckeditor/ckeditor-dev/issues/426): Fixed: [CloneContents](http://docs.ckeditor.com/#!/api/CKEDITOR.dom.range-method-cloneContents) selects whole element when selection starts at the beginning of that element.
 
 ## CKEditor 4.7.1
 

--- a/core/dom/range.js
+++ b/core/dom/range.js
@@ -204,9 +204,16 @@ CKEDITOR.dom.range = function( root ) {
 		// This allows us to not think about startNode == endNode case later on.
 		// We do that only when cloning, because in other cases we can safely split this text node
 		// and hence we can easily handle this case as many others.
-		if ( isClone && endNode.type == CKEDITOR.NODE_TEXT && startNode.equals( endNode ) ) {
-			startNode = range.document.createText( startNode.substring( startOffset, endOffset ) );
-			docFrag.append( startNode );
+		// #426 We need to handle situation when selection is located at the beginning of node,
+		// so in selection range start node get type == NODE_ELEMENT instead of NODE_TEXT
+		// We gain selecion like <b>[foo} bar</b>, instead of <b>{foo} bar</b>
+		if ( isClone &&
+			endNode.type == CKEDITOR.NODE_TEXT &&
+			( startNode.equals( endNode ) || ( startNode.type === CKEDITOR.NODE_ELEMENT && startNode.getFirst().equals( endNode ) ) ) ) {
+
+			// endNode is always text
+			endNode = range.document.createText( endNode.substring( startOffset, endOffset ) );
+			docFrag.append( endNode );
 			return;
 		}
 

--- a/core/dom/range.js
+++ b/core/dom/range.js
@@ -204,16 +204,14 @@ CKEDITOR.dom.range = function( root ) {
 		// This allows us to not think about startNode == endNode case later on.
 		// We do that only when cloning, because in other cases we can safely split this text node
 		// and hence we can easily handle this case as many others.
-		// #426 We need to handle situation when selection is located at the beginning of node,
-		// so in selection range start node get type == NODE_ELEMENT instead of NODE_TEXT
-		// We gain selecion like <b>[foo} bar</b>, instead of <b>{foo} bar</b>
+
+		// We need to handle situation when selection startNode is type of NODE_ELEMENT (#426).
 		if ( isClone &&
 			endNode.type == CKEDITOR.NODE_TEXT &&
 			( startNode.equals( endNode ) || ( startNode.type === CKEDITOR.NODE_ELEMENT && startNode.getFirst().equals( endNode ) ) ) ) {
 
-			// endNode is always text
-			endNode = range.document.createText( endNode.substring( startOffset, endOffset ) );
-			docFrag.append( endNode );
+			// this should be always text
+			docFrag.append( range.document.createText( endNode.substring( startOffset, endOffset ) ) );
 			return;
 		}
 

--- a/core/dom/range.js
+++ b/core/dom/range.js
@@ -210,7 +210,7 @@ CKEDITOR.dom.range = function( root ) {
 			endNode.type == CKEDITOR.NODE_TEXT &&
 			( startNode.equals( endNode ) || ( startNode.type === CKEDITOR.NODE_ELEMENT && startNode.getFirst().equals( endNode ) ) ) ) {
 
-			// this should be always text
+			// Here we should always be inside one text node.
 			docFrag.append( range.document.createText( endNode.substring( startOffset, endOffset ) ) );
 			return;
 		}

--- a/tests/core/dom/range/clonecontents.js
+++ b/tests/core/dom/range/clonecontents.js
@@ -538,7 +538,7 @@
 			assert.isInnerHtmlMatching( '<p>Foo bar</p>', docFrag.getHtml(), 'Cloned HTML' );
 		},
 
-		// #426
+		// Variety of edge test cases with selection range in text and elements nodes inside one element and multiple ones (#426).
 		'test cloneContents - inner selection1': function() {
 			this.assertHtmlFragment( this.editors.classic, '<p>foo <strong>[bar} baz</strong> foo</p>', 'bar' );
 		},

--- a/tests/core/dom/range/clonecontents.js
+++ b/tests/core/dom/range/clonecontents.js
@@ -233,7 +233,6 @@
 
 			root.setHtml( 'foo<b>bar</b>' );
 			doc.getBody().append( root );
-
 			var startContainer = root.getFirst(),
 				endContainer = root.getLast().getFirst();
 
@@ -526,6 +525,58 @@
 
 			// See: execContentsAction in range.js.
 			assert.isInnerHtmlMatching( '<p>Foo bar</p>', docFrag.getHtml(), 'Cloned HTML' );
+		},
+
+		// #426
+		'test cloneContents - beginning element end text': function() {
+			var editor = this.editors.classic,
+				range,
+				clone;
+
+			bender.tools.selection.setWithHtml( editor, '<p>foo <strong>[bar} baz</strong></p>' );
+
+			range = editor.getSelection().getRanges()[ 0 ];
+			clone = range.cloneContents();
+
+			assert.areSame( 'bar', clone.getHtml() );
+		},
+
+		'test cloneContents - beginning text outside end element': function() {
+			var editor = this.editors.classic,
+				range,
+				clone;
+
+			bender.tools.selection.setWithHtml( editor, '<p>foo {<strong>bar] baz</strong></p>' );
+
+			range = editor.getSelection().getRanges()[ 0 ];
+			clone = range.cloneContents();
+
+			assert.areSame( 'bar', clone.getHtml() );
+		},
+
+		'test cloneContents - beginning beginning and end text': function() {
+			var editor = this.editors.classic,
+				range,
+				clone;
+
+			bender.tools.selection.setWithHtml( editor, '<p>foo {<strong>bar} baz</strong></p>' );
+
+			range = editor.getSelection().getRanges()[ 0 ];
+			clone = range.cloneContents();
+
+			assert.areSame( 'bar', clone.getHtml() );
+		},
+		'test cloneContents - beginning and end element': function() {
+			var editor = this.editors.classic,
+				range,
+				clone;
+
+			bender.tools.selection.setWithHtml( editor, '<p>foo [<strong>bar] baz</strong></p>' );
+
+			range = editor.getSelection().getRanges()[ 0 ];
+			clone = range.cloneContents();
+
+			assert.areSame( 'bar', clone.getHtml() );
 		}
 	} );
 } )();

--- a/tests/core/dom/range/clonecontents.js
+++ b/tests/core/dom/range/clonecontents.js
@@ -26,7 +26,7 @@
 
 			range = editor.getSelection().getRanges()[ 0 ];
 			clone = range.cloneContents();
-			assert.areSame( expectedHtml, clone.getHtml() );
+			assert.isInnerHtmlMatching( expectedHtml, clone.getHtml() );
 		},
 
 		test_cloneContents_W3C_1: function() {
@@ -569,17 +569,18 @@
 		'test cloneContents - outer selection4': function() {
 			this.assertHtmlFragment( this.editors.classic, '<p>foo [<strong>bar} baz</strong> foo</p>', '<strong>bar</strong>' );
 		},
+		// IE8 requires some text after
 		'test cloneContents - outer selection5': function() {
-			this.assertHtmlFragment( this.editors.classic, '<p>foo <strong>bar {baz</strong>] foo</p>', '<strong>baz</strong>' );
+			this.assertHtmlFragment( this.editors.classic, '<p>foo <strong>bar {baz</strong>x] foo</p>', '<strong>baz</strong>x' );
 		},
 		'test cloneContents - outer selection6': function() {
-			this.assertHtmlFragment( this.editors.classic, '<p>foo <strong>bar {baz</strong>} foo</p>', '<strong>baz</strong>' );
+			this.assertHtmlFragment( this.editors.classic, '<p>foo <strong>bar {baz</strong>x} foo</p>', '<strong>baz</strong>x' );
 		},
 		'test cloneContents - outer selection7': function() {
-			this.assertHtmlFragment( this.editors.classic, '<p>foo <strong>bar [baz</strong>] foo</p>', '<strong>baz</strong>' );
+			this.assertHtmlFragment( this.editors.classic, '<p>foo <strong>bar [baz</strong>x] foo</p>', '<strong>baz</strong>x' );
 		},
 		'test cloneContents - outer selection8': function() {
-			this.assertHtmlFragment( this.editors.classic, '<p>foo <strong>bar [baz</strong>} foo</p>', '<strong>baz</strong>' );
+			this.assertHtmlFragment( this.editors.classic, '<p>foo <strong>bar [baz</strong>x} foo</p>', '<strong>baz</strong>x' );
 		}
 
 	} );

--- a/tests/core/dom/range/clonecontents.js
+++ b/tests/core/dom/range/clonecontents.js
@@ -18,6 +18,17 @@
 			document.getElementById( 'playground' ).innerHTML = html1;
 		},
 
+		assertHtmlFragment: function( editor, innerHtmlWithSelection, expectedHtml ) {
+			var range,
+				clone;
+
+			bender.tools.selection.setWithHtml( editor, innerHtmlWithSelection );
+
+			range = editor.getSelection().getRanges()[ 0 ];
+			clone = range.cloneContents();
+			assert.areSame( expectedHtml, clone.getHtml() );
+		},
+
 		test_cloneContents_W3C_1: function() {
 			// W3C DOM Range Specs - Section 2.7 - Example 1
 
@@ -528,55 +539,48 @@
 		},
 
 		// #426
-		'test cloneContents - beginning element end text': function() {
-			var editor = this.editors.classic,
-				range,
-				clone;
-
-			bender.tools.selection.setWithHtml( editor, '<p>foo <strong>[bar} baz</strong></p>' );
-
-			range = editor.getSelection().getRanges()[ 0 ];
-			clone = range.cloneContents();
-
-			assert.areSame( 'bar', clone.getHtml() );
+		'test cloneContents - inner selection1': function() {
+			this.assertHtmlFragment( this.editors.classic, '<p>foo <strong>[bar} baz</strong> foo</p>', 'bar' );
 		},
-
-		'test cloneContents - beginning text outside end element': function() {
-			var editor = this.editors.classic,
-				range,
-				clone;
-
-			bender.tools.selection.setWithHtml( editor, '<p>foo {<strong>bar] baz</strong></p>' );
-
-			range = editor.getSelection().getRanges()[ 0 ];
-			clone = range.cloneContents();
-
-			assert.areSame( 'bar', clone.getHtml() );
+		'test cloneContents - inner selection2': function() {
+			this.assertHtmlFragment( this.editors.classic, '<p>foo <strong>{bar} baz</strong> foo</p>', 'bar' );
 		},
-
-		'test cloneContents - beginning beginning and end text': function() {
-			var editor = this.editors.classic,
-				range,
-				clone;
-
-			bender.tools.selection.setWithHtml( editor, '<p>foo {<strong>bar} baz</strong></p>' );
-
-			range = editor.getSelection().getRanges()[ 0 ];
-			clone = range.cloneContents();
-
-			assert.areSame( 'bar', clone.getHtml() );
+		'test cloneContents - inner selection3': function() {
+			this.assertHtmlFragment( this.editors.classic, '<p>foo <strong>{bar] baz</strong> foo</p>', 'bar' );
 		},
-		'test cloneContents - beginning and end element': function() {
-			var editor = this.editors.classic,
-				range,
-				clone;
-
-			bender.tools.selection.setWithHtml( editor, '<p>foo [<strong>bar] baz</strong></p>' );
-
-			range = editor.getSelection().getRanges()[ 0 ];
-			clone = range.cloneContents();
-
-			assert.areSame( 'bar', clone.getHtml() );
+		'test cloneContents - inner selection4': function() {
+			this.assertHtmlFragment( this.editors.classic, '<p>foo <strong>bar [baz}</strong> foo</p>', 'baz' );
+		},
+		'test cloneContents - inner selection5': function() {
+			this.assertHtmlFragment( this.editors.classic, '<p>foo <strong>bar {baz}</strong> foo</p>', 'baz' );
+		},
+		'test cloneContents - inner selection6': function() {
+			this.assertHtmlFragment( this.editors.classic, '<p>foo <strong>bar {baz]</strong> foo</p>', 'baz' );
+		},
+		'test cloneContents - outer selection1': function() {
+			this.assertHtmlFragment( this.editors.classic, '<p>foo {<strong>bar] baz</strong> foo</p>', '<strong>bar</strong>' );
+		},
+		'test cloneContents - outer selection2': function() {
+			this.assertHtmlFragment( this.editors.classic, '<p>foo {<strong>bar} baz</strong> foo</p>', '<strong>bar</strong>' );
+		},
+		'test cloneContents - outer selection3': function() {
+			this.assertHtmlFragment( this.editors.classic, '<p>foo [<strong>bar] baz</strong> foo</p>', '<strong>bar</strong>' );
+		},
+		'test cloneContents - outer selection4': function() {
+			this.assertHtmlFragment( this.editors.classic, '<p>foo [<strong>bar} baz</strong> foo</p>', '<strong>bar</strong>' );
+		},
+		'test cloneContents - outer selection5': function() {
+			this.assertHtmlFragment( this.editors.classic, '<p>foo <strong>bar {baz</strong>] foo</p>', '<strong>baz</strong>' );
+		},
+		'test cloneContents - outer selection6': function() {
+			this.assertHtmlFragment( this.editors.classic, '<p>foo <strong>bar {baz</strong>} foo</p>', '<strong>baz</strong>' );
+		},
+		'test cloneContents - outer selection7': function() {
+			this.assertHtmlFragment( this.editors.classic, '<p>foo <strong>bar [baz</strong>] foo</p>', '<strong>baz</strong>' );
+		},
+		'test cloneContents - outer selection8': function() {
+			this.assertHtmlFragment( this.editors.classic, '<p>foo <strong>bar [baz</strong>} foo</p>', '<strong>baz</strong>' );
 		}
+
 	} );
 } )();

--- a/tests/core/dom/range/clonecontents.js
+++ b/tests/core/dom/range/clonecontents.js
@@ -581,7 +581,19 @@
 		},
 		'test cloneContents - outer selection8': function() {
 			this.assertHtmlFragment( this.editors.classic, '<p>foo <strong>bar [baz</strong>x} foo</p>', '<strong>baz</strong>x' );
+		},
+		'test cloneContents - no gap between': function() {
+			this.assertHtmlFragment( this.editors.classic, '<p>[<strong>bar baz</strong>]</p>', '<strong>bar baz</strong>' );
+		},
+		'test cloneContents - nested elements1': function() {
+			this.assertHtmlFragment( this.editors.classic, '<p>foo <strong>[bar <em>baz</em>]</strong> foo</p>', 'bar <em>baz</em>' );
+		},
+		'test cloneContents - nested elements2': function() {
+			this.assertHtmlFragment( this.editors.classic, '<p>fo[o <strong>bar <em>b]az</em></strong> foo</p>', 'o <strong>bar <em>b</em></strong>' );
+		},
+		'test cloneContents - multiple nested elements': function() {
+			this.assertHtmlFragment( this.editors.classic, '<p>fo[o <strong>bar <em>baz</em></strong></p><table><tbody><tr><td>hello</td></tr><tr><td>world</td></tr></tbody></table><p>fo]o</p>',
+			'<p>o <strong>bar <em>baz</em></strong></p><table><tbody><tr><td>hello</td></tr><tr><td>world</td></tr></tbody></table><p>fo</p>' );
 		}
-
 	} );
 } )();

--- a/tests/core/dom/range/clonecontents.js
+++ b/tests/core/dom/range/clonecontents.js
@@ -557,32 +557,60 @@
 		'test cloneContents - inner selection6': function() {
 			this.assertHtmlFragment( this.editors.classic, '<p>foo <strong>bar {baz]</strong> foo</p>', 'baz' );
 		},
+		// Safari always keeps selection insdie node.
 		'test cloneContents - outer selection1': function() {
+			if ( CKEDITOR.env.safari ) {
+				assert.ignore();
+			}
 			this.assertHtmlFragment( this.editors.classic, '<p>foo {<strong>bar] baz</strong> foo</p>', '<strong>bar</strong>' );
 		},
 		'test cloneContents - outer selection2': function() {
+			if ( CKEDITOR.env.safari ) {
+				assert.ignore();
+			}
 			this.assertHtmlFragment( this.editors.classic, '<p>foo {<strong>bar} baz</strong> foo</p>', '<strong>bar</strong>' );
 		},
 		'test cloneContents - outer selection3': function() {
+			if ( CKEDITOR.env.safari ) {
+				assert.ignore();
+			}
 			this.assertHtmlFragment( this.editors.classic, '<p>foo [<strong>bar] baz</strong> foo</p>', '<strong>bar</strong>' );
 		},
 		'test cloneContents - outer selection4': function() {
+			if ( CKEDITOR.env.safari ) {
+				assert.ignore();
+			}
 			this.assertHtmlFragment( this.editors.classic, '<p>foo [<strong>bar} baz</strong> foo</p>', '<strong>bar</strong>' );
 		},
-		// IE8 requires some text after
+		// IE8 keeps selection of endpoint inside node.
 		'test cloneContents - outer selection5': function() {
-			this.assertHtmlFragment( this.editors.classic, '<p>foo <strong>bar {baz</strong>x] foo</p>', '<strong>baz</strong>x' );
+			if ( ( CKEDITOR.env.ie && CKEDITOR.env.version < 9 ) || CKEDITOR.env.safari ) {
+				assert.ignore();
+			}
+			this.assertHtmlFragment( this.editors.classic, '<p>foo <strong>bar {baz</strong>] foo</p>', '<strong>baz</strong>' );
 		},
 		'test cloneContents - outer selection6': function() {
-			this.assertHtmlFragment( this.editors.classic, '<p>foo <strong>bar {baz</strong>x} foo</p>', '<strong>baz</strong>x' );
+			if ( ( CKEDITOR.env.ie && CKEDITOR.env.version < 9 ) || CKEDITOR.env.safari ) {
+				assert.ignore();
+			}
+			this.assertHtmlFragment( this.editors.classic, '<p>foo <strong>bar {baz</strong>} foo</p>', '<strong>baz</strong>' );
 		},
 		'test cloneContents - outer selection7': function() {
-			this.assertHtmlFragment( this.editors.classic, '<p>foo <strong>bar [baz</strong>x] foo</p>', '<strong>baz</strong>x' );
+			if ( ( CKEDITOR.env.ie && CKEDITOR.env.version < 9 ) || CKEDITOR.env.safari ) {
+				assert.ignore();
+			}
+			this.assertHtmlFragment( this.editors.classic, '<p>foo <strong>bar [baz</strong>] foo</p>', '<strong>baz</strong>' );
 		},
 		'test cloneContents - outer selection8': function() {
-			this.assertHtmlFragment( this.editors.classic, '<p>foo <strong>bar [baz</strong>x} foo</p>', '<strong>baz</strong>x' );
+			if ( ( CKEDITOR.env.ie && CKEDITOR.env.version < 9 ) || CKEDITOR.env.safari ) {
+				assert.ignore();
+			}
+			this.assertHtmlFragment( this.editors.classic, '<p>foo <strong>bar [baz</strong>} foo</p>', '<strong>baz</strong>' );
 		},
 		'test cloneContents - no gap between': function() {
+			if ( ( CKEDITOR.env.ie && CKEDITOR.env.version < 9 ) || CKEDITOR.env.safari ) {
+				assert.ignore();
+			}
 			this.assertHtmlFragment( this.editors.classic, '<p>[<strong>bar baz</strong>]</p>', '<strong>bar baz</strong>' );
 		},
 		'test cloneContents - nested elements1': function() {
@@ -593,7 +621,7 @@
 		},
 		'test cloneContents - multiple nested elements': function() {
 			this.assertHtmlFragment( this.editors.classic, '<p>fo[o <strong>bar <em>baz</em></strong></p><table><tbody><tr><td>hello</td></tr><tr><td>world</td></tr></tbody></table><p>fo]o</p>',
-			'<p>o <strong>bar <em>baz</em></strong></p><table><tbody><tr><td>hello</td></tr><tr><td>world</td></tr></tbody></table><p>fo</p>' );
+			'<p>o <strong>bar <em>baz</em></strong>@</p><table><tbody><tr><td>hello</td></tr><tr><td>world</td></tr></tbody></table><p>fo</p>' );
 		}
 	} );
 } )();

--- a/tests/core/dom/range/clonecontents.js
+++ b/tests/core/dom/range/clonecontents.js
@@ -557,57 +557,64 @@
 		'test cloneContents - inner selection6': function() {
 			this.assertHtmlFragment( this.editors.classic, '<p>foo <strong>bar {baz]</strong> foo</p>', 'baz' );
 		},
-		// Safari always keeps selection insdie node.
 		'test cloneContents - outer selection1': function() {
+			// Safari always keeps selection insdie node.
 			if ( CKEDITOR.env.safari ) {
 				assert.ignore();
 			}
 			this.assertHtmlFragment( this.editors.classic, '<p>foo {<strong>bar] baz</strong> foo</p>', '<strong>bar</strong>' );
 		},
 		'test cloneContents - outer selection2': function() {
+			// Safari always keeps selection insdie node.
 			if ( CKEDITOR.env.safari ) {
 				assert.ignore();
 			}
 			this.assertHtmlFragment( this.editors.classic, '<p>foo {<strong>bar} baz</strong> foo</p>', '<strong>bar</strong>' );
 		},
 		'test cloneContents - outer selection3': function() {
+			// Safari always keeps selection insdie node.
 			if ( CKEDITOR.env.safari ) {
 				assert.ignore();
 			}
 			this.assertHtmlFragment( this.editors.classic, '<p>foo [<strong>bar] baz</strong> foo</p>', '<strong>bar</strong>' );
 		},
 		'test cloneContents - outer selection4': function() {
+			// Safari always keeps selection insdie node.
 			if ( CKEDITOR.env.safari ) {
 				assert.ignore();
 			}
 			this.assertHtmlFragment( this.editors.classic, '<p>foo [<strong>bar} baz</strong> foo</p>', '<strong>bar</strong>' );
 		},
-		// IE8 keeps selection of endpoint inside node.
 		'test cloneContents - outer selection5': function() {
+			// IE8 keeps selection of endpoint inside node, and Safari always keeps selection inside.
 			if ( ( CKEDITOR.env.ie && CKEDITOR.env.version < 9 ) || CKEDITOR.env.safari ) {
 				assert.ignore();
 			}
 			this.assertHtmlFragment( this.editors.classic, '<p>foo <strong>bar {baz</strong>] foo</p>', '<strong>baz</strong>' );
 		},
 		'test cloneContents - outer selection6': function() {
+			// IE8 keeps selection of endpoint inside node, and Safari always keeps selection inside.
 			if ( ( CKEDITOR.env.ie && CKEDITOR.env.version < 9 ) || CKEDITOR.env.safari ) {
 				assert.ignore();
 			}
 			this.assertHtmlFragment( this.editors.classic, '<p>foo <strong>bar {baz</strong>} foo</p>', '<strong>baz</strong>' );
 		},
 		'test cloneContents - outer selection7': function() {
+			// IE8 keeps selection of endpoint inside node, and Safari always keeps selection inside.
 			if ( ( CKEDITOR.env.ie && CKEDITOR.env.version < 9 ) || CKEDITOR.env.safari ) {
 				assert.ignore();
 			}
 			this.assertHtmlFragment( this.editors.classic, '<p>foo <strong>bar [baz</strong>] foo</p>', '<strong>baz</strong>' );
 		},
 		'test cloneContents - outer selection8': function() {
+			// IE8 keeps selection of endpoint inside node, and Safari always keeps selection inside.
 			if ( ( CKEDITOR.env.ie && CKEDITOR.env.version < 9 ) || CKEDITOR.env.safari ) {
 				assert.ignore();
 			}
 			this.assertHtmlFragment( this.editors.classic, '<p>foo <strong>bar [baz</strong>} foo</p>', '<strong>baz</strong>' );
 		},
 		'test cloneContents - no gap between': function() {
+			// IE8 keeps selection of endpoint inside node, and Safari always keeps selection inside.
 			if ( ( CKEDITOR.env.ie && CKEDITOR.env.version < 9 ) || CKEDITOR.env.safari ) {
 				assert.ignore();
 			}

--- a/tests/core/dom/range/manual/clonecontentsstartnodeproblem.html
+++ b/tests/core/dom/range/manual/clonecontentsstartnodeproblem.html
@@ -1,0 +1,18 @@
+<div id="editor1">
+	<p>foo <strong>bar baz</strong> foo</p>
+</div>
+<button id="getFragment">Press me</button>
+<br>
+<pre id="result" style="background-color:lightgreen"></pre>
+<script>
+	if ( bender.tools.env.mobile ) {
+		bender.ignore();
+	}
+
+	var editor = CKEDITOR.replace( 'editor1' );
+
+	document.getElementById( 'getFragment' ).onclick = function() {
+		// debugger;
+		document.getElementById( 'result' ).innerText = editor.getSelection().getRanges()[ 0 ].cloneContents().getHtml()
+	}
+</script>

--- a/tests/core/dom/range/manual/clonecontentsstartnodeproblem.html
+++ b/tests/core/dom/range/manual/clonecontentsstartnodeproblem.html
@@ -12,7 +12,6 @@
 	var editor = CKEDITOR.replace( 'editor1' );
 
 	document.getElementById( 'getFragment' ).onclick = function() {
-		// debugger;
 		document.getElementById( 'result' ).innerText = editor.getSelection().getRanges()[ 0 ].cloneContents().getHtml()
 	}
 </script>

--- a/tests/core/dom/range/manual/clonecontentsstartnodeproblem.md
+++ b/tests/core/dom/range/manual/clonecontentsstartnodeproblem.md
@@ -1,0 +1,10 @@
+@bender-tags: 4.7.2, bug, 426
+@bender-ui: collapsed
+@bender-ckeditor-plugins: divarea, toolbar, basicstyles
+
+1. Make selection of **bar** word
+1. Press button below editor
+
+**Expected:** There will be displayed `bar` below with green background. It's possible that, result will be as follows: `<strong>bar</strong>`, what is ok.
+
+**Unexpected:** There will be displayed `bar baz` below with green background.

--- a/tests/core/dom/range/manual/clonecontentsstartnodeproblem.md
+++ b/tests/core/dom/range/manual/clonecontentsstartnodeproblem.md
@@ -2,9 +2,10 @@
 @bender-ui: collapsed
 @bender-ckeditor-plugins: divarea, toolbar, basicstyles
 
-1. Make selection of **bar** word
-1. Press button below editor
+1. Select `bar` word in the editor.
+1. Press button below editor.
+1. Check result below.
 
-**Expected:** There will be displayed `bar` below with green background. It's possible that, result will be as follows: `<strong>bar</strong>`, what is ok.
+**Expected:** There will be displayed `bar` below editor within green background. It's possible that result will be `<strong>bar</strong>`, what is also ok.
 
 **Unexpected:** There will be displayed `bar baz` below with green background.


### PR DESCRIPTION
## What is the purpose of this pull request?
bug fix

## Does your PR contain necessary tests?
yep!

### This PR contains

- [x] Unit tests
- [x] Manual tests

## What changes did you make?

Modify `if` statement to accept situation when selection start and ends in this same element, but `startNode` has type of `element` where `endNode` has type of `text`

close #426 