### PR TITLE
CKEDITOR.plugins.link.getSelectedLink does not fetch all links

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -7,6 +7,7 @@ Fixed Issues:
 
 * [#1048](https://github.com/ckeditor/ckeditor-dev/issues/1048): Fixed: [Balloon Panel](https://ckeditor.com/cke4/addon/balloonpanel) is not properly positioned when margin added to its non-static parent.
 * [#889](https://github.com/ckeditor/ckeditor-dev/issues/889): Fixed: Unclear error message for width and height fields in [Image](https://ckeditor.com/cke4/addon/image) and [Enhanced Image](https://ckeditor.com/cke4/addon/image2) plugins.
+* [#859](https://github.com/ckeditor/ckeditor-dev/issues/859): Fixed: Can't edit link after double click on text in link.
 
 ## CKEditor 4.8
 

--- a/plugins/link/plugin.js
+++ b/plugins/link/plugin.js
@@ -335,6 +335,7 @@
 				range = selection.getRanges()[ i ];
 
 				// Skip bogus to cover cases of multiple selection inside tables (#tp2245).
+				// Shrink to element to prevent losing anchor (859).
 				range.shrink( CKEDITOR.SHRINK_ELEMENT, true, { skipBogus: true } );
 				link = editor.elementPath( range.getCommonAncestor() ).contains( 'a', 1 );
 

--- a/plugins/link/plugin.js
+++ b/plugins/link/plugin.js
@@ -335,7 +335,7 @@
 				range = selection.getRanges()[ i ];
 
 				// Skip bogus to cover cases of multiple selection inside tables (#tp2245).
-				// Shrink to element to prevent losing anchor (859).
+				// Shrink to element to prevent losing anchor (#859).
 				range.shrink( CKEDITOR.SHRINK_ELEMENT, true, { skipBogus: true } );
 				link = editor.elementPath( range.getCommonAncestor() ).contains( 'a', 1 );
 

--- a/plugins/link/plugin.js
+++ b/plugins/link/plugin.js
@@ -335,7 +335,7 @@
 				range = selection.getRanges()[ i ];
 
 				// Skip bogus to cover cases of multiple selection inside tables (#tp2245).
-				range.shrink( CKEDITOR.SHRINK_TEXT, false, { skipBogus: true } );
+				range.shrink( CKEDITOR.SHRINK_ELEMENT, true, { skipBogus: true } );
 				link = editor.elementPath( range.getCommonAncestor() ).contains( 'a', 1 );
 
 				if ( link && returnMultiple ) {

--- a/tests/plugins/link/link.js
+++ b/tests/plugins/link/link.js
@@ -558,6 +558,7 @@
 
 				bot.dialog( 'link', function( dialog ) {
 					assert.areSame( dialog.getValueOf( 'info', 'url' ), 'linkUrl' );
+					dialog.hide();
 				} );
 			} );
 		}

--- a/tests/plugins/link/link.js
+++ b/tests/plugins/link/link.js
@@ -1,5 +1,5 @@
 /* bender-tags: editor */
-/* bender-ckeditor-plugins: link,toolbar */
+/* bender-ckeditor-plugins: link,toolbar,image */
 
 ( function() {
 	'use strict';
@@ -546,6 +546,20 @@
 			editor.ui.get( 'Unlink' ).click( editor );
 
 			assert.areSame( '<p>I am<a href="http://foo"> an </a>in<a href="http://bar">sta</a>nce of ^<s>CKEditor</s>.</p>', bot.htmlWithSelection() );
+		},
+		// 859
+		'test edit link with selction': function() {
+			var bot = this.editorBot;
+
+			bot.setData( '<p><a class="linkClass" href="linkUrl"><img src="someUrl"/>some button text</a>some text</p>', function() {
+				var editable = bot.editor.editable();
+
+				bot.editor.getSelection().selectElement( editable.findOne( 'a' ) );
+
+				bot.dialog( 'link', function( dialog ) {
+					assert.areSame( dialog.getValueOf( 'info', 'url' ), 'linkUrl' );
+				} );
+			} );
 		}
 	} );
 } )();

--- a/tests/plugins/link/link.js
+++ b/tests/plugins/link/link.js
@@ -547,8 +547,9 @@
 
 			assert.areSame( '<p>I am<a href="http://foo"> an </a>in<a href="http://bar">sta</a>nce of ^<s>CKEditor</s>.</p>', bot.htmlWithSelection() );
 		},
+
 		// 859
-		'test edit link with selction': function() {
+		'test edit link with selection': function() {
 			var bot = this.editorBot;
 
 			bot.setData( '<p><a class="linkClass" href="linkUrl"><img src="someUrl"/>some button text</a>some text</p>', function() {

--- a/tests/plugins/link/manual/getselectedlink.html
+++ b/tests/plugins/link/manual/getselectedlink.html
@@ -5,9 +5,26 @@
 					some button text
 			</a>
 			some text
+			<table border="1" cellpadding="1" cellspacing="1" style="width:500px">
+				<tbody>
+					<tr>
+						<td>&nbsp;</td>
+						<td>&nbsp;</td>
+					</tr>
+					<tr>
+						<td>
+							<a class="linkClass" href="https://www.google.pl">
+								<img src="http://lorempixel.com/10/20/"/>
+								some button text
+							</a>
+						</td>
+						<td>&nbsp;</td>
+					</tr>
+				</tbody>
+			</table>
 	</p>
 </div>
 
 <script>
-	CKEDITOR.replace( 'editor' /*,{ allowedContent: true }*/);
+	CKEDITOR.replace( 'editor' );
 </script>

--- a/tests/plugins/link/manual/getselectedlink.html
+++ b/tests/plugins/link/manual/getselectedlink.html
@@ -1,0 +1,13 @@
+<div id="editor">
+	<p>
+			<a class="linkClass" href="https://www.google.pl">
+					<img src="http://lorempixel.com/10/20/"/>
+					some button text
+			</a>
+			some text
+	</p>
+</div>
+
+<script>
+	CKEDITOR.replace( 'editor' /*,{ allowedContent: true }*/);
+</script>

--- a/tests/plugins/link/manual/getselectedlink.html
+++ b/tests/plugins/link/manual/getselectedlink.html
@@ -1,7 +1,7 @@
 <div id="editor">
 	<p>
 			<a class="linkClass" href="https://www.google.pl">
-					<img src="http://lorempixel.com/10/20/"/>
+					<img src="%BASE_PATH%_assets/logo.png"/>
 					some button text
 			</a>
 			some text
@@ -14,7 +14,7 @@
 					<tr>
 						<td>
 							<a class="linkClass" href="https://www.google.pl">
-								<img src="http://lorempixel.com/10/20/"/>
+								<img src="%BASE_PATH%_assets/logo.png"/>
 								some button text
 							</a>
 						</td>

--- a/tests/plugins/link/manual/getselectedlink.md
+++ b/tests/plugins/link/manual/getselectedlink.md
@@ -1,11 +1,11 @@
 @bender-tags: link, 4.8.0, 859, bug
 @bender-ui: collapsed
-@bender-ckeditor-plugins: link,toolbar,wysiwygarea,elementspath,contextmenu,image
+@bender-ckeditor-plugins: link,toolbar,wysiwygarea,elementspath,contextmenu,image,table
 
 1. Right-click on the span ("some button text") and select "Edit Link".
 
 **Expected:**
-* Link should have class `someClass`.
+* Link should have class `linkClass`.
 * Link should point to `https://www.google.pl`.
 
 

--- a/tests/plugins/link/manual/getselectedlink.md
+++ b/tests/plugins/link/manual/getselectedlink.md
@@ -1,0 +1,15 @@
+@bender-tags: link, 4.8.0, 859, bug
+@bender-ui: collapsed
+@bender-ckeditor-plugins: link,toolbar,wysiwygarea,elementspath,contextmenu,image
+
+1. Right-click on the span ("some button text") and select "Edit Link".
+
+**Expected:**
+* Link should have class `someClass`.
+* Link should point to `https://www.google.pl`.
+
+
+1. Double-click on the span ("some button text").
+
+**Excepted:**
+* link also should have class and href as above.


### PR DESCRIPTION
## What is the purpose of this pull request?

Bug fix

## Does your PR contain necessary tests?

All patches which change the editor code must include tests. You can always read more
on [PR testing](http://docs.ckeditor.com/#!/guide/dev_contributing_code-section-tests),
[how to set the testing environment](http://docs.ckeditor.com/#!/guide/dev_tests) and
[how to create tests](http://docs.ckeditor.com/#!/guide/dev_tests-section-creating-your-own-test)
in the official CKEditor documentation.

### This PR contains

- [X] Unit tests
- [X] Manual tests

## What changes did you make?
Fix double click on anchor with image and text.

closes #859 
