### PR TITLE
Force toolbar plugin not to be loaded in notoolbarnotifications manual tests

### DIFF
--- a/tests/plugins/notification/manual/notoolbarnotifications.html
+++ b/tests/plugins/notification/manual/notoolbarnotifications.html
@@ -39,6 +39,7 @@
 	<script>
 		var editor = CKEDITOR.replace( 'editor1', {
 			extraPlugins: 'notification',
+			removePlugins: 'toolbar,clipboard,pastefromword,pastetext,tableselection',
 			width: 650,
 		} );
 

--- a/tests/plugins/notification/manual/notoolbarnotificationsinline.html
+++ b/tests/plugins/notification/manual/notoolbarnotificationsinline.html
@@ -10,7 +10,9 @@
 		<input onclick="manualPlayground.emulateProgress();" type="button" value="Show progress notification">
 	</p>
 	<script>
-		var editor = CKEDITOR.inline( 'editor1' );
+		var editor = CKEDITOR.inline( 'editor1', {
+			removePlugins: 'toolbar,clipboard,pastefromword,pastetext,tableselection'
+		} );
 
 		manualPlayground.init();
 		window.scrollTo( 2950, 2950 );


### PR DESCRIPTION
## What is the purpose of this pull request?

Task

 ## Does your PR contain necessary tests?

This is a fix in the manual test itself.

 ## What changes did you make?

Just a small change making sure that no toolbar plugin is loaded in tests:

* http://tests.ckeditor.dev:1030/tests/plugins/notification/manual/notoolbarnotifications
* http://tests.ckeditor.dev:1030/tests/plugins/notification/manual/notoolbarnotificationsinline

Without this it would load toolbar plugins on a built version of CKEditor.