### PR TITLE
[#704] Fix broken widget after using Ctrl+Z in Edge

### DIFF
--- a/plugins/wysiwygarea/plugin.js
+++ b/plugins/wysiwygarea/plugin.js
@@ -165,7 +165,7 @@
 		if ( CKEDITOR.env.ie && !CKEDITOR.env.edge && editor.enterMode != CKEDITOR.ENTER_P ) {
 			removeSuperfluousElement( 'p' );
 		}
-		// From version Edge 15 additional `div` are not added to the editor.
+		// Starting from Edge 15 additional `div` is not added to the editor.
 		else if ( CKEDITOR.env.edge && editor.enterMode != CKEDITOR.ENTER_DIV && CKEDITOR.env.version < 15 ) {
 			removeSuperfluousElement( 'div' );
 		}

--- a/plugins/wysiwygarea/plugin.js
+++ b/plugins/wysiwygarea/plugin.js
@@ -297,7 +297,7 @@
 				var elements = doc.getElementsByTag( tagName );
 				if ( lockRetain ) {
 					if ( elements.count() == 1 && !elements.getItem( 0 ).getCustomData( 'retain' ) &&
-						!elements.getItem( 0 ).hasAttribute( 'data-cke-temp' ) ) {
+						CKEDITOR.tools.isEmpty( elements.getItem( 0 ).getAttributes() ) ) {
 						elements.getItem( 0 ).remove( 1 );
 					}
 					lockRetain = false;

--- a/plugins/wysiwygarea/plugin.js
+++ b/plugins/wysiwygarea/plugin.js
@@ -161,10 +161,12 @@
 			doc.getDocumentElement().addClass( doc.$.compatMode );
 		}
 
-		// Prevent IE/Edge from leaving a new paragraph/div after deleting all contents in body. (http://dev.ckeditor.com/ticket/6966, http://dev.ckeditor.com/ticket/13142)
+		// Prevent IE/Edge from leaving a new paragraph/div after deleting all contents in body (http://dev.ckeditor.com/ticket/6966, http://dev.ckeditor.com/ticket/13142).
 		if ( CKEDITOR.env.ie && !CKEDITOR.env.edge && editor.enterMode != CKEDITOR.ENTER_P ) {
 			removeSuperfluousElement( 'p' );
-		} else if ( CKEDITOR.env.edge && editor.enterMode != CKEDITOR.ENTER_DIV && CKEDITOR.env.version < 15 ) {
+		}
+		// From version Edge 15 additional `div` are not added to the editor.
+		else if ( CKEDITOR.env.edge && editor.enterMode != CKEDITOR.ENTER_DIV && CKEDITOR.env.version < 15 ) {
 			removeSuperfluousElement( 'div' );
 		}
 

--- a/plugins/wysiwygarea/plugin.js
+++ b/plugins/wysiwygarea/plugin.js
@@ -166,7 +166,7 @@
 			removeSuperfluousElement( 'p' );
 		}
 		// Starting from Edge 15 additional `div` is not added to the editor.
-		else if ( CKEDITOR.env.edge && editor.enterMode != CKEDITOR.ENTER_DIV && CKEDITOR.env.version < 15 ) {
+		else if ( CKEDITOR.env.edge && CKEDITOR.env.version < 15 && editor.enterMode != CKEDITOR.ENTER_DIV  ) {
 			removeSuperfluousElement( 'div' );
 		}
 

--- a/plugins/wysiwygarea/plugin.js
+++ b/plugins/wysiwygarea/plugin.js
@@ -164,7 +164,7 @@
 		// Prevent IE/Edge from leaving a new paragraph/div after deleting all contents in body. (http://dev.ckeditor.com/ticket/6966, http://dev.ckeditor.com/ticket/13142)
 		if ( CKEDITOR.env.ie && !CKEDITOR.env.edge && editor.enterMode != CKEDITOR.ENTER_P ) {
 			removeSuperfluousElement( 'p' );
-		} else if ( CKEDITOR.env.edge && editor.enterMode != CKEDITOR.ENTER_DIV ) {
+		} else if ( CKEDITOR.env.edge && editor.enterMode != CKEDITOR.ENTER_DIV && CKEDITOR.env.version < 15 ) {
 			removeSuperfluousElement( 'div' );
 		}
 

--- a/tests/plugins/widget/integration/wysiwygarea/manual/preventofremovingdiv.html
+++ b/tests/plugins/widget/integration/wysiwygarea/manual/preventofremovingdiv.html
@@ -13,7 +13,10 @@
 	var editor = CKEDITOR.replace( 'editor1', {
 		height: '600px'
 	} );
-	setInterval( function() {
-		document.getElementById( 'output' ).innerText = editor.editable().getFirst().getName();
-	}, 200)
+	var output = document.getElementById( 'output' )
+	editor.on( 'instanceReady', function() {
+		editor.editable().$.addEventListener( 'keyup', function() {
+			output.innerText = editor.editable().getFirst().getName();
+		} );
+	});
 </script>

--- a/tests/plugins/widget/integration/wysiwygarea/manual/preventofremovingdiv.html
+++ b/tests/plugins/widget/integration/wysiwygarea/manual/preventofremovingdiv.html
@@ -10,13 +10,17 @@
 </textarea>
 <pre id="output" style="background-color: lightgreen;"></pre>
 <script>
+	if ( !CKEDITOR.env.edge ) {
+		bender.ignore();
+	}
+
 	var editor = CKEDITOR.replace( 'editor1', {
 		height: '600px'
 	} );
-	var output = document.getElementById( 'output' )
+	var output = document.getElementById( 'output' );
 	editor.on( 'instanceReady', function() {
-		editor.editable().$.addEventListener( 'keyup', function() {
+		editor.editable().$.onkeyup = function() {
 			output.innerText = editor.editable().getFirst().getName();
-		} );
-	});
+		};
+	} );
 </script>

--- a/tests/plugins/widget/integration/wysiwygarea/manual/preventofremovingdiv.html
+++ b/tests/plugins/widget/integration/wysiwygarea/manual/preventofremovingdiv.html
@@ -1,0 +1,19 @@
+<textarea id="editor1" name="editor1">
+	<figure class="image illustration" style="float:left">
+		<img alt="" height="266" src="http://c.cksource.com/a/1/img/demo/brownie.jpg" width="400" />
+		<figcaption>Bon App&eacute;tit!</figcaption>
+	</figure>
+	<p>Preheat the oven to <strong>350°F</strong> and grease the baking pan.
+	Combine the flour, sugar and cocoa powder in a medium bowl. In another small bowl, whisk together the butter and eggs. Stir the two mixtures until just combined.
+	Bake the brownies for 25 to 35 minutes. Remove from the oven and let it cool for 5 minutes.
+	</p>
+</textarea>
+<pre id="output" style="background-color: lightgreen;"></pre>
+<script>
+	var editor = CKEDITOR.replace( 'editor1', {
+		height: '600px'
+	} );
+	setInterval( function() {
+		document.getElementById( 'output' ).innerText = editor.editable().getFirst().getName();
+	}, 200)
+</script>

--- a/tests/plugins/widget/integration/wysiwygarea/manual/preventofremovingdiv.md
+++ b/tests/plugins/widget/integration/wysiwygarea/manual/preventofremovingdiv.md
@@ -1,5 +1,5 @@
 @bender-ui: collapsed
-@bender-tags: bug, 4.7.2, 704
+@bender-tags: bug, 4.8.0, 704
 @bender-ckeditor-plugins: image2, wysiwygarea, undo, sourcearea
 
 ----

--- a/tests/plugins/widget/integration/wysiwygarea/manual/preventofremovingdiv.md
+++ b/tests/plugins/widget/integration/wysiwygarea/manual/preventofremovingdiv.md
@@ -3,8 +3,8 @@
 @bender-ckeditor-plugins: image2, wysiwygarea, undo, sourcearea
 
 ----
-1. Put caret in the text on the right and type some character.
-1. Use `Ctrl + Z` or `Cmd + Z` shortcut to make undo.
+1. Put caret in the text on the right and type some text.
+1. Use `Ctrl + Z` or `Cmd + Z` shortcut to make undo few times.
 
 **Expected:** Text returns to previous form. Below editor will be written `div` on green background.
 

--- a/tests/plugins/widget/integration/wysiwygarea/manual/preventofremovingdiv.md
+++ b/tests/plugins/widget/integration/wysiwygarea/manual/preventofremovingdiv.md
@@ -6,6 +6,6 @@
 1. Put caret in the text on the right and type some text.
 1. Use `Ctrl + Z` or `Cmd + Z` shortcut to make undo few times.
 
-**Expected:** Text returns to previous form. Below editor will be written `div` on green background.
+**Expected:** Text returns to previous form. Below the editor, you should see `div` on green background.
 
-**Unexpected:** Text moves below the image. Below editor will be written `figure` instead of `div`.
+**Unexpected:** Text moves below the image. Below editor, it will be written `figure` instead of `div` on the green background.

--- a/tests/plugins/widget/integration/wysiwygarea/manual/preventofremovingdiv.md
+++ b/tests/plugins/widget/integration/wysiwygarea/manual/preventofremovingdiv.md
@@ -1,0 +1,11 @@
+@bender-ui: collapsed
+@bender-tags: bug, 4.7.2, 704
+@bender-ckeditor-plugins: image2, wysiwygarea, undo, sourcearea
+
+----
+1. Put caret in the text on the right and type some character.
+1. Use `Ctrl + Z` or `Cmd + Z` shortcut to make undo.
+
+**Expected:** Text returns to previous form. Below editor will be written `div` on green background.
+
+**Unexpected:** Text moves below the image. Below editor will be written `figure` instead of `div`.

--- a/tests/plugins/widget/integration/wysiwygarea/superflousdoesntremovedivwrapper.js
+++ b/tests/plugins/widget/integration/wysiwygarea/superflousdoesntremovedivwrapper.js
@@ -1,0 +1,57 @@
+/* bender-ckeditor-plugins: widget,wysiwygarea,undo,toolbar */
+
+
+( function() {
+	'use strict';
+
+	bender.editor = {
+		config: {
+			allowedContent: true
+		}
+	};
+
+	bender.test( {
+		'test keeping widget wrapper in editor when superflous elemnts are checked': function() {
+			CKEDITOR.plugins.add( 'test', {
+				requires: 'widget',
+				init: function( editor ) {
+					editor.widgets.add( 'test', {
+						upcast: function( element ) {
+							if ( element.hasClass( 'test' ) ) {
+								return true;
+							}
+						},
+
+						init: function() {
+							this.element.setStyle( 'background-color', '#FFBB00' );
+							this.element.setStyle( 'padding', '30px' );
+						}
+					} );
+				}
+			} );
+			bender.editorBot.create( {
+				name: 'test_widget',
+				startupData: '<h2 class="test">Test</h2><p>Preheat the oven to</p>',
+				config: {
+					extraPlugins: 'test',
+					allowedContent: true
+				}
+			}, function( bot ) {
+				var editor = bot.editor;
+
+				editor.editable().fire( 'keydown', new CKEDITOR.dom.event( {
+					keyCode: 90,
+					ctrlKey: true,
+					shiftKey: false
+				} ) );
+
+				var snap = editor.getSnapshot();
+				editor.loadSnapshot( snap );
+
+				editor.editable().fire( 'keyup', new CKEDITOR.dom.event( {} ) );
+
+				assert.areSame( 'div', editor.editable().getFirst().getName().toLowerCase() );
+			} );
+		}
+	} );
+} )();

--- a/tests/plugins/widget/integration/wysiwygarea/superflousdoesntremovedivwrapper.js
+++ b/tests/plugins/widget/integration/wysiwygarea/superflousdoesntremovedivwrapper.js
@@ -11,6 +11,7 @@
 	};
 
 	bender.test( {
+		// #704
 		'test keeping widget wrapper in editor when superflous elemnts are checked': function() {
 			CKEDITOR.plugins.add( 'test', {
 				requires: 'widget',

--- a/tests/plugins/widget/integration/wysiwygarea/superflousdoesntremovedivwrapper.js
+++ b/tests/plugins/widget/integration/wysiwygarea/superflousdoesntremovedivwrapper.js
@@ -12,7 +12,7 @@
 
 	bender.test( {
 		// #704
-		'test keeping widget wrapper in editor when superflous elemnts are checked': function() {
+		'test keeping widget wrapper in editor when superfluous elements are checked': function() {
 			CKEDITOR.plugins.add( 'test', {
 				requires: 'widget',
 				init: function( editor ) {

--- a/tests/plugins/wysiwygarea/superfluouselement.js
+++ b/tests/plugins/wysiwygarea/superfluouselement.js
@@ -16,7 +16,7 @@ bender.editor = {
 };
 
 bender.test( {
-	'Test removing superfluous <p> inserted by IE11': function() {
+	'test removing superfluous <p> inserted by IE11': function() {
 		if ( !CKEDITOR.env.ie || CKEDITOR.env.edge ) {
 			assert.ignore();
 		}
@@ -44,7 +44,7 @@ bender.test( {
 		wait();
 	},
 
-	'Test removing superfluous <div> inserted by Edge < v15': function() {
+	'test removing superfluous <div> inserted by Edge': function() {
 		if ( !CKEDITOR.env.edge || CKEDITOR.env.version >= 15 ) {
 			assert.ignore();
 		}
@@ -70,7 +70,7 @@ bender.test( {
 		wait();
 	},
 
-	'Test not removing non-superfluous <div> in Edge < v15': function() {
+	'test not removing non-superfluous <div> in Edge': function() {
 		if ( !CKEDITOR.env.edge || CKEDITOR.env.version >= 15 ) {
 			assert.ignore();
 		}
@@ -95,7 +95,7 @@ bender.test( {
 		wait();
 	},
 
-	'Test removing superfluous <div> when typing in Edge < v15': function() {
+	'test removing superfluous <div> when typing in Edge': function() {
 		if ( !CKEDITOR.env.edge || CKEDITOR.env.version >= 15 ) {
 			assert.ignore();
 		}
@@ -145,7 +145,7 @@ bender.test( {
 		wait();
 	},
 
-	'Test not removing non-superfluous <div> when typing in Edge < v15': function() {
+	'test not removing non-superfluous <div> when typing in Edge': function() {
 		if ( !CKEDITOR.env.edge || CKEDITOR.env.version >= 15 ) {
 			assert.ignore();
 		}
@@ -179,7 +179,7 @@ bender.test( {
 	},
 
 	// http://dev.ckeditor.com/ticket/14831
-	'Test not removing [data-cke-temp] <div> when typing': function() {
+	'test not removing [data-cke-temp] <div> when typing': function() {
 		if ( !CKEDITOR.env.edge || CKEDITOR.env.version < 14 ) {
 			assert.ignore();
 		}
@@ -229,7 +229,7 @@ bender.test( {
 		wait();
 	},
 
-	'Test not-removing <div> with any attributes in Edge < v15': function() {
+	'test not removing <div> with any attributes in Edge': function() {
 		if ( !CKEDITOR.env.edge || CKEDITOR.env.version >= 15 ) {
 			assert.ignore();
 		}

--- a/tests/plugins/wysiwygarea/superfluouselement.js
+++ b/tests/plugins/wysiwygarea/superfluouselement.js
@@ -44,8 +44,8 @@ bender.test( {
 		wait();
 	},
 
-	'Test removing superfluous <div> inserted by Edge': function() {
-		if ( !CKEDITOR.env.edge ) {
+	'Test removing superfluous <div> inserted by Edge < v15': function() {
+		if ( !CKEDITOR.env.edge || CKEDITOR.env.version >= 15 ) {
 			assert.ignore();
 		}
 
@@ -70,8 +70,8 @@ bender.test( {
 		wait();
 	},
 
-	'Test not removing non-superfluous <div> in Edge': function() {
-		if ( !CKEDITOR.env.edge ) {
+	'Test not removing non-superfluous <div> in Edge < v15': function() {
+		if ( !CKEDITOR.env.edge || CKEDITOR.env.version >= 15 ) {
 			assert.ignore();
 		}
 
@@ -95,8 +95,8 @@ bender.test( {
 		wait();
 	},
 
-	'Test removing superfluous <div> when typing': function() {
-		if ( !CKEDITOR.env.edge ) {
+	'Test removing superfluous <div> when typing in Edge < v15': function() {
+		if ( !CKEDITOR.env.edge || CKEDITOR.env.version >= 15 ) {
 			assert.ignore();
 		}
 
@@ -145,8 +145,8 @@ bender.test( {
 		wait();
 	},
 
-	'Test not removing non-superfluous <div> when typing': function() {
-		if ( !CKEDITOR.env.edge ) {
+	'Test not removing non-superfluous <div> when typing in Edge < v15': function() {
+		if ( !CKEDITOR.env.edge || CKEDITOR.env.version >= 15 ) {
 			assert.ignore();
 		}
 
@@ -229,8 +229,8 @@ bender.test( {
 		wait();
 	},
 
-	'Test not-removing <div> with any attributes in Edge': function() {
-		if ( !CKEDITOR.env.edge ) {
+	'Test not-removing <div> with any attributes in Edge < v15': function() {
+		if ( !CKEDITOR.env.edge || CKEDITOR.env.version >= 15 ) {
 			assert.ignore();
 		}
 

--- a/tests/plugins/wysiwygarea/superfluouselement.js
+++ b/tests/plugins/wysiwygarea/superfluouselement.js
@@ -227,5 +227,31 @@ bender.test( {
 			} );
 		} );
 		wait();
+	},
+
+	'Test not-removing <div> with any attributes in Edge': function() {
+		if ( !CKEDITOR.env.edge ) {
+			assert.ignore();
+		}
+
+		var editor = this.editor;
+
+		editor.setData( '', function() {
+			resume( function() {
+
+				editor.editable().fire( 'keydown', new CKEDITOR.dom.event( {
+					keyCode: 75,
+					ctrlKey: false,
+					shiftKey: false
+				} ) );
+
+				bender.tools.setHtmlWithSelection( editor, '<div some="atribute">k^</div>' );
+
+				editor.editable().fire( 'keyup', new CKEDITOR.dom.event( {} ) );
+
+				assert.isInnerHtmlMatching( '<div some="atribute">k^</div>', bender.tools.getHtmlWithSelection( editor ) );
+			} );
+		} );
+		wait();
 	}
 } );


### PR DESCRIPTION
## What is the purpose of this pull request?

Bug fix

## Does your PR contain necessary tests?

yes

### This PR contains

- [x] Unit tests
- [x] Manual tests

## What changes did you make?

* Modify condition which remove unnecessary `div` in Edge.
* Modify condition to work only in Edge up to 14.xxx. (Edge 15 doesn't add `div`).
* Modify tests to respect new condition related to Edge version.

Close #704 