### PR TITLE
Fix for selection after pasting a non table content

### DIFF
--- a/plugins/tableselection/plugin.js
+++ b/plugins/tableselection/plugin.js
@@ -799,7 +799,7 @@
 				editor.fire( 'lockSnapshot' );
 				tableSel.emptyCells( tableSel.cells.all.slice( 1 ) );
 				// Reselecting cells allows to create correct undo snapshot (#763).
-				fakeSelectCells( editor, tableSel.cells.all.slice( 1 ) );
+				fakeSelectCells( editor, tableSel.cells.all );
 				editor.fire( 'unlockSnapshot' );
 			} );
 


### PR DESCRIPTION
This can be seen in case 2 of manual test tests/plugins/tableselection/manual/integrations/image2/paste.

 ## What is the purpose of this pull request?

Bug fix

 ## What changes did you make?

A change to make `/tests/plugins/tableselection/manual/integrations/image2/paste` test pass.