### PR TITLE
Styling easyimage

### DIFF
--- a/plugins/easyimage/styles/easyimage.css
+++ b/plugins/easyimage/styles/easyimage.css
@@ -4,11 +4,47 @@ For licensing, see LICENSE.md or http://ckeditor.com/license
 */
 
 .easyimage {
+	background-color: #fff;
+	border: none;
 	display: block;
+	padding: 0;
 }
+
 .easyimage img {
+	display: block;
+	height: auto;
+	margin: 0 auto;
 	max-width: 100%;
 }
+
 .easyimage-side {
 	float: right;
+}
+
+.easyimage .cke_widget_editable {
+	background-color: #f7f7f7;
+	color: #333;
+    padding: .8em;
+}
+
+.cke_widget_wrapper:hover .easyimage .cke_widget_editable {
+	outline: 3px solid transparent;
+}
+
+.cke_widget_wrapper .easyimage .cke_widget_editable.cke_widget_editable_focused {
+	background-color: #fff;
+	border: 1px solid #48a3f5;
+	outline: none;
+}
+
+.cke_widget_wrapper:hover .easyimage.cke_widget_element {
+	outline: 3px solid #ffd25c;
+}
+
+.cke_widget_wrapper.cke_widget_focused.cke_widget_selected .easyimage.cke_widget_element {
+	outline: 3px solid #48a3f5;
+}
+
+.cke_widget_wrapper.cke_widget_selected .easyimage.cke_widget_element {
+	outline: 3px solid #ddd;
 }

--- a/plugins/easyimage/styles/easyimage.css
+++ b/plugins/easyimage/styles/easyimage.css
@@ -36,15 +36,3 @@ For licensing, see LICENSE.md or http://ckeditor.com/license
 	border: 1px solid #48a3f5;
 	outline: none;
 }
-
-.cke_widget_wrapper:hover .easyimage.cke_widget_element {
-	outline: 3px solid #ffd25c;
-}
-
-.cke_widget_wrapper.cke_widget_focused.cke_widget_selected .easyimage.cke_widget_element {
-	outline: 3px solid #48a3f5;
-}
-
-.cke_widget_wrapper.cke_widget_selected .easyimage.cke_widget_element {
-	outline: 3px solid #ddd;
-}


### PR DESCRIPTION
## What is the purpose of this pull request?

Styling easyimage.

## Does your PR contain necessary tests?

Not required.

## What changes did you make?

1. Hover state:

<img width="924" alt="hover" src="https://user-images.githubusercontent.com/12029308/30859604-b6e7c5f0-a2c4-11e7-9a53-8f4c034b6162.png">

2. Focus state:

<img width="927" alt="focus" src="https://user-images.githubusercontent.com/12029308/30859625-cafeba58-a2c4-11e7-956e-ce59a0aee4d5.png">

3. Selected:

<img width="917" alt="selected" src="https://user-images.githubusercontent.com/12029308/30859641-dba5cae0-a2c4-11e7-9a22-06914102afa3.png">

4. Figcaption focused. There is a visible gap between image and figcaption because image is wrapped by image resizer. This gap should be fixed after disabling image resize.

<img width="915" alt="figcaption_focused" src="https://user-images.githubusercontent.com/12029308/30859659-e87c2b42-a2c4-11e7-8356-7a4e51b5a6be.png">

