### PR TITLE
[#830] Add possibility to define default tab in dialog

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -19,6 +19,7 @@ Fixed Issues:
 Other Changes:
 
 * [#800](https://github.com/ckeditor/ckeditor-dev/issues/800): Added the [`CKEDITOR.dom.selection.isCollapsed`](https://docs.ckeditor.com/#!/api/CKEDITOR.dom.selection-method-isCollapsed) method which is a simpler way to check if the selection is collapsed.
+* [#830](https://github.com/ckeditor/ckeditor-dev/issues/830): Added option to define which dialog tab should be shown by default when creating [`CKEDITOR.dialogCommand`](https://docs.ckeditor.com/#!/api/CKEDITOR.dialogCommand).
 
 ## CKEditor 4.7.2
 

--- a/plugins/dialog/plugin.js
+++ b/plugins/dialog/plugin.js
@@ -862,8 +862,10 @@ CKEDITOR.DIALOG_STATE_BUSY = 2;
 			// Reset all inputs back to their default value.
 			this.reset();
 
-			// Select the first tab by default.
-			this.selectPage( this.definition.contents[ 0 ].id );
+			// Select provided tab or first one if there is nothing provided.
+			if ( this._.currentTabId === null ) {
+				this.selectPage( this.definition.contents[ 0 ].id );
+			}
 
 			// Set z-index.
 			if ( CKEDITOR.dialog._.currentZIndex === null )
@@ -2993,6 +2995,9 @@ CKEDITOR.DIALOG_STATE_BUSY = 2;
 	 * @param {String} dialogName The name of the dialog to open when executing
 	 * this command.
 	 * @param {Object} [ext] Additional command definition's properties.
+	 * You can provide additional property (`tab`) to ext object if you wish to open dialog on specific tab.
+	 * 		// Open dialog on 'keystroke' tab
+	 *		editor.addCommand( 'keystroke', new CKEDITOR.dalogCommand( 'a11yHelp', { tab: 'keystroke' } ) );
 	 */
 	CKEDITOR.dialogCommand = function( dialogName, ext ) {
 		this.dialogName = dialogName;
@@ -3001,7 +3006,13 @@ CKEDITOR.DIALOG_STATE_BUSY = 2;
 
 	CKEDITOR.dialogCommand.prototype = {
 		exec: function( editor ) {
-			editor.openDialog( this.dialogName );
+			var that = this;
+			editor.openDialog( this.dialogName, function( dialog ) {
+				// Select different tab if it's provided (#830).
+				if ( that && that.tab ) {
+					dialog.selectPage( that.tab );
+				}
+			} );
 		},
 
 		// Dialog commands just open a dialog ui, thus require no undo logic,

--- a/plugins/dialog/plugin.js
+++ b/plugins/dialog/plugin.js
@@ -862,7 +862,7 @@ CKEDITOR.DIALOG_STATE_BUSY = 2;
 			// Reset all inputs back to their default value.
 			this.reset();
 
-			// Select provided tab or first one if there is nothing provided.
+			// Selects the first tab if no tab is already selected.
 			if ( this._.currentTabId === null ) {
 				this.selectPage( this.definition.contents[ 0 ].id );
 			}
@@ -2995,9 +2995,10 @@ CKEDITOR.DIALOG_STATE_BUSY = 2;
 	 * @param {String} dialogName The name of the dialog to open when executing
 	 * this command.
 	 * @param {Object} [ext] Additional command definition's properties.
-	 * You can provide additional property (`tab`) to ext object if you wish to open dialog on specific tab.
-	 * 		// Open dialog on 'keystroke' tab
-	 *		editor.addCommand( 'keystroke', new CKEDITOR.dalogCommand( 'a11yHelp', { tab: 'keystroke' } ) );
+	 * @param {String} [ext.tabId] You can provide additional property (`tabId`) if you wish to open dialog on specific tabId.
+	 *
+	 *		// Open dialog on 'keystroke' tabId.
+	 *		editor.addCommand( 'keystroke', new CKEDITOR.dialogCommand( 'a11yHelp', { tabId: 'keystroke' } ) );
 	 */
 	CKEDITOR.dialogCommand = function( dialogName, ext ) {
 		this.dialogName = dialogName;
@@ -3006,11 +3007,11 @@ CKEDITOR.DIALOG_STATE_BUSY = 2;
 
 	CKEDITOR.dialogCommand.prototype = {
 		exec: function( editor ) {
-			var that = this;
+			var tabId = this.tabId;
 			editor.openDialog( this.dialogName, function( dialog ) {
 				// Select different tab if it's provided (#830).
-				if ( that && that.tab ) {
-					dialog.selectPage( that.tab );
+				if ( tabId ) {
+					dialog.selectPage( tabId );
 				}
 			} );
 		},

--- a/tests/plugins/dialog/manual/opennonfirsttabasdefault.html
+++ b/tests/plugins/dialog/manual/opennonfirsttabasdefault.html
@@ -1,0 +1,48 @@
+<textarea name="" id="editor" cols="30" rows="10">
+	hello world
+</textarea>
+<button id="press">Press me</button>
+<script>
+	var editor = CKEDITOR.replace( 'editor' );
+
+	CKEDITOR.once( 'instanceLoaded', function() {
+		CKEDITOR.dialog.add( 'testDialog', function() {
+			return {
+				title: 'Test dialog',
+				contents: [
+					{
+						id: 'tab1',
+						label: 'Tab one',
+						elements: [
+							{
+								type: 'html',
+								id: 'field11',
+								html: 'foo'
+							}
+						]
+					},
+					{
+						id: 'tab2',
+						label: 'Tab two',
+						elements: [
+							{
+								type: 'html',
+								id: 'field21',
+								html: 'bar'
+							}
+						]
+					}
+				]
+			}
+		} );
+
+		editor.addCommand( 'testDialog', new CKEDITOR.dialogCommand( 'testDialog', {
+			tab: 'tab2'
+		} ) );
+
+	} );
+
+	document.getElementById( 'press' ).onclick = function() {
+		editor.execCommand( 'testDialog' );
+	};
+</script>

--- a/tests/plugins/dialog/manual/opennonfirsttabasdefault.html
+++ b/tests/plugins/dialog/manual/opennonfirsttabasdefault.html
@@ -1,7 +1,7 @@
 <textarea name="" id="editor" cols="30" rows="10">
 	hello world
 </textarea>
-<button id="press">Press me</button>
+<button id="press">Open Dialog</button>
 <script>
 	var editor = CKEDITOR.replace( 'editor' );
 
@@ -37,7 +37,7 @@
 		} );
 
 		editor.addCommand( 'testDialog', new CKEDITOR.dialogCommand( 'testDialog', {
-			tab: 'tab2'
+			tabId: 'tab2'
 		} ) );
 
 	} );

--- a/tests/plugins/dialog/manual/opennonfirsttabasdefault.md
+++ b/tests/plugins/dialog/manual/opennonfirsttabasdefault.md
@@ -4,8 +4,8 @@
 
 ----
 
-1. Press button below editor with name `Press me`.
+1. Press `Open Dialog` button below editor.
 
-**Expected:** Dialog shows up, where `Tab two` will be displayed as default.
+**Expected:** `Tab two` is active when dialog is shown.
 
-**Unexpected:** Dialog shows upe, where `Tab one` will be displayed as default.
+**Unexpected:** `Tab one` is active when dialog is shown.

--- a/tests/plugins/dialog/manual/opennonfirsttabasdefault.md
+++ b/tests/plugins/dialog/manual/opennonfirsttabasdefault.md
@@ -1,0 +1,11 @@
+@bender-tags: 830, feature, 4.7.3
+@bender-ui: collapsed
+@bender-ckeditor-plugins: wysiwygarea, toolbar, dialog
+
+----
+
+1. Press button below editor with name `Press me`.
+
+**Expected:** Dialog shows up, where `Tab two` will be displayed as default.
+
+**Unexpected:** Dialog shows upe, where `Tab one` will be displayed as default.

--- a/tests/plugins/dialog/plugin.js
+++ b/tests/plugins/dialog/plugin.js
@@ -1,347 +1,407 @@
 /* bender-tags: editor */
 /* bender-ckeditor-plugins: dialog */
 
-CKEDITOR.on( 'instanceLoaded', function() {
-	CKEDITOR.dialog.add( 'testDialog1', function() {
-		return {
-			title: 'Test Dialog 1',
-			contents: [
-				{
-					id: 'info',
-					label: 'Test',
-					elements: [
-						{
-							type: 'text',
-							id: 'foo',
-							label: 'bar'
-						}
-					]
-				}
-			]
-		};
-	} );
-	CKEDITOR.dialog.add( 'testDialog2', '%TEST_DIR%_assets/testdialog.js' );
-} );
+( function() {
+	'use strict';
 
-bender.editor = {};
-
-bender.test( {
-	'test open dialog from local': function() {
-		var ed = this.editor, tc = this;
-		ed.openDialog( 'testDialog1', function( dialog ) {
-			tc.resume( function() {
-				assert.isNotNull( dialog );
-
-				wait( function() {
-					dialog.getButton( 'cancel' ).click();
-				}, 100 );
-			} );
-		} );
-		tc.wait();
-	},
-
-	'test open dialog from url': function() {
-		var ed = this.editor, tc = this;
-		ed.openDialog( 'testDialog2', function( dialog ) {
-			tc.resume( function() {
-				assert.isNotNull( dialog );
-
-				wait( function() {
-					dialog.getButton( 'cancel' ).click();
-				}, 100 );
-			} );
-		} );
-		tc.wait();
-	},
-
-	// Code of this test is poor (checking isVisible and operations on DOM), but that's caused
-	// by very closed and poor dialog API.
-	'test dialog\'s field are disabled when not allowed': function() {
-		var ed = this.editor;
-
-		CKEDITOR.dialog.add( 'testDialog3', function() {
+	CKEDITOR.on( 'instanceLoaded', function() {
+		CKEDITOR.dialog.add( 'testDialog1', function() {
 			return {
-				title: 'Test Dialog 3',
+				title: 'Test Dialog 1',
 				contents: [
 					{
-						id: 'tab1',
-						label: 'Test 1',
+						id: 'info',
+						label: 'Test',
 						elements: [
 							{
 								type: 'text',
 								id: 'foo',
-								label: 'foo',
-								requiredContent: 'p'
-							},
-							{
-								type: 'text',
-								id: 'bar',
-								label: 'bar',
-								requiredContent: 'x'
-							}
-						]
-					},
-					{
-						id: 'tab2',
-						label: 'Test 2',
-						elements: [
-							// vbox shouldn't be count as visible uielement,
-							// so entire tab2 should be hidden.
-							{
-								type: 'vbox',
-								children: [
-									{
-										type: 'text',
-										id: 'bom',
-										label: 'bom',
-										requiredContent: 'y'
-									}
-								]
-							}
-						]
-					},
-					{
-						id: 'tab3',
-						label: 'Test 3',
-						elements: [
-							{
-								type: 'text',
-								id: 'bim',
-								label: 'bim'
+								label: 'bar'
 							}
 						]
 					}
 				]
 			};
 		} );
+		CKEDITOR.dialog.add( 'testDialog2', '%TEST_DIR%_assets/testdialog.js' );
+	} );
 
-		ed.openDialog( 'testDialog3', function( dialog ) {
-			setTimeout( function() {
-				resume( function() {
-					// Tab 2 has no visible elements, so it should be hidden.
-					assert.areSame( 2, dialog.getPageCount() );
-					assert.isTrue( dialog.parts.tabs.getChild( 0 ).isVisible() );
-					assert.isFalse( dialog.parts.tabs.getChild( 1 ).isVisible() );
-					assert.isTrue( dialog.parts.tabs.getChild( 2 ).isVisible() );
+	bender.editor = {};
 
-					assert.isTrue( dialog.getContentElement( 'tab1', 'foo' ).getInputElement().isVisible() );
-					assert.isFalse( dialog.getContentElement( 'tab1', 'bar' ).getInputElement().isVisible() );
-					assert.isFalse( dialog.getContentElement( 'tab2', 'bom' ).getInputElement().isVisible() );
-
-					// Element tab2:bom should be still invisible after switching to second tab.
-					dialog.selectPage( 'tab2' );
-					assert.isFalse( dialog.getContentElement( 'tab2', 'bom' ).getInputElement().isVisible() );
-
-					dialog.selectPage( 'tab3' );
-					assert.isTrue( dialog.getContentElement( 'tab3', 'bim' ).getInputElement().isVisible() );
+	bender.test( {
+		'test open dialog from local': function() {
+			var ed = this.editor, tc = this;
+			ed.openDialog( 'testDialog1', function( dialog ) {
+				tc.resume( function() {
+					assert.isNotNull( dialog );
 
 					wait( function() {
 						dialog.getButton( 'cancel' ).click();
 					}, 100 );
 				} );
-			}, 200 );
-		} );
-		wait();
-	},
+			} );
+			tc.wait();
+		},
 
-	// Code of this test is poor (checking isVisible and operations on DOM), but that's caused
-	// by very closed and poor dialog API.
-	// http://dev.ckeditor.com/ticket/12546
-	'test dialog\'s HTML field always count as allowed field unless requiredContent is specified': function() {
-		var ed = this.editor;
-
-		CKEDITOR.dialog.add( 'testDialog4', function() {
-			return {
-				title: 'Test Dialog 4',
-				contents: [
-					{
-						id: 'tab1',
-						label: 'Test 1',
-						elements: [
-							{
-								type: 'html',
-								id: 'field1',
-								html: 'foo'
-							}
-						]
-					},
-					{
-						id: 'tab2a',
-						label: 'Test 2a',
-						elements: [
-							{
-								type: 'html',
-								id: 'field2a',
-								html: 'foo',
-								requiredContent: 'x'
-							}
-						]
-					},
-					{
-						id: 'tab2b',
-						label: 'Test 2b',
-						elements: [
-							{
-								type: 'html',
-								id: 'field2b',
-								html: 'foo',
-								requiredContent: 'p'
-							}
-						]
-					},
-					{
-						id: 'tab3',
-						label: 'Test 3',
-						requiredContent: 'y',
-						elements: [
-							{
-								type: 'html',
-								id: 'field3',
-								html: 'foo'
-							}
-						]
-					}
-				]
-			};
-		} );
-
-		ed.openDialog( 'testDialog4', function( dialog ) {
-			setTimeout( function() {
-				resume( function() {
-					assert.areSame( 2, dialog.getPageCount() );
-					assert.isTrue( dialog.parts.tabs.getChild( 0 ).isVisible(), 'tab1' );
-					// Tab 2a is hidden.
-					assert.isFalse( dialog.parts.tabs.getChild( 1 ).isVisible(), 'tab2a' );
-					assert.isTrue( dialog.parts.tabs.getChild( 2 ).isVisible(), 'tab2b' );
-					// Tab 3 wasn't created at all.
-					assert.isNull( dialog.parts.tabs.getChild( 3 ), 'tab3' );
-
-					assert.isTrue( dialog.getContentElement( 'tab1', 'field1' ).getInputElement().isVisible(), 'field1' );
-
-					dialog.selectPage( 'tab2b' );
-					assert.isTrue( dialog.getContentElement( 'tab2b', 'field2b' ).getInputElement().isVisible(), 'field2b' );
+		'test open dialog from url': function() {
+			var ed = this.editor, tc = this;
+			ed.openDialog( 'testDialog2', function( dialog ) {
+				tc.resume( function() {
+					assert.isNotNull( dialog );
 
 					wait( function() {
 						dialog.getButton( 'cancel' ).click();
 					}, 100 );
 				} );
-			}, 200 );
-		} );
-		wait();
-	},
+			} );
+			tc.wait();
+		},
 
-	'test dialog is triggered on doubleclick': function() {
-		var editor = this.editor,
+		// Code of this test is poor (checking isVisible and operations on DOM), but that's caused
+		// by very closed and poor dialog API.
+		'test dialog\'s field are disabled when not allowed': function() {
+			var ed = this.editor;
+
+			CKEDITOR.dialog.add( 'testDialog3', function() {
+				return {
+					title: 'Test Dialog 3',
+					contents: [
+						{
+							id: 'tab1',
+							label: 'Test 1',
+							elements: [
+								{
+									type: 'text',
+									id: 'foo',
+									label: 'foo',
+									requiredContent: 'p'
+								},
+								{
+									type: 'text',
+									id: 'bar',
+									label: 'bar',
+									requiredContent: 'x'
+								}
+							]
+						},
+						{
+							id: 'tab2',
+							label: 'Test 2',
+							elements: [
+								// vbox shouldn't be count as visible uielement,
+								// so entire tab2 should be hidden.
+								{
+									type: 'vbox',
+									children: [
+										{
+											type: 'text',
+											id: 'bom',
+											label: 'bom',
+											requiredContent: 'y'
+										}
+									]
+								}
+							]
+						},
+						{
+							id: 'tab3',
+							label: 'Test 3',
+							elements: [
+								{
+									type: 'text',
+									id: 'bim',
+									label: 'bim'
+								}
+							]
+						}
+					]
+				};
+			} );
+
+			ed.openDialog( 'testDialog3', function( dialog ) {
+				setTimeout( function() {
+					resume( function() {
+						// Tab 2 has no visible elements, so it should be hidden.
+						assert.areSame( 2, dialog.getPageCount() );
+						assert.isTrue( dialog.parts.tabs.getChild( 0 ).isVisible() );
+						assert.isFalse( dialog.parts.tabs.getChild( 1 ).isVisible() );
+						assert.isTrue( dialog.parts.tabs.getChild( 2 ).isVisible() );
+
+						assert.isTrue( dialog.getContentElement( 'tab1', 'foo' ).getInputElement().isVisible() );
+						assert.isFalse( dialog.getContentElement( 'tab1', 'bar' ).getInputElement().isVisible() );
+						assert.isFalse( dialog.getContentElement( 'tab2', 'bom' ).getInputElement().isVisible() );
+
+						// Element tab2:bom should be still invisible after switching to second tab.
+						dialog.selectPage( 'tab2' );
+						assert.isFalse( dialog.getContentElement( 'tab2', 'bom' ).getInputElement().isVisible() );
+
+						dialog.selectPage( 'tab3' );
+						assert.isTrue( dialog.getContentElement( 'tab3', 'bim' ).getInputElement().isVisible() );
+
+						wait( function() {
+							dialog.getButton( 'cancel' ).click();
+						}, 100 );
+					} );
+				}, 200 );
+			} );
+			wait();
+		},
+
+		// Code of this test is poor (checking isVisible and operations on DOM), but that's caused
+		// by very closed and poor dialog API.
+		// http://dev.ckeditor.com/ticket/12546
+		'test dialog\'s HTML field always count as allowed field unless requiredContent is specified': function() {
+			var ed = this.editor;
+
+			CKEDITOR.dialog.add( 'testDialog4', function() {
+				return {
+					title: 'Test Dialog 4',
+					contents: [
+						{
+							id: 'tab1',
+							label: 'Test 1',
+							elements: [
+								{
+									type: 'html',
+									id: 'field1',
+									html: 'foo'
+								}
+							]
+						},
+						{
+							id: 'tab2a',
+							label: 'Test 2a',
+							elements: [
+								{
+									type: 'html',
+									id: 'field2a',
+									html: 'foo',
+									requiredContent: 'x'
+								}
+							]
+						},
+						{
+							id: 'tab2b',
+							label: 'Test 2b',
+							elements: [
+								{
+									type: 'html',
+									id: 'field2b',
+									html: 'foo',
+									requiredContent: 'p'
+								}
+							]
+						},
+						{
+							id: 'tab3',
+							label: 'Test 3',
+							requiredContent: 'y',
+							elements: [
+								{
+									type: 'html',
+									id: 'field3',
+									html: 'foo'
+								}
+							]
+						}
+					]
+				};
+			} );
+
+			ed.openDialog( 'testDialog4', function( dialog ) {
+				setTimeout( function() {
+					resume( function() {
+						assert.areSame( 2, dialog.getPageCount() );
+						assert.isTrue( dialog.parts.tabs.getChild( 0 ).isVisible(), 'tab1' );
+						// Tab 2a is hidden.
+						assert.isFalse( dialog.parts.tabs.getChild( 1 ).isVisible(), 'tab2a' );
+						assert.isTrue( dialog.parts.tabs.getChild( 2 ).isVisible(), 'tab2b' );
+						// Tab 3 wasn't created at all.
+						assert.isNull( dialog.parts.tabs.getChild( 3 ), 'tab3' );
+
+						assert.isTrue( dialog.getContentElement( 'tab1', 'field1' ).getInputElement().isVisible(), 'field1' );
+
+						dialog.selectPage( 'tab2b' );
+						assert.isTrue( dialog.getContentElement( 'tab2b', 'field2b' ).getInputElement().isVisible(), 'field2b' );
+
+						wait( function() {
+							dialog.getButton( 'cancel' ).click();
+						}, 100 );
+					} );
+				}, 200 );
+			} );
+			wait();
+		},
+
+		'test dialog is triggered on doubleclick': function() {
+			var editor = this.editor,
 			openedDialog = null,
 			revert = bender.tools.replaceMethod( editor, 'openDialog', function( name ) {
 				openedDialog = name;
 			} );
 
-		editor.fire( 'doubleclick', { element: editor.editable() } );
+			editor.fire( 'doubleclick', { element: editor.editable() } );
 
-		assert.isNull( openedDialog, 'dialog was not opened' );
+			assert.isNull( openedDialog, 'dialog was not opened' );
 
-		editor.once( 'doubleclick', function( evt ) {
-			evt.data.dialog = 'testdoubleclick';
-		} );
+			editor.once( 'doubleclick', function( evt ) {
+				evt.data.dialog = 'testdoubleclick';
+			} );
 
-		editor.fire( 'doubleclick', { element: editor.editable() } );
+			editor.fire( 'doubleclick', { element: editor.editable() } );
 
-		assert.areSame( 'testdoubleclick', openedDialog, 'dialog was opened on doubleclick' );
+			assert.areSame( 'testdoubleclick', openedDialog, 'dialog was opened on doubleclick' );
 
-		revert();
-	},
+			revert();
+		},
 
-	'test dialog setState': function() {
-		var stateEventFired = 0,
+		'test dialog setState': function() {
+			var stateEventFired = 0,
 			editor = this.editor;
 
-		CKEDITOR.dialog.add( 'testDialog5', function() {
-			return {
-				title: 'Test Dialog 5',
-				contents: [
-					{
-						id: 'tab1',
-						label: 'Test 1',
-						elements: [
-							{
-								type: 'text',
-								id: 'foo',
-								label: 'foo',
-								requiredContent: 'p'
-							}
-						]
-					}
-				]
-			};
-		} );
-
-		editor.addCommand( 'testDialog5', new CKEDITOR.dialogCommand( 'testDialog5' ) );
-
-		editor.once( 'dialogShow', function( evt ) {
-			var dialog = evt.data;
-
-			resume( function() {
-				try {
-					assert.isTrue( dialog.getButton( 'ok' ).isEnabled(), 'OK button is enabled.' );
-					assert.isUndefined( dialog.parts.spinner, 'By default dialog has no spinner' );
-					assert.areSame( CKEDITOR.DIALOG_STATE_IDLE, dialog.state, 'Default dialog state' );
-
-					var stateListener = dialog.on( 'state', function( evt ) {
-						try {
-							assert.areSame( CKEDITOR.DIALOG_STATE_BUSY, dialog.state, 'New dialog state' );
-							assert.isFalse( dialog.getButton( 'ok' ).isEnabled(), 'OK button is disabled' );
-							assert.isObject( dialog.parts.spinner, 'Dialog has a spinner element' );
-
-							++stateEventFired;
-						} catch ( e ) {
-							evt.removeListener();
-							throw e;
+			CKEDITOR.dialog.add( 'testDialog5', function() {
+				return {
+					title: 'Test Dialog 5',
+					contents: [
+						{
+							id: 'tab1',
+							label: 'Test 1',
+							elements: [
+								{
+									type: 'text',
+									id: 'foo',
+									label: 'foo',
+									requiredContent: 'p'
+								}
+							]
 						}
-					} );
+					]
+				};
+			} );
 
-					// Change dialog's state and assert related properties.
-					dialog.setState( CKEDITOR.DIALOG_STATE_BUSY );
+			editor.addCommand( 'testDialog5', new CKEDITOR.dialogCommand( 'testDialog5' ) );
 
-					// Remove the listener because the dialog will be reopened and those assertions would be invalid.
-					stateListener.removeListener();
+			editor.once( 'dialogShow', function( evt ) {
+				var dialog = evt.data;
 
-					assert.areSame( 1, stateEventFired, 'State event has been fired' );
+				resume( function() {
+					try {
+						assert.isTrue( dialog.getButton( 'ok' ).isEnabled(), 'OK button is enabled.' );
+						assert.isUndefined( dialog.parts.spinner, 'By default dialog has no spinner' );
+						assert.areSame( CKEDITOR.DIALOG_STATE_IDLE, dialog.state, 'Default dialog state' );
 
-					dialog.hide();
-
-					// Call the dialog again to tell what happens to the state and the UI once reopened.
-					editor.execCommand( 'testDialog5' );
-
-					editor.once( 'dialogShow', function( evt ) {
-						var dialog = evt.data;
-
-						resume( function() {
+						var stateListener = dialog.on( 'state', function( evt ) {
 							try {
-								assert.areSame( CKEDITOR.DIALOG_STATE_IDLE, dialog.state, 'Default dialog state after re–open' );
-								assert.isTrue( dialog.getButton( 'ok' ).isEnabled(), 'OK button is enabled after re–open' );
-								assert.isObject( dialog.parts.spinner, 'Dialog has been given a spinner before' );
+								assert.areSame( CKEDITOR.DIALOG_STATE_BUSY, dialog.state, 'New dialog state' );
+								assert.isFalse( dialog.getButton( 'ok' ).isEnabled(), 'OK button is disabled' );
+								assert.isObject( dialog.parts.spinner, 'Dialog has a spinner element' );
+
+								++stateEventFired;
 							} catch ( e ) {
+								evt.removeListener();
 								throw e;
-							} finally {
-								dialog.hide();
 							}
 						} );
-					} );
 
-					wait();
-				} catch ( e ) {
-					throw e;
-				} finally {
-					dialog.hide();
-				}
+						// Change dialog's state and assert related properties.
+						dialog.setState( CKEDITOR.DIALOG_STATE_BUSY );
+
+						// Remove the listener because the dialog will be reopened and those assertions would be invalid.
+						stateListener.removeListener();
+
+						assert.areSame( 1, stateEventFired, 'State event has been fired' );
+
+						dialog.hide();
+
+						// Call the dialog again to tell what happens to the state and the UI once reopened.
+						editor.execCommand( 'testDialog5' );
+
+						editor.once( 'dialogShow', function( evt ) {
+							var dialog = evt.data;
+
+							resume( function() {
+								try {
+									assert.areSame( CKEDITOR.DIALOG_STATE_IDLE, dialog.state, 'Default dialog state after re–open' );
+									assert.isTrue( dialog.getButton( 'ok' ).isEnabled(), 'OK button is enabled after re–open' );
+									assert.isObject( dialog.parts.spinner, 'Dialog has been given a spinner before' );
+								} catch ( e ) {
+									throw e;
+								} finally {
+									dialog.hide();
+								}
+							} );
+						} );
+
+						wait();
+					} catch ( e ) {
+						throw e;
+					} finally {
+						dialog.hide();
+					}
+				} );
 			} );
-		} );
 
-		editor.execCommand( 'testDialog5' );
+			editor.execCommand( 'testDialog5' );
 
-		wait();
-	}
-} );
+			wait();
+		},
 
-//]]>
+		// #830
+		'test dialog opens non first tab as default': function() {
+			var editor = this.editor;
+
+			CKEDITOR.dialog.add( 'testDialog6', function() {
+				return {
+					title: 'Test dialog 6',
+					contents: [
+						{
+							id: 'tab1',
+							label: 'Tab one',
+							elements: [
+								{
+									type: 'html',
+									id: 'field11',
+									html: 'foo'
+								}
+							]
+						},
+						{
+							id: 'tab2',
+							label: 'Tab two',
+							elements: [
+								{
+									type: 'html',
+									id: 'field21',
+									html: 'bar'
+								}
+							]
+						}
+					]
+				};
+			} );
+
+			editor.addCommand( 'testDialog6', new CKEDITOR.dialogCommand( 'testDialog6', {
+				tab: 'tab2'
+			} ) );
+
+
+			editor.once( 'dialogShow', function( evt ) {
+				resume( function() {
+					try {
+						var dialog = evt.data;
+						assert.areSame( 'tab2', dialog._.currentTabId );
+					} catch ( e ) {
+						throw e;
+					}
+					finally {
+						dialog.hide();
+					}
+				} );
+			} );
+
+			editor.execCommand( 'testDialog6' );
+			wait();
+		}
+	} );
+
+} )();

--- a/tests/plugins/dialog/plugin.js
+++ b/tests/plugins/dialog/plugin.js
@@ -347,7 +347,7 @@
 		},
 
 		// #830
-		'test dialog opens non first tab as default': function() {
+		'test dialog opens tab defined in tabId as default': function() {
 			var editor = this.editor;
 
 			CKEDITOR.dialog.add( 'testDialog6', function() {
@@ -381,7 +381,7 @@
 			} );
 
 			editor.addCommand( 'testDialog6', new CKEDITOR.dialogCommand( 'testDialog6', {
-				tab: 'tab2'
+				tabId: 'tab2'
 			} ) );
 
 


### PR DESCRIPTION
## What is the purpose of this pull request?

task request

## Does your PR contain necessary tests?
yes
### This PR contains

- [x] Unit tests
- [x] Manual tests

## What changes did you make?
- provide possibility to define tab which should be open as default one after loading dialog.
- `tests/plugins/dialog/plugin.js` can seems to have a lot of changes. I've wrapped entire test suite with IIFE and add `'use strict;'`. That's why there was added extra tabs in entire file. 

Close #830