### PR TITLE
Fixing bug which cleared clipboard when collapsed selection was copied

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -7,6 +7,10 @@ New Features:
 
 * [#1338](https://github.com/ckeditor/ckeditor-dev/issues/1338): Keystroke labels are displayed for function keys (like F7, F8).
 
+Fixed Issues:
+
+* [#869](https://github.com/ckeditor/ckeditor-dev/issues/869): Fixed: Empty selection won't clear cached clipboard data in editor.
+
 ## CKEditor 4.8.1
 
 New Features:

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -9,7 +9,7 @@ New Features:
 
 Fixed Issues:
 
-* [#869](https://github.com/ckeditor/ckeditor-dev/issues/869): Fixed: Empty selection won't clear cached clipboard data in editor.
+* [#869](https://github.com/ckeditor/ckeditor-dev/issues/869): Fixed: Empty selection clears cached clipboard data in editor.
 
 ## CKEditor 4.8.1
 

--- a/plugins/clipboard/plugin.js
+++ b/plugins/clipboard/plugin.js
@@ -510,12 +510,13 @@
 
 			if ( CKEDITOR.plugins.clipboard.isCustomCopyCutSupported ) {
 				var initOnCopyCut = function( evt ) {
-					// Make copy/cut only when we have non-collapsed selection (#869).
-					// If user tries to cut in read-only editor, we must prevent default action (https://dev.ckeditor.com/ticket/13872).
-					var collapsedSelection = editor.getSelection().isCollapsed(),
-						readOnlyCut = editor.readOnly && evt.name == 'cut';
+					// There shouldn't be anythong to copy/cut when selection is collapsed (#869).
+					if ( editor.getSelection().isCollapsed() ) {
+						return;
+					}
 
-					if ( !collapsedSelection && !readOnlyCut ) {
+					// If user tries to cut in read-only editor, we must prevent default action (https://dev.ckeditor.com/ticket/13872).
+					if ( !editor.readOnly || evt.name != 'cut' ) {
 						clipboard.initPasteDataTransfer( evt, editor );
 					}
 					evt.data.preventDefault();

--- a/plugins/clipboard/plugin.js
+++ b/plugins/clipboard/plugin.js
@@ -510,7 +510,7 @@
 
 			if ( CKEDITOR.plugins.clipboard.isCustomCopyCutSupported ) {
 				var initOnCopyCut = function( evt ) {
-					// There shouldn't be anythong to copy/cut when selection is collapsed (#869).
+					// There shouldn't be anything to copy/cut when selection is collapsed (#869).
 					if ( editor.getSelection().isCollapsed() ) {
 						return;
 					}

--- a/plugins/clipboard/plugin.js
+++ b/plugins/clipboard/plugin.js
@@ -510,9 +510,12 @@
 
 			if ( CKEDITOR.plugins.clipboard.isCustomCopyCutSupported ) {
 				var initOnCopyCut = function( evt ) {
-					// If user tries to cut in read-only editor, we must prevent default action (https://dev.ckeditor.com/ticket/13872).
 					// Make copy/cut only when we have non-collapsed selection (#869).
-					if ( !editor.getSelection().isCollapsed() && ( !editor.readOnly || evt.name != 'cut' ) ) {
+					// If user tries to cut in read-only editor, we must prevent default action (https://dev.ckeditor.com/ticket/13872).
+					var collapsedSelection = editor.getSelection().isCollapsed(),
+						readOnlyCut = editor.readOnly && evt.name == 'cut';
+
+					if ( !collapsedSelection && !readOnlyCut ) {
 						clipboard.initPasteDataTransfer( evt, editor );
 					}
 					evt.data.preventDefault();

--- a/plugins/clipboard/plugin.js
+++ b/plugins/clipboard/plugin.js
@@ -510,8 +510,9 @@
 
 			if ( CKEDITOR.plugins.clipboard.isCustomCopyCutSupported ) {
 				var initOnCopyCut = function( evt ) {
-					// If user tries to cut in read-only editor, we must prevent default action. (https://dev.ckeditor.com/ticket/13872)
-					if ( !editor.readOnly || evt.name != 'cut' ) {
+					// If user tries to cut in read-only editor, we must prevent default action (https://dev.ckeditor.com/ticket/13872).
+					// Make copy/cut only when we have non-collapsed selection (#869).
+					if ( !editor.getSelection().isCollapsed() && ( !editor.readOnly || evt.name != 'cut' ) ) {
 						clipboard.initPasteDataTransfer( evt, editor );
 					}
 					evt.data.preventDefault();

--- a/tests/plugins/clipboard/clipboard.js
+++ b/tests/plugins/clipboard/clipboard.js
@@ -23,5 +23,28 @@ bender.test( {
 		} );
 
 		editor.execCommand( 'cut' );
+	},
+
+	// #869
+	'test check if collapse selection is not copied': function() {
+		if ( !CKEDITOR.plugins.clipboard.isCustomCopyCutSupported ) {
+			assert.ignore();
+		}
+
+		var editor = this.editor,
+			bot = this.editorBot,
+			range;
+
+		bot.setHtmlWithSelection( '<p>[Some] text</p>' );
+
+		editor.editable().fire( 'copy', new CKEDITOR.dom.event( {} ) );
+		assert.areSame( 'Some', CKEDITOR.plugins.clipboard.copyCutData.getData( 'text/html' ) );
+
+		range = editor.getSelection().getRanges()[ 0 ];
+		range.collapse();
+		range.select();
+
+		editor.editable().fire( 'copy', new CKEDITOR.dom.event( {} ) );
+		assert.areSame( 'Some', CKEDITOR.plugins.clipboard.copyCutData.getData( 'text/html' ) );
 	}
 } );

--- a/tests/plugins/clipboard/manual/dontcopyemptyselection.html
+++ b/tests/plugins/clipboard/manual/dontcopyemptyselection.html
@@ -1,0 +1,6 @@
+<textarea name="editor" id="editor" cols="30" rows="10">
+	<p>Hello world</p>
+</textarea>
+<script>
+	CKEDITOR.replace( 'editor' );
+</script>

--- a/tests/plugins/clipboard/manual/dontcopyemptyselection.md
+++ b/tests/plugins/clipboard/manual/dontcopyemptyselection.md
@@ -1,0 +1,16 @@
+@bender-ui: collapsed
+@bender-tags: 4.8.0, bug, 869
+@bender-ckeditor-plugins: wysiwygarea, toolbar, clipboard
+
+----
+
+1. Select some text in editor.
+1. Copy text with shortcut `Ctrl/Cmd + C`.
+1. Paste text in editor.
+1. Now make collapsed selection.
+1. Copy this collapsed selection with shortcut `Ctrl/Cmd + C`.
+1. Paste text in editor.
+
+**Expected:** Previously selected text is paste in editor.
+
+**Unexpected:** There is nothing pasted in editor.

--- a/tests/plugins/clipboard/manual/dontcopyemptyselection.md
+++ b/tests/plugins/clipboard/manual/dontcopyemptyselection.md
@@ -1,5 +1,5 @@
 @bender-ui: collapsed
-@bender-tags: 4.8.0, bug, 869
+@bender-tags: 4.9.0, bug, 869
 @bender-ckeditor-plugins: wysiwygarea, toolbar, clipboard
 
 ----


### PR DESCRIPTION
## What is the purpose of this pull request?

Bug fix

## Does your PR contain necessary tests?
yes

### This PR contains

- [x] Unit tests
- [X] Manual tests

## What changes did you make?

- activate copying or cutting only when selection is non-collapsed

_**Note:** Because browse doesn't allow on free access to clipboard, there is no unit test which would simulate properly this case._

Close #869 