### PR TITLE
Cutting from nested table

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -15,6 +15,7 @@ Fixed Issues:
 * [#834](https://github.com/ckeditor/ckeditor-dev/issues/834): [IE9-11] Fixed: Editor does not save selected state of radiobuttons inserted by [Form Elements](https://ckeditor.com/addon/forms) plugin.
 * [#704](https://github.com/ckeditor/ckeditor-dev/issues/704): [Edge] Fixed: Using `Ctrl/Cmd + Z` breaks widgets structure.
 * [#591](https://github.com/ckeditor/ckeditor-dev/issues/591): Fixed: Column is inserted in a wrong order inside table if any cell has a vertical split.
+* [#787](https://github.com/ckeditor/ckeditor-dev/issues/787): Fixed: Using cut inside nested table does not cut selected content.
 
 ## CKEditor 4.7.3
 

--- a/core/editable.js
+++ b/core/editable.js
@@ -2986,6 +2986,11 @@
 
 				// #787
 				function checkNested( node ) {
+					// Check only table cells, not every node inside table.
+					if ( !node.is( tableEditable ) ) {
+						return;
+					}
+
 					var startTable = startCell && startCell.getAscendant( 'table', true ),
 						endTable = endCell && endCell.getAscendant( 'table', true ),
 						nodeTable = node.getAscendant( 'table', true );

--- a/core/editable.js
+++ b/core/editable.js
@@ -2968,7 +2968,9 @@
 					// the start and end cells to correctly handle case like:
 					// <td>x{x</td><td><table>..<td>y}y</td>..</table></td>
 					// without the check the second cell's content would be entirely removed.
-					if ( !leaving && checkRemoveCellContents( node ) ) {
+					// We also handle all nested cells (#787).
+					if ( ( !leaving && checkRemoveCellContents( node ) ) ||
+						( leaving && checkNested( node ) ) ) {
 						editableRange = range.clone();
 						editableRange.selectNodeContents( node );
 						contentsRanges.push( editableRange );
@@ -2981,6 +2983,16 @@
 				CKEDITOR.dom.element.clearAllMarkers( database );
 
 				return contentsRanges;
+
+				// #787
+				function checkNested( node ) {
+					var startTable = startCell && startCell.getAscendant( 'table', true ),
+						endTable = endCell && endCell.getAscendant( 'table', true ),
+						nodeTable = node.getAscendant( 'table', true );
+
+					return ( startTable && startTable.contains( nodeTable ) ) ||
+						( endTable && endTable.contains( nodeTable ) );
+				}
 
 				function checkRemoveCellContents( node ) {
 					return (

--- a/tests/core/editable/getextracthtmlfromrange.js
+++ b/tests/core/editable/getextracthtmlfromrange.js
@@ -308,7 +308,10 @@
 			// #26 Context again, making our lives a misery.
 			[ '<p>a</p><table class="t1"><tbody><tr><td><p>b{c</p></td><td><table class="t2"><tbody><tr><td><p>d}e</p></td></tr></tbody></table></td></tr></tbody></table><p>g</p>',
 				'<table class="t1"><tbody><tr><td><p>c</p></td><td><table class="t2"><tbody><tr><td><p>d</p></td></tr></tbody></table></td></tr></tbody></table>',
-				'<p>a</p><table class="t1"><tbody><tr><td><p>b[]</p></td><td><table class="t2"><tbody><tr><td><p>e</p></td></tr></tbody></table></td></tr></tbody></table><p>g</p>' ]
+				'<p>a</p><table class="t1"><tbody><tr><td><p>b[]</p></td><td><table class="t2"><tbody><tr><td><p>e</p></td></tr></tbody></table></td></tr></tbody></table><p>g</p>' ],
+
+			// #787
+			[ '<table><tbody><tr><td>ab<table><tbody><tr>[<td>cd</td>]</tr></tbody></table>ef</td></tr></tbody></table>', 'cd', '<table><tbody><tr><td>ab<table><tbody><tr><td>[]@!</td></tr></tbody></table>ef</td></tr></tbody></table>' ]
 		],
 
 		'lists': [

--- a/tests/core/editable/getextracthtmlfromrange.js
+++ b/tests/core/editable/getextracthtmlfromrange.js
@@ -317,7 +317,7 @@
 
 			// #787 – br case
 			[ '<table><tbody><tr><td>ab<table><tbody><tr>[<td>cd@</td>]</tr></tbody></table>ef</td></tr></tbody></table>',
-				CKEDITOR.env.ie && CKEDITOR.env.version <= 8 ? 'cd' : '<table><tbody><tr><td>cd</td></tr></tbody></table>',
+				CKEDITOR.env.ie && CKEDITOR.env.version < 11 ? 'cd' : '<table><tbody><tr><td>cd</td></tr></tbody></table>',
 				'<table><tbody><tr><td>ab<table><tbody><tr><td>[]@!</td></tr></tbody></table>ef</td></tr></tbody></table>' ]
 		],
 

--- a/tests/core/editable/getextracthtmlfromrange.js
+++ b/tests/core/editable/getextracthtmlfromrange.js
@@ -22,7 +22,8 @@
 
 	var setWithHtml = bender.tools.range.setWithHtml,
 		getWithHtml = bender.tools.range.getWithHtml,
-		img_src = '%BASE_PATH%_assets/img.gif';
+		img_src = '%BASE_PATH%_assets/img.gif',
+		tests;
 
 	// <DEV>
 	// var playground = CKEDITOR.document.createElement( 'dl' );
@@ -113,7 +114,7 @@
 // output HTML	|	@	|	like compareInnerHtml (accept)	|	like compareInnerHtml		(we use it for uncertain cases)
 //				|	@!	|	like compareInnerHtml (expect)	|	like compareInnerHtml		(we use it for empty blocks)
 
-	var tests = {
+	tests = {
 		init: function() {
 			this.editables = {};
 
@@ -311,7 +312,8 @@
 				'<p>a</p><table class="t1"><tbody><tr><td><p>b[]</p></td><td><table class="t2"><tbody><tr><td><p>e</p></td></tr></tbody></table></td></tr></tbody></table><p>g</p>' ],
 
 			// #787
-			[ '<table><tbody><tr><td>ab<table><tbody><tr>[<td>cd</td>]</tr></tbody></table>ef</td></tr></tbody></table>', 'cd', '<table><tbody><tr><td>ab<table><tbody><tr><td>[]@!</td></tr></tbody></table>ef</td></tr></tbody></table>' ]
+			[ '<table><tbody><tr><td>ab<table><tbody><tr>[<td>cd</td>]</tr></tbody></table>ef</td></tr></tbody></table>', 'cd',
+				'<table><tbody><tr><td>ab<table><tbody><tr><td>[]@!</td></tr></tbody></table>ef</td></tr></tbody></table>' ]
 		],
 
 		'lists': [

--- a/tests/core/editable/getextracthtmlfromrange.js
+++ b/tests/core/editable/getextracthtmlfromrange.js
@@ -313,6 +313,11 @@
 
 			// #787
 			[ '<table><tbody><tr><td>ab<table><tbody><tr>[<td>cd</td>]</tr></tbody></table>ef</td></tr></tbody></table>', 'cd',
+				'<table><tbody><tr><td>ab<table><tbody><tr><td>[]@!</td></tr></tbody></table>ef</td></tr></tbody></table>' ],
+
+			// #787 – br case
+			[ '<table><tbody><tr><td>ab<table><tbody><tr>[<td>cd@</td>]</tr></tbody></table>ef</td></tr></tbody></table>',
+				CKEDITOR.env.ie && CKEDITOR.env.version <= 8 ? 'cd' : '<table><tbody><tr><td>cd</td></tr></tbody></table>',
 				'<table><tbody><tr><td>ab<table><tbody><tr><td>[]@!</td></tr></tbody></table>ef</td></tr></tbody></table>' ]
 		],
 

--- a/tests/core/editable/getextracthtmlfromrange.js
+++ b/tests/core/editable/getextracthtmlfromrange.js
@@ -159,7 +159,7 @@
 			[ '<p>ab{</p><p>c</p><p>}de</p>',										'<br data-cke-eol="1" /><p>c</p><br data-cke-eol="1" />',		'<p>ab[]de</p>' ],
 			[ '<h1><b>{a</b></h1><p>b}</p>',										'<h1><b>a</b></h1><p>b</p>',									'<h1>[]@!</h1>' ],
 
-			// http://dev.ckeditor.com/ticket/13449
+			// (http://dev.ckeditor.com/ticket/13449)
 			[ '<h1>{a</h1><p><b>b}</b></p>',										'<h1>a</h1><p><b>b</b></p>',									'<h1>[]@!</h1>' ],
 			[ '<h1>{abc</h1><p><strong>de</strong>gh}<strong>jl</strong>mn</p>',	'<h1>abc</h1><p><strong>de</strong>gh</p>',						'<h1>[]<strong>jl</strong>mn</h1>' ]
 		],
@@ -205,7 +205,7 @@
 
 		],
 
-		// http://dev.ckeditor.com/ticket/13101
+		// (http://dev.ckeditor.com/ticket/13101)
 		'html5': [
 			[ '<div>[<figure>img</figure>]</div>',											'<figure>img</figure>',											'<div>[]@!</div>' ],
 			[ '<div>[<div><figure>img<figcaption>cap</figcaption></figure></div>]</div>',	'<div><figure>img<figcaption>cap</figcaption></figure></div>',	'<div>[]@!</div>' ]
@@ -311,11 +311,11 @@
 				'<table class="t1"><tbody><tr><td><p>c</p></td><td><table class="t2"><tbody><tr><td><p>d</p></td></tr></tbody></table></td></tr></tbody></table>',
 				'<p>a</p><table class="t1"><tbody><tr><td><p>b[]</p></td><td><table class="t2"><tbody><tr><td><p>e</p></td></tr></tbody></table></td></tr></tbody></table><p>g</p>' ],
 
-			// #787
+			// #27 (#787)
 			[ '<table><tbody><tr><td>ab<table><tbody><tr>[<td>cd</td>]</tr></tbody></table>ef</td></tr></tbody></table>', 'cd',
 				'<table><tbody><tr><td>ab<table><tbody><tr><td>[]@!</td></tr></tbody></table>ef</td></tr></tbody></table>' ],
 
-			// #787 – br case
+			// #28 - br case (#787).
 			[ '<table><tbody><tr><td>ab<table><tbody><tr>[<td>cd@</td>]</tr></tbody></table>ef</td></tr></tbody></table>',
 				CKEDITOR.env.ie && CKEDITOR.env.version < 11 ? 'cd' : '<table><tbody><tr><td>cd</td></tr></tbody></table>',
 				'<table><tbody><tr><td>ab<table><tbody><tr><td>[]@!</td></tr></tbody></table>ef</td></tr></tbody></table>' ]
@@ -380,15 +380,15 @@
 			[ '<p>a</p><p><b>[b]</b></p><p>c</p>',									'<b>b</b>',														'<p>a</p><p>c</p>' ],
 			[ '<p>a[b]c</p>',														'b',															'<p>ac</p>' ],
 			[ '<table><tbody><tr><td>{a</td><td>b}</td></tr></tbody></table>',		'<table><tbody><tr><td>a</td><td>b</td></tr></tbody></table>',	'' ],
-			// http://dev.ckeditor.com/ticket/13465
+			// (http://dev.ckeditor.com/ticket/13465)
 			[
 				'<p>[<span>foo</span>]<span data-cke-bookmark="1">&nbsp;</span></p>',
 				'<span>foo</span>',
 				'<p><span data-cke-bookmark="1">&nbsp;</span></p>'
 			],
-			// http://dev.ckeditor.com/ticket/13465
+			// (http://dev.ckeditor.com/ticket/13465)
 			[ '<p>a</p><p><span class="foo">{b}</span></p><p>c</p>',				'<span class="foo">b</span>',									'<p>a</p><p>c</p>' ],
-			// http://dev.ckeditor.com/ticket/13465
+			// (http://dev.ckeditor.com/ticket/13465)
 			[ '<p>a</p><p><b>{b}</b><span class="foo"></span></p><p>c</p>',			'<b>b</b>',														'<p>a</p><p>c</p>' ]
 		]
 	}, 'inline', 1 );

--- a/tests/plugins/tableselection/integrations/core/getextractselectedhtml.html
+++ b/tests/plugins/tableselection/integrations/core/getextractselectedhtml.html
@@ -77,3 +77,39 @@
 	</tbody>
 </table>
 </textarea>
+
+<textarea id="nested">
+<table>
+	<tr>
+		<td>11</td>
+		<td>2
+			<table>
+				<tr>
+					<td>33</td>
+					<td>44</td>
+				</tr>
+			</table>
+		2</td>
+		<td>55</td>
+	</tr>
+</table>
+=>
+<table>
+	<tbody>
+		<tr>
+			<td>11</td>
+			<td>2
+				<table>
+					<tbody>
+						<tr>
+							<td>^&nbsp;</td>
+							<td>&nbsp;</td>
+						</tr>
+					</tbody>
+				</table>
+			2</td>
+			<td>55</td>
+		</tr>
+	</tbody>
+</table>
+</textarea>

--- a/tests/plugins/tableselection/integrations/core/getextractselectedhtml.js
+++ b/tests/plugins/tableselection/integrations/core/getextractselectedhtml.js
@@ -67,6 +67,25 @@
 
 				assert.isInnerHtmlMatching( stripExpectWhitespaces( expected ), editor.getSelectedHtml( true ) );
 			} );
+		},
+
+		// #787
+		'test extractSelectedHtml inside nested table': function( editor ) {
+			bender.tools.testInputOut( 'nested', function( input, expected ) {
+				var sel = editor.getSelection(),
+					ranges = [];
+
+				bender.tools.selection.setWithHtml( editor, input );
+
+				// Get ranges for all cells.
+				ranges = tableSelectionHelpers.getRangesForCells( editor, [ 2, 3 ] );
+
+				sel.selectRanges( ranges );
+
+				assert.areSame( '3344', editor.extractSelectedHtml( true ) );
+
+				bender.assert.beautified.html( expected, bender.tools.getHtmlWithSelection( editor ) );
+			} );
 		}
 	};
 

--- a/tests/plugins/tableselection/integrations/core/getextractselectedhtml.js
+++ b/tests/plugins/tableselection/integrations/core/getextractselectedhtml.js
@@ -19,7 +19,7 @@
 	}
 
 	var tests = {
-		// http://dev.ckeditor.com/ticket/13884.
+		// (http://dev.ckeditor.com/ticket/13884)
 		'test getSelectedHtml with multiple ranges': function( editor ) {
 			bender.tools.testInputOut( 'multipleRanges', function( input, expected ) {
 				var sel = editor.getSelection(),
@@ -36,7 +36,7 @@
 			} );
 		},
 
-		// http://dev.ckeditor.com/ticket/13884.
+		// (http://dev.ckeditor.com/ticket/13884)
 		'test getSelectedHtml with partial table selection': function( editor ) {
 			bender.tools.testInputOut( 'partialTableSeleciton', function( input, expected ) {
 				var sel = editor.getSelection(),
@@ -69,7 +69,7 @@
 			} );
 		},
 
-		// #787
+		// (#787)
 		'test extractSelectedHtml inside nested table': function( editor ) {
 			bender.tools.testInputOut( 'nested', function( input, expected ) {
 				var sel = editor.getSelection(),

--- a/tests/plugins/tableselection/manual/integrations/clipboard/nestedtablecut.html
+++ b/tests/plugins/tableselection/manual/integrations/clipboard/nestedtablecut.html
@@ -1,0 +1,34 @@
+<div id="editor1">
+	<table border="1">
+	 <tbody>
+		 <tr>
+			 <td>Cell 1.1.1</td>
+			 <td>Cell
+				 <table border="1">
+					 <tbody>
+						 <tr>
+							 <td>Cell 2.1.1</td>
+							 <td>Cell 2.1.2</td>
+							 <td>Cell 2.1.3</td>
+						 </tr>
+						 <tr>
+							 <td>Cell 2.2.1</td>
+							 <td>Cell 2.2.2</td>
+							 <td>Cell 2.2.3</td>
+						 </tr>
+					 </tbody>
+				 </table> 1.1.2</td>
+		 </tr>
+	 </tbody>
+	</table>
+</div>
+
+<script>
+	if ( ( CKEDITOR.env.ie && CKEDITOR.env.version < 11 ) || bender.tools.env.mobile ) {
+		bender.ignore();
+	}
+
+	CKEDITOR.replace( 'editor1', {
+		height: 350
+	} );
+</script>

--- a/tests/plugins/tableselection/manual/integrations/clipboard/nestedtablecut.md
+++ b/tests/plugins/tableselection/manual/integrations/clipboard/nestedtablecut.md
@@ -1,0 +1,16 @@
+@bender-ui: collapsed
+@bender-tags: bug, 4.7.3, 787
+@bender-ckeditor-plugins: wysiwygarea, toolbar, tableselection, clipboard, sourcearea, undo, elementspath
+
+**Procedure:**
+
+1. Select some cells inside nested table.
+2. Cut them.
+
+**Expected result:**
+
+Content from the cells is removed.
+
+**Unexpected result:**
+
+Content remains untouched.

--- a/tests/plugins/tableselection/manual/integrations/clipboard/nestedtablecut.md
+++ b/tests/plugins/tableselection/manual/integrations/clipboard/nestedtablecut.md
@@ -1,5 +1,5 @@
 @bender-ui: collapsed
-@bender-tags: bug, 4.7.3, 787
+@bender-tags: bug, 4.8.0, 787
 @bender-ckeditor-plugins: wysiwygarea, toolbar, tableselection, clipboard, sourcearea, undo, elementspath
 
 **Procedure:**


### PR DESCRIPTION
## What is the purpose of this pull request?

Bug fix

## Does your PR contain necessary tests?

All patches which change the editor code must include tests. You can always read more
on [PR testing](http://docs.ckeditor.com/#!/guide/dev_contributing_code-section-tests),
[how to set the testing environment](http://docs.ckeditor.com/#!/guide/dev_tests) and
[how to create tests](http://docs.ckeditor.com/#!/guide/dev_tests-section-creating-your-own-test)
in the official CKEditor documentation.

### This PR contains

- [x] Unit tests
- [x] Manual tests

## What changes did you make?

I've introduced additional check to `editable.extractHtmlFromRange` to detect if selected cells are located inside nested table.

closes #787.
