### PR TITLE
Automatically pick CKEditor version in bash build script

### DIFF
--- a/dev/builder/build.sh
+++ b/dev/builder/build.sh
@@ -57,8 +57,7 @@ echo "Starting CKBuilder..."
 
 JAVA_ARGS=${ARGS// -t / } # Remove -t from args.
 
-SEMANTIC_VERSION=`node -pe "require('./../../package.json').version"`
-VERSION="$SEMANTIC_VERSION DEV"
+VERSION=`node -pe "require('./../../package.json').version"`
 REVISION=$(git rev-parse --verify --short HEAD)
 
 # If the current revision is not tagged with any CKE version, it means it's a "dirty" build. We
@@ -66,10 +65,9 @@ REVISION=$(git rev-parse --verify --short HEAD)
 TAG=$(git tag --points-at HEAD) || true
 
 # This fancy construction check str length of $TAG variable.
-if [ ${#TAG} -ge 1 ];
+if [ ${#TAG} -le 0 ];
 then
-	echo "Setting version to $SEMANTIC_VERSION"
-	VERSION=$SEMANTIC_VERSION
+	VERSION="$VERSION DEV"
 fi
 
 java -jar ckbuilder/$CKBUILDER_VERSION/ckbuilder.jar --build ../../ release $JAVA_ARGS --version="$VERSION" --revision="$REVISION" --overwrite

--- a/dev/builder/build.sh
+++ b/dev/builder/build.sh
@@ -57,19 +57,17 @@ echo "Starting CKBuilder..."
 
 JAVA_ARGS=${ARGS// -t / } # Remove -t from args.
 
-VERSION=`node -pe "require('./package.json').version"`
-VERSION="$VERSION DEV"
+SEMANTIC_VERSION=`node -pe "require('./../../package.json').version"`
+VERSION="$SEMANTIC_VERSION DEV"
 REVISION=$(git rev-parse --verify --short HEAD)
-SEMVER_REGEX="^([0-9]+)\.([0-9]+)\.([0-9]+)(\-[0-9A-Za-z-]+)?(\+[0-9A-Za-z-]+)?$"
 
-# Get version number from tag (if available and follows semantic versioning principles).
-# Use 2>/dev/null to block "fatal: no tag exactly matches", true is needed because of "set -e".
+# If the current revision is not tagged with any CKE version, it means it's a "dirty" build. We
+# mark such builds with a " DEV" suffix. true is needed because of "set -e".
 TAG=$(git symbolic-ref -q --short HEAD || git describe --tags --exact-match 2>/dev/null) || true
-# "Git Bash" does not support regular expressions.
-if echo $TAG | grep -E "$SEMVER_REGEX" > /dev/null
+if echo $TAG
 then
-	echo "Setting version to $TAG"
-	VERSION=$TAG
+	echo "Setting version to $SEMANTIC_VERSION"
+	VERSION=$SEMANTIC_VERSION
 fi
 
 java -jar ckbuilder/$CKBUILDER_VERSION/ckbuilder.jar --build ../../ release $JAVA_ARGS --version="$VERSION" --revision="$REVISION" --overwrite

--- a/dev/builder/build.sh
+++ b/dev/builder/build.sh
@@ -57,7 +57,8 @@ echo "Starting CKBuilder..."
 
 JAVA_ARGS=${ARGS// -t / } # Remove -t from args.
 
-VERSION="4.7.2 DEV"
+VERSION=`node -pe "require('./package.json').version"`
+VERSION="$VERSION DEV"
 REVISION=$(git rev-parse --verify --short HEAD)
 SEMVER_REGEX="^([0-9]+)\.([0-9]+)\.([0-9]+)(\-[0-9A-Za-z-]+)?(\+[0-9A-Za-z-]+)?$"
 

--- a/dev/builder/build.sh
+++ b/dev/builder/build.sh
@@ -63,8 +63,10 @@ REVISION=$(git rev-parse --verify --short HEAD)
 
 # If the current revision is not tagged with any CKE version, it means it's a "dirty" build. We
 # mark such builds with a " DEV" suffix. true is needed because of "set -e".
-TAG=$(git symbolic-ref -q --short HEAD || git describe --tags --exact-match 2>/dev/null) || true
-if echo $TAG
+TAG=$(git tag --points-at HEAD) || true
+
+# This fancy construction check str length of $TAG variable.
+if [ ${#TAG} -ge 1 ];
 then
 	echo "Setting version to $SEMANTIC_VERSION"
 	VERSION=$SEMANTIC_VERSION


### PR DESCRIPTION
## What is the purpose of this pull request?

Task

 ## Does your PR contain necessary tests?

None needed, a bash script change.

 ## What changes did you make?

The main reason for this PR is to fix #572, so that we no longer need to remember about updating some magic strings after each release.

With that I had to update some [vague bash operations](https://github.com/ckeditor/ckeditor-dev/blob/aa600bd52a147e2ac1afd726ca6bf8c32ec7437e/dev/builder/build.sh#L64-L72) including regexp tricks. Since we operate on semver compliant version in package.json we no longer need this checking, and we can simplify the check.

Closes #572.