### PR TITLE
[#801] Fix elementspath plugin to work properly with Firefox 55+

### DIFF
--- a/plugins/elementspath/plugin.js
+++ b/plugins/elementspath/plugin.js
@@ -153,7 +153,7 @@
 				return true;
 			} );
 
-		editor.on( 'selectionChange', function() {
+		editor.on( 'selectionChange', function( evt ) {
 			var html = [],
 				elementsList = elementsPath.list = [],
 				namesList = [],
@@ -161,7 +161,7 @@
 				isContentEditable = true,
 
 				// Use elementPath to consider children of editable only (http://dev.ckeditor.com/ticket/11124).
-				elementsChain = editor.elementPath().elements,
+				elementsChain = evt.data.path.elements,
 				name;
 
 			// Starts iteration from body element, skipping html.

--- a/plugins/elementspath/plugin.js
+++ b/plugins/elementspath/plugin.js
@@ -161,6 +161,7 @@
 				isContentEditable = true,
 
 				// Use elementPath to consider children of editable only (http://dev.ckeditor.com/ticket/11124).
+				// Use elementPath provided in evt, which is accurate in all cases (#801).
 				elementsChain = evt.data.path.elements,
 				name;
 

--- a/plugins/elementspath/plugin.js
+++ b/plugins/elementspath/plugin.js
@@ -161,7 +161,7 @@
 				isContentEditable = true,
 
 				// Use elementPath to consider children of editable only (http://dev.ckeditor.com/ticket/11124).
-				// Use elementPath provided in evt, which is accurate in all cases (#801).
+				// Use elementPath from event (instead of editor.elementPath()), which is accurate in all cases (#801).
 				elementsChain = evt.data.path.elements,
 				name;
 

--- a/tests/plugins/elementspath/manual/elementspath.html
+++ b/tests/plugins/elementspath/manual/elementspath.html
@@ -1,0 +1,82 @@
+<textarea id="editor1">
+	<p>Hello world. <strong>Bold text and <em>italic with additional <u>underline</u></em></strong>.</p>
+	<p>Hello world. <strong contenteditable="false">Bold text and <em contenteditable="true">italic with additional <u>underline</u></em></strong>.</p>
+	<ul>
+		<li>One</li>
+		<li>Two<ol>
+			<li><strong>STRONG: </strong>1111</li>
+			<li><em>ITALIC: </em>2222</li>
+		</ol></li>
+	</ul>
+	<div><div><div><div><div><div><div><div><div><div><div>Divception</div></div></div></div></div></div></div></div></div></div></div>
+	<table border='1'>
+		<thead>
+			<tr>
+				<th>Something</th>
+				<th>else</th>
+			</tr>
+		</thead>
+		<tbody>
+			<tr>
+				<td>One</td>
+				<td>Two</td>
+			</tr>
+			<tr>
+				<td>Three</td>
+				<td>Four</td>
+			</tr>
+		</tbody>
+	</table>
+	<figure class="image">
+		<img src="/tests/_assets/lena.jpg" alt="avatar" />
+		<figcaption>Lena</figcaption>
+	</figure>
+
+</textarea>
+
+<div id="editor2" contenteditable="true">
+		<p>Hello world. <strong>Bold text and <em>italic with additional <u>underline</u></em></strong>.</p>
+		<p>Hello world. <strong contenteditable="false">Bold text and <em contenteditable="true">italic with additional <u>underline</u></em></strong>.</p>
+		<ul>
+			<li>One</li>
+			<li>Two<ol>
+				<li><strong>STRONG: </strong>1111</li>
+				<li><em>ITALIC: </em>2222</li>
+			</ol></li>
+		</ul>
+		<div><div><div><div><div><div><div><div><div><div><div>Divception</div></div></div></div></div></div></div></div></div></div></div>
+		<table border='1'>
+			<thead>
+				<tr>
+					<th>Something</th>
+					<th>else</th>
+				</tr>
+			</thead>
+			<tbody>
+				<tr>
+					<td>One</td>
+					<td>Two</td>
+				</tr>
+				<tr>
+					<td>Three</td>
+					<td>Four</td>
+				</tr>
+			</tbody>
+		</table>
+		<figure class="image">
+			<img src="/tests/_assets/lena.jpg" alt="avatar" />
+			<figcaption>Caption</figcaption>
+		</figure>
+
+</div>
+
+<script>
+	CKEDITOR.replace( 'editor1', {
+		extraPlugins: 'image2',
+		allowedContent: true
+	} );
+	CKEDITOR.replace( 'editor2', {
+		extraPlugins: 'divarea,image2',
+		allowedContent: true
+	} );
+</script>

--- a/tests/plugins/elementspath/manual/elementspath.html
+++ b/tests/plugins/elementspath/manual/elementspath.html
@@ -1,19 +1,28 @@
 <textarea id="editor1">
-	<p>Hello world. <strong>Bold text and <em>italic with additional <u>underline</u></em></strong>.</p>
-	<p>Hello world. <strong contenteditable="false">Bold text and <em contenteditable="true">italic with additional <u>underline</u></em></strong>.</p>
+	<p>Regular text. <strong>Bold text and <em>italic embeded in bold <u>and underline embeded once more</u></em></strong>.</p>
 	<ul>
 		<li>One</li>
 		<li>Two<ol>
-			<li><strong>STRONG: </strong>1111</li>
-			<li><em>ITALIC: </em>2222</li>
+			<li><strong>STRONG: </strong>regular text</li>
+			<li><em>ITALIC: </em>regular text</li>
 		</ol></li>
 	</ul>
-	<div><div><div><div><div><div><div><div><div><div><div>Divception</div></div></div></div></div></div></div></div></div></div></div>
+	<div><div><div><div><div>Spanception - This text is embed in 5 spans.</div></div></div></div></div>
+	<figure class="image">
+		<img src="/tests/_assets/lena.jpg" alt="avatar" />
+		<figcaption>Lena</figcaption>
+	</figure>
+
+</textarea>
+<br>
+<div id="editor2" contenteditable="true">
+	<p>You can type here <strong contenteditable="false">This is uneditable part <em contenteditable="true">and you can type again inside this widget<u> and some underline inside</u></em></strong>.</p>
+	<p><a href="http://ckeditor.com" target="_blank">This is link</a></p>
 	<table border='1'>
 		<thead>
 			<tr>
-				<th>Something</th>
-				<th>else</th>
+				<th>Just</th>
+				<th>header</th>
 			</tr>
 		</thead>
 		<tbody>
@@ -23,60 +32,22 @@
 			</tr>
 			<tr>
 				<td>Three</td>
-				<td>Four</td>
+				<td><span><span><span><span><span>Divception - This text is embed in 5 divs.</span></span></span></span></span></td>
+			</tr>
+			<tr>
+				<td><strong>Strong text</strong></td>
+				<td><em>Emphasised text</em></td>
 			</tr>
 		</tbody>
 	</table>
-	<figure class="image">
-		<img src="/tests/_assets/lena.jpg" alt="avatar" />
-		<figcaption>Lena</figcaption>
-	</figure>
-
-</textarea>
-
-<div id="editor2" contenteditable="true">
-		<p>Hello world. <strong>Bold text and <em>italic with additional <u>underline</u></em></strong>.</p>
-		<p>Hello world. <strong contenteditable="false">Bold text and <em contenteditable="true">italic with additional <u>underline</u></em></strong>.</p>
-		<ul>
-			<li>One</li>
-			<li>Two<ol>
-				<li><strong>STRONG: </strong>1111</li>
-				<li><em>ITALIC: </em>2222</li>
-			</ol></li>
-		</ul>
-		<div><div><div><div><div><div><div><div><div><div><div>Divception</div></div></div></div></div></div></div></div></div></div></div>
-		<table border='1'>
-			<thead>
-				<tr>
-					<th>Something</th>
-					<th>else</th>
-				</tr>
-			</thead>
-			<tbody>
-				<tr>
-					<td>One</td>
-					<td>Two</td>
-				</tr>
-				<tr>
-					<td>Three</td>
-					<td>Four</td>
-				</tr>
-			</tbody>
-		</table>
-		<figure class="image">
-			<img src="/tests/_assets/lena.jpg" alt="avatar" />
-			<figcaption>Caption</figcaption>
-		</figure>
-
 </div>
 
 <script>
 	CKEDITOR.replace( 'editor1', {
-		extraPlugins: 'image2',
 		allowedContent: true
 	} );
 	CKEDITOR.replace( 'editor2', {
-		extraPlugins: 'divarea,image2',
+		extraPlugins: 'divarea',
 		allowedContent: true
 	} );
 </script>

--- a/tests/plugins/elementspath/manual/elementspath.html
+++ b/tests/plugins/elementspath/manual/elementspath.html
@@ -7,7 +7,7 @@
 			<li><em>ITALIC: </em>regular text</li>
 		</ol></li>
 	</ul>
-	<div><div><div><div><div>Spanception - This text is embed in 5 spans.</div></div></div></div></div>
+	<div><div><div><div><div>Divception - This text is embed in 5 divs.</div></div></div></div></div>
 	<figure class="image">
 		<img src="/tests/_assets/lena.jpg" alt="avatar" />
 		<figcaption>Lena</figcaption>
@@ -16,7 +16,7 @@
 </textarea>
 <br>
 <div id="editor2" contenteditable="true">
-	<p>You can type here <strong contenteditable="false">This is uneditable part <em contenteditable="true">and you can type again inside this widget<u> and some underline inside</u></em></strong>.</p>
+	<p>You can type here <strong contenteditable="false">This is uneditable part <em contenteditable="true">and you can type again inside this editable part<u> and some underline inside</u></em></strong>.</p>
 	<p><a href="http://ckeditor.com" target="_blank">This is link</a></p>
 	<table border='1'>
 		<thead>
@@ -32,7 +32,7 @@
 			</tr>
 			<tr>
 				<td>Three</td>
-				<td><span><span><span><span><span>Divception - This text is embed in 5 divs.</span></span></span></span></span></td>
+				<td><span><span><span><span><span>Spanception - This text is embed in 5 spans.</span></span></span></span></span></td>
 			</tr>
 			<tr>
 				<td><strong>Strong text</strong></td>

--- a/tests/plugins/elementspath/manual/elementspath.md
+++ b/tests/plugins/elementspath/manual/elementspath.md
@@ -1,6 +1,6 @@
 @bender-ui: collapsed
 @bender-tags: 4.8.0, bug
-@bender-ckeditor-plugins: wysiwygarea, toolbar, undo, basicstyles, elementspath, table, image2
+@bender-ckeditor-plugins: wysiwygarea, toolbar, undo, basicstyles, link, elementspath, table, image2
 
 ----
 

--- a/tests/plugins/elementspath/manual/elementspath.md
+++ b/tests/plugins/elementspath/manual/elementspath.md
@@ -1,0 +1,11 @@
+@bender-ui: collapsed
+@bender-tags: 4.8.0, bug
+@bender-ckeditor-plugins: wysiwygarea, toolbar, undo, basicstyles, elementspath, table, image2
+
+----
+
+### Repeat below step in both editors.
+
+1. Put cursor in various places of editor and verify elements path.
+
+**Expected:** Elements path shows proper path of current selection in editor.

--- a/tests/plugins/elementspath/manual/elementspath.md
+++ b/tests/plugins/elementspath/manual/elementspath.md
@@ -1,5 +1,5 @@
 @bender-ui: collapsed
-@bender-tags: 4.8.0, bug
+@bender-tags: 4.8.0, 801, bug
 @bender-ckeditor-plugins: wysiwygarea, toolbar, undo, basicstyles, link, elementspath, table, image2
 
 ----


### PR DESCRIPTION
## What is the purpose of this pull request?

Bug fix

## Does your PR contain necessary tests?

All patches which change the editor code must include tests. You can always read more
on [PR testing](http://docs.ckeditor.com/#!/guide/dev_contributing_code-section-tests),
[how to set the testing environment](http://docs.ckeditor.com/#!/guide/dev_tests) and
[how to create tests](http://docs.ckeditor.com/#!/guide/dev_tests-section-creating-your-own-test)
in the official CKEditor documentation.

PR fix tests

### This PR contains

- [ ] Unit tests
- [ ] Manual tests

## What changes did you make?
- change in elementspath plugin to use `evt.data.path` instead of `editor.elementPath()`

Close #801 