### PR TITLE
[#834] Fix radio button selection problem when used in IE browser.

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -12,6 +12,7 @@ New Features:
 Fixed Issues:
 
 * [#796](https://github.com/ckeditor/ckeditor-dev/issues/796): Fixed: List is pasted from OneNote in a reversed order.
+* [#834](https://github.com/ckeditor/ckeditor-dev/issues/834): [IE9-11] Fixed: Editor does not save selected state of radiobuttons inserted by [Form Elements](https://ckeditor.com/addon/forms) plugin.
 
 ## CKEditor 4.7.3
 

--- a/plugins/forms/dialogs/radio.js
+++ b/plugins/forms/dialogs/radio.js
@@ -26,10 +26,9 @@ CKEDITOR.dialog.add( 'radio', function( editor ) {
 				editor = this.getParentEditor();
 				element = editor.document.createElement( 'input' );
 				element.setAttribute( 'type', 'radio' );
+				editor.insertElement( element );
 			}
 
-			if ( isInsertMode )
-				editor.insertElement( element );
 			this.commitContent( { element: element } );
 		},
 		contents: [ {
@@ -107,6 +106,12 @@ CKEDITOR.dialog.add( 'radio', function( editor ) {
 								'></input>', editor.document );
 							element.copyAttributes( replace, { type: 1, checked: 1 } );
 							replace.replace( element );
+
+							// Ugly hack which fix IE issues with radiobuttons (#834).
+							if ( isChecked ) {
+								replace.setAttribute( 'checked', 'checked' );
+							}
+
 							editor.getSelection().selectElement( replace );
 							data.element = replace;
 						}

--- a/tests/plugins/forms/manual/ieradiofix.html
+++ b/tests/plugins/forms/manual/ieradiofix.html
@@ -4,6 +4,9 @@
 	</div>
 
 	<script>
+		if ( !CKEDITOR.env.ie ) {
+			bender.ignore();
+		}
 		CKEDITOR.replace( 'editor' );
 	</script>
 	</body>

--- a/tests/plugins/forms/manual/ieradiofix.html
+++ b/tests/plugins/forms/manual/ieradiofix.html
@@ -1,0 +1,9 @@
+<body>
+	<div id="editor">
+		<p>Example text</p>
+	</div>
+
+	<script>
+		CKEDITOR.replace( 'editor' );
+	</script>
+	</body>

--- a/tests/plugins/forms/manual/ieradiofix.md
+++ b/tests/plugins/forms/manual/ieradiofix.md
@@ -1,0 +1,20 @@
+@bender-tags: bug, 4.7.3, forms, 834
+@bender-ui: collapsed
+@bender-ckeditor-plugins: forms, wysiwygarea, toolbar, sourcearea
+
+----
+
+1. Click in the editor.
+2. Click "Radio" button.
+3. Check "Selected" field in the dialog and press "Ok" to create a radio button.
+4. Check source in editor.
+5. Double click the radio.
+6. Check "Selected" field in the dialog and press "Ok" to modify radio.
+7. Check source in editor.
+
+**Expected:**
+* The state of radio button is changed according to settings.
+* In source mode appeaers 'checked' attribute when radio button is marked as selected.
+
+**Unexpected:**
+* The state of radio button is not saved. 'Checked' attribute is **not present** in source mode when it should be.

--- a/tests/plugins/forms/manual/ieradiofix.md
+++ b/tests/plugins/forms/manual/ieradiofix.md
@@ -1,4 +1,4 @@
-@bender-tags: bug, 4.7.3, forms, 834
+@bender-tags: bug, 4.8.0, forms, 834
 @bender-ui: collapsed
 @bender-ckeditor-plugins: forms, wysiwygarea, toolbar, sourcearea
 
@@ -17,4 +17,4 @@
 * In source mode appeaers 'checked' attribute when radio button is marked as selected.
 
 **Unexpected:**
-* The state of radio button is not saved. 'Checked' attribute is **not present** in source mode when it should be.
+* The state of radio button is not saved. 'Checked' attribute is **not present** in source mode.

--- a/tests/plugins/forms/radio.js
+++ b/tests/plugins/forms/radio.js
@@ -24,23 +24,19 @@ bender.test( {
 	},
 
 	'test empty fields': function() {
-		// IE is quite problematic. You cannot remove `value` from the input. There are some hacks design specially for IE to fix `value` problem.
-		// Those customization should be removed if #844 will be fixed.
 		var bot = this.editorBot;
 
+		bot.setHtmlWithSelection( '[<input checked="checked" name="name" required="required" type="radio" value="value" />]' );
+
+		// We need to add attribute 'checked', after adding radio input to editable.
+		// From uknown reason IE omits this attribute when add radio input element to DOM tree.
 		if ( CKEDITOR.env.ie ) {
-			bot.setHtmlWithSelection( '[<input checked="checked" name="name" required="required" type="radio" />]' );
-			// We need to add 'checked', after adding input to editable by setHtmlWithSelection. There is some magic with IE ;)
 			this.editor.editable().findOne( 'input' ).setAttribute( 'checked', 'checked' );
-		} else {
-			bot.setHtmlWithSelection( '[<input checked="checked" name="name" required="required" type="radio" value="value" />]' );
 		}
 
 		bot.dialog( 'radio', function( dialog ) {
 			assert.areSame( 'name', dialog.getValueOf( 'info', 'name' ) );
-			if ( !CKEDITOR.env.ie ) {
-				assert.areSame( 'value', dialog.getValueOf( 'info', 'value' ) );
-			}
+			assert.areSame( 'value', dialog.getValueOf( 'info', 'value' ) );
 			assert.areSame( true, dialog.getValueOf( 'info', 'checked' ) );
 			assert.areSame( true, dialog.getValueOf( 'info', 'required' ) );
 
@@ -51,7 +47,13 @@ bender.test( {
 
 			dialog.getButton( 'ok' ).click();
 
-			assert.areSame( '<input type="radio" />', bot.getData( false, true ) );
+			// IE is problematic: you cannot remove `value` from the input.
+			// This customization should be removed if #844 will be fixed.
+			if ( CKEDITOR.env.ie ) {
+				assert.areSame( '<input type="radio" value="value" />', bot.getData( false, true ) );
+			} else {
+				assert.areSame( '<input type="radio" />', bot.getData( false, true ) );
+			}
 		} );
 	}
 } );

--- a/tests/plugins/forms/radio.js
+++ b/tests/plugins/forms/radio.js
@@ -9,10 +9,6 @@ bender.editor = {
 
 bender.test( {
 	'test fill fields': function() {
-		// That feature is generally broken in IEs.
-		if ( CKEDITOR.env.ie )
-			assert.ignore();
-
 		var bot = this.editorBot;
 
 		bot.dialog( 'radio', function( dialog ) {
@@ -28,17 +24,23 @@ bender.test( {
 	},
 
 	'test empty fields': function() {
-		// That feature is generally broken in IEs.
-		if ( CKEDITOR.env.ie )
-			assert.ignore();
-
+		// IE is quite problematic. You cannot remove `value` from the input. There are some hacks design specially for IE to fix `value` problem.
+		// Those customization should be removed if #844 will be fixed.
 		var bot = this.editorBot;
 
-		bot.setHtmlWithSelection( '[<input checked="checked" name="name" required="required" type="radio" value="value" />]' );
+		if ( CKEDITOR.env.ie ) {
+			bot.setHtmlWithSelection( '[<input checked="checked" name="name" required="required" type="radio" />]' );
+			// We need to add 'checked', after adding input to editable by setHtmlWithSelection. There is some magic with IE ;)
+			this.editor.editable().findOne( 'input' ).setAttribute( 'checked', 'checked' );
+		} else {
+			bot.setHtmlWithSelection( '[<input checked="checked" name="name" required="required" type="radio" value="value" />]' );
+		}
 
 		bot.dialog( 'radio', function( dialog ) {
 			assert.areSame( 'name', dialog.getValueOf( 'info', 'name' ) );
-			assert.areSame( 'value', dialog.getValueOf( 'info', 'value' ) );
+			if ( !CKEDITOR.env.ie ) {
+				assert.areSame( 'value', dialog.getValueOf( 'info', 'value' ) );
+			}
 			assert.areSame( true, dialog.getValueOf( 'info', 'checked' ) );
 			assert.areSame( true, dialog.getValueOf( 'info', 'required' ) );
 


### PR DESCRIPTION
## What is the purpose of this pull request?

Bug fix

## Does your PR contain necessary tests?

All patches which change the editor code must include tests. You can always read more
on [PR testing](http://docs.ckeditor.com/#!/guide/dev_contributing_code-section-tests),
[how to set the testing environment](http://docs.ckeditor.com/#!/guide/dev_tests) and
[how to create tests](http://docs.ckeditor.com/#!/guide/dev_tests-section-creating-your-own-test)
in the official CKEditor documentation.

### This PR contains

- [x] Unit tests
- [x] Manual tests

## What changes did you make?

- include little hack designed for IE to properly check radio buttons, when those are added to editor.

Close #834