### PR TITLE
Fix for `range.extractContents` to work like `cloneContents`

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -18,6 +18,7 @@ Fixed Issues:
 * [#9780](https://dev.ckeditor.com/ticket/9780): [IE8-9] Fixed: Clicking inside empty [read-only](http://docs.ckeditor.com/#!/api/CKEDITOR.editor-property-readOnly) editor throws an error.
 * [#16820](https://dev.ckeditor.com/ticket/16820): [IE10] Fixed: Clicking below single horizontal rule throws an error.
 * [#426](https://github.com/ckeditor/ckeditor-dev/issues/426): Fixed: [CloneContents](http://docs.ckeditor.com/#!/api/CKEDITOR.dom.range-method-cloneContents) selects whole element when selection starts at the beginning of that element.
+* [#644](https://github.com/ckeditor/ckeditor-dev/issues/644): Fixed: The [`range.extractContents`](http://docs.ckeditor.com/#!/api/CKEDITOR.dom.range-method-extractContents) returns incorrect result when multiple nodes are selected.
 
 ## CKEditor 4.7.1
 

--- a/core/dom/range.js
+++ b/core/dom/range.js
@@ -410,7 +410,7 @@ CKEDITOR.dom.range = function( root ) {
 
 				// When Extracting, move the removed node to the docFrag.
 				if ( isExtract ) {
-					newParent.append( node );
+					newParent.append( node, toStart );
 				}
 			}
 

--- a/tests/core/dom/range/extractcontents.html
+++ b/tests/core/dom/range/extractcontents.html
@@ -1,2 +1,3 @@
 <div id="playground" style="visibility:hidden"><h1 id="_H1">FCKW3CRange Test</h1><p id="_Para">This is <b id="_B">some</b> text.</p><p>Another paragraph.</p></div>
 <div id="bogus"><p>Foo bar<br /></p></div>
+<div id="numbers"><p id="_pe">111<strong>222<span>333<em>444</em></span>555<sup>666</sup>777<sub id="_sub">888</sub></strong></p></div>

--- a/tests/core/dom/range/extractcontents.js
+++ b/tests/core/dom/range/extractcontents.js
@@ -379,6 +379,38 @@
 
 			// See: execContentsAction in range.js.
 			assert.isInnerHtmlMatching( '<p>Foo bar</p>', docFrag.getHtml(), 'Extracted HTML' );
+		},
+
+		// #644
+		'test extract nested tags': function() {
+			bender.editorBot.create( {
+				name: 'extract1',
+				config: {
+					extraAllowedContent: 'p strong em sup sub span'
+				}
+			}, function( bot ) {
+				var selection = bender.tools.selection.setWithHtml( bot.editor, '<p>{111<strong>222<span>333<em>444</em></span>555<sup>666</sup>777<sub>888}</sub></strong></p>' ),
+					result = selection.getRanges()[ 0 ].extractContents();
+
+				assert.isInnerHtmlMatching( '111<strong>222<span>333<em>444</em></span>555<sup>666</sup>777<sub>888</sub></strong>', result.getHtml() );
+			} );
+		},
+
+		// #644
+		'test extractContents and cloneContents provides equal results': function() {
+			bender.editorBot.create( {
+				name: 'extract2',
+				config: {
+					extraAllowedContent: 'p strong em span sup sub'
+				}
+			}, function( bot ) {
+				var selection = bender.tools.selection.setWithHtml( bot.editor, '<p>{111<strong>222<span>333<em>444</em></span>555<sup>666</sup>777<sub>888}</sub></strong></p>' ),
+					range = selection.getRanges()[ 0 ],
+					clone = range.cloneContents(),
+					extract = range.extractContents();
+
+				assert.isInnerHtmlMatching( bender.tools.fixHtml( clone.getHtml() ), bender.tools.fixHtml( extract.getHtml() ) );
+			} );
 		}
 	};
 

--- a/tests/core/dom/range/extractcontents.js
+++ b/tests/core/dom/range/extractcontents.js
@@ -5,11 +5,13 @@
 
 	var getInnerHtml = bender.tools.getInnerHtml,
 		doc = CKEDITOR.document,
-		html1 = document.getElementById( 'playground' ).innerHTML;
+		html1 = document.getElementById( 'playground' ).innerHTML,
+		numbers = document.getElementById( 'numbers' ).innerHTML;
 
 	var tests = {
 		setUp: function() {
 			document.getElementById( 'playground' ).innerHTML = html1;
+			document.getElementById( 'numbers' ).innerHTML = numbers;
 		},
 
 		test_extractContents_W3C_1: function() {
@@ -383,34 +385,31 @@
 
 		// #644
 		'test extract nested tags': function() {
-			bender.editorBot.create( {
-				name: 'extract1',
-				config: {
-					extraAllowedContent: 'p strong em sup sub span'
-				}
-			}, function( bot ) {
-				var selection = bender.tools.selection.setWithHtml( bot.editor, '<p>{111<strong>222<span>333<em>444</em></span>555<sup>666</sup>777<sub>888}</sub></strong></p>' ),
-					result = selection.getRanges()[ 0 ].extractContents();
+			var range = new CKEDITOR.dom.range( doc ),
+				docFrag;
 
-				assert.isInnerHtmlMatching( '111<strong>222<span>333<em>444</em></span>555<sup>666</sup>777<sub>888</sub></strong>', result.getHtml() );
-			} );
+			// You want to select text nodes.
+			range.setStart( doc.getById( '_pe' ).getFirst(), 0 );
+			range.setEnd( doc.getById( '_sub' ).getFirst(), 3 );
+
+			docFrag = range.extractContents();
+
+			assert.isInnerHtmlMatching( '111<strong>222<span>333<em>444</em></span>555<sup>666</sup>777<sub id="_sub">888</sub></strong>', docFrag.getHtml() );
+
 		},
 
 		// #644
 		'test extractContents and cloneContents provides equal results': function() {
-			bender.editorBot.create( {
-				name: 'extract2',
-				config: {
-					extraAllowedContent: 'p strong em span sup sub'
-				}
-			}, function( bot ) {
-				var selection = bender.tools.selection.setWithHtml( bot.editor, '<p>{111<strong>222<span>333<em>444</em></span>555<sup>666</sup>777<sub>888}</sub></strong></p>' ),
-					range = selection.getRanges()[ 0 ],
-					clone = range.cloneContents(),
-					extract = range.extractContents();
+			var range = new CKEDITOR.dom.range( doc ),
+				extractFrag, cloneFrag;
 
-				assert.isInnerHtmlMatching( bender.tools.fixHtml( clone.getHtml() ), bender.tools.fixHtml( extract.getHtml() ) );
-			} );
+			range.setStart( doc.getById( '_pe' ).getFirst(), 0 );
+			range.setEnd( doc.getById( '_sub' ).getFirst(), 3 );
+
+			cloneFrag = range.cloneContents(),
+			extractFrag = range.extractContents();
+
+			assert.isInnerHtmlMatching( bender.tools.fixHtml( cloneFrag.getHtml() ), bender.tools.fixHtml( extractFrag.getHtml() ) );
 		}
 	};
 

--- a/tests/core/dom/range/extractcontents.js
+++ b/tests/core/dom/range/extractcontents.js
@@ -360,7 +360,7 @@
 			var playground = doc.getById( 'playground' );
 
 			// See: execContentsAction in range.js.
-			assert.isInnerHtmlMatching( '<h1>Test</h1><p>t<b id="_B">some</b>This is</p>', tmpDiv.getHtml(), 'Extracted HTML' );
+			assert.isInnerHtmlMatching( '<h1>Test</h1><p>This is <b id="_B">some</b> t</p>', tmpDiv.getHtml(), 'Extracted HTML' );
 			assert.isInnerHtmlMatching( '<h1 id="_H1">FCKW3CRange</h1><p id="_Para">ext.</p><p>Another paragraph.</p>',
 				playground.getHtml(), 'HTML after extraction' );
 

--- a/tests/core/dom/range/extractcontents.js
+++ b/tests/core/dom/range/extractcontents.js
@@ -395,13 +395,13 @@
 			docFrag = range.extractContents();
 
 			assert.isInnerHtmlMatching( '111<strong>222<span>333<em>444</em></span>555<sup>666</sup>777<sub id="_sub">888</sub></strong>', docFrag.getHtml() );
-
 		},
 
 		// #644
 		'test extractContents and cloneContents provides equal results': function() {
 			var range = new CKEDITOR.dom.range( doc ),
-				extractFrag, cloneFrag;
+				extractFrag,
+				cloneFrag;
 
 			range.setStart( doc.getById( '_pe' ).getFirst(), 0 );
 			range.setEnd( doc.getById( '_sub' ).getFirst(), 3 );
@@ -409,7 +409,7 @@
 			cloneFrag = range.cloneContents(),
 			extractFrag = range.extractContents();
 
-			assert.isInnerHtmlMatching( bender.tools.fixHtml( cloneFrag.getHtml() ), bender.tools.fixHtml( extractFrag.getHtml() ) );
+			assert.beautified.html( cloneFrag.getHtml(), extractFrag.getHtml() );
 		}
 	};
 

--- a/tests/core/dom/range/manual/extractcontentsreturnproperstructure.html
+++ b/tests/core/dom/range/manual/extractcontentsreturnproperstructure.html
@@ -1,0 +1,23 @@
+<textarea name="ed" id="editor" cols="30" rows="10">
+	<p>111<strong>222<span class="marker">333<em>444</em></span>555<sup>666</sup>777<sub>888</sub></strong></p>
+</textarea>
+<button onclick="run()">Press me</button>
+<pre id="outputa" style="background-color:lightgoldenrodyellow;"></pre>
+<pre id="outputb" style="background-color:lightgreen;"></pre>
+
+<script>
+	var editor = CKEDITOR.replace( 'editor' );
+
+	function run() {
+		var a = document.getElementById( 'outputa' );
+		var b = document.getElementById( 'outputb' );
+
+		var range = editor.getSelection().getRanges()[0];
+		if ( range ) {
+			a.innerText = range.cloneContents().getHtml();
+			b.innerText = range.extractContents().getHtml();
+		} else {
+			editor.showNotification( 'Please select text', 'warning' );
+		}
+	}
+</script>

--- a/tests/core/dom/range/manual/extractcontentsreturnproperstructure.html
+++ b/tests/core/dom/range/manual/extractcontentsreturnproperstructure.html
@@ -13,8 +13,6 @@
 		var b = document.getElementById( 'outputb' );
 
 		var range = editor.getSelection().getRanges()[0];
-		console.log( range );
-		debugger;
 		if ( range ) {
 			a.innerText = range.cloneContents().getHtml();
 			b.innerText = range.extractContents().getHtml();

--- a/tests/core/dom/range/manual/extractcontentsreturnproperstructure.html
+++ b/tests/core/dom/range/manual/extractcontentsreturnproperstructure.html
@@ -13,6 +13,8 @@
 		var b = document.getElementById( 'outputb' );
 
 		var range = editor.getSelection().getRanges()[0];
+		console.log( range );
+		debugger;
 		if ( range ) {
 			a.innerText = range.cloneContents().getHtml();
 			b.innerText = range.extractContents().getHtml();

--- a/tests/core/dom/range/manual/extractcontentsreturnproperstructure.md
+++ b/tests/core/dom/range/manual/extractcontentsreturnproperstructure.md
@@ -1,6 +1,6 @@
 @bender-tags: 4.7.2, bug, 644, range
 @bender-ui: collapsed
-@bender-ckeditor-plugins: wysiwygarea, toolbar, basicstyles, stylescombo, sourcearea, notification
+@bender-ckeditor-plugins: wysiwygarea, toolbar, basicstyles, stylescombo, sourcearea
 
 1. Select all text in editor.
 1. Press button below editor.

--- a/tests/core/dom/range/manual/extractcontentsreturnproperstructure.md
+++ b/tests/core/dom/range/manual/extractcontentsreturnproperstructure.md
@@ -1,6 +1,6 @@
 @bender-tags: 4.7.2, bug, 644, range
 @bender-ui: collapsed
-@bender-ckeditor-plugins: wysiwygarea, toolbar, basicstyles, stylescombo, elementspath, sourcearea, notification
+@bender-ckeditor-plugins: wysiwygarea, toolbar, basicstyles, stylescombo, sourcearea, notification
 
 1. Select all text in editor.
 1. Press button bellow.

--- a/tests/core/dom/range/manual/extractcontentsreturnproperstructure.md
+++ b/tests/core/dom/range/manual/extractcontentsreturnproperstructure.md
@@ -3,9 +3,9 @@
 @bender-ckeditor-plugins: wysiwygarea, toolbar, basicstyles, stylescombo, sourcearea, notification
 
 1. Select all text in editor.
-1. Press button bellow.
-1. There should appear 2 belowe button, and selected text should be removed from editor.
+1. Press button below editor.
+1. There should appear 2 HTML markups extracted from the editor. Selected text should be removed from editor.
 
-**Expected:** Texts in both lines are the same.
+**Expected:** Both HTML markups are the same.
 
-**Unexpected:** Texts differ. Words are rearranged.
+**Unexpected:** Markups differ. Words are rearranged.

--- a/tests/core/dom/range/manual/extractcontentsreturnproperstructure.md
+++ b/tests/core/dom/range/manual/extractcontentsreturnproperstructure.md
@@ -1,0 +1,11 @@
+@bender-tags: 4.7.2, bug, 644, range
+@bender-ui: collapsed
+@bender-ckeditor-plugins: wysiwygarea, toolbar, basicstyles, stylescombo, elementspath, sourcearea, notification
+
+1. Select all text in editor.
+1. Press button bellow.
+1. There should appear 2 belowe button, and selected text should be removed from editor.
+
+**Expected:** Texts in both lines are the same.
+
+**Unexpected:** Texts differ. Words are rearranged.


### PR DESCRIPTION
## What is the purpose of this pull request?

Bug fix

## Does your PR contain necessary tests?

yes

### This PR contains

- [x] Unit tests
- [x] Manual tests

## What changes did you make?
- pass flag `toStart` to append method in extract mode
- fix test which was wrongly design and accept previously wrong code

close #644 