### PR TITLE
Corrections to table selection pasting improvements PR

### DIFF
--- a/core/selection.js
+++ b/core/selection.js
@@ -2273,10 +2273,12 @@
 		 *		editor.getSelection().isInTable();
 		 *
 		 * @since 4.7.0
+		 * @param {Boolean} [allowPartially=false] Whether partial cell selection should be included.
+		 * This parameter was added in 4.7.2.
 		 * @returns {Boolean}
 		 */
-		isInTable: function() {
-			return isTableSelection( this.getRanges() );
+		isInTable: function( allowPartially ) {
+			return isTableSelection( this.getRanges(), allowPartially );
 		},
 
 		/**

--- a/plugins/tableselection/plugin.js
+++ b/plugins/tableselection/plugin.js
@@ -612,6 +612,69 @@
 			} );
 
 			return tmpContainer.getChildCount() > 1 ? null : tmpContainer.findOne( 'table' );
+		},
+
+		// Performs an actual paste into selectedTableMap based on content in pastedTableMap.
+		pasteTable: function( selectedTable, tableSel, selectedTableMap, pastedTableMap, startIndex ) {
+			var cellToReplace,
+				markers = {},
+				currentRow,
+				prevCell,
+				cellToPaste,
+				i,
+				j;
+
+			// And now paste!
+			for ( i = 0; i < pastedTableMap.length; i++ ) {
+				currentRow = new CKEDITOR.dom.element( selectedTable.$.rows[ tableSel.rows.first.$.rowIndex + i ] );
+
+				for ( j = 0; j < pastedTableMap[ i ].length; j++ ) {
+					cellToPaste = new CKEDITOR.dom.element( pastedTableMap[ i ][ j ] );
+
+					if ( selectedTableMap[ i ] && selectedTableMap[ i ][ j ] ) {
+						cellToReplace = new CKEDITOR.dom.element( selectedTableMap[ i ][ j ] );
+					} else {
+						cellToReplace = null;
+					}
+
+					// Only try to paste cells that aren't already pasted (it can occur if the pasted cell
+					// has [colspan] or [rowspan]).
+					if ( cellToPaste && !cellToPaste.getCustomData( 'processed' ) ) {
+						// If the cell to being replaced has [colspan], it could have been already
+						// replaced. In that case, it won't have parent.
+						if ( cellToReplace && cellToReplace.getParent() ) {
+							cellToPaste.replace( cellToReplace );
+						} else if ( j === 0 || pastedTableMap[ i ][ j - 1 ] ) {
+							if ( j !== 0 ) {
+								prevCell = new CKEDITOR.dom.element( pastedTableMap[ i ][ j - 1 ] );
+							} else {
+								prevCell = null;
+							}
+
+							// If the cell that should be replaced is not in the table, we must cover at least 3 cases:
+							// 1. Pasting cell in the same row as the previous pasted cell.
+							// 2. Pasting cell into the next row at the proper position.
+							// 3. If the selection started from the left edge of the table,
+							// prepending the proper row with the cell.
+							if ( prevCell && currentRow.equals( prevCell.getParent() ) ) {
+								cellToPaste.insertAfter( prevCell );
+							} else if ( startIndex > 0 ) {
+								cellToPaste.insertAfter( new CKEDITOR.dom.element( currentRow.$.cells[ startIndex ] ) );
+							} else {
+								currentRow.append( cellToPaste, true );
+							}
+						}
+
+						CKEDITOR.dom.element.setMarker( markers, cellToPaste, 'processed', true );
+					} else if ( cellToPaste.getCustomData( 'processed' ) && cellToReplace ) {
+						// If the cell was already pasted, but the cell to replace still exists (e.g. pasted
+						// cell has [colspan]), remove it.
+						cellToReplace.remove();
+					}
+				}
+			}
+
+			CKEDITOR.dom.element.clearAllMarkers( markers );
 		}
 	};
 
@@ -621,12 +684,9 @@
 			selectedCells = getSelectedCells( selection ),
 			pastedTable = this.findTableInPastedContent( editor, evt.data.dataValue ),
 			boundarySelection = selection.isInTable( true ) && this.isBoundarySelection( selection ),
-			pastedTableColCount = 0,
-			selectedTableColCount = 0,
 			selectedTable,
 			selectedTableMap,
-			pastedTableMap,
-			cellToPaste;
+			pastedTableMap;
 
 		function getLongestRowLength( map ) {
 			var longest = 0,
@@ -677,11 +737,16 @@
 		selectedTable = selectedCells[ 0 ].getAscendant( 'table' );
 		var tableSel = new TableSelection( getSelectedCells( selection, selectedTable ) );
 
+		function getLastArrayItem( arr ) {
+			return arr[ arr.length - 1 ];
+		}
+
 		// Schedule selecting appropriate table cells after pasting. It covers both table and not-table
 		// content (#520).
 		editor.once( 'afterPaste', function() {
-			var toSelect = cellToPaste ?
-				getCellsBetween( new CKEDITOR.dom.element( pastedTableMap[ 0 ][ 0 ] ), cellToPaste ) :
+			var toSelect = pastedTableMap ?
+				getCellsBetween( new CKEDITOR.dom.element( pastedTableMap[ 0 ][ 0 ] ),
+					new CKEDITOR.dom.element( getLastArrayItem( getLastArrayItem( pastedTableMap ) ) ) ) :
 				tableSel.cells.all;
 
 			fakeSelectCells( editor, toSelect );
@@ -730,64 +795,7 @@
 		// Rebuild map for selected table.
 		selectedTableMap = tableSel.getTableMap();
 
-		var cellToReplace,
-			markers = {},
-			currentRow,
-			prevCell,
-			i,
-			j;
-
-		// And now paste!
-		for ( i = 0; i < pastedTableMap.length; i++ ) {
-			currentRow = new CKEDITOR.dom.element( selectedTable.$.rows[ tableSel.rows.first.$.rowIndex + i ] );
-
-			for ( j = 0; j < pastedTableMap[ i ].length; j++ ) {
-				cellToPaste = new CKEDITOR.dom.element( pastedTableMap[ i ][ j ] );
-
-				if ( selectedTableMap[ i ] && selectedTableMap[ i ][ j ] ) {
-					cellToReplace = new CKEDITOR.dom.element( selectedTableMap[ i ][ j ] );
-				} else {
-					cellToReplace = null;
-				}
-
-				// Only try to paste cells that aren't already pasted (it can occur if the pasted cell
-				// has [colspan] or [rowspan]).
-				if ( cellToPaste && !cellToPaste.getCustomData( 'processed' ) ) {
-					// If the cell to being replaced has [colspan], it could have been already
-					// replaced. In that case, it won't have parent.
-					if ( cellToReplace && cellToReplace.getParent() ) {
-						cellToPaste.replace( cellToReplace );
-					} else if ( j === 0 || pastedTableMap[ i ][ j - 1 ] ) {
-						if ( j !== 0 ) {
-							prevCell = new CKEDITOR.dom.element( pastedTableMap[ i ][ j - 1 ] );
-						} else {
-							prevCell = null;
-						}
-
-						// If the cell that should be replaced is not in the table, we must cover at least 3 cases:
-						// 1. Pasting cell in the same row as the previous pasted cell.
-						// 2. Pasting cell into the next row at the proper position.
-						// 3. If the selection started from the left edge of the table,
-						// prepending the proper row with the cell.
-						if ( prevCell && currentRow.equals( prevCell.getParent() ) ) {
-							cellToPaste.insertAfter( prevCell );
-						} else if ( startIndex > 0 ) {
-							cellToPaste.insertAfter( new CKEDITOR.dom.element( currentRow.$.cells[ startIndex ] ) );
-						} else {
-							currentRow.append( cellToPaste, true );
-						}
-					}
-
-					CKEDITOR.dom.element.setMarker( markers, cellToPaste, 'processed', true );
-				} else if ( cellToPaste.getCustomData( 'processed' ) && cellToReplace ) {
-					// If the cell was already pasted, but the cell to replace still exists (e.g. pasted
-					// cell has [colspan]), remove it.
-					cellToReplace.remove();
-				}
-			}
-		}
-
-		CKEDITOR.dom.element.clearAllMarkers( markers );
+		this.pasteTable( selectedTable, tableSel, selectedTableMap, pastedTableMap, startIndex );
 
 		editor.fire( 'saveSnapshot' );
 

--- a/plugins/tableselection/plugin.js
+++ b/plugins/tableselection/plugin.js
@@ -497,6 +497,10 @@
 	// @param {CKEDITOR.dom.element[]} [cells] An array of cells considered to be selected.
 	TableSelection.prototype.setSelectedCells = function( cells ) {
 		this._reset();
+		// Make sure we're not modifying input array.
+		cells = cells.slice( 0 );
+		this._arraySortByDOMOrder( cells );
+
 		this.cells.all = cells;
 
 		this.cells.first = cells[ 0 ];

--- a/plugins/tableselection/plugin.js
+++ b/plugins/tableselection/plugin.js
@@ -593,6 +593,17 @@
 		this.setSelectedCells( selectedCells );
 	};
 
+	// Clears the content of selected cells.
+	//
+	// @param {CKEDITOR.dom.element[]} [cells] If given, this cells will be cleared.
+	TableSelection.prototype.emptyCells =  function( cells ) {
+		cells = cells || this.cells.all;
+
+		for ( var i = 0; i < cells.length; i++ ) {
+			cells[ i ].setHtml( '' );
+		}
+	};
+
 	// Sorts given arr according to DOM position.
 	//
 	// @param {CKEDITOR.dom.node[]} arr
@@ -742,22 +753,6 @@
 			range.select();
 		}
 
-		function emptyCells( cells, lockSnapshot ) {
-			var i;
-
-			if ( lockSnapshot ) {
-				editor.fire( 'lockSnapshot' );
-			}
-
-			for ( i = 0; i < cells.length; i++ ) {
-				cells[ i ].setHtml( '' );
-			}
-
-			if ( lockSnapshot ) {
-				editor.fire( 'unlockSnapshot' );
-			}
-		}
-
 		// Do not customize paste process in following cases:
 		// No cells are selected.
 		if ( !selectedCells.length ||
@@ -795,7 +790,9 @@
 			// Due to limitations of our undo manager, in case of mixed content
 			// cells must be emptied after pasting (#520).
 			editor.once( 'afterPaste', function() {
-				emptyCells( tableSel.cells.all.slice( 1 ), true );
+				editor.fire( 'lockSnapshot' );
+				tableSel.emptyCells( tableSel.cells.all.slice( 1 ) );
+				editor.fire( 'unlockSnapshot' );
 			} );
 
 			return;
@@ -811,7 +808,7 @@
 			selection.selectElement( tableSel.rows.first );
 		} else {
 			// Otherwise simply clear all the selected cells.
-			emptyCells( tableSel.cells.all );
+			tableSel.emptyCells();
 		}
 
 		// Build table map only for selected fragment.

--- a/plugins/tableselection/plugin.js
+++ b/plugins/tableselection/plugin.js
@@ -103,6 +103,22 @@
 		return domEvent.button === 0;
 	}
 
+	// Checks whether a given range fully contains a table element (cell/tbody/table etc).
+	// @param {CKEDITOR.dom.range} range
+	// @returns {Boolean}
+	function rangeContainsTableElement( range ) {
+		if ( range ) {
+			// Clone the range as we're going to enlarge it, and we don't want to modify the input.
+			range = range.clone();
+
+			range.enlarge( CKEDITOR.ENLARGE_ELEMENT );
+
+			var enclosedNode = range.getEnclosedNode();
+
+			return enclosedNode && enclosedNode.is && enclosedNode.is( CKEDITOR.dtd.$tableContent );
+		}
+	}
+
 	function getFakeSelectedTable( editor ) {
 		var selectedCell = editor.editable().findOne( '.' + fakeSelectedClass );
 
@@ -738,8 +754,9 @@
 		// Do not customize paste process in following cases:
 		// No cells are selected.
 		if ( !selectedCells.length ||
-			// It's a collapsed selection in a non-boundary position.
-			( selectedCells.length === 1 && selection.getRanges()[ 0 ].collapsed && !boundarySelection ) ||
+			// It's single range that does not fully contain table element and is not boundary, e.g. collapsed selection within
+			// cell, part of cell etc.
+			( selectedCells.length === 1 && !rangeContainsTableElement( selection.getRanges()[ 0 ] )  && !boundarySelection ) ||
 			// It's a boundary position but with no table pasted.
 			( boundarySelection && !pastedTable ) ) {
 			return;

--- a/plugins/tableselection/plugin.js
+++ b/plugins/tableselection/plugin.js
@@ -720,7 +720,11 @@
 							if ( prevCell && currentRow.equals( prevCell.getParent() ) ) {
 								cellToPaste.insertAfter( prevCell );
 							} else if ( startIndex > 0 ) {
-								cellToPaste.insertAfter( new CKEDITOR.dom.element( currentRow.$.cells[ startIndex ] ) );
+								if ( currentRow.$.cells[ startIndex ] ) {
+									cellToPaste.insertAfter( new CKEDITOR.dom.element( currentRow.$.cells[ startIndex ] ) )
+								} else {
+									currentRow.append( cellToPaste );
+								}
 							} else {
 								currentRow.append( cellToPaste, true );
 							}

--- a/plugins/tableselection/plugin.js
+++ b/plugins/tableselection/plugin.js
@@ -450,7 +450,7 @@
 
 	function fakeSelectionCopyCutHandler( evt ) {
 		var editor = evt.editor || evt.sender.editor,
-		selection = editor.getSelection();
+			selection = editor.getSelection();
 
 		if ( !selection.isInTable() ) {
 			return;
@@ -545,14 +545,16 @@
 
 		var cellIndexFirst = this.cells.first.$.cellIndex,
 			cellIndexLast = this.cells.last.$.cellIndex,
-			selectedCells = clearSelection ? [] : this.cells.all;
+			selectedCells = clearSelection ? [] : this.cells.all,
+			row,
+			newCells;
 
 		for ( var i = 0; i < count; i++ ) {
 			// In case of clearSelection we need explicitly use cached cells, as selectedCells is empty.
-			var row = insertRow( clearSelection ? this.cells.all : selectedCells, insertBefore );
+			row = insertRow( clearSelection ? this.cells.all : selectedCells, insertBefore );
 
 			// Append cells from added row.
-			var newCells = CKEDITOR.tools.array.filter( this._nodeListToArray( row.find( 'td, th' ) ), function( cell ) {
+			newCells = CKEDITOR.tools.array.filter( this._nodeListToArray( row.find( 'td, th' ) ), function( cell ) {
 				return clearSelection ?
 					true : cell.$.cellIndex >= cellIndexFirst && cell.$.cellIndex <= cellIndexLast;
 			} );
@@ -718,6 +720,7 @@
 			selectedCells = getSelectedCells( selection ),
 			pastedTable = this.findTableInPastedContent( editor, evt.data.dataValue ),
 			boundarySelection = selection.isInTable( true ) && this.isBoundarySelection( selection ),
+			tableSel,
 			selectedTable,
 			selectedTableMap,
 			pastedTableMap;
@@ -763,7 +766,7 @@
 		}
 
 		selectedTable = selectedCells[ 0 ].getAscendant( 'table' );
-		var tableSel = new TableSelection( getSelectedCells( selection, selectedTable ) );
+		tableSel = new TableSelection( getSelectedCells( selection, selectedTable ) );
 
 		function getLastArrayItem( arr ) {
 			return arr[ arr.length - 1 ];

--- a/plugins/tableselection/plugin.js
+++ b/plugins/tableselection/plugin.js
@@ -596,10 +596,7 @@
 			fakeSelectCells( editor, toSelect );
 		} );
 
-		// Handle mixed content (if the table is not the only child in the tmpContainer, we
-		// are probably dealing with mixed content). We handle also non-table content here.
-		// We just collapse selection to the first selected cell and pass non-table/mixed
-		// content to other paste handlers (#520).
+		// In case of mixed content or non table content just insert it to a first cell, erasing the others.
 		if ( !pastedTable ) {
 			selectCellContents( selectedCells[ 0 ] );
 

--- a/plugins/tableselection/plugin.js
+++ b/plugins/tableselection/plugin.js
@@ -615,8 +615,12 @@
 		},
 
 		// Performs an actual paste into selectedTableMap based on content in pastedTableMap.
-		pasteTable: function( selectedTable, tableSel, selectedTableMap, pastedTableMap, startIndex ) {
+		pasteTable: function( tableSel, selectedTableMap, pastedTableMap ) {
 			var cellToReplace,
+				// Index of first selected cell, it needs to be reused later, to calculate the
+				// proper position of newly pasted cells.
+				startIndex = getCellColIndex( tableSel.cells.first, true ),
+				selectedTable = tableSel._getTable(),
 				markers = {},
 				currentRow,
 				prevCell,
@@ -689,16 +693,9 @@
 			pastedTableMap;
 
 		function getLongestRowLength( map ) {
-			var longest = 0,
-				i;
-
-			for ( i = 0; i < map.length; i++ ) {
-				if ( map[ i ].length > longest ) {
-					longest = map[ i ].length;
-				}
-			}
-
-			return longest;
+			return Math.max.apply( null, CKEDITOR.tools.array.map( map, function( rowMap ) {
+				return rowMap.length;
+			}, 0 ) );
 		}
 
 		function selectCellContents( cell ) {
@@ -788,14 +785,10 @@
 		// If the pasted one is bigger, we add missing rows and columns.
 		tableSel.insertColumn( getLongestRowLength( pastedTableMap ) - getLongestRowLength( selectedTableMap ) );
 
-		// Index of first selected cell, it needs to be reused later, to calculate the
-		// proper position of newly pasted cells.
-		var startIndex = getCellColIndex( tableSel.cells.first, true );
-
 		// Rebuild map for selected table.
 		selectedTableMap = tableSel.getTableMap();
 
-		this.pasteTable( selectedTable, tableSel, selectedTableMap, pastedTableMap, startIndex );
+		this.pasteTable( tableSel, selectedTableMap, pastedTableMap );
 
 		editor.fire( 'saveSnapshot' );
 

--- a/plugins/tableselection/plugin.js
+++ b/plugins/tableselection/plugin.js
@@ -500,12 +500,12 @@
 			selection = editor.getSelection(),
 			selectedCells = getSelectedCells( selection ),
 			pastedTable = this.findTableInPastedContent( editor, evt.data.dataValue ),
+			boundarySelection = selection.isInTable( true ) && this.isBoundarySelection( selection ),
 			newRowsCount = 0,
 			newColsCount = 0,
 			pastedTableColCount = 0,
 			selectedTableColCount = 0,
 			markers = {},
-			boundarySelection,
 			selectedTable,
 			selectedTableMap,
 			pastedTableMap,
@@ -571,9 +571,13 @@
 			}
 		}
 
-		// If no cells are selected, and the selection is not in a row boundary position skip paste customization.
+		// Do not customize paste process in following cases:
+		// No cells are selected.
 		if ( !selectedCells.length ||
-			( !selection.isInTable() && !( boundarySelection = this.isBoundarySelection( selection ) ) ) ) {
+			// It's a collapsed selection in a non-boundary position.
+			( selectedCells.length === 1 && selection.getRanges()[ 0 ].collapsed && !boundarySelection ) ||
+			// It's a boundary position but with no table pasted.
+			( boundarySelection && !pastedTable ) ) {
 			return;
 		}
 

--- a/plugins/tableselection/plugin.js
+++ b/plugins/tableselection/plugin.js
@@ -563,11 +563,16 @@
 		for ( var i = 0; i < count; i++ ) {
 			// Prepend added cells, then pass it to setSelectionCells so that it will
 			// take care of refreshing the whole state.
-			// @todo the cells should be sorted in the DOM order.
 			selectedCells = selectedCells.concat( insertColumn( this.cells.all ) );
 		}
 
 		this.setSelectedCells( selectedCells );
+	};
+
+	TableSelection.prototype._arraySortByDOMOrder = function( arr ) {
+		arr.sort( function( el1, el2 ) {
+			return el1.getPosition( el2 ) & CKEDITOR.POSITION_PRECEDING ? -1 : 1;
+		} );
 	};
 
 	TableSelection.prototype._nodeListToArray = function( nodeList ) {

--- a/plugins/tableselection/plugin.js
+++ b/plugins/tableselection/plugin.js
@@ -609,7 +609,7 @@
 	};
 
 	var fakeSelectionPasteHandler = {
-		onPaste: fakeSelectionPasteHandler_,
+		onPaste: pasteListener,
 		// Check if the selection is collapsed on the beginning of the row (1) or at the end (2).
 		isBoundarySelection: function( selection ) {
 			var ranges = selection.getRanges(),
@@ -714,7 +714,7 @@
 		}
 	};
 
-	function fakeSelectionPasteHandler_( evt ) {
+	function pasteListener( evt ) {
 		var editor = evt.editor,
 			selection = editor.getSelection(),
 			selectedCells = getSelectedCells( selection ),

--- a/plugins/tableselection/plugin.js
+++ b/plugins/tableselection/plugin.js
@@ -499,6 +499,7 @@
 		var editor = evt.editor,
 			selection = editor.getSelection(),
 			selectedCells = getSelectedCells( selection ),
+			pastedTable = this.findTableInPastedContent( editor, evt.data.dataValue ),
 			newRowsCount = 0,
 			newColsCount = 0,
 			pastedTableColCount = 0,
@@ -507,7 +508,6 @@
 			boundarySelection,
 			selectedTable,
 			selectedTableMap,
-			pastedTable,
 			pastedTableMap,
 			firstCell,
 			startIndex,
@@ -571,8 +571,6 @@
 			}
 		}
 
-		pastedTable = this.findTableInPastedContent( editor, evt.data.dataValue );
-
 		// If no cells are selected, and the selection is not in a row boundary position skip paste customization.
 		if ( !selectedCells.length ||
 			( !selection.isInTable() && !( boundarySelection = this.isBoundarySelection( selection ) ) ) ) {
@@ -612,11 +610,6 @@
 		// Preventing other paste handlers should be done after all early returns (#520).
 		evt.stop();
 
-		// Empty all selected cells.
-		if ( !boundarySelection ) {
-			emptyCells( selectedCells );
-		}
-
 		// In case of boundary selection, insert new row before/after selected one, select it
 		// and resume the rest of the algorithm.
 		if ( boundarySelection ) {
@@ -627,6 +620,9 @@
 
 			selection.selectElement( firstRow );
 			selectedCells = getSelectedCells( selection );
+		} else {
+			// Otherwise simply clear all the selected cells.
+			emptyCells( selectedCells );
 		}
 
 		// Build table map only for selected fragment.

--- a/plugins/tableselection/plugin.js
+++ b/plugins/tableselection/plugin.js
@@ -532,7 +532,8 @@
 			selectedCells = clearSelection ? [] : this.cells.all;
 
 		for ( var i = 0; i < count; i++ ) {
-			var row = insertRow( selectedCells, insertBefore );
+			// In case of clearSelection we need explicitly use cached cells, as selectedCells is empty.
+			var row = insertRow( clearSelection ? this.cells.all : selectedCells, insertBefore );
 
 			// Append cells from added row.
 			var newCells = CKEDITOR.tools.array.filter( this._nodeListToArray( row.find( 'td, th' ) ), function( cell ) {

--- a/plugins/tableselection/plugin.js
+++ b/plugins/tableselection/plugin.js
@@ -447,6 +447,7 @@
 		var editor = evt.editor,
 			dataProcessor = editor.dataProcessor,
 			selection = editor.getSelection(),
+			selectedCells = getSelectedCells( selection ),
 			tmpContainer = new CKEDITOR.dom.element( 'body' ),
 			newRowsCount = 0,
 			newColsCount = 0,
@@ -456,7 +457,6 @@
 			boundarySelection,
 			selectedTable,
 			selectedTableMap,
-			selectedCells,
 			pastedTable,
 			pastedTableMap,
 			firstCell,
@@ -549,13 +549,9 @@
 		} );
 		pastedTable = tmpContainer.findOne( 'table' );
 
-		if ( !selection.getRanges().length || !selection.isInTable() && !( boundarySelection = isBoundarySelection( selection ) ) ) {
-			return;
-		}
-
-		selectedCells = getSelectedCells( selection );
-
-		if ( !selectedCells.length ) {
+		// If no cells are selected, and the selection is not in a row boundary position skip paste customization.
+		if ( !selectedCells.length ||
+			( !selection.isInTable() && !( boundarySelection = isBoundarySelection( selection ) ) ) ) {
 			return;
 		}
 

--- a/plugins/tableselection/plugin.js
+++ b/plugins/tableselection/plugin.js
@@ -787,7 +787,8 @@
 			fakeSelectCells( editor, toSelect );
 		} );
 
-		// In case of mixed content or non table content just insert it to a first cell, erasing the others.
+		// In case of mixed content or non table content just select first cell, and erase content of other selected cells.
+		// Selection is left in first cell, so that default CKEditor logic puts pasted content in the selection.
 		if ( !pastedTable ) {
 			selectCellContents( tableSel.cells.first );
 

--- a/plugins/tableselection/plugin.js
+++ b/plugins/tableselection/plugin.js
@@ -551,6 +551,7 @@
 		this.setSelectedCells( selectedCells );
 	};
 
+	// @param {Number} count Number of columns to be inserted.
 	TableSelection.prototype.insertColumn = function( count ) {
 		if ( typeof count === 'undefined' ) {
 			count = 1;
@@ -569,12 +570,19 @@
 		this.setSelectedCells( selectedCells );
 	};
 
+	// Sorts given arr according to DOM position.
+	//
+	// @param {CKEDITOR.dom.node[]} arr
 	TableSelection.prototype._arraySortByDOMOrder = function( arr ) {
 		arr.sort( function( el1, el2 ) {
 			return el1.getPosition( el2 ) & CKEDITOR.POSITION_PRECEDING ? -1 : 1;
 		} );
 	};
 
+	// Converts a given node list wrapper into an array.
+	//
+	// @param {CKEDITOR.dom.nodeList} nodeList
+	// @returns {CKEDITOR.dom.node[]}
 	TableSelection.prototype._nodeListToArray = function( nodeList ) {
 		return CKEDITOR.tools.array.map( nodeList.$, function( nativeEl ) {
 			return new CKEDITOR.dom.node( nativeEl );

--- a/plugins/tableselection/plugin.js
+++ b/plugins/tableselection/plugin.js
@@ -613,6 +613,9 @@
 		// In case of boundary selection, insert new row before/after selected one, select it
 		// and resume the rest of the algorithm.
 		if ( boundarySelection ) {
+			// @todo: this could be further simplified, given that tabletools.insertRow returns inserted row.
+			// firstRow = lastRow = insertRow( boundarySelection === 1 ? [firstCell] : [lastCell],
+			// 	boundarySelection === 1 );
 			firstRow = lastRow = this.addRow( firstRow, boundarySelection === 1 );
 
 			firstCell = firstRow.getFirst();

--- a/plugins/tableselection/plugin.js
+++ b/plugins/tableselection/plugin.js
@@ -720,9 +720,11 @@
 							if ( prevCell && currentRow.equals( prevCell.getParent() ) ) {
 								cellToPaste.insertAfter( prevCell );
 							} else if ( startIndex > 0 ) {
+								// It might happen that there's no cell with startIndex, as it might be used by a rowspan.
 								if ( currentRow.$.cells[ startIndex ] ) {
-									cellToPaste.insertAfter( new CKEDITOR.dom.element( currentRow.$.cells[ startIndex ] ) )
+									cellToPaste.insertAfter( new CKEDITOR.dom.element( currentRow.$.cells[ startIndex ] ) );
 								} else {
+									// Since rowspans are erased from current selection, we want need to append a cell.
 									currentRow.append( cellToPaste );
 								}
 							} else {

--- a/plugins/tableselection/plugin.js
+++ b/plugins/tableselection/plugin.js
@@ -532,7 +532,7 @@
 			selectedCells = clearSelection ? [] : this.cells.all;
 
 		for ( var i = 0; i < count; i++ ) {
-			var row = insertRow( this.cells.all, insertBefore );
+			var row = insertRow( selectedCells, insertBefore );
 
 			// Append cells from added row.
 			var newCells = CKEDITOR.tools.array.filter( this._nodeListToArray( row.find( 'td, th' ) ), function( cell ) {
@@ -564,7 +564,7 @@
 		for ( var i = 0; i < count; i++ ) {
 			// Prepend added cells, then pass it to setSelectionCells so that it will
 			// take care of refreshing the whole state.
-			selectedCells = selectedCells.concat( insertColumn( this.cells.all ) );
+			selectedCells = selectedCells.concat( insertColumn( selectedCells ) );
 		}
 
 		this.setSelectedCells( selectedCells );

--- a/plugins/tabletools/plugin.js
+++ b/plugins/tabletools/plugin.js
@@ -147,6 +147,8 @@
 		}
 
 		insertBefore ? newRow.insertBefore( row ) : newRow.insertAfter( row );
+
+		return newRow;
 	}
 
 	function deleteRows( selectionOrRow ) {
@@ -265,6 +267,7 @@
 		var map = CKEDITOR.tools.buildTableMap( table ),
 			cloneCol = [],
 			nextCol = [],
+			addedCells = [],
 			height = map.length;
 
 		for ( var i = 0; i < height; i++ ) {
@@ -289,11 +292,14 @@
 				cell.removeAttribute( 'colSpan' );
 				cell.appendBogus();
 				cell[ insertBefore ? 'insertBefore' : 'insertAfter' ].call( cell, originalCell );
+				addedCells.push( cell );
 				cell = cell.$;
 			}
 
 			i += cell.rowSpan - 1;
 		}
+
+		return addedCells;
 	}
 
 	function deleteColumns( selection ) {

--- a/plugins/tabletools/plugin.js
+++ b/plugins/tabletools/plugin.js
@@ -8,13 +8,14 @@
 		isArray = CKEDITOR.tools.isArray;
 
 	function getSelectedCells( selection, table ) {
+		var retval = [];
+		var database = {};
+
 		if ( !selection ) {
-			return;
+			return retval;
 		}
 
 		var ranges = selection.getRanges();
-		var retval = [];
-		var database = {};
 
 		function isInTable( cell ) {
 			if ( !table ) {

--- a/tests/plugins/tableselection/_helpers/tableselection.js
+++ b/tests/plugins/tableselection/_helpers/tableselection.js
@@ -88,7 +88,8 @@
 
 				bot.setHtmlWithSelection( source );
 
-				bender.tools.emulatePaste( editor, CKEDITOR.document.getById( pasteFixtureId ).getOuterHtml() );
+				// Use clone, so that pasted table does not have an ID.
+				bender.tools.emulatePaste( editor, CKEDITOR.document.getById( pasteFixtureId ).clone( true ).getOuterHtml() );
 
 				wait();
 			} );

--- a/tests/plugins/tableselection/integrations/clipboard/pastemerge.html
+++ b/tests/plugins/tableselection/integrations/clipboard/pastemerge.html
@@ -164,6 +164,51 @@
 </table>
 </textarea>
 
+<textarea id="merge-larger-table">
+<table>
+	<tbody>
+		<tr>
+			<td>[cell1]</td>
+			<td>cell2</td>
+		</tr>
+		<tr>
+			<td>cell3</td>
+			<td>cell4</td>
+		</tr>
+	</tbody>
+</table>
+
+=>
+<table>
+	<tbody>
+		<tr>
+			<td>[row1]</td>
+			<td>[row1]</td>
+			<td>[row1]</td>
+			<td>cell2</td>
+		</tr>
+		<tr>
+			<td>[row2]</td>
+			<td>[row2]</td>
+			<td>[row2]</td>
+			<td>&nbsp;</td>
+		</tr>
+		<tr>
+			<td>[row3]</td>
+			<td>[row3]</td>
+			<td>[row3]</td>
+			<td>&nbsp;</td>
+		</tr>
+		<tr>
+			<td>cell3</td>
+			<td>&nbsp;</td>
+			<td>&nbsp;</td>
+			<td>cell4</td>
+		</tr>
+	</tbody>
+</table>
+</textarea>
+
 <table id="2cells1row">
 	<tr>
 		<td>foo</td>
@@ -181,4 +226,24 @@
 		<td>21</td>
 		<td>22</td>
 	</tr>
+</table>
+
+<table id="3cells3rows">
+	<tbody>
+		<tr>
+			<td>row1</td>
+			<td>row1</td>
+			<td>row1</td>
+		</tr>
+		<tr>
+			<td>row2</td>
+			<td>row2</td>
+			<td>row2</td>
+		</tr>
+		<tr>
+			<td>row3</td>
+			<td>row3</td>
+			<td>row3</td>
+		</tr>
+	</tbody>
 </table>

--- a/tests/plugins/tableselection/integrations/clipboard/pastemerge.html
+++ b/tests/plugins/tableselection/integrations/clipboard/pastemerge.html
@@ -246,6 +246,51 @@
 </table>
 </textarea>
 
+<textarea id="merge-bigger-table">
+<table>
+	<tbody>
+		<tr>
+			<td>cell1</td>
+			<td>cell2</td>
+		</tr>
+		<tr>
+			<td>[cell3]</td>
+			<td>cell4</td>
+		</tr>
+	</tbody>
+</table>
+
+=>
+<table>
+	<tbody>
+		<tr>
+			<td>cell1</td>
+			<td>&nbsp;</td>
+			<td>&nbsp;</td>
+			<td>cell2</td>
+		</tr>
+		<tr>
+			<td>[row1]</td>
+			<td>[row1]</td>
+			<td>[row1]</td>
+			<td>cell4</td>
+		</tr>
+		<tr>
+			<td>[row2]</td>
+			<td>[row2]</td>
+			<td>[row2]</td>
+			<td>&nbsp;</td>
+		</tr>
+		<tr>
+			<td>[row3]</td>
+			<td>[row3]</td>
+			<td>[row3]</td>
+			<td>&nbsp;</td>
+		</tr>
+	</tbody>
+</table>
+</textarea>
+
 <table id="2cells1row">
 	<tr>
 		<td>foo</td>

--- a/tests/plugins/tableselection/integrations/clipboard/pastemerge.html
+++ b/tests/plugins/tableselection/integrations/clipboard/pastemerge.html
@@ -209,6 +209,43 @@
 </table>
 </textarea>
 
+<textarea id="dont-merge-partial-selection">
+<table>
+	<tbody>
+		<tr>
+			<td>ce[l]l1</td>
+			<td>cell2</td>
+		</tr>
+		<tr>
+			<td>cell3</td>
+			<td>cell4</td>
+		</tr>
+	</tbody>
+</table>
+
+=>
+<table>
+	<tbody>
+		<tr>
+			<td>ce
+			<table>
+				<tbody>
+					<tr>
+						<td>foo</td>
+						<td>foo^</td>
+					</tr>
+				</tbody>
+			</table>l1</td>
+			<td>cell2</td>
+		</tr>
+		<tr>
+			<td>cell3</td>
+			<td>cell4</td>
+		</tr>
+	</tbody>
+</table>
+</textarea>
+
 <table id="2cells1row">
 	<tr>
 		<td>foo</td>

--- a/tests/plugins/tableselection/integrations/clipboard/pastemerge.html
+++ b/tests/plugins/tableselection/integrations/clipboard/pastemerge.html
@@ -291,6 +291,74 @@
 </table>
 </textarea>
 
+<textarea id="merge-smaller-table-edge">
+<table>
+	<tbody>
+		<tr>
+			<td>row1</td>
+			<td>row1</td>
+		</tr>
+		<tr>
+			<td>row2</td>
+			<td rowspan="2">[row2]</td>
+		</tr>
+		<tr>
+			<td>row3</td>
+		</tr>
+		<tr>
+			<td>row4</td>
+			<td rowspan="2">[row4]</td>
+		</tr>
+		<tr>
+			<td>row5</td>
+		</tr>
+		<tr>
+			<td>row6</td>
+			<td>row6</td>
+		</tr>
+	</tbody>
+</table>
+
+=>
+<table>
+	<tbody>
+		<tr>
+			<td>row1</td>
+			<td>row1</td>
+			<td>&nbsp;</td>
+			<td>&nbsp;</td>
+		</tr>
+		<tr>
+			<td>row2</td>
+			<td>[row1]</td>
+			<td>[row1]</td>
+			<td>[row1]</td>
+		</tr>
+		<tr>
+			<td>row3</td>
+			<td>[row2]</td>
+			<td>[row2]</td>
+			<td>[row2]</td>
+		</tr>
+		<tr>
+			<td>row4</td>
+			<td>[row3]</td>
+			<td>[row3]</td>
+			<td>[row3]</td>
+		</tr>
+		<tr>
+			<td>row5</td>
+		</tr>
+		<tr>
+			<td>row6</td>
+			<td>row6</td>
+			<td>&nbsp;</td>
+			<td>&nbsp;</td>
+		</tr>
+	</tbody>
+</table>
+</textarea>
+
 <table id="2cells1row">
 	<tr>
 		<td>foo</td>

--- a/tests/plugins/tableselection/integrations/clipboard/pastemerge.js
+++ b/tests/plugins/tableselection/integrations/clipboard/pastemerge.js
@@ -34,7 +34,9 @@
 
 		'test merge multi rows after empty cell': createPasteTestCase( 'merge-rows-after-empty', '2cells2rows' ),
 
-		'test merge multi rows before empty cell': createPasteTestCase( 'merge-rows-before-empty', '2cells2rows' )
+		'test merge multi rows before empty cell': createPasteTestCase( 'merge-rows-before-empty', '2cells2rows' ),
+
+		'test table expansion on larger table': createPasteTestCase( 'merge-larger-table', '3cells3rows' ),
 	};
 
 	tests = bender.tools.createTestsForEditors( CKEDITOR.tools.objectKeys( bender.editors ), tests );

--- a/tests/plugins/tableselection/integrations/clipboard/pastemerge.js
+++ b/tests/plugins/tableselection/integrations/clipboard/pastemerge.js
@@ -37,6 +37,8 @@
 		'test merge multi rows before empty cell': createPasteTestCase( 'merge-rows-before-empty', '2cells2rows' ),
 
 		'test table expansion on larger table': createPasteTestCase( 'merge-larger-table', '3cells3rows' ),
+
+		'test partial paste doesnt cause merge': createPasteTestCase( 'dont-merge-partial-selection', '2cells1row' )
 	};
 
 	tests = bender.tools.createTestsForEditors( CKEDITOR.tools.objectKeys( bender.editors ), tests );

--- a/tests/plugins/tableselection/integrations/clipboard/pastemerge.js
+++ b/tests/plugins/tableselection/integrations/clipboard/pastemerge.js
@@ -38,7 +38,9 @@
 
 		'test table expansion on larger table': createPasteTestCase( 'merge-larger-table', '3cells3rows' ),
 
-		'test partial paste doesnt cause merge': createPasteTestCase( 'dont-merge-partial-selection', '2cells1row' )
+		'test partial paste doesnt cause merge': createPasteTestCase( 'dont-merge-partial-selection', '2cells1row' ),
+
+		'test paste bigger table into a smaller selection': createPasteTestCase( 'merge-bigger-table', '3cells3rows' )
 	};
 
 	tests = bender.tools.createTestsForEditors( CKEDITOR.tools.objectKeys( bender.editors ), tests );

--- a/tests/plugins/tableselection/integrations/clipboard/pastemerge.js
+++ b/tests/plugins/tableselection/integrations/clipboard/pastemerge.js
@@ -43,7 +43,7 @@
 		'test paste bigger table into a smaller selection': createPasteTestCase( 'merge-bigger-table', '3cells3rows' ),
 
 		// This case includes some rowspan trickery.
-		'test paste smaller table into a bigger selection edge case': createPasteTestCase( 'merge-bigger-table-edge', '3cells3rows' )
+		'test paste smaller table into a bigger selection edge case': createPasteTestCase( 'merge-smaller-table-edge', '3cells3rows' )
 	};
 
 	tests = bender.tools.createTestsForEditors( CKEDITOR.tools.objectKeys( bender.editors ), tests );

--- a/tests/plugins/tableselection/integrations/clipboard/pastemerge.js
+++ b/tests/plugins/tableselection/integrations/clipboard/pastemerge.js
@@ -40,7 +40,10 @@
 
 		'test partial paste doesnt cause merge': createPasteTestCase( 'dont-merge-partial-selection', '2cells1row' ),
 
-		'test paste bigger table into a smaller selection': createPasteTestCase( 'merge-bigger-table', '3cells3rows' )
+		'test paste bigger table into a smaller selection': createPasteTestCase( 'merge-bigger-table', '3cells3rows' ),
+
+		// This case includes some rowspan trickery.
+		'test paste smaller table into a bigger selection edge case': createPasteTestCase( 'merge-bigger-table-edge', '3cells3rows' )
 	};
 
 	tests = bender.tools.createTestsForEditors( CKEDITOR.tools.objectKeys( bender.editors ), tests );

--- a/tests/plugins/tableselection/integrations/tabletools/tabletools.js
+++ b/tests/plugins/tableselection/integrations/tabletools/tabletools.js
@@ -161,6 +161,14 @@
 			assert.isTrue( expectedCell.equals( selectedCells[ 0 ] ), 'Correct table cell is selected.' );
 		},
 
+		'test getSelectedCells API': function() {
+			arrayAssert.itemsAreEqual( [], CKEDITOR.plugins.tabletools.getSelectedCells( null ), 'Return for null' );
+
+			var emptySelectionMock = { getRanges: sinon.stub().returns( [ ] ) };
+
+			arrayAssert.itemsAreEqual( [], CKEDITOR.plugins.tabletools.getSelectedCells( emptySelectionMock ), 'Ret for empty range list' );
+		},
+
 		'test delete all cells': function( editor, bot ) {
 			doCommandTest( bot, 'cellDelete', { 'case': 'delete-all-cells', cells: [ 0, 1, 2, 3 ], skipCheckingSelection: true } );
 		}

--- a/tests/plugins/tabletools/tabletools.html
+++ b/tests/plugins/tabletools/tabletools.html
@@ -1531,3 +1531,5 @@
 		</tbody>
 	</table>
 </textarea>
+
+<div id="playground"></div>

--- a/tests/plugins/tabletools/tabletools.js
+++ b/tests/plugins/tabletools/tabletools.js
@@ -38,6 +38,22 @@
 			this.doTest( 'add-row-after-multi', 'rowInsertAfter' );
 		},
 
+		'test tabletools.insertRow() return value': function() {
+			var doc = CKEDITOR.document,
+				playground = doc.getById( 'playground' ),
+				table,
+				ret;
+
+			playground.setHtml( doc.findOne( '#row-height-conversion' ).getValue() );
+
+			table = playground.findOne( 'table' );
+
+			ret = CKEDITOR.plugins.tabletools.insertRow( [ table.findOne( 'td' ) ] );
+
+			assert.isInstanceOf( CKEDITOR.dom.element, ret, 'Returned type' );
+			assert.areSame( table.find( 'tr' ).getItem( 1 ), ret, 'Returned element' );
+		},
+
 		'test insert col before': function() {
 			this.doTest( 'add-col-before', 'columnInsertBefore' );
 			this.doTest( 'add-col-before-2', 'columnInsertBefore' );
@@ -53,6 +69,24 @@
 			this.doTest( 'add-col-after-3', 'columnInsertAfter' );
 			this.doTest( 'add-col-after-4', 'columnInsertAfter' );
 			this.doTest( 'add-col-after-multi', 'columnInsertAfter' );
+		},
+
+		'test tabletools.insertColumn() return value': function() {
+			var doc = CKEDITOR.document,
+				playground = doc.getById( 'playground' ),
+				table,
+				ret;
+
+			playground.setHtml( doc.findOne( '#delete-cell-trailing' ).getValue() );
+
+			table = playground.findOne( 'table' );
+
+			ret = CKEDITOR.plugins.tabletools.insertColumn( [ table.find( 'td' ).getItem( 1 ), table.find( 'td' ).getItem( 3 ) ] );
+
+			assert.isArray( ret, 'Return type' );
+			assert.areSame( 2, ret.length, 'Returned items' );
+			assert.areSame( table.find( 'td' ).getItem( 2 ), ret[ 0 ], 'Returned element  0' );
+			assert.areSame( table.find( 'td' ).getItem( 5 ), ret[ 1 ], 'Returned element  1' );
 		},
 
 		'test merge cells': function() {


### PR DESCRIPTION
 ## What is the purpose of this pull request?

Bug fix

 ## Does your PR contain necessary tests?

- [x] Unit tests
- [x] Manual tests (unit tests inherited from intiial PR)

 ## What changes did you make?

Since paste listener was huge, and very difficult to understand I had to split the logic into smaller pieces, so that it's easier to work with it.

The biggest change is encapsulated `TableSelection` type in tableselection plugin, so that there's no `firstCell`, `lastRow` etc reassigning all over the place. Instead new types take care of that. It also features methods related to the manipulation on the table selection itself.

Also `insertRow` and `insertColumn` in tabletools now returns added DOM elements.
