### PR TITLE
Introduced CKEDITOR.tools.keystrokeToArray

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -7,6 +7,7 @@ New Features:
 
 * [#607](https://github.com/ckeditor/ckeditor-dev/issues/607): Manually inserted hex color is prefixed with hash tag if needed. It ensures a valid hex color is used when setting table cell border or background color via [Color Dialog](http://ckeditor.com/addon/colordialog) window.
 * [#584](https://github.com/ckeditor/ckeditor-dev/issues/584): [Font size and Family](http://ckeditor.com/addon/font) and [Format](http://ckeditor.com/addon/format) drop-downs are not toggleable anymore. Default option to reset styles added.
+* [#856](https://github.com/ckeditor/ckeditor-dev/issues/856): Introduced [`CKEDITOR.tools.keystrokeToArray`](https://docs.ckeditor.com/ckeditor-docs/build/#!/api/CKEDITOR.tools-method-keystrokeToArray). It converts given keystroke into its string representation, returning every key name as separate array element.
 
 ## CKEditor 4.7.3
 

--- a/core/tools.js
+++ b/core/tools.js
@@ -1373,6 +1373,49 @@
 			};
 		},
 
+		keystrokeToArray: function( lang, keystroke ) {
+			var special = keystroke & 0xFF0000,
+				key = keystroke & 0x00FFFF,
+				isMac = CKEDITOR.env.mac,
+				CTRL = 17,
+				CMD = 224,
+				ALT = 18,
+				SHIFT = 16,
+				display = [],
+				aria = [];
+
+
+			if ( special & CKEDITOR.CTRL ) {
+				display.push( isMac ? '⌘' : lang[ CTRL ] );
+				aria.push( isMac ? lang[ CMD ] : lang[ CTRL ] );
+			}
+
+			if ( special & CKEDITOR.ALT ) {
+				display.push( isMac ? '⌥' : lang[ ALT ] );
+				aria.push( lang[ ALT ] );
+			}
+
+			if ( special & CKEDITOR.SHIFT ) {
+				display.push( isMac ? '⇧' : lang[ SHIFT ] );
+				aria.push( lang[ SHIFT ] );
+			}
+
+			if ( key ) {
+				if ( lang[ key ] ) {
+					display.push( lang[ key ] );
+					aria.push( lang[ key ] );
+				} else {
+					display.push( String.fromCharCode( key ) );
+					aria.push( String.fromCharCode( key ) );
+				}
+			}
+
+			return {
+				display: display,
+				aria: aria
+			};
+		},
+
 		/**
 		 * The data URI of a transparent image. May be used e.g. in HTML as an image source or in CSS in `url()`.
 		 *

--- a/core/tools.js
+++ b/core/tools.js
@@ -1345,7 +1345,7 @@
 		 * It does not use special characters such as `⌥`, `⇧` or `⌘`.
 		 *
 		 * 		var lang = editor.lang.common.keyboard;
-		 * 		var shortcut = CKEDITOR.tools.keystrokeToString( lang, CKEDITOR.CTRL + 88 );
+		 * 		var shortcut = CKEDITOR.tools.keystrokeToArray( lang, CKEDITOR.CTRL + 88 );
 		 * 		console.log( shortcut.display ); // [ 'CTRL', 'X' ], on Mac [ '⌘', 'X' ].
 		 * 		console.log( shortcut.aria ); // [ 'CTRL', 'X' ], on Mac [ 'COMMAND', 'X' ].
 		 *

--- a/core/tools.js
+++ b/core/tools.js
@@ -1313,12 +1313,9 @@
 		},
 
 		/**
-		 * Converts a keystroke to its string representation. Returns an object with two fields:
-		 *
-		 * * `display` &ndash; A string that should be used for visible labels.
-		 * For Mac devices it uses `⌥` for `ALT`, `⇧` for `SHIFT` and `⌘` for `COMMAND`.
-		 * * `aria` &ndash; A string that should be used for ARIA descriptions.
-		 * It does not use special characters such as `⌥`, `⇧` or `⌘`.
+		 * Converts a keystroke to its string representation. Returns exactly the same
+		 * members as {@link #keystrokeToArray}, but returned object contains strings of
+		 * keys joined with "+" rather than an array of keystrokes.
 		 *
 		 * 		var lang = editor.lang.common.keyboard;
 		 * 		var shortcut = CKEDITOR.tools.keystrokeToString( lang, CKEDITOR.CTRL + 88 );
@@ -1328,49 +1325,15 @@
 		 * @since 4.6.0
 		 * @param {Object} lang A language object with the key name translation.
 		 * @param {Number} keystroke The keystroke to convert.
-		 * @returns {{display: String, aria: String}}
+		 * @returns {{display: String, aria: String}} See {@link #keystrokeToArray}.
 		 */
 		keystrokeToString: function( lang, keystroke ) {
-			var special = keystroke & 0xFF0000,
-				key = keystroke & 0x00FFFF,
-				isMac = CKEDITOR.env.mac,
-				CTRL = 17,
-				CMD = 224,
-				ALT = 18,
-				SHIFT = 16,
-				display = [],
-				aria = [];
+			var ret = this.keystrokeToArray( lang, keystroke );
 
+			ret.display = ret.display.join( '+' );
+			ret.aria = ret.aria.join( '+' );
 
-			if ( special & CKEDITOR.CTRL ) {
-				display.push( isMac ? '⌘' : lang[ CTRL ] );
-				aria.push( isMac ? lang[ CMD ] : lang[ CTRL ] );
-			}
-
-			if ( special & CKEDITOR.ALT ) {
-				display.push( isMac ? '⌥' : lang[ ALT ] );
-				aria.push( lang[ ALT ] );
-			}
-
-			if ( special & CKEDITOR.SHIFT ) {
-				display.push( isMac ? '⇧' : lang[ SHIFT ] );
-				aria.push( lang[ SHIFT ] );
-			}
-
-			if ( key ) {
-				if ( lang[ key ] ) {
-					display.push( lang[ key ] );
-					aria.push( lang[ key ] );
-				} else {
-					display.push( String.fromCharCode( key ) );
-					aria.push( String.fromCharCode( key ) );
-				}
-			}
-
-			return {
-				display: display.join( '+' ),
-				aria: aria.join( '+' )
-			};
+			return ret;
 		},
 
 		/**

--- a/core/tools.js
+++ b/core/tools.js
@@ -1373,6 +1373,24 @@
 			};
 		},
 
+		/**
+		 * Converts a keystroke to its string representation. Returns an object with two fields:
+		 *
+		 * * `display` &ndash; An array of strings that should be used for visible labels.
+		 * For Mac devices it uses `⌥` for `ALT`, `⇧` for `SHIFT` and `⌘` for `COMMAND`.
+		 * * `aria` &ndash; An array of strings that should be used for ARIA descriptions.
+		 * It does not use special characters such as `⌥`, `⇧` or `⌘`.
+		 *
+		 * 		var lang = editor.lang.common.keyboard;
+		 * 		var shortcut = CKEDITOR.tools.keystrokeToString( lang, CKEDITOR.CTRL + 88 );
+		 * 		console.log( shortcut.display ); // [ 'CTRL', 'X' ], on Mac [ '⌘', 'X' ].
+		 * 		console.log( shortcut.aria ); // [ 'CTRL', 'X' ], on Mac [ 'COMMAND', 'X' ].
+		 *
+		 * @since 4.8.0
+		 * @param {Object} lang A language object with the key name translation.
+		 * @param {Number} keystroke The keystroke to convert.
+		 * @returns {{display: String[], aria: String[]}}
+		 */
 		keystrokeToArray: function( lang, keystroke ) {
 			var special = keystroke & 0xFF0000,
 				key = keystroke & 0x00FFFF,

--- a/tests/core/tools.js
+++ b/tests/core/tools.js
@@ -708,31 +708,6 @@
 			assert.areEqual( token, CKEDITOR.tools.getCsrfToken(), 'getCsrfToken returns token from cookie' );
 		},
 
-		'test keystrokeToString': function() {
-			var toString = CKEDITOR.tools.keystrokeToString,
-				lang = this.editor.lang.common.keyboard,
-				tests = [
-					// [ Keystroke, display string, display string on Mac, ARIA string, ARIA string on Mac ]
-					[ CKEDITOR.CTRL + 65 /*A*/, 'Ctrl+A', '⌘+A', 'Ctrl+A', 'Command+A' ],
-					[ CKEDITOR.ALT + 66 /*B*/, 'Alt+B', '⌥+B', 'Alt+B', 'Alt+B' ],
-					[ CKEDITOR.SHIFT + 67 /*C*/, 'Shift+C', '⇧+C', 'Shift+C', 'Shift+C' ],
-					[ CKEDITOR.CTRL + CKEDITOR.ALT + 68 /*D*/, 'Ctrl+Alt+D', '⌘+⌥+D', 'Ctrl+Alt+D', 'Command+Alt+D' ],
-					[ CKEDITOR.CTRL + CKEDITOR.SHIFT + 69 /*E*/, 'Ctrl+Shift+E', '⌘+⇧+E', 'Ctrl+Shift+E', 'Command+Shift+E' ],
-					[ CKEDITOR.ALT + CKEDITOR.SHIFT + 70 /*F*/, 'Alt+Shift+F', '⌥+⇧+F', 'Alt+Shift+F', 'Alt+Shift+F' ],
-					[ CKEDITOR.CTRL + CKEDITOR.ALT + CKEDITOR.SHIFT + 71 /*G*/, 'Ctrl+Alt+Shift+G', '⌘+⌥+⇧+G', 'Ctrl+Alt+Shift+G', 'Command+Alt+Shift+G' ],
-					[ CKEDITOR.CTRL + 32 /*SPACE*/, 'Ctrl+Space', '⌘+Space', 'Ctrl+Space', 'Command+Space' ],
-					[ CKEDITOR.ALT + 13 /*ENTER*/, 'Alt+Enter', '⌥+Enter', 'Alt+Enter', 'Alt+Enter' ]
-				],
-				test,
-				expIndex = CKEDITOR.env.mac ? 2 : 1;
-
-			for ( var i = 0, l = tests.length; i < l; i++ ) {
-				test = tests[ i ];
-				assert.areEqual( test[ expIndex ], toString( lang, test[ 0 ] ).display, 'Keystroke display string representation is invalid.' );
-				assert.areEqual( test[ expIndex + 2 ], toString( lang, test[ 0 ] ).aria, 'Keystroke ARIA string representation is invalid.' );
-			}
-		},
-
 		'test escapeCss - invalid selector': function() {
 			var selector;
 			var escapedSelector = CKEDITOR.tools.escapeCss( selector );

--- a/tests/core/tools/keystroke.js
+++ b/tests/core/tools/keystroke.js
@@ -33,6 +33,35 @@
 				assert.areEqual( test[ expIndex ], toString( lang, test[ 0 ] ).display, 'Keystroke display string representation is invalid.' );
 				assert.areEqual( test[ expIndex + 2 ], toString( lang, test[ 0 ] ).aria, 'Keystroke ARIA string representation is invalid.' );
 			}
+		},
+
+		'test keystrokeToArray': function() {
+			var toArray = CKEDITOR.tools.keystrokeToArray,
+				lang = this.editor.lang.common.keyboard,
+				tests = [
+					// [ Keystroke, display string, display string on Mac, ARIA string, ARIA string on Mac ]
+					[ CKEDITOR.CTRL + 65 /*A*/, ['Ctrl', 'A'], ['⌘', 'A'], ['Ctrl', 'A'], ['Command', 'A'] ],
+					[ CKEDITOR.ALT + 66 /*B*/, ['Alt', 'B'], ['⌥', 'B'], ['Alt', 'B'], ['Alt', 'B'] ],
+					// [ CKEDITOR.SHIFT + 67 /*C*/, 'Shift+C', '⇧+C', 'Shift+C', 'Shift+C' ],
+					// [ CKEDITOR.CTRL + CKEDITOR.ALT + 68 /*D*/, 'Ctrl+Alt+D', '⌘+⌥+D', 'Ctrl+Alt+D', 'Command+Alt+D' ],
+					// [ CKEDITOR.CTRL + CKEDITOR.SHIFT + 69 /*E*/, 'Ctrl+Shift+E', '⌘+⇧+E', 'Ctrl+Shift+E', 'Command+Shift+E' ],
+					// [ CKEDITOR.ALT + CKEDITOR.SHIFT + 70 /*F*/, 'Alt+Shift+F', '⌥+⇧+F', 'Alt+Shift+F', 'Alt+Shift+F' ],
+					// [ CKEDITOR.CTRL + CKEDITOR.ALT + CKEDITOR.SHIFT + 71 /*G*/, 'Ctrl+Alt+Shift+G', '⌘+⌥+⇧+G', 'Ctrl+Alt+Shift+G', 'Command+Alt+Shift+G' ],
+					// [ CKEDITOR.CTRL + 32 /*SPACE*/, 'Ctrl+Space', '⌘+Space', 'Ctrl+Space', 'Command+Space' ],
+					// [ CKEDITOR.ALT + 13 /*ENTER*/, 'Alt+Enter', '⌥+Enter', 'Alt+Enter', 'Alt+Enter' ]
+				],
+				test,
+				expIndex = CKEDITOR.env.mac ? 2 : 1;
+
+			for ( var i = 0, l = tests.length; i < l; i++ ) {
+				test = tests[ i ];
+				console.log( test[ expIndex ], toArray( lang, test[ 0 ] ).display );
+				console.log( test[ expIndex + 2 ], toArray( lang, test[ 0 ] ).aria );
+				arrayAssert.itemsAreEqual( test[ expIndex ], toArray( lang, test[ 0 ] ).display,
+					'Keystroke display string representation is invalid.' );
+				arrayAssert.itemsAreEqual( test[ expIndex + 2 ], toArray( lang, test[ 0 ] ).aria,
+					'Keystroke ARIA string representation is invalid.' );
+			}
 		}
 	} );
 } )();

--- a/tests/core/tools/keystroke.js
+++ b/tests/core/tools/keystroke.js
@@ -12,7 +12,6 @@
 	bender.test( {
 		'test keystrokeToString': function() {
 			var tests = [
-				// [ Keystroke, display string, display string on Mac, ARIA string, ARIA string on Mac ]
 				[ CKEDITOR.CTRL + 65 /*A*/, 'Ctrl+A', '⌘+A', 'Ctrl+A', 'Command+A' ],
 				[ CKEDITOR.ALT + 66 /*B*/, 'Alt+B', '⌥+B', 'Alt+B', 'Alt+B' ],
 				[ CKEDITOR.SHIFT + 67 /*C*/, 'Shift+C', '⇧+C', 'Shift+C', 'Shift+C' ],
@@ -29,16 +28,15 @@
 
 		'test keystrokeToArray': function() {
 			var tests = [
-				// [ Keystroke, display string, display string on Mac, ARIA string, ARIA string on Mac ]
 				[ CKEDITOR.CTRL + 65 /*A*/, [ 'Ctrl', 'A' ], [ '⌘', 'A' ], [ 'Ctrl', 'A' ], [ 'Command', 'A' ] ],
 				[ CKEDITOR.ALT + 66 /*B*/, [ 'Alt', 'B' ], [ '⌥', 'B' ], [ 'Alt', 'B' ], [ 'Alt', 'B' ] ],
-				// [ CKEDITOR.SHIFT + 67 /*C*/, 'Shift+C', '⇧+C', 'Shift+C', 'Shift+C' ],
-				// [ CKEDITOR.CTRL + CKEDITOR.ALT + 68 /*D*/, 'Ctrl+Alt+D', '⌘+⌥+D', 'Ctrl+Alt+D', 'Command+Alt+D' ],
-				// [ CKEDITOR.CTRL + CKEDITOR.SHIFT + 69 /*E*/, 'Ctrl+Shift+E', '⌘+⇧+E', 'Ctrl+Shift+E', 'Command+Shift+E' ],
-				// [ CKEDITOR.ALT + CKEDITOR.SHIFT + 70 /*F*/, 'Alt+Shift+F', '⌥+⇧+F', 'Alt+Shift+F', 'Alt+Shift+F' ],
-				// [ CKEDITOR.CTRL + CKEDITOR.ALT + CKEDITOR.SHIFT + 71 /*G*/, 'Ctrl+Alt+Shift+G', '⌘+⌥+⇧+G', 'Ctrl+Alt+Shift+G', 'Command+Alt+Shift+G' ],
-				// [ CKEDITOR.CTRL + 32 /*SPACE*/, 'Ctrl+Space', '⌘+Space', 'Ctrl+Space', 'Command+Space' ],
-				// [ CKEDITOR.ALT + 13 /*ENTER*/, 'Alt+Enter', '⌥+Enter', 'Alt+Enter', 'Alt+Enter' ]
+				[ CKEDITOR.SHIFT + 67 /*C*/, [ 'Shift', 'C' ], [ '⇧', 'C' ], [ 'Shift', 'C' ], [ 'Shift', 'C' ] ],
+				[ CKEDITOR.CTRL + CKEDITOR.ALT + 68 /*D*/, [ 'Ctrl', 'Alt', 'D' ], [ '⌘', '⌥', 'D' ], [ 'Ctrl', 'Alt', 'D' ], [ 'Command', 'Alt', 'D' ] ],
+				[ CKEDITOR.CTRL + CKEDITOR.SHIFT + 69 /*E*/, [ 'Ctrl', 'Shift', 'E' ], [ '⌘', '⇧', 'E' ], [ 'Ctrl', 'Shift', 'E' ], [ 'Command', 'Shift', 'E' ] ],
+				[ CKEDITOR.ALT + CKEDITOR.SHIFT + 70 /*F*/, [ 'Alt', 'Shift', 'F' ], [ '⌥', '⇧', 'F' ], [ 'Alt', 'Shift', 'F' ], [ 'Alt', 'Shift', 'F' ] ],
+				[ CKEDITOR.CTRL + 32 /*SPACE*/, [ 'Ctrl', 'Space' ], [ '⌘', 'Space' ], [ 'Ctrl', 'Space' ], [ 'Command', 'Space' ] ],
+				[ CKEDITOR.ALT + 13 /*ENTER*/, [ 'Alt', 'Enter' ], [ '⌥', 'Enter' ], [ 'Alt', 'Enter' ], [ 'Alt', 'Enter' ] ],
+				[ CKEDITOR.CTRL + CKEDITOR.ALT + CKEDITOR.SHIFT + 71 /*G*/, [ 'Ctrl', 'Alt', 'Shift', 'G' ], [ '⌘', '⌥', '⇧', 'G' ], [ 'Ctrl', 'Alt', 'Shift', 'G' ], [ 'Command', 'Alt', 'Shift', 'G' ] ]
 			];
 
 			this._assertKeyboardMatrix( 'keystrokeToArray', tests, true );
@@ -49,9 +47,12 @@
 		 *
 		 * Each entry in `tests` should have the structure as follows:
 		 *
-		 * [ <keystroke>, <display>, <macDisplay>, <aria>, <macAria> ]
+		 * [
+		 * 	[ <keystroke>, <display>, <macDisplay>, <aria>, <macAria> ],
+		 * 	(...)
+		 * ]
 		 *
-		 * e.g. [ CKEDITOR.CTRL + 65, 'Ctrl+A', '⌘+A', 'Ctrl+A', 'Command+A' ]
+		 * e.g. [ [ CKEDITOR.CTRL + 65, 'Ctrl+A', '⌘+A', 'Ctrl+A', 'Command+A' ] ]
 		 *
 		 * @param {String} methodName Name of method to be called in `CKEDITOR.tools`.
 		 * @param {Array[]} tests An object containing the tests.

--- a/tests/core/tools/keystroke.js
+++ b/tests/core/tools/keystroke.js
@@ -1,0 +1,38 @@
+﻿/* bender-tags: editor */
+
+( function() {
+	'use strict';
+
+	bender.editor = {
+		config: {
+			language: 'en'
+		}
+	};
+
+	bender.test( {
+		'test keystrokeToString': function() {
+			var toString = CKEDITOR.tools.keystrokeToString,
+				lang = this.editor.lang.common.keyboard,
+				tests = [
+					// [ Keystroke, display string, display string on Mac, ARIA string, ARIA string on Mac ]
+					[ CKEDITOR.CTRL + 65 /*A*/, 'Ctrl+A', '⌘+A', 'Ctrl+A', 'Command+A' ],
+					[ CKEDITOR.ALT + 66 /*B*/, 'Alt+B', '⌥+B', 'Alt+B', 'Alt+B' ],
+					[ CKEDITOR.SHIFT + 67 /*C*/, 'Shift+C', '⇧+C', 'Shift+C', 'Shift+C' ],
+					[ CKEDITOR.CTRL + CKEDITOR.ALT + 68 /*D*/, 'Ctrl+Alt+D', '⌘+⌥+D', 'Ctrl+Alt+D', 'Command+Alt+D' ],
+					[ CKEDITOR.CTRL + CKEDITOR.SHIFT + 69 /*E*/, 'Ctrl+Shift+E', '⌘+⇧+E', 'Ctrl+Shift+E', 'Command+Shift+E' ],
+					[ CKEDITOR.ALT + CKEDITOR.SHIFT + 70 /*F*/, 'Alt+Shift+F', '⌥+⇧+F', 'Alt+Shift+F', 'Alt+Shift+F' ],
+					[ CKEDITOR.CTRL + CKEDITOR.ALT + CKEDITOR.SHIFT + 71 /*G*/, 'Ctrl+Alt+Shift+G', '⌘+⌥+⇧+G', 'Ctrl+Alt+Shift+G', 'Command+Alt+Shift+G' ],
+					[ CKEDITOR.CTRL + 32 /*SPACE*/, 'Ctrl+Space', '⌘+Space', 'Ctrl+Space', 'Command+Space' ],
+					[ CKEDITOR.ALT + 13 /*ENTER*/, 'Alt+Enter', '⌥+Enter', 'Alt+Enter', 'Alt+Enter' ]
+				],
+				test,
+				expIndex = CKEDITOR.env.mac ? 2 : 1;
+
+			for ( var i = 0, l = tests.length; i < l; i++ ) {
+				test = tests[ i ];
+				assert.areEqual( test[ expIndex ], toString( lang, test[ 0 ] ).display, 'Keystroke display string representation is invalid.' );
+				assert.areEqual( test[ expIndex + 2 ], toString( lang, test[ 0 ] ).aria, 'Keystroke ARIA string representation is invalid.' );
+			}
+		}
+	} );
+} )();

--- a/tests/core/tools/keystroke.js
+++ b/tests/core/tools/keystroke.js
@@ -11,55 +11,64 @@
 
 	bender.test( {
 		'test keystrokeToString': function() {
-			var toString = CKEDITOR.tools.keystrokeToString,
-				lang = this.editor.lang.common.keyboard,
-				tests = [
-					// [ Keystroke, display string, display string on Mac, ARIA string, ARIA string on Mac ]
-					[ CKEDITOR.CTRL + 65 /*A*/, 'Ctrl+A', '⌘+A', 'Ctrl+A', 'Command+A' ],
-					[ CKEDITOR.ALT + 66 /*B*/, 'Alt+B', '⌥+B', 'Alt+B', 'Alt+B' ],
-					[ CKEDITOR.SHIFT + 67 /*C*/, 'Shift+C', '⇧+C', 'Shift+C', 'Shift+C' ],
-					[ CKEDITOR.CTRL + CKEDITOR.ALT + 68 /*D*/, 'Ctrl+Alt+D', '⌘+⌥+D', 'Ctrl+Alt+D', 'Command+Alt+D' ],
-					[ CKEDITOR.CTRL + CKEDITOR.SHIFT + 69 /*E*/, 'Ctrl+Shift+E', '⌘+⇧+E', 'Ctrl+Shift+E', 'Command+Shift+E' ],
-					[ CKEDITOR.ALT + CKEDITOR.SHIFT + 70 /*F*/, 'Alt+Shift+F', '⌥+⇧+F', 'Alt+Shift+F', 'Alt+Shift+F' ],
-					[ CKEDITOR.CTRL + CKEDITOR.ALT + CKEDITOR.SHIFT + 71 /*G*/, 'Ctrl+Alt+Shift+G', '⌘+⌥+⇧+G', 'Ctrl+Alt+Shift+G', 'Command+Alt+Shift+G' ],
-					[ CKEDITOR.CTRL + 32 /*SPACE*/, 'Ctrl+Space', '⌘+Space', 'Ctrl+Space', 'Command+Space' ],
-					[ CKEDITOR.ALT + 13 /*ENTER*/, 'Alt+Enter', '⌥+Enter', 'Alt+Enter', 'Alt+Enter' ]
-				],
-				test,
-				expIndex = CKEDITOR.env.mac ? 2 : 1;
+			var tests = [
+				// [ Keystroke, display string, display string on Mac, ARIA string, ARIA string on Mac ]
+				[ CKEDITOR.CTRL + 65 /*A*/, 'Ctrl+A', '⌘+A', 'Ctrl+A', 'Command+A' ],
+				[ CKEDITOR.ALT + 66 /*B*/, 'Alt+B', '⌥+B', 'Alt+B', 'Alt+B' ],
+				[ CKEDITOR.SHIFT + 67 /*C*/, 'Shift+C', '⇧+C', 'Shift+C', 'Shift+C' ],
+				[ CKEDITOR.CTRL + CKEDITOR.ALT + 68 /*D*/, 'Ctrl+Alt+D', '⌘+⌥+D', 'Ctrl+Alt+D', 'Command+Alt+D' ],
+				[ CKEDITOR.CTRL + CKEDITOR.SHIFT + 69 /*E*/, 'Ctrl+Shift+E', '⌘+⇧+E', 'Ctrl+Shift+E', 'Command+Shift+E' ],
+				[ CKEDITOR.ALT + CKEDITOR.SHIFT + 70 /*F*/, 'Alt+Shift+F', '⌥+⇧+F', 'Alt+Shift+F', 'Alt+Shift+F' ],
+				[ CKEDITOR.CTRL + CKEDITOR.ALT + CKEDITOR.SHIFT + 71 /*G*/, 'Ctrl+Alt+Shift+G', '⌘+⌥+⇧+G', 'Ctrl+Alt+Shift+G', 'Command+Alt+Shift+G' ],
+				[ CKEDITOR.CTRL + 32 /*SPACE*/, 'Ctrl+Space', '⌘+Space', 'Ctrl+Space', 'Command+Space' ],
+				[ CKEDITOR.ALT + 13 /*ENTER*/, 'Alt+Enter', '⌥+Enter', 'Alt+Enter', 'Alt+Enter' ]
+			];
 
-			for ( var i = 0, l = tests.length; i < l; i++ ) {
-				test = tests[ i ];
-				assert.areEqual( test[ expIndex ], toString( lang, test[ 0 ] ).display, 'Keystroke display string representation is invalid.' );
-				assert.areEqual( test[ expIndex + 2 ], toString( lang, test[ 0 ] ).aria, 'Keystroke ARIA string representation is invalid.' );
-			}
+			this._assertKeyboardMatrix( 'keystrokeToString', tests );
 		},
 
 		'test keystrokeToArray': function() {
-			var toArray = CKEDITOR.tools.keystrokeToArray,
+			var tests = [
+				// [ Keystroke, display string, display string on Mac, ARIA string, ARIA string on Mac ]
+				[ CKEDITOR.CTRL + 65 /*A*/, [ 'Ctrl', 'A' ], [ '⌘', 'A' ], [ 'Ctrl', 'A' ], [ 'Command', 'A' ] ],
+				[ CKEDITOR.ALT + 66 /*B*/, [ 'Alt', 'B' ], [ '⌥', 'B' ], [ 'Alt', 'B' ], [ 'Alt', 'B' ] ],
+				// [ CKEDITOR.SHIFT + 67 /*C*/, 'Shift+C', '⇧+C', 'Shift+C', 'Shift+C' ],
+				// [ CKEDITOR.CTRL + CKEDITOR.ALT + 68 /*D*/, 'Ctrl+Alt+D', '⌘+⌥+D', 'Ctrl+Alt+D', 'Command+Alt+D' ],
+				// [ CKEDITOR.CTRL + CKEDITOR.SHIFT + 69 /*E*/, 'Ctrl+Shift+E', '⌘+⇧+E', 'Ctrl+Shift+E', 'Command+Shift+E' ],
+				// [ CKEDITOR.ALT + CKEDITOR.SHIFT + 70 /*F*/, 'Alt+Shift+F', '⌥+⇧+F', 'Alt+Shift+F', 'Alt+Shift+F' ],
+				// [ CKEDITOR.CTRL + CKEDITOR.ALT + CKEDITOR.SHIFT + 71 /*G*/, 'Ctrl+Alt+Shift+G', '⌘+⌥+⇧+G', 'Ctrl+Alt+Shift+G', 'Command+Alt+Shift+G' ],
+				// [ CKEDITOR.CTRL + 32 /*SPACE*/, 'Ctrl+Space', '⌘+Space', 'Ctrl+Space', 'Command+Space' ],
+				// [ CKEDITOR.ALT + 13 /*ENTER*/, 'Alt+Enter', '⌥+Enter', 'Alt+Enter', 'Alt+Enter' ]
+			];
+
+			this._assertKeyboardMatrix( 'keystrokeToArray', tests, true );
+		},
+
+		/*
+		 * Calls `methodName` in `CKEDITOR.tools`, using each entry given in `tests`.
+		 *
+		 * Each entry in `tests` should have the structure as follows:
+		 *
+		 * [ <keystroke>, <display>, <macDisplay>, <aria>, <macAria> ]
+		 *
+		 * e.g. [ CKEDITOR.CTRL + 65, 'Ctrl+A', '⌘+A', 'Ctrl+A', 'Command+A' ]
+		 *
+		 * @param {String} methodName Name of method to be called in `CKEDITOR.tools`.
+		 * @param {Array[]} tests An object containing the tests.
+		 * @param {Boolean} [compareAsArray]
+		 */
+		_assertKeyboardMatrix: function( methodName, tests, compareAsArray ) {
+			var assertValue = compareAsArray ? arrayAssert.itemsAreEqual : assert.areEqual,
+				expIndex = CKEDITOR.env.mac ? 2 : 1,
 				lang = this.editor.lang.common.keyboard,
-				tests = [
-					// [ Keystroke, display string, display string on Mac, ARIA string, ARIA string on Mac ]
-					[ CKEDITOR.CTRL + 65 /*A*/, ['Ctrl', 'A'], ['⌘', 'A'], ['Ctrl', 'A'], ['Command', 'A'] ],
-					[ CKEDITOR.ALT + 66 /*B*/, ['Alt', 'B'], ['⌥', 'B'], ['Alt', 'B'], ['Alt', 'B'] ],
-					// [ CKEDITOR.SHIFT + 67 /*C*/, 'Shift+C', '⇧+C', 'Shift+C', 'Shift+C' ],
-					// [ CKEDITOR.CTRL + CKEDITOR.ALT + 68 /*D*/, 'Ctrl+Alt+D', '⌘+⌥+D', 'Ctrl+Alt+D', 'Command+Alt+D' ],
-					// [ CKEDITOR.CTRL + CKEDITOR.SHIFT + 69 /*E*/, 'Ctrl+Shift+E', '⌘+⇧+E', 'Ctrl+Shift+E', 'Command+Shift+E' ],
-					// [ CKEDITOR.ALT + CKEDITOR.SHIFT + 70 /*F*/, 'Alt+Shift+F', '⌥+⇧+F', 'Alt+Shift+F', 'Alt+Shift+F' ],
-					// [ CKEDITOR.CTRL + CKEDITOR.ALT + CKEDITOR.SHIFT + 71 /*G*/, 'Ctrl+Alt+Shift+G', '⌘+⌥+⇧+G', 'Ctrl+Alt+Shift+G', 'Command+Alt+Shift+G' ],
-					// [ CKEDITOR.CTRL + 32 /*SPACE*/, 'Ctrl+Space', '⌘+Space', 'Ctrl+Space', 'Command+Space' ],
-					// [ CKEDITOR.ALT + 13 /*ENTER*/, 'Alt+Enter', '⌥+Enter', 'Alt+Enter', 'Alt+Enter' ]
-				],
-				test,
-				expIndex = CKEDITOR.env.mac ? 2 : 1;
+				test;
 
 			for ( var i = 0, l = tests.length; i < l; i++ ) {
 				test = tests[ i ];
-				console.log( test[ expIndex ], toArray( lang, test[ 0 ] ).display );
-				console.log( test[ expIndex + 2 ], toArray( lang, test[ 0 ] ).aria );
-				arrayAssert.itemsAreEqual( test[ expIndex ], toArray( lang, test[ 0 ] ).display,
+
+				assertValue( test[ expIndex ], CKEDITOR.tools[ methodName ]( lang, test[ 0 ] ).display,
 					'Keystroke display string representation is invalid.' );
-				arrayAssert.itemsAreEqual( test[ expIndex + 2 ], toArray( lang, test[ 0 ] ).aria,
+				assertValue( test[ expIndex + 2 ], CKEDITOR.tools[ methodName ]( lang, test[ 0 ] ).aria,
 					'Keystroke ARIA string representation is invalid.' );
 			}
 		}


### PR DESCRIPTION
## What is the purpose of this pull request?

New feature

 ### This PR contains

- [x] Unit tests
- [ ] Manual tests - no manual tests, this is API only enhancement.

 ## What changes did you make?

Added missing method. Actually it uses pretty much original `keystrokeToString` implementation, without joining the array members at the end.

I have also extracted the unit tests into a separate file.

Closes #856.