### PR TITLE
Fix error which appear with `columnDelete` command when table contained colspans

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -14,6 +14,7 @@ Fixed Issues:
 * [#779](https://github.com/ckeditor/ckeditor-dev/issues/779): Fixed: [Remove Format](https://ckeditor.com/addon/removeformat) plugin removes elements with language definition inserted by [Language](https://ckeditor.com/addon/language) plugin.
 * [#423](https://github.com/ckeditor/ckeditor-dev/issues/423): Fixed: [Paste from Word](https://ckeditor.com/addon/pastefromword) plugin pastes paragraphs into the editor even if [`CKEDITOR.config.enterMode`](https://docs.ckeditor.com/#!/api/CKEDITOR.config-cfg-enterMode) is set to `CKEDITOR.ENTER_BR`.
 * [#719](https://github.com/ckeditor/ckeditor-dev/issues/719): Fixed: Image inserted using [Enhanced Image](https://ckeditor.com/addon/image2) plugin could be resized when editor is in read-only mode.
+* [#577](https://github.com/ckeditor/ckeditor-dev/issues/577): Fixed: "Delete Columns" command provided by [Table Tools](https://ckeditor.com/addon/tabletools) plugin throws an error while trying to delete columns.
 
 Other Changes:
 

--- a/plugins/tabletools/plugin.js
+++ b/plugins/tabletools/plugin.js
@@ -304,24 +304,32 @@
 
 	function deleteColumns( selection ) {
 		function processSelection( selection ) {
-			// If selection leakt to next td/th cell, then move it back to previous cell.
-			var ranges = selection.getRanges();
+			// If selection leak to next td/th cell, then preserve it in previous cell.
+
+			var ranges,
+				range,
+				endNode,
+				endNodeName,
+				previous;
+
+			ranges = selection.getRanges();
 			if ( ranges.length !== 1 ) {
 				return selection;
 			}
 
-			var range = ranges[0];
-			if ( range.endOffset !== 0 ) {
+			range = ranges[0];
+			if ( range.collapsed || range.endOffset !== 0 ) {
 				return selection;
 			}
 
-			var endNode = range.endContainer;
-			var endNodeName = endNode.getName().toLowerCase();
+			endNode = range.endContainer;
+			endNodeName = endNode.getName().toLowerCase();
 			if ( !( endNodeName === 'td' || endNodeName === 'th' ) ) {
 				return selection;
 			}
+
 			// Get previous td/th element or the last from previous row.
-			var previous = endNode.getPrevious();
+			previous = endNode.getPrevious();
 			if ( !previous ) {
 				previous = endNode.getParent().getPrevious().getLast();
 			}
@@ -339,8 +347,9 @@
 			return range.select();
 		}
 
-		// Problem occures only on webkit in case of native selection (#577
-		if ( CKEDITOR.env.webkit && !selection.isFake && selection.getNative().type === 'Range' ) {
+		// Problem occures only on webkit in case of native selection (#577).
+		// Upstream: https://bugs.webkit.org/show_bug.cgi?id=175131, https://bugs.chromium.org/p/chromium/issues/detail?id=752091
+		if ( CKEDITOR.env.webkit && !selection.isFake ) {
 			selection = processSelection( selection );
 		}
 

--- a/plugins/tabletools/plugin.js
+++ b/plugins/tabletools/plugin.js
@@ -303,7 +303,6 @@
 	}
 
 	function deleteColumns( selection ) {
-		// debugger;
 		var ranges = selection.getRanges(),
 			cells = getSelectedCells( selection ),
 			firstCell = cells[ 0 ],
@@ -321,7 +320,7 @@
 				// #577
 				// Map might contain multiple times this same element, because of existings collspan.
 				// We don't want to overwrite startIndex in such situation and take first one.
-				if ( !startColIndex && map[ i ][ j ] == firstCell.$ ) {
+				if ( startColIndex === undefined && map[ i ][ j ] == firstCell.$ ) {
 					startColIndex = j;
 				}
 				if ( map[ i ][ j ] == lastCell.$ ) {

--- a/plugins/tabletools/plugin.js
+++ b/plugins/tabletools/plugin.js
@@ -358,7 +358,7 @@
 		// 2. Into previous cell of the first row if any;
 		// 3. Into table's parent element;
 		var cursorPosition;
-		if ( map[ 0 ].length - 1 > endColIndex && map[ 0 ][ endColIndex + 1 ].cellIndex !== -1 ) {
+		if ( map[ 0 ].length - 1 > endColIndex ) {
 			cursorPosition = new CKEDITOR.dom.element( map[ 0 ][ endColIndex + 1 ] );
 		} else if ( startColIndex && map[ 0 ][ startColIndex - 1 ].cellIndex !== -1 ) {
 			cursorPosition = new CKEDITOR.dom.element( map[ 0 ][ startColIndex - 1 ] );

--- a/tests/plugins/tableselection/integrations/tabletools/columndeletion.html
+++ b/tests/plugins/tableselection/integrations/tabletools/columndeletion.html
@@ -1,12 +1,12 @@
 <textarea id="table-1">
 <table>
 	<tr>
-		<td>fo^o</td>
+		<td>[foo]</td>
 		<td>bar</td>
 		<td>baz</td>
 	</tr>
 	<tr>
-		<td>foo</td>
+		<td>[foo]</td>
 		<td>bar</td>
 		<td>baz</td>
 	</tr>
@@ -35,8 +35,8 @@
 	</tr>
 	<tr>
 		<td>foo</td>
-		<td>b[ar</td>
-		<td>ba]z</td>
+		<td>[bar</td>
+		<td>baz]</td>
 	</tr>
 	<tr>
 		<td>foo</td>
@@ -65,7 +65,7 @@
 	<thead>
 		<tr>
 			<th colspan="2" scope="col">
-				He[ad]er1
+				[Header1]
 			</th>
 			<th colspan="1" scope="col">
 				Header2
@@ -126,7 +126,7 @@
 	<tr>
 		<td>foo</td>
 		<td>bar</td>
-		<td>b^az</td>
+		<td>[baz]</td>
 	</tr>
 	<tr>
 		<td>foo</td>
@@ -198,8 +198,8 @@
 	<tr>
 		<td>foo</td>
 		<td>bar</td>
-		<td>b[az</td>
-		<td>fo]o</td>
+		<td>[baz</td>
+		<td>foo]</td>
 		<td>bar</td>
 		<td>baz</td>
 	</tr>
@@ -257,25 +257,25 @@
 		<td>foo</td>
 		<td>bar</td>
 		<td>baz</td>
-		<td>fo[o</td>
+		<td>[foo</td>
 		<td>bar</td>
-		<td>b]az</td>
+		<td>baz]</td>
 	</tr>
 	<tr>
 		<td>foo</td>
 		<td>bar</td>
 		<td>baz</td>
-		<td>foo</td>
+		<td>[foo</td>
 		<td>bar</td>
-		<td>baz</td>
+		<td>baz]</td>
 	</tr>
 	<tr>
 		<td>foo</td>
 		<td>bar</td>
 		<td>baz</td>
-		<td>foo</td>
+		<td>[foo</td>
 		<td>bar</td>
-		<td>baz</td>
+		<td>baz]</td>
 	</tr>
 	</tbody>
 </table>

--- a/tests/plugins/tableselection/integrations/tabletools/columndeletion.js
+++ b/tests/plugins/tableselection/integrations/tabletools/columndeletion.js
@@ -1,5 +1,5 @@
 /* bender-tags: editor,unit */
-/* bender-ckeditor-plugins: wysiwygarea, table, tabletools, toolbar */
+/* bender-ckeditor-plugins: wysiwygarea, table, tabletools, tableselection */
 
 ( function() {
 	'use strict';
@@ -21,30 +21,57 @@
 
 		// #577
 		'test remove first column': function() {
+			if ( ( CKEDITOR.env.ie && CKEDITOR.env.version < 11 ) || bender.tools.env.mobile ) {
+				assert.ignore();
+			}
 			this.doTest( 'table-1', 'columnDelete' );
 		},
 
+		// #577
 		'test remove 2 last columns by single row selection': function() {
+			if ( ( CKEDITOR.env.ie && CKEDITOR.env.version < 11 ) || bender.tools.env.mobile ) {
+				assert.ignore();
+			}
 			this.doTest( 'table-2', 'columnDelete' );
 		},
 
+		// #577
 		'test remove selection collspan': function() {
+			if ( ( CKEDITOR.env.ie && CKEDITOR.env.version < 11 ) || bender.tools.env.mobile ) {
+				assert.ignore();
+			}
 			this.doTest( 'table-3', 'columnDelete' );
 		},
 
+		// #577
 		'test remove single column under collspan': function() {
+			if ( ( CKEDITOR.env.ie && CKEDITOR.env.version < 11 ) || bender.tools.env.mobile ) {
+				assert.ignore();
+			}
 			this.doTest( 'table-4', 'columnDelete' );
 		},
 
+		// #577
 		'test remove middle columns half with 2 collspans': function() {
+			if ( ( CKEDITOR.env.ie && CKEDITOR.env.version < 11 ) || bender.tools.env.mobile ) {
+				assert.ignore();
+			}
 			this.doTest( 'table-5', 'columnDelete' );
 		},
 
+		// #577
 		'test remove multirange selection under collspan': function() {
+			if ( ( CKEDITOR.env.ie && CKEDITOR.env.version < 11 ) || bender.tools.env.mobile ) {
+				assert.ignore();
+			}
 			this.doTest( 'table-6', 'columnDelete' );
 		},
 
+		// #577
 		'test remove entire table by column delete': function() {
+			if ( ( CKEDITOR.env.ie && CKEDITOR.env.version < 11 ) || bender.tools.env.mobile ) {
+				assert.ignore();
+			}
 			this.doTest( 'table-7', 'columnDelete' );
 		}
 

--- a/tests/plugins/tableselection/integrations/tabletools/columndeletion.js
+++ b/tests/plugins/tableselection/integrations/tabletools/columndeletion.js
@@ -36,7 +36,7 @@
 		},
 
 		// #577
-		'test remove selection collspan': function() {
+		'test remove selection colspan': function() {
 			if ( ( CKEDITOR.env.ie && CKEDITOR.env.version < 11 ) || bender.tools.env.mobile ) {
 				assert.ignore();
 			}
@@ -44,7 +44,7 @@
 		},
 
 		// #577
-		'test remove single column under collspan': function() {
+		'test remove single column under colspan': function() {
 			if ( ( CKEDITOR.env.ie && CKEDITOR.env.version < 11 ) || bender.tools.env.mobile ) {
 				assert.ignore();
 			}
@@ -52,7 +52,7 @@
 		},
 
 		// #577
-		'test remove middle columns half with 2 collspans': function() {
+		'test remove middle columns half with 2 colspans': function() {
 			if ( ( CKEDITOR.env.ie && CKEDITOR.env.version < 11 ) || bender.tools.env.mobile ) {
 				assert.ignore();
 			}
@@ -60,7 +60,7 @@
 		},
 
 		// #577
-		'test remove multirange selection under collspan': function() {
+		'test remove multirange selection under colspan': function() {
 			if ( ( CKEDITOR.env.ie && CKEDITOR.env.version < 11 ) || bender.tools.env.mobile ) {
 				assert.ignore();
 			}

--- a/tests/plugins/tableselection/manual/integrations/tabletools/columndeletionerror.html
+++ b/tests/plugins/tableselection/manual/integrations/tabletools/columndeletionerror.html
@@ -1,0 +1,104 @@
+<textarea id="editor">
+<table border="2" summary="Balance Sheet &amp; Cash Flow Statement Information">
+	<thead>
+		<tr>
+			<th colspan="1" scope="row" style="width:167px">&nbsp;</th>
+			<th colspan="3" scope="col" style="background-color:#1d7373; width:224px">Full Year (unaudited)</th>
+			<th colspan="4" scope="col" style="background-color:#1d7373; width:360px">2013 (unaudited)</th>
+		</tr>
+	</thead>
+	<tbody>
+		<tr>
+			<th scope="row" style="width:167px">&nbsp;</th>
+			<td style="background-color:#5ccccc; width:78px">2011</td>
+			<td style="background-color:#5ccccc; width:73px">2012</td>
+			<td style="background-color:#5ccccc; width:72px">2013</td>
+			<td style="background-color:#5ccccc; width:72px">Q1</td>
+			<td style="background-color:#5ccccc; width:72px">Q2</td>
+			<td style="background-color:#5ccccc; width:72px">Q3</td>
+			<td style="background-color:#5ccccc; width:72px">Q4</td>
+		</tr>
+		<tr>
+			<th scope="row" style="background-color:#ffd5b2; width:167px"><strong>Cash, Cash Equivalents &amp; Marketable Securities</strong></th>
+			<td style="width:78px">$44,626</td>
+			<td style="width:73px">$48,088</td>
+			<td style="width:72px">$58,717</td>
+			<td style="width:72px">$50,098</td>
+			<td style="width:72px">$54,432</td>
+			<td style="width:72px">$56,523</td>
+			<td style="width:72px">$58,717</td>
+		</tr>
+		<tr>
+			<th scope="row" style="background-color:#ffd5b2; width:167px"><strong>Accounts Receivable, Net of Allowance (Google stand-alone)</strong></th>
+			<td style="width:78px">$5,427</td>
+			<td style="width:73px">$6,769</td>
+			<td style="width:72px">$8,098</td>
+			<td style="width:72px">$6,526</td>
+			<td style="width:72px">$6,792</td>
+			<td style="width:72px">$7,083</td>
+			<td style="width:72px">$8,098</td>
+		</tr>
+		<tr>
+			<th scope="row" style="background-color:#ffd5b2; width:167px"><em>DSO for Company stand-alone<br />
+			(in days, using ending AR)</em></th>
+			<td style="width:78px">52</td>
+			<td style="width:73px">54</td>
+			<td style="width:72px">53</td>
+			<td style="width:72px">45</td>
+			<td style="width:72px">47</td>
+			<td style="width:72px">47</td>
+			<td style="width:72px">47</td>
+		</tr>
+		<tr>
+			<th scope="row" style="background-color:#ffd5b2; width:167px"><strong>Property and Equipment, Net</strong></th>
+			<td style="width:78px">$9,603</td>
+			<td style="width:73px">$11,854</td>
+			<td style="width:72px">$16,524</td>
+			<td style="width:72px">$12,300</td>
+			<td style="width:72px">$12,912</td>
+			<td style="width:72px">$14,867</td>
+			<td style="width:72px">$16,524</td>
+		</tr>
+		<tr>
+			<th scope="row" style="background-color:#ffd5b2; width:167px"><strong>Total Assets</strong></th>
+			<td style="width:78px">$72,574</td>
+			<td style="width:73px">$93,798</td>
+			<td style="width:72px">$110,920</td>
+			<td style="width:72px">$96,692</td>
+			<td style="width:72px">$101,182</td>
+			<td style="width:72px">$105,068</td>
+			<td style="width:72px">$110,920</td>
+		</tr>
+		<tr>
+			<th scope="row" style="background-color:#ffd5b2; width:167px"><strong>Cash Flow from Operations</strong></th>
+			<td style="width:78px">$14,565</td>
+			<td style="width:73px">$16,619</td>
+			<td style="width:72px">$18,659</td>
+			<td style="width:72px">$3,633</td>
+			<td style="width:72px">$4,705</td>
+			<td style="width:72px">$5,083</td>
+			<td style="width:72px">$5,238</td>
+		</tr>
+		<tr>
+			<th scope="row" style="background-color:#ffd5b2; width:167px"><strong>Capital Expenditures</strong></th>
+			<td style="width:78px">$3,438</td>
+			<td style="width:73px">$3,273</td>
+			<td style="width:72px">$7,358</td>
+			<td style="width:72px">$1,203</td>
+			<td style="width:72px">$1,611</td>
+			<td style="width:72px">$2,289</td>
+			<td style="width:72px">$2,255<br />
+			&nbsp;</td>
+		</tr>
+	</tbody>
+</table>
+</textarea>
+
+<script>
+	if ( ( CKEDITOR.env.ie && CKEDITOR.env.version < 11 ) || bender.tools.env.mobile ) {
+		bender.ignore();
+	}
+	CKEDITOR.replace( 'editor', {
+		height: 800,
+	} );
+</script>

--- a/tests/plugins/tableselection/manual/integrations/tabletools/columndeletionerror.md
+++ b/tests/plugins/tableselection/manual/integrations/tabletools/columndeletionerror.md
@@ -1,4 +1,4 @@
-@bender-tags: 4.7.2, bug, 577
+@bender-tags: 4.7.3, bug, 577
 @bender-ui: collapsed
 @bender-ckeditor-plugins: wysiwygarea, toolbar, table, tabletools, tableselection, contextmenu, undo
 
@@ -7,7 +7,7 @@
 1. Select some cells somewhere under merged header.
 1. Selection should use `tableselection` plugin.
 1. Right click to open context menu.
-1. Select Column -> Delete Column.
+1. Select Column -> Delete Columns.
 1. You can use `Undo` command and try remove different columns.
 
 **Expected:** Columns are deleted. There is no error in the console.
@@ -18,7 +18,7 @@
 
 1. Make collapsed selection at the end of one cell.
 1. Right click to open context menu.
-1. Select Column -> Delete Column.
+1. Select Column -> Delete Columns.
 
 **Expected:** Only one column is deleted.
 

--- a/tests/plugins/tableselection/manual/integrations/tabletools/columndeletionerror.md
+++ b/tests/plugins/tableselection/manual/integrations/tabletools/columndeletionerror.md
@@ -1,10 +1,10 @@
 @bender-tags: 4.7.2, bug, 577
 @bender-ui: collapsed
-@bender-ckeditor-plugins: wysiwygarea, toolbar, table, tabletools, contextmenu, undo
+@bender-ckeditor-plugins: wysiwygarea, toolbar, table, tabletools, tableselection, contextmenu, undo
 
 1. Open browser console.
 1. Select some cells somewhere under merged header.
-1. Selection should use native selection.
+1. Selection should use `tableselection` plugin.
 1. Right click to open context menu.
 1. Select Column -> Delete Column.
 1. You can use `Undo` command and try remove different columns.

--- a/tests/plugins/tableselection/manual/integrations/tabletools/columndeletionerror.md
+++ b/tests/plugins/tableselection/manual/integrations/tabletools/columndeletionerror.md
@@ -2,6 +2,7 @@
 @bender-ui: collapsed
 @bender-ckeditor-plugins: wysiwygarea, toolbar, table, tabletools, tableselection, contextmenu, undo
 
+----
 1. Open browser console.
 1. Select some cells somewhere under merged header.
 1. Selection should use `tableselection` plugin.
@@ -12,3 +13,13 @@
 **Expected:** Columns are deleted. There is no error in the console.
 
 **Unexpected:** Error is thrown in a console. Columns are not removed.
+
+----
+
+1. Make collapsed selection at the end of one cell.
+1. Right click to open context menu.
+1. Select Column -> Delete Column.
+
+**Expected:** Only one column is deleted.
+
+**Unexpected:** Two columns are deleted (with selection and next one).

--- a/tests/plugins/tabletools/columndeletion.html
+++ b/tests/plugins/tabletools/columndeletion.html
@@ -1,0 +1,331 @@
+<textarea id="table-1">
+<table>
+	<tr>
+		<td>[foo]</td>
+		<td>bar</td>
+		<td>baz</td>
+	</tr>
+	<tr>
+		<td>[foo]</td>
+		<td>bar</td>
+		<td>baz</td>
+	</tr>
+</table>
+=>
+<table>
+	<tbody>
+	<tr>
+		<td>bar</td>
+		<td>baz</td>
+	</tr>
+	<tr>
+		<td>bar</td>
+		<td>baz</td>
+	</tr>
+	</tbody>
+</table>
+</textarea>
+
+<textarea id="table-2">
+<table>
+	<tr>
+		<td>foo</td>
+		<td>bar</td>
+		<td>baz</td>
+	</tr>
+	<tr>
+		<td>foo</td>
+		<td>[bar</td>
+		<td>baz]</td>
+	</tr>
+	<tr>
+		<td>foo</td>
+		<td>bar</td>
+		<td>baz</td>
+	</tr>
+</table>
+=>
+<table>
+	<tbody>
+	<tr>
+		<td>foo</td>
+	</tr>
+	<tr>
+		<td>foo</td>
+	</tr>
+	<tr>
+		<td>foo</td>
+	</tr>
+	</tbody>
+</table>
+</textarea>
+
+<textarea id="table-3">
+<table>
+	<thead>
+		<tr>
+			<th colspan="2" scope="col">
+				[Header1]
+			</th>
+			<th colspan="1" scope="col">
+				Header2
+			</th>
+		</tr>
+	</thead>
+	<tbody>
+	<tr>
+		<td>foo</td>
+		<td>bar</td>
+		<td>baz</td>
+	</tr>
+	<tr>
+		<td>foo</td>
+		<td>bar</td>
+		<td>baz</td>
+	</tr>
+	<tr>
+		<td>foo</td>
+		<td>bar</td>
+		<td>baz</td>
+	</tr>
+	</tbody>
+</table>
+=>
+<table>
+	<thead>
+		<tr>
+			<th colspan="1" scope="col">
+				Header2
+			</th>
+		</tr>
+	</thead>
+	<tbody>
+	<tr>
+		<td>baz</td>
+	</tr>
+	<tr>
+		<td>baz</td>
+	</tr>
+	<tr>
+		<td>baz</td>
+	</tr>
+	</tbody>
+</table>
+</textarea>
+
+<textarea id="table-4">
+<table>
+	<thead>
+		<tr>
+			<th colspan="3" scope="col">
+				Header
+			</th>
+		</tr>
+	</thead>
+	<tbody>
+	<tr>
+		<td>foo</td>
+		<td>bar</td>
+		<td>[baz]</td>
+	</tr>
+	<tr>
+		<td>foo</td>
+		<td>bar</td>
+		<td>baz</td>
+	</tr>
+	<tr>
+		<td>foo</td>
+		<td>bar</td>
+		<td>baz</td>
+	</tr>
+	</tbody>
+</table>
+=>
+<table>
+	<thead>
+		<tr>
+			<th colspan="2" scope="col">
+				Header
+			</th>
+		</tr>
+	</thead>
+	<tbody>
+	<tr>
+		<td>foo</td>
+		<td>bar</td>
+	</tr>
+	<tr>
+		<td>foo</td>
+		<td>bar</td>
+	</tr>
+	<tr>
+		<td>foo</td>
+		<td>bar</td>
+	</tr>
+	</tbody>
+</table>
+</textarea>
+
+<textarea id="table-5">
+<table>
+	<thead>
+		<tr>
+			<th colspan="3" scope="col">
+				Header1
+			</th>
+			<th colspan="3" scope="col">
+				Header2
+			</th>
+		</tr>
+	</thead>
+	<tbody>
+	<tr>
+		<td>foo</td>
+		<td>bar</td>
+		<td>baz</td>
+		<td>foo</td>
+		<td>bar</td>
+		<td>baz</td>
+	</tr>
+	<tr>
+		<td>foo</td>
+		<td>bar</td>
+		<td>baz</td>
+		<td>foo</td>
+		<td>bar</td>
+		<td>baz</td>
+	</tr>
+	<tr>
+		<td>foo</td>
+		<td>bar</td>
+		<td>[baz</td>
+		<td>foo]</td>
+		<td>bar</td>
+		<td>baz</td>
+	</tr>
+	</tbody>
+</table>
+=>
+<table>
+	<thead>
+		<tr>
+			<th colspan="2" scope="col">
+				Header1
+			</th>
+			<th colspan="2" scope="col">
+				Header2
+			</th>
+		</tr>
+	</thead>
+	<tbody>
+	<tr>
+		<td>foo</td>
+		<td>bar</td>
+		<td>bar</td>
+		<td>baz</td>
+	</tr>
+	<tr>
+		<td>foo</td>
+		<td>bar</td>
+		<td>bar</td>
+		<td>baz</td>
+	</tr>
+	<tr>
+		<td>foo</td>
+		<td>bar</td>
+		<td>bar</td>
+		<td>baz</td>
+	</tr>
+	</tbody>
+</table>
+</textarea>
+
+<textarea id="table-6">
+<table>
+	<thead>
+		<tr>
+			<th colspan="3" scope="col">
+				Header1
+			</th>
+			<th colspan="3" scope="col">
+				Header2
+			</th>
+		</tr>
+	</thead>
+	<tbody>
+	<tr>
+		<td>foo</td>
+		<td>bar</td>
+		<td>baz</td>
+		<td>[foo</td>
+		<td>bar</td>
+		<td>baz]</td>
+	</tr>
+	<tr>
+		<td>foo</td>
+		<td>bar</td>
+		<td>baz</td>
+		<td>[foo</td>
+		<td>bar</td>
+		<td>baz]</td>
+	</tr>
+	<tr>
+		<td>foo</td>
+		<td>bar</td>
+		<td>baz</td>
+		<td>[foo</td>
+		<td>bar</td>
+		<td>baz]</td>
+	</tr>
+	</tbody>
+</table>
+=>
+<table>
+	<thead>
+		<tr>
+			<th colspan="3" scope="col">
+				Header1
+			</th>
+		</tr>
+	</thead>
+	<tbody>
+	<tr>
+		<td>foo</td>
+		<td>bar</td>
+		<td>baz</td>
+	</tr>
+	<tr>
+		<td>foo</td>
+		<td>bar</td>
+		<td>baz</td>
+	</tr>
+	<tr>
+		<td>foo</td>
+		<td>bar</td>
+		<td>baz</td>
+	</tr>
+	</tbody>
+</table>
+</textarea>
+
+<textarea id="table-7">
+<table>
+	<tr>
+		<td>[foo</td>
+		<td>bar</td>
+		<td>baz]</td>
+	</tr>
+	<tr>
+		<td>foo</td>
+		<td>bar</td>
+		<td>baz</td>
+	</tr>
+	<tr>
+		<td>foo</td>
+		<td>bar</td>
+		<td>baz</td>
+	</tr>
+</table>
+=>
+
+</textarea>

--- a/tests/plugins/tabletools/columndeletion.js
+++ b/tests/plugins/tabletools/columndeletion.js
@@ -1,0 +1,74 @@
+/* bender-tags: editor,unit */
+/* bender-ckeditor-plugins: wysiwygarea, table, tabletools, tableselection */
+
+( function() {
+	'use strict';
+
+	bender.editor = true;
+
+	bender.test( {
+		doTest: function( name, command ) {
+			var bot = this.editorBot;
+			bender.tools.testInputOut( name, function( source, expected ) {
+				bot.setHtmlWithSelection( source );
+				bot.execCommand( command );
+
+				var output = bot.getData( true );
+				output = output.replace( /\u00a0/g, '&nbsp;' );
+				assert.areSame( bender.tools.compatHtml( expected ), output );
+			} );
+		},
+
+		// #577
+		'test remove first column': function() {
+			// tests requires tableselection
+			if ( ( CKEDITOR.env.ie && CKEDITOR.env.version < 11 ) || bender.tools.env.mobile ) {
+				assert.ignore();
+			}
+			this.doTest( 'table-1', 'columnDelete' );
+		},
+
+		'test remove 2 last columns by single row selection': function() {
+			if ( ( CKEDITOR.env.ie && CKEDITOR.env.version < 11 ) || bender.tools.env.mobile ) {
+				assert.ignore();
+			}
+			this.doTest( 'table-2', 'columnDelete' );
+		},
+
+		'test remove selection collspan': function() {
+			if ( ( CKEDITOR.env.ie && CKEDITOR.env.version < 11 ) || bender.tools.env.mobile ) {
+				assert.ignore();
+			}
+			this.doTest( 'table-3', 'columnDelete' );
+		},
+
+		'test remove single column under collspan': function() {
+			if ( ( CKEDITOR.env.ie && CKEDITOR.env.version < 11 ) || bender.tools.env.mobile ) {
+				assert.ignore();
+			}
+			this.doTest( 'table-4', 'columnDelete' );
+		},
+
+		'test remove middle columns half with 2 collspans': function() {
+			if ( ( CKEDITOR.env.ie && CKEDITOR.env.version < 11 ) || bender.tools.env.mobile ) {
+				assert.ignore();
+			}
+			this.doTest( 'table-5', 'columnDelete' );
+		},
+
+		'test remove multirange selection under collspan': function() {
+			if ( ( CKEDITOR.env.ie && CKEDITOR.env.version < 11 ) || bender.tools.env.mobile ) {
+				assert.ignore();
+			}
+			this.doTest( 'table-6', 'columnDelete' );
+		},
+
+		'test remove entire table by column delete': function() {
+			if ( ( CKEDITOR.env.ie && CKEDITOR.env.version < 11 ) || bender.tools.env.mobile ) {
+				assert.ignore();
+			}
+			this.doTest( 'table-7', 'columnDelete' );
+		}
+
+	} );
+} )();

--- a/tests/plugins/tabletools/columndeletion.js
+++ b/tests/plugins/tabletools/columndeletion.js
@@ -24,26 +24,32 @@
 			this.doTest( 'table-1', 'columnDelete' );
 		},
 
+		// #577
 		'test remove 2 last columns by single row selection': function() {
 			this.doTest( 'table-2', 'columnDelete' );
 		},
 
-		'test remove selection collspan': function() {
+		// #577
+		'test remove selection colspan': function() {
 			this.doTest( 'table-3', 'columnDelete' );
 		},
 
-		'test remove single column under collspan': function() {
+		// #577
+		'test remove single column under colspan': function() {
 			this.doTest( 'table-4', 'columnDelete' );
 		},
 
-		'test remove middle columns half with 2 collspans': function() {
+		// #577
+		'test remove middle columns half with 2 colspans': function() {
 			this.doTest( 'table-5', 'columnDelete' );
 		},
 
-		'test remove multirange selection under collspan': function() {
+		// #577
+		'test remove multirange selection under colspan': function() {
 			this.doTest( 'table-6', 'columnDelete' );
 		},
 
+		// #577
 		'test remove entire table by column delete': function() {
 			this.doTest( 'table-7', 'columnDelete' );
 		}

--- a/tests/plugins/tabletools/manual/columndeletionerror.html
+++ b/tests/plugins/tabletools/manual/columndeletionerror.html
@@ -1,0 +1,104 @@
+<textarea id="editor">
+<table border="2" summary="Balance Sheet &amp; Cash Flow Statement Information">
+	<thead>
+		<tr>
+			<th colspan="1" scope="row" style="width:167px">&nbsp;</th>
+			<th colspan="3" scope="col" style="background-color:#1d7373; width:224px">Full Year (unaudited)</th>
+			<th colspan="4" scope="col" style="background-color:#1d7373; width:360px">2013 (unaudited)</th>
+		</tr>
+	</thead>
+	<tbody>
+		<tr>
+			<th scope="row" style="width:167px">&nbsp;</th>
+			<td style="background-color:#5ccccc; width:78px">2011</td>
+			<td style="background-color:#5ccccc; width:73px">2012</td>
+			<td style="background-color:#5ccccc; width:72px">2013</td>
+			<td style="background-color:#5ccccc; width:72px">Q1</td>
+			<td style="background-color:#5ccccc; width:72px">Q2</td>
+			<td style="background-color:#5ccccc; width:72px">Q3</td>
+			<td style="background-color:#5ccccc; width:72px">Q4</td>
+		</tr>
+		<tr>
+			<th scope="row" style="background-color:#ffd5b2; width:167px"><strong>Cash, Cash Equivalents &amp; Marketable Securities</strong></th>
+			<td style="width:78px">$44,626</td>
+			<td style="width:73px">$48,088</td>
+			<td style="width:72px">$58,717</td>
+			<td style="width:72px">$50,098</td>
+			<td style="width:72px">$54,432</td>
+			<td style="width:72px">$56,523</td>
+			<td style="width:72px">$58,717</td>
+		</tr>
+		<tr>
+			<th scope="row" style="background-color:#ffd5b2; width:167px"><strong>Accounts Receivable, Net of Allowance (Google stand-alone)</strong></th>
+			<td style="width:78px">$5,427</td>
+			<td style="width:73px">$6,769</td>
+			<td style="width:72px">$8,098</td>
+			<td style="width:72px">$6,526</td>
+			<td style="width:72px">$6,792</td>
+			<td style="width:72px">$7,083</td>
+			<td style="width:72px">$8,098</td>
+		</tr>
+		<tr>
+			<th scope="row" style="background-color:#ffd5b2; width:167px"><em>DSO for Company stand-alone<br />
+			(in days, using ending AR)</em></th>
+			<td style="width:78px">52</td>
+			<td style="width:73px">54</td>
+			<td style="width:72px">53</td>
+			<td style="width:72px">45</td>
+			<td style="width:72px">47</td>
+			<td style="width:72px">47</td>
+			<td style="width:72px">47</td>
+		</tr>
+		<tr>
+			<th scope="row" style="background-color:#ffd5b2; width:167px"><strong>Property and Equipment, Net</strong></th>
+			<td style="width:78px">$9,603</td>
+			<td style="width:73px">$11,854</td>
+			<td style="width:72px">$16,524</td>
+			<td style="width:72px">$12,300</td>
+			<td style="width:72px">$12,912</td>
+			<td style="width:72px">$14,867</td>
+			<td style="width:72px">$16,524</td>
+		</tr>
+		<tr>
+			<th scope="row" style="background-color:#ffd5b2; width:167px"><strong>Total Assets</strong></th>
+			<td style="width:78px">$72,574</td>
+			<td style="width:73px">$93,798</td>
+			<td style="width:72px">$110,920</td>
+			<td style="width:72px">$96,692</td>
+			<td style="width:72px">$101,182</td>
+			<td style="width:72px">$105,068</td>
+			<td style="width:72px">$110,920</td>
+		</tr>
+		<tr>
+			<th scope="row" style="background-color:#ffd5b2; width:167px"><strong>Cash Flow from Operations</strong></th>
+			<td style="width:78px">$14,565</td>
+			<td style="width:73px">$16,619</td>
+			<td style="width:72px">$18,659</td>
+			<td style="width:72px">$3,633</td>
+			<td style="width:72px">$4,705</td>
+			<td style="width:72px">$5,083</td>
+			<td style="width:72px">$5,238</td>
+		</tr>
+		<tr>
+			<th scope="row" style="background-color:#ffd5b2; width:167px"><strong>Capital Expenditures</strong></th>
+			<td style="width:78px">$3,438</td>
+			<td style="width:73px">$3,273</td>
+			<td style="width:72px">$7,358</td>
+			<td style="width:72px">$1,203</td>
+			<td style="width:72px">$1,611</td>
+			<td style="width:72px">$2,289</td>
+			<td style="width:72px">$2,255<br />
+			&nbsp;</td>
+		</tr>
+	</tbody>
+</table>
+</textarea>
+
+<script>
+	if ( ( CKEDITOR.env.ie && CKEDITOR.env.version < 11 ) || bender.tools.env.mobile ) {
+		bender.ignore();
+	}
+	CKEDITOR.replace( 'editor', {
+		height: 800,
+	} );
+</script>

--- a/tests/plugins/tabletools/manual/columndeletionerror.html
+++ b/tests/plugins/tabletools/manual/columndeletionerror.html
@@ -95,9 +95,6 @@
 </textarea>
 
 <script>
-	if ( ( CKEDITOR.env.ie && CKEDITOR.env.version < 11 ) || bender.tools.env.mobile ) {
-		bender.ignore();
-	}
 	CKEDITOR.replace( 'editor', {
 		height: 800,
 	} );

--- a/tests/plugins/tabletools/manual/columndeletionerror.md
+++ b/tests/plugins/tabletools/manual/columndeletionerror.md
@@ -1,4 +1,4 @@
-@bender-tags: 4.7.2, bug, 577
+@bender-tags: 4.7.3, bug, 577
 @bender-ui: collapsed
 @bender-ckeditor-plugins: wysiwygarea, toolbar, table, tabletools, contextmenu, undo
 
@@ -7,17 +7,18 @@
 1. Select some cells somewhere under merged header.
 1. Selection should use native selection.
 1. Right click to open context menu.
-1. Select Column -> Delete Column.
+1. Select Column -> Delete Columns.
 1. You can use `Undo` command and try remove different columns.
 
 **Expected:** Columns are deleted. There is no error in the console.
 
 **Unexpected:** Error is thrown in a console. Columns are not removed.
+
 ----
 
 1. Make collapsed selection at the end of one cell.
 1. Right click to open context menu.
-1. Select Column -> Delete Column.
+1. Select Column -> Delete Columns.
 
 **Expected:** Only one column is deleted.
 

--- a/tests/plugins/tabletools/manual/columndeletionerror.md
+++ b/tests/plugins/tabletools/manual/columndeletionerror.md
@@ -1,0 +1,14 @@
+@bender-tags: 4.7.2, bug, 577
+@bender-ui: collapsed
+@bender-ckeditor-plugins: wysiwygarea, toolbar, table, tabletools, tableselection, contextmenu, undo
+
+1. Open browser console.
+1. Select some cells somwhere under merged header.
+1. Selection should use `tableselection` plugin.
+1. Right click to open cntentxt menu.
+1. Select Column -> Delete Column.
+1. You can use `Undo` command and try remove different columns.
+
+**Expected:** Columns are deleted. There is no error in the console.
+
+**Unexpected:** Error is thrown in a console. Columns are not removed.

--- a/tests/plugins/tabletools/manual/columndeletionerror.md
+++ b/tests/plugins/tabletools/manual/columndeletionerror.md
@@ -2,6 +2,7 @@
 @bender-ui: collapsed
 @bender-ckeditor-plugins: wysiwygarea, toolbar, table, tabletools, contextmenu, undo
 
+----
 1. Open browser console.
 1. Select some cells somewhere under merged header.
 1. Selection should use native selection.
@@ -12,3 +13,12 @@
 **Expected:** Columns are deleted. There is no error in the console.
 
 **Unexpected:** Error is thrown in a console. Columns are not removed.
+----
+
+1. Make collapsed selection at the end of one cell.
+1. Right click to open context menu.
+1. Select Column -> Delete Column.
+
+**Expected:** Only one column is deleted.
+
+**Unexpected:** Two columns are deleted (with selection and next one).


### PR DESCRIPTION
## What is the purpose of this pull request?
bug fix

## Does your PR contain necessary tests?
yes

### This PR contains
- [x] Unit tests
- [x] Manual tests

## What changes did you make?
- fix bug which forbid to delete columns when those were under colspans.
- fix bug where only last column was removed when colspan cell was selected.
- fix bug where cursor position might won't be returned, what generat the console error.
- add some brackets `{}` to if statements.

close #577 