### PR TITLE
Simplify find/replace dialog using tabId

### DIFF
--- a/plugins/find/dialogs/find.js
+++ b/plugins/find/dialogs/find.js
@@ -56,16 +56,16 @@
 		// 1. Defined as full match style to avoid compromising ordinary text color styles.
 		// 2. Must be apply onto inner-most text to avoid conflicting with ordinary text color styles visually.
 		var highlightConfig = {
-			attributes: {
-				'data-cke-highlight': 1
+				attributes: {
+					'data-cke-highlight': 1
+				},
+				fullMatch: 1,
+				ignoreReadonly: 1,
+				childRule: function() {
+					return 0;
+				}
 			},
-			fullMatch: 1,
-			ignoreReadonly: 1,
-			childRule: function() {
-				return 0;
-			}
-		};
-		var highlightStyle = new CKEDITOR.style( CKEDITOR.tools.extend( highlightConfig, editor.config.find_highlight, true ) );
+			highlightStyle = new CKEDITOR.style( CKEDITOR.tools.extend( highlightConfig, editor.config.find_highlight, true ) );
 
 		// Iterator which walk through the specified range char by char. By
 		// default the walking will not stop at the character boundaries, until
@@ -778,9 +778,9 @@
 				// Fill in the find field with selected text.
 				var startupPage = this._.currentTabId,
 					selectedText = this.getParentEditor().getSelection().getSelectedText(),
-					patternFieldId = ( startupPage == 'find' ? 'txtFindFind' : 'txtFindReplace' );
+					patternFieldId = ( startupPage == 'find' ? 'txtFindFind' : 'txtFindReplace' ),
+					field = this.getContentElement( startupPage, patternFieldId );
 
-				var field = this.getContentElement( startupPage, patternFieldId );
 				field.setValue( selectedText );
 				field.select();
 
@@ -805,10 +805,11 @@
 				delete finder.matchRange;
 			},
 			onFocus: function() {
-				if ( this._.currentTabId == 'replace' )
+				if ( this._.currentTabId == 'replace' ) {
 					return this.getContentElement( 'replace', 'txtFindReplace' );
-				else
+				} else {
 					return this.getContentElement( 'find', 'txtFindFind' );
+				}
 			}
 		};
 	}

--- a/plugins/find/dialogs/find.js
+++ b/plugins/find/dialogs/find.js
@@ -51,7 +51,7 @@
 		}
 	}
 
-	function findDialog( editor, startupPage ) {
+	function findDialog( editor ) {
 		// Style object for highlights: (http://dev.ckeditor.com/ticket/5018)
 		// 1. Defined as full match style to avoid compromising ordinary text color styles.
 		// 2. Must be apply onto inner-most text to avoid conflicting with ordinary text color styles visually.
@@ -776,14 +776,13 @@
 				finder.searchRange = getSearchRange();
 
 				// Fill in the find field with selected text.
-				var selectedText = this.getParentEditor().getSelection().getSelectedText(),
+				var startupPage = this._.currentTabId,
+					selectedText = this.getParentEditor().getSelection().getSelectedText(),
 					patternFieldId = ( startupPage == 'find' ? 'txtFindFind' : 'txtFindReplace' );
 
 				var field = this.getContentElement( startupPage, patternFieldId );
 				field.setValue( selectedText );
 				field.select();
-
-				this.selectPage( startupPage );
 
 				this[ ( startupPage == 'find' && this._.editor.readOnly ? 'hide' : 'show' ) + 'Page' ]( 'replace' );
 			},
@@ -806,7 +805,7 @@
 				delete finder.matchRange;
 			},
 			onFocus: function() {
-				if ( startupPage == 'replace' )
+				if ( this._.currentTabId == 'replace' )
 					return this.getContentElement( 'replace', 'txtFindReplace' );
 				else
 					return this.getContentElement( 'find', 'txtFindFind' );
@@ -814,11 +813,5 @@
 		};
 	}
 
-	CKEDITOR.dialog.add( 'find', function( editor ) {
-		return findDialog( editor, 'find' );
-	} );
-
-	CKEDITOR.dialog.add( 'replace', function( editor ) {
-		return findDialog( editor, 'replace' );
-	} );
+	CKEDITOR.dialog.add( 'find', findDialog );
 } )();

--- a/plugins/find/plugin.js
+++ b/plugins/find/plugin.js
@@ -15,7 +15,10 @@ CKEDITOR.plugins.add( 'find', {
 		findCommand.canUndo = false;
 		findCommand.readOnly = 1;
 
-		var replaceCommand = editor.addCommand( 'replace', new CKEDITOR.dialogCommand( 'replace' ) );
+		var replaceCommand = editor.addCommand( 'replace', new CKEDITOR.dialogCommand( 'find', {
+			tabId: 'replace'
+		} ) );
+
 		replaceCommand.canUndo = false;
 
 		if ( editor.ui.addButton ) {
@@ -33,7 +36,6 @@ CKEDITOR.plugins.add( 'find', {
 		}
 
 		CKEDITOR.dialog.add( 'find', this.path + 'dialogs/find.js' );
-		CKEDITOR.dialog.add( 'replace', this.path + 'dialogs/find.js' );
 	}
 } );
 

--- a/plugins/find/plugin.js
+++ b/plugins/find/plugin.js
@@ -11,13 +11,13 @@ CKEDITOR.plugins.add( 'find', {
 	icons: 'find,find-rtl,replace', // %REMOVE_LINE_CORE%
 	hidpi: true, // %REMOVE_LINE_CORE%
 	init: function( editor ) {
-		var findCommand = editor.addCommand( 'find', new CKEDITOR.dialogCommand( 'find' ) );
+		var findCommand = editor.addCommand( 'find', new CKEDITOR.dialogCommand( 'find' ) ),
+			replaceCommand = editor.addCommand( 'replace', new CKEDITOR.dialogCommand( 'find', {
+				tabId: 'replace'
+			} ) );
+
 		findCommand.canUndo = false;
 		findCommand.readOnly = 1;
-
-		var replaceCommand = editor.addCommand( 'replace', new CKEDITOR.dialogCommand( 'find', {
-			tabId: 'replace'
-		} ) );
 
 		replaceCommand.canUndo = false;
 

--- a/tests/plugins/find/manual/find.html
+++ b/tests/plugins/find/manual/find.html
@@ -1,0 +1,8 @@
+
+<textarea cols="80" id="editor1" name="editor1" rows="10">
+	<p>A regular paragraph.</p>
+</textarea>
+
+<script>
+	CKEDITOR.replace( 'editor1' );
+</script>

--- a/tests/plugins/find/manual/find.md
+++ b/tests/plugins/find/manual/find.md
@@ -1,0 +1,12 @@
+@bender-tags: find, feature, 4.8.0
+@bender-ui: collapsed
+@bender-ckeditor-plugins: find, wysiwygarea, toolbar
+
+1. Select a word, e.g. `regular`.
+2. Click "Find" toolbar button.
+	**Expected:**
+	* Find dialog is open.
+	* "Find what" field has `regular` value preset.
+3. Set "Find what:" to `ar`.
+4. Press "Find" button.
+	**Expected:** `ar` part of `regular` word gets highlighted.

--- a/tests/plugins/find/manual/replacereadonly.html
+++ b/tests/plugins/find/manual/replacereadonly.html
@@ -1,0 +1,18 @@
+
+<h1>Editor 1</h1>
+
+<textarea cols="80" id="editor1" name="editor1" rows="10">
+	<p>A regular paragraph.</p>
+</textarea>
+
+<h1>Editor 2</h1>
+
+<textarea cols="80" id="editor2" name="editor1" rows="10">
+	<p>A regular paragraph.</p>
+</textarea>
+
+<script>
+	CKEDITOR.replace( 'editor1', { readOnly: true } );
+
+	CKEDITOR.replace( 'editor2' );
+</script>

--- a/tests/plugins/find/manual/replacereadonly.md
+++ b/tests/plugins/find/manual/replacereadonly.md
@@ -1,0 +1,25 @@
+@bender-tags: find, feature, 4.8.0
+@bender-ui: collapsed
+@bender-ckeditor-plugins: find, wysiwygarea, toolbar
+
+Replace tab should not be visible in readonly mode.
+
+## Editor 1
+
+1. Select a word, e.g. "regular"
+2. Click "Replace" toolbar button.
+	**Expected:** Nothing happens.
+	**Unexpected:** Replace dialog is open.
+3. Click "Find" toolbar button.
+	**Expected:** Dialog is open, there is no replace tab.
+	**Unexpected:** Replace tab is visible.
+
+## Editor 2
+
+1. Select a word, e.g. "regular"
+2. Click "Replace" toolbar button.
+	**Expected:** Replace dialog is open.
+	**Unexpected:** Nothing happens.
+3. Click "Find" toolbar button.
+	**Expected:** Replace tab is visible.
+	**Unexpected:** Dialog is open, there is no replace tab.


### PR DESCRIPTION
## What is the purpose of this pull request?

Refactoring

 ## Does your PR contain necessary tests?

Since there were no generic manual tests for find function I have created one. In addition to that added a dedicated (feature) manual test for replace dialog in read only mode (as it's the weirdest case that could be broken by this change).

 ### This PR contains

- [ ] Unit tests - _the code is already somewhat covered with unit tests_
- [ x ] Manual tests

 ## What changes did you make?

See original ticket for the issue description.

I believe there could be far more things refactored in this dialog, but TBH I wanted to touch as little as possible as there are maaany dependencies going on there.

I left `findDialog` function/closure as it encloses some, not that pretty, legacy code.

Closes #850.