### PR TITLE
Fixed elementPath.contains when fromTop is set to true.

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -19,6 +19,7 @@ Fixed Issues:
 * [#16820](https://dev.ckeditor.com/ticket/16820): [IE10] Fixed: Clicking below single horizontal rule throws an error.
 * [#426](https://github.com/ckeditor/ckeditor-dev/issues/426): Fixed: [`range.cloneContents`](http://docs.ckeditor.com/#!/api/CKEDITOR.dom.range-method-cloneContents) selects whole element when selection starts at the beginning of that element.
 * [#644](https://github.com/ckeditor/ckeditor-dev/issues/644): Fixed: The [`range.extractContents`](http://docs.ckeditor.com/#!/api/CKEDITOR.dom.range-method-extractContents) returns incorrect result when multiple nodes are selected.
+* [#684](https://github.com/ckeditor/ckeditor-dev/issues/684): Fixed: The [`elementPath.contains`](http://docs.ckeditor.com/#!/api/CKEDITOR.dom.elementPath-method-contains) incorrectly excludes last element instead of root when `fromTop` parameter is set to true.
 
 ## CKEditor 4.7.1
 

--- a/core/dom/elementpath.js
+++ b/core/dom/elementpath.js
@@ -186,7 +186,9 @@ CKEDITOR.dom.elementPath.prototype = {
 	 * @returns {CKEDITOR.dom.element} The first matched dom element or `null`.
 	 */
 	contains: function( query, excludeRoot, fromTop ) {
-		var evaluator;
+		var i = 0,
+			evaluator;
+
 		if ( typeof query == 'string' )
 			evaluator = function( node ) {
 				return node.getName() == query;
@@ -208,14 +210,21 @@ CKEDITOR.dom.elementPath.prototype = {
 
 		var elements = this.elements,
 			length = elements.length;
-		excludeRoot && length--;
+
+		if ( excludeRoot ) {
+			if ( !fromTop ) {
+				length -= 1;
+			} else {
+				i += 1;
+			}
+		}
 
 		if ( fromTop ) {
 			elements = Array.prototype.slice.call( elements, 0 );
 			elements.reverse();
 		}
 
-		for ( var i = 0; i < length; i++ ) {
+		for ( ; i < length; i++ ) {
 			if ( evaluator( elements[ i ] ) )
 				return elements[ i ];
 		}

--- a/tests/core/dom/elementpath/elementpath.html
+++ b/tests/core/dom/elementpath/elementpath.html
@@ -1,0 +1,1 @@
+<div id="playground"></div>

--- a/tests/core/dom/elementpath/elementpath.js
+++ b/tests/core/dom/elementpath/elementpath.js
@@ -9,7 +9,7 @@ bender.test( {
 
 		var path = doc.getSelection().getRanges()[ 0 ].startPath();
 
-		assert.areSame( path.root, path.contains( path.root ), 'Root is not excluded by the default' );
+		assert.areSame( path.root, path.contains( path.root ), 'Root is not excluded by default' );
 		assert.isNull( path.contains( path.root, true ), 'Root is excluded correctly' );
 	},
 

--- a/tests/core/dom/elementpath/elementpath.js
+++ b/tests/core/dom/elementpath/elementpath.js
@@ -1,0 +1,27 @@
+
+var tools = bender.tools,
+	doc = CKEDITOR.document,
+	playground = doc.getById( 'playground' );
+
+bender.test( {
+	'test elementPath.contains skipRoot': function() {
+		tools.setHtmlWithSelection( playground, '<p><b>fo^o</b></p>' );
+
+		var path = doc.getSelection().getRanges()[ 0 ].startPath();
+
+		assert.areSame( path.root, path.contains( path.root ), 'Root is not excluded by the default' );
+		assert.isNull( path.contains( path.root, true ), 'Root is excluded correctly' );
+	},
+
+	// (#684)
+	'test elementPath.contains skipRoot with fromTop': function() {
+		tools.setHtmlWithSelection( playground, '<p><b>fo^o</b></p>' );
+
+		var path = doc.getSelection().getRanges()[ 0 ].startPath();
+
+		assert.areSame( doc.findOne( '#playground b' ), path.contains( 'b', true, true ),
+			'Regular element is still in the path' );
+
+		assert.isNull( path.contains( path.root, true, true ), 'Root is excluded' );
+	}
+} );


### PR DESCRIPTION
## What is the purpose of this pull request?

Bug fix

 ### This PR contains

- [x] Unit tests
- [x] Manual tests

 ## What changes did you make?

Fixes a simple bug in `elementPath.contains()` method.

Closes #684.