### PR TITLE
check if element is dom.element

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -9,6 +9,7 @@ New Features:
 
 Fixed Issues:
 
+* [#663](https://github.com/ckeditor/ckeditor-dev/issues/663): [Chrome] Fixed: Clicking on scrollbar throws an `Uncaught TypeError: element.is is not a function` error.
 * [#579](https://github.com/ckeditor/ckeditor-dev/issues/579): Fixed: Internal `cke_table-faked-selection-table` class visible in Stylesheet Classes field in [Table Properties](http://ckeditor.com/addon/table) dialog.
 * [#545](https://github.com/ckeditor/ckeditor-dev/issues/545): [Edge] Fixed: Error thrown when pressing the Select All button in a [Source Mode](http://ckeditor.com/addon/sourcearea).
 * [#582](https://github.com/ckeditor/ckeditor-dev/issues/582): Fixed: Double slash in path to stylesheet needed by [Table Selection](http://ckeditor.com/addon/tableselection) plugin. Thanks to [Marius Dumitru Florea](https://github.com/mflorea)!

--- a/plugins/widget/plugin.js
+++ b/plugins/widget/plugin.js
@@ -2503,10 +2503,9 @@
 			editable.attachListener( evtRoot, 'mousedown', function( evt ) {
 				var target = evt.data.getTarget();
 
-				// http://dev.ckeditor.com/ticket/10887 Clicking scrollbar in IE8 will invoke event with empty target object.
-				if ( !target.type )
-					return false;
-
+				// Clicking scrollbar in Chrome will invoke event with target object of document type (#663).
+				// In IE8 the target object will be empty (http://dev.ckeditor.com/ticket/10887).
+				// We need to check if target is a proper element.
 				widget = ( target instanceof CKEDITOR.dom.element ) ? widgetsRepo.getByElement( target ) : null;
 
 				mouseDownOnDragHandler = 0; // Reset.

--- a/plugins/widget/plugin.js
+++ b/plugins/widget/plugin.js
@@ -2507,7 +2507,8 @@
 				if ( !target.type )
 					return false;
 
-				widget = widgetsRepo.getByElement( target );
+				widget = ( target instanceof CKEDITOR.dom.element ) ? widgetsRepo.getByElement( target ) : null;
+
 				mouseDownOnDragHandler = 0; // Reset.
 
 				// Widget was clicked, but not editable nested in it.

--- a/tests/tickets/gh663/manual/1.html
+++ b/tests/tickets/gh663/manual/1.html
@@ -1,0 +1,30 @@
+<div id="editor">
+	Sample Text Sample Text Sample Text Sample Text Sample Text Sample Text Sample Text Sample Text Sample Text Sample Text
+	Sample Text Sample Text Sample Text Sample Text Sample Text Sample Text Sample Text Sample Text Sample Text Sample Text
+	Sample Text Sample Text Sample Text Sample Text Sample Text Sample Text Sample Text Sample Text Sample Text Sample Text
+	Sample Text Sample Text Sample Text Sample Text Sample Text Sample Text Sample Text Sample Text Sample Text Sample Text
+	Sample Text Sample Text Sample Text Sample Text Sample Text Sample Text Sample Text Sample Text Sample Text Sample Text
+	Sample Text Sample Text Sample Text Sample Text Sample Text Sample Text Sample Text Sample Text Sample Text Sample Text
+	Sample Text Sample Text Sample Text Sample Text Sample Text Sample Text Sample Text Sample Text Sample Text Sample Text
+	Sample Text Sample Text Sample Text Sample Text Sample Text Sample Text Sample Text Sample Text Sample Text Sample Text
+	Sample Text Sample Text Sample Text Sample Text Sample Text Sample Text Sample Text Sample Text Sample Text Sample Text
+	Sample Text Sample Text Sample Text Sample Text Sample Text Sample Text Sample Text Sample Text Sample Text Sample Text
+	Sample Text Sample Text Sample Text Sample Text Sample Text Sample Text Sample Text Sample Text Sample Text Sample Text
+	Sample Text Sample Text Sample Text Sample Text Sample Text Sample Text Sample Text Sample Text Sample Text Sample Text
+	Sample Text Sample Text Sample Text Sample Text Sample Text Sample Text Sample Text Sample Text Sample Text Sample Text
+	Sample Text Sample Text Sample Text Sample Text Sample Text Sample Text Sample Text Sample Text Sample Text Sample Text
+	Sample Text Sample Text Sample Text Sample Text Sample Text Sample Text Sample Text Sample Text Sample Text Sample Text
+	Sample Text Sample Text Sample Text Sample Text Sample Text Sample Text Sample Text Sample Text Sample Text Sample Text
+	Sample Text Sample Text Sample Text Sample Text Sample Text Sample Text Sample Text Sample Text Sample Text Sample Text
+	Sample Text Sample Text Sample Text Sample Text Sample Text Sample Text Sample Text Sample Text Sample Text Sample Text
+	Sample Text Sample Text Sample Text Sample Text Sample Text Sample Text Sample Text Sample Text Sample Text Sample Text
+	Sample Text Sample Text Sample Text Sample Text Sample Text Sample Text Sample Text Sample Text Sample Text Sample Text
+	Sample Text Sample Text Sample Text Sample Text Sample Text Sample Text Sample Text Sample Text Sample Text Sample Text
+	Sample Text Sample Text Sample Text Sample Text Sample Text Sample Text Sample Text Sample Text Sample Text Sample Text
+	Sample Text Sample Text Sample Text Sample Text Sample Text Sample Text Sample Text Sample Text Sample Text Sample Text
+	Sample Text Sample Text Sample Text Sample Text Sample Text Sample Text Sample Text Sample Text Sample Text Sample Text
+</div>
+
+<script>
+	CKEDITOR.replace( 'editor' );
+</script>

--- a/tests/tickets/gh663/manual/1.md
+++ b/tests/tickets/gh663/manual/1.md
@@ -1,0 +1,10 @@
+@bender-tags: 4.7.2, bug, 663
+@bender-ui: collapsed
+@bender-ckeditor-plugins: wysiwygarea, widget
+
+----
+
+1. Open developer console.
+1. Click on scrollbar.
+
+**Expected result:** No error in the console.


### PR DESCRIPTION
## What is the purpose of this pull request?

Bug fix

## Does your PR contain necessary tests?

All patches which change the editor code must include tests. You can always read more
on [PR testing](http://docs.ckeditor.com/#!/guide/dev_contributing_code-section-tests),
[how to set the testing environment](http://docs.ckeditor.com/#!/guide/dev_tests) and
[how to create tests](http://docs.ckeditor.com/#!/guide/dev_tests-section-creating-your-own-test)
in the official CKEditor documentation.

### This PR contains

- [ ] Unit tests
- [x] Manual tests

## What changes did you make?

I added check if `element` in widget plugin is` CKEDITOR.dom.element`

Closes #663 