### PR TITLE
save support in source mode

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -16,6 +16,7 @@ Fixed Issues:
 * [#719](https://github.com/ckeditor/ckeditor-dev/issues/719): Fixed: Image inserted using [Enhanced Image](https://ckeditor.com/addon/image2) plugin could be resized when editor is in read-only mode.
 * [#577](https://github.com/ckeditor/ckeditor-dev/issues/577): Fixed: "Delete Columns" command provided by [Table Tools](https://ckeditor.com/addon/tabletools) plugin throws an error while trying to delete columns.
 * [#867](https://github.com/ckeditor/ckeditor-dev/issues/867): Fixed: Typing into selected table throws an error.
+* [#817](https://github.com/ckeditor/ckeditor-dev/issues/817): Fixed: [Save](https://ckeditor.com/addon/save) plugin does not work in [Source Mode](https://ckeditor.com/addon/sourcearea).
 
 Other Changes:
 

--- a/plugins/save/plugin.js
+++ b/plugins/save/plugin.js
@@ -10,6 +10,7 @@
 ( function() {
 	var saveCmd = {
 		readOnly: 1,
+		modes: { wysiwyg: 1,source: 1 },
 
 		exec: function( editor ) {
 			if ( editor.fire( 'save' ) ) {
@@ -44,9 +45,8 @@
 			if ( editor.elementMode != CKEDITOR.ELEMENT_MODE_REPLACE )
 				return;
 
-			saveCmd.startDisabled = !( editor.element.$.form );
 			var command = editor.addCommand( pluginName, saveCmd );
-			command.modes = { wysiwyg: 1,source: 1 };
+			command.startDisabled = !( editor.element.$.form );
 
 			editor.ui.addButton && editor.ui.addButton( 'Save', {
 				label: editor.lang.save.toolbar,

--- a/plugins/save/plugin.js
+++ b/plugins/save/plugin.js
@@ -44,8 +44,9 @@
 			if ( editor.elementMode != CKEDITOR.ELEMENT_MODE_REPLACE )
 				return;
 
+			saveCmd.startDisabled = !( editor.element.$.form );
 			var command = editor.addCommand( pluginName, saveCmd );
-			command.modes = { wysiwyg: !!( editor.element.$.form ), source: !!( editor.element.$.form ) };
+			command.modes = { wysiwyg: 1,source: 1 };
 
 			editor.ui.addButton && editor.ui.addButton( 'Save', {
 				label: editor.lang.save.toolbar,

--- a/plugins/save/plugin.js
+++ b/plugins/save/plugin.js
@@ -45,7 +45,7 @@
 				return;
 
 			var command = editor.addCommand( pluginName, saveCmd );
-			command.modes = { wysiwyg: !!( editor.element.$.form ) };
+			command.modes = { wysiwyg: !!( editor.element.$.form ), source: !!( editor.element.$.form ) };
 
 			editor.ui.addButton && editor.ui.addButton( 'Save', {
 				label: editor.lang.save.toolbar,

--- a/tests/plugins/save/manual/sourcemode.html
+++ b/tests/plugins/save/manual/sourcemode.html
@@ -1,0 +1,9 @@
+<form>
+	<textarea id="editor1">editor</textarea>
+</form>
+
+<script>
+	CKEDITOR.replace( 'editor1', {
+		startupMode: 'source'
+	} );
+</script>

--- a/tests/plugins/save/manual/sourcemode.md
+++ b/tests/plugins/save/manual/sourcemode.md
@@ -1,0 +1,13 @@
+@bender-ui: collapsed
+@bender-tags: 817, 4.7.3, bug
+@bender-ckeditor-plugins: wysiwygarea, save, sourcearea, toolbar
+
+**Procedure:**
+
+1. Check if "Save" button is enabled.
+2. Switch to WYSIWYG mode.
+3. Check if "Save" button is enabled.
+
+**Expected result:**
+
+* "Save" button should be enabled in both modes.

--- a/tests/plugins/save/save.html
+++ b/tests/plugins/save/save.html
@@ -1,3 +1,7 @@
-<form id="form">
-	<textarea id="editor">editor</textarea>
+<form id="form1">
+	<textarea id="editor1">editor</textarea>
+</form>
+
+<form id="form2">
+	<textarea id="editor2">editor</textarea>
 </form>

--- a/tests/plugins/save/save.js
+++ b/tests/plugins/save/save.js
@@ -19,7 +19,7 @@ function saveTest( editor ) {
 		return false;
 	} );
 
-wait();
+	wait();
 }
 
 bender.test( {

--- a/tests/plugins/save/save.js
+++ b/tests/plugins/save/save.js
@@ -1,9 +1,31 @@
 /* bender-tags: editor */
-/* bender-ckeditor-plugins: toolbar,save,wysiwygarea */
+/* bender-ckeditor-plugins: toolbar,save,wysiwygarea,sourcearea */
 
 bender.test( {
-	'test save event': function() {
-		var editor = CKEDITOR.replace( 'editor' ),
+	'test save event in WYSIWYG mode': function() {
+		var editor = CKEDITOR.replace( 'editor1' ),
+			count = 0;
+
+		editor.on( 'instanceReady', function() {
+			editor.execCommand( 'save' );
+
+			setTimeout( function() {
+				resume( function() {
+					assert.areSame( 1, count, 'save was fired once' );
+				} );
+			} );
+		} );
+
+		editor.on( 'save', function() {
+			count++;
+			return false;
+		} );
+
+		wait();
+	},
+
+	'test save event in source mode': function() {
+		var editor = CKEDITOR.replace( 'editor2' , { startupMode: 'source' } ),
 			count = 0;
 
 		editor.on( 'instanceReady', function() {

--- a/tests/plugins/save/save.js
+++ b/tests/plugins/save/save.js
@@ -1,48 +1,35 @@
 /* bender-tags: editor */
 /* bender-ckeditor-plugins: toolbar,save,wysiwygarea,sourcearea */
 
-bender.test( {
-	'test save event in WYSIWYG mode': function() {
-		var editor = CKEDITOR.replace( 'editor1' ),
-			count = 0;
+function saveTest( editor ) {
+	var count = 0;
 
-		editor.on( 'instanceReady', function() {
-			editor.execCommand( 'save' );
+	editor.on( 'instanceReady', function() {
+		editor.execCommand( 'save' );
 
-			setTimeout( function() {
-				resume( function() {
-					assert.areSame( 1, count, 'save was fired once' );
-				} );
+		setTimeout( function() {
+			resume( function() {
+				assert.areSame( 1, count, 'save was fired once' );
 			} );
 		} );
+	} );
 
-		editor.on( 'save', function() {
-			count++;
-			return false;
-		} );
+	editor.on( 'save', function() {
+		count++;
+		return false;
+	} );
 
-		wait();
+wait();
+}
+
+bender.test( {
+	'test save event in WYSIWYG mode': function() {
+		var editor = CKEDITOR.replace( 'editor1' );
+		saveTest( editor );
 	},
 
 	'test save event in source mode': function() {
-		var editor = CKEDITOR.replace( 'editor2' , { startupMode: 'source' } ),
-			count = 0;
-
-		editor.on( 'instanceReady', function() {
-			editor.execCommand( 'save' );
-
-			setTimeout( function() {
-				resume( function() {
-					assert.areSame( 1, count, 'save was fired once' );
-				} );
-			} );
-		} );
-
-		editor.on( 'save', function() {
-			count++;
-			return false;
-		} );
-
-		wait();
+		var editor = CKEDITOR.replace( 'editor2' , { startupMode: 'source' } );
+		saveTest( editor );
 	}
 } );


### PR DESCRIPTION
## What is the purpose of this pull request?

bug fix

## Does your PR contain necessary tests?

All patches which change the editor code must include tests. You can always read more
on [PR testing](http://docs.ckeditor.com/#!/guide/dev_contributing_code-section-tests),
[how to set the testing environment](http://docs.ckeditor.com/#!/guide/dev_tests) and
[how to create tests](http://docs.ckeditor.com/#!/guide/dev_tests-section-creating-your-own-test)
in the official CKEditor documentation.

### This PR contains

- [X] Unit tests
- [x] Manual tests

## What changes did you make?

Added support for save button is source mode

closes #817 