### PR TITLE
Fix for double-click on link opening an empty link dialog

### DIFF
--- a/plugins/link/plugin.js
+++ b/plugins/link/plugin.js
@@ -327,8 +327,14 @@
 				range,
 				i;
 
-			if ( !returnMultiple && selectedElement && selectedElement.is( 'a' ) ) {
-				return selectedElement;
+			if ( selectedElement && selectedElement.is( 'a' ) ) {
+			
+				if ( returnMultiple ) {
+					links.push( selectedElement );
+				}
+				else {
+					return selectedElement;
+				}
 			}
 
 			for ( i = 0; i < ranges.length; i++ ) {


### PR DESCRIPTION
fix for #859
