### PR TITLE
Switch outline to box-shadow for Firefox consistency.

### DIFF
--- a/plugins/widget/plugin.js
+++ b/plugins/widget/plugin.js
@@ -21,22 +21,22 @@
 			CKEDITOR.addCss(
 				'.cke_widget_wrapper{' +
 					'position:relative;' +
-					'outline:none' +
+					'box-shadow:none' +
 				'}' +
 				'.cke_widget_inline{' +
 					'display:inline-block' +
 				'}' +
 				'.cke_widget_wrapper:hover>.cke_widget_element{' +
-					'outline:2px solid yellow;' +
+					'box-shadow:0 0 2px yellow;' +
 					'cursor:default' +
 				'}' +
 				'.cke_widget_wrapper:hover .cke_widget_editable{' +
-					'outline:2px solid yellow' +
+					'box-shadow:0 0 2px yellow' +
 				'}' +
 				'.cke_widget_wrapper.cke_widget_focused>.cke_widget_element,' +
 				// We need higher specificity than hover style.
 				'.cke_widget_wrapper .cke_widget_editable.cke_widget_editable_focused{' +
-					'outline:2px solid #ace' +
+					'box-shadow:0 0 2px #ace' +
 				'}' +
 				'.cke_widget_editable{' +
 					'cursor:text' +


### PR DESCRIPTION
## What is the purpose of this pull request?

Fixes https://github.com/ckeditor/ckeditor-dev/issues/804.

## Does your PR contain necessary tests?

Style changes only.

### This PR contains

- [ ] Unit tests
- [ ] Manual tests

## What changes did you make?

Switches the outline CSS to use box-shadow instead, making Firefox consistent with other browsers.
