### PR TITLE
removed nodejs dependency in build.sh script

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -18,6 +18,10 @@ Fixed Issues:
 * [#787](https://github.com/ckeditor/ckeditor-dev/issues/787): Fixed: Using cut inside nested table does not cut selected content.
 * [#842](https://github.com/ckeditor/ckeditor-dev/issues/842): Fixed: List style not restored when toggling list indent level in [Indent List](http://ckeditor.com/addon/indentlist) plugin.
 
+Other Changes:
+
+* [#815](https://github.com/ckeditor/ckeditor-dev/issues/815): Removed Node.js dependency from CKEditor build script. 
+
 ## CKEditor 4.7.3
 
 New Features:

--- a/dev/builder/build.sh
+++ b/dev/builder/build.sh
@@ -57,7 +57,7 @@ echo "Starting CKBuilder..."
 
 JAVA_ARGS=${ARGS// -t / } # Remove -t from args.
 
-VERSION=$(cat ./../../package.json | grep \"version\"\: | awk -F: '{ print $2}' | sed 's/[\",]//g' | tr -d '[[:space:]]')
+VERSION=$(grep '"version":' ./../../package.json | sed $'s/[\t\",: ]//g; s/version//g' | tr -d '[[:space:]]')
 REVISION=$(git rev-parse --verify --short HEAD)
 
 # If the current revision is not tagged with any CKE version, it means it's a "dirty" build. We

--- a/dev/builder/build.sh
+++ b/dev/builder/build.sh
@@ -57,7 +57,7 @@ echo "Starting CKBuilder..."
 
 JAVA_ARGS=${ARGS// -t / } # Remove -t from args.
 
-VERSION=`node -pe "require('./../../package.json').version"`
+VERSION=$(cat ./../../package.json | grep \"version\"\: | awk -F: '{ print $2}' | sed 's/[\",]//g' | tr -d '[[:space:]]')
 REVISION=$(git rev-parse --verify --short HEAD)
 
 # If the current revision is not tagged with any CKE version, it means it's a "dirty" build. We


### PR DESCRIPTION
## What is the purpose of this pull request?

New feature

## Does your PR contain necessary tests?

All patches which change the editor code must include tests. You can always read more
on [PR testing](http://docs.ckeditor.com/#!/guide/dev_contributing_code-section-tests),
[how to set the testing environment](http://docs.ckeditor.com/#!/guide/dev_tests) and
[how to create tests](http://docs.ckeditor.com/#!/guide/dev_tests-section-creating-your-own-test)
in the official CKEditor documentation.

### This PR contains

- [ ] Unit tests
- [ ] Manual tests

## What changes did you make?

now build.sh script use only bash tools to get version from package.json

closes #815
