### PR TITLE
New widget for Easy Image

### DIFF
--- a/plugins/easyimage/plugin.js
+++ b/plugins/easyimage/plugin.js
@@ -21,7 +21,7 @@
 			return function( editor ) {
 				var widget = editor.widgets.focused;
 
-				if ( widget && widget.name === 'image' ) {
+				if ( widget && widget.name === 'easyimage' ) {
 					this.setState( ( enableCheck && enableCheck( widget ) ) ? CKEDITOR.TRISTATE_ON : CKEDITOR.TRISTATE_OFF );
 				} else {
 					this.setState( CKEDITOR.TRISTATE_DISABLED );
@@ -94,32 +94,16 @@
 	}
 
 	function registerWidget( editor ) {
-		// Overwrite some image2 defaults.
-		editor.on( 'widgetDefinition', function( evt ) {
-			var oldInit = evt.data.init;
-
-			if ( evt.data.name !== 'image' ) {
-				return;
-			}
-
-			evt.data.allowedContent.figure.classes += ',!' + editor.config.easyimage_class + ',' +
-				editor.config.easyimage_sideClass;
-
-			// Block default image dialog.
-			evt.data.dialog = null;
-
-			evt.data.init = function() {
-				oldInit.call( this );
-
+		CKEDITOR.plugins.imagebase.createWidget( editor, 'easyimage', {
+			basicClass: editor.config.easyimage_class,
+			additionalClasses: [ editor.config.easyimage_sideClass ],
+			init: function() {
 				this.on( 'contextMenu', function( evt ) {
-					// Remove "Image Properties" option.
-					delete evt.data.image;
-
 					evt.data.easyimageFull = editor.getCommand( 'easyimageFull' ).state;
 					evt.data.easyimageSide = editor.getCommand( 'easyimageSide' ).state;
 					evt.data.easyimageAlt = editor.getCommand( 'easyimageAlt' ).state;
 				} );
-			};
+			}
 		} );
 	}
 
@@ -135,7 +119,7 @@
 	}
 
 	CKEDITOR.plugins.add( 'easyimage', {
-		requires: 'image2,contextmenu,dialog',
+		requires: 'imagebase,contextmenu,dialog',
 		lang: 'en',
 
 		onLoad: function() {

--- a/plugins/easyimage/plugin.js
+++ b/plugins/easyimage/plugin.js
@@ -96,7 +96,7 @@
 	function registerWidget( editor ) {
 		var config = editor.config;
 
-		CKEDITOR.plugins.imagebase.createWidget( editor, 'easyimage', {
+		CKEDITOR.plugins.imagebase.addImageWidget( editor, 'easyimage', {
 			allowedContent: {
 				figure: {
 					classes: '!' + config.easyimage_class + ',' + config.easyimage_sideClass

--- a/plugins/easyimage/plugin.js
+++ b/plugins/easyimage/plugin.js
@@ -94,10 +94,28 @@
 	}
 
 	function registerWidget( editor ) {
+		var config = editor.config;
+
 		CKEDITOR.plugins.imagebase.createWidget( editor, 'easyimage', {
-			basicClass: editor.config.easyimage_class,
-			additionalClasses: [ editor.config.easyimage_sideClass ],
-			captionAllowedContent: 'br em strong sub sup u s; a[!href,target]',
+			allowedContent: {
+				figure: {
+					classes: '!' + config.easyimage_class + ',' + config.easyimage_sideClass
+				}
+			},
+
+			requiredContent: 'figure(!' + config.easyimage_class + ')',
+
+			upcast: function( element ) {
+				// http://dev.ckeditor.com/ticket/11110 Don't initialize on pasted fake objects.
+				if ( element.attributes[ 'data-cke-realelement' ] ) {
+					return;
+				}
+
+				if ( element.name === 'figure' && element.hasClass( config.easyimage_class ) ) {
+					return element;
+				}
+			},
+
 			init: function() {
 				this.on( 'contextMenu', function( evt ) {
 					evt.data.easyimageFull = editor.getCommand( 'easyimageFull' ).state;

--- a/plugins/easyimage/plugin.js
+++ b/plugins/easyimage/plugin.js
@@ -97,6 +97,7 @@
 		CKEDITOR.plugins.imagebase.createWidget( editor, 'easyimage', {
 			basicClass: editor.config.easyimage_class,
 			additionalClasses: [ editor.config.easyimage_sideClass ],
+			captionAllowedContent: 'br em strong sub sup u s; a[!href,target]',
 			init: function() {
 				this.on( 'contextMenu', function( evt ) {
 					evt.data.easyimageFull = editor.getCommand( 'easyimageFull' ).state;

--- a/plugins/easyimage/plugin.js
+++ b/plugins/easyimage/plugin.js
@@ -105,14 +105,16 @@
 
 			requiredContent: 'figure(!' + config.easyimage_class + ')',
 
-			upcast: function( element ) {
-				// http://dev.ckeditor.com/ticket/11110 Don't initialize on pasted fake objects.
-				if ( element.attributes[ 'data-cke-realelement' ] ) {
-					return;
-				}
+			upcasts: {
+				figure: function( element ) {
+					// http://dev.ckeditor.com/ticket/11110 Don't initialize on pasted fake objects.
+					if ( element.attributes[ 'data-cke-realelement' ] ) {
+						return;
+					}
 
-				if ( element.name === 'figure' && element.hasClass( config.easyimage_class ) ) {
-					return element;
+					if ( element.name === 'figure' && element.hasClass( config.easyimage_class ) ) {
+						return element;
+					}
 				}
 			},
 

--- a/plugins/easyimage/plugin.js
+++ b/plugins/easyimage/plugin.js
@@ -103,11 +103,12 @@
 					}
 				},
 
-				requiredContent: 'figure',
+				requiredContent: 'figure; img[!src]',
 
 				upcasts: {
 					figure: function( element ) {
-						if ( !figureClass || element.hasClass( figureClass ) ) {
+						if ( ( !figureClass || element.hasClass( figureClass ) ) &&
+							element.find( 'img' ).length === 1 ) {
 							return element;
 						}
 					}

--- a/plugins/easyimage/plugin.js
+++ b/plugins/easyimage/plugin.js
@@ -94,38 +94,40 @@
 	}
 
 	function registerWidget( editor ) {
-		var config = editor.config;
-
-		CKEDITOR.plugins.imagebase.addImageWidget( editor, 'easyimage', {
-			allowedContent: {
-				figure: {
-					classes: '!' + config.easyimage_class + ',' + config.easyimage_sideClass
-				}
-			},
-
-			requiredContent: 'figure(!' + config.easyimage_class + ')',
-
-			upcasts: {
-				figure: function( element ) {
-					// http://dev.ckeditor.com/ticket/11110 Don't initialize on pasted fake objects.
-					if ( element.attributes[ 'data-cke-realelement' ] ) {
-						return;
+		var config = editor.config,
+			figureClass = config.easyimage_class,
+			widgetDefinition = {
+				allowedContent: {
+					figure: {
+						classes: config.easyimage_sideClass
 					}
+				},
 
-					if ( element.name === 'figure' && element.hasClass( config.easyimage_class ) ) {
-						return element;
+				requiredContent: 'figure',
+
+				upcasts: {
+					figure: function( element ) {
+						if ( !figureClass || element.hasClass( figureClass ) ) {
+							return element;
+						}
 					}
-				}
-			},
+				},
 
-			init: function() {
-				this.on( 'contextMenu', function( evt ) {
-					evt.data.easyimageFull = editor.getCommand( 'easyimageFull' ).state;
-					evt.data.easyimageSide = editor.getCommand( 'easyimageSide' ).state;
-					evt.data.easyimageAlt = editor.getCommand( 'easyimageAlt' ).state;
-				} );
-			}
-		} );
+				init: function() {
+					this.on( 'contextMenu', function( evt ) {
+						evt.data.easyimageFull = editor.getCommand( 'easyimageFull' ).state;
+						evt.data.easyimageSide = editor.getCommand( 'easyimageSide' ).state;
+						evt.data.easyimageAlt = editor.getCommand( 'easyimageAlt' ).state;
+					} );
+				}
+			};
+
+		if ( figureClass ) {
+			widgetDefinition.requiredContent += '(!' + figureClass + ')';
+			widgetDefinition.allowedContent.figure.classes = '!' + figureClass + ',' + widgetDefinition.allowedContent.figure.classes;
+		}
+
+		CKEDITOR.plugins.imagebase.addImageWidget( editor, 'easyimage', widgetDefinition );
 	}
 
 	function loadStyles( editor, plugin ) {
@@ -156,13 +158,16 @@
 	} );
 
 	/**
-	 * A CSS class applied to all Easy Image widgets
+	 * A CSS class applied to all Easy Image widgets. If set to `null` all `<figure>` elements are converted into widgets.
 	 *
 	 *		// Changes the class to "my-image".
 	 *		config.easyimage_class = 'my-image';
 	 *
+	 *		// This will cause plugin to convert any figure into a widget.
+	 *		config.easyimage_class = null;
+	 *
 	 * @since 4.8.0
-	 * @cfg {String} [easyimage_class='easyimage']
+	 * @cfg {String/null} [easyimage_class='easyimage']
 	 * @member CKEDITOR.config
 	 */
 	CKEDITOR.config.easyimage_class = 'easyimage';

--- a/plugins/imagebase/lang/en.js
+++ b/plugins/imagebase/lang/en.js
@@ -1,0 +1,21 @@
+/*
+Copyright (c) 2003-2017, CKSource - Frederico Knabben. All rights reserved.
+For licensing, see LICENSE.md or http://ckeditor.com/license
+*/
+CKEDITOR.plugins.setLang( 'imagebase', 'en', {
+	alt: 'Alternative Text',
+	btnUpload: 'Send it to the Server',
+	captioned: 'Captioned image',
+	captionPlaceholder: 'Caption',
+	infoTab: 'Image Info',
+	lockRatio: 'Lock Ratio',
+	menu: 'Image Properties',
+	pathName: 'image',
+	pathNameCaption: 'caption',
+	resetSize: 'Reset Size',
+	resizer: 'Click and drag to resize',
+	title: 'Image Properties',
+	uploadTab: 'Upload',
+	urlMissing: 'Image source URL is missing.',
+	altMissing: 'Alternative text is missing.'
+} );

--- a/plugins/imagebase/lang/en.js
+++ b/plugins/imagebase/lang/en.js
@@ -3,19 +3,5 @@ Copyright (c) 2003-2017, CKSource - Frederico Knabben. All rights reserved.
 For licensing, see LICENSE.md or http://ckeditor.com/license
 */
 CKEDITOR.plugins.setLang( 'imagebase', 'en', {
-	alt: 'Alternative Text',
-	btnUpload: 'Send it to the Server',
-	captioned: 'Captioned image',
-	captionPlaceholder: 'Caption',
-	infoTab: 'Image Info',
-	lockRatio: 'Lock Ratio',
-	menu: 'Image Properties',
-	pathName: 'image',
-	pathNameCaption: 'caption',
-	resetSize: 'Reset Size',
-	resizer: 'Click and drag to resize',
-	title: 'Image Properties',
-	uploadTab: 'Upload',
-	urlMissing: 'Image source URL is missing.',
-	altMissing: 'Alternative text is missing.'
+	captionPlaceholder: 'Caption'
 } );

--- a/plugins/imagebase/plugin.js
+++ b/plugins/imagebase/plugin.js
@@ -58,25 +58,32 @@
 				caption: 'figcaption'
 			},
 
-			/**
-			 * Image widget definition overwrites the {@link CKEDITOR.plugins.widget.definition#upcast} property.
-			 * This should not be changed.
-			 *
-			 * @property {Function}
-			 */
-			upcast: function( element ) {
-				// http://dev.ckeditor.com/ticket/11110 Don't initialize on pasted fake objects.
-				if ( element.attributes[ 'data-cke-realelement' ] ) {
-					return;
-				}
+			upcasts: {
+				figure: function( element ) {
+					// http://dev.ckeditor.com/ticket/11110 Don't initialize on pasted fake objects.
+					if ( element.attributes[ 'data-cke-realelement' ] ) {
+						return;
+					}
 
-				if ( element.name === 'figure' && element.hasClass( 'imagebase' ) ) {
-					return element;
+					if ( element.name === 'figure' ) {
+						return element;
+					}
 				}
 			}
 		};
 
-		return CKEDITOR.tools.object.merge( baseDefinition, definition );
+		definition = CKEDITOR.tools.object.merge( baseDefinition, definition );
+
+		/**
+		 * Image widget definition overwrites the {@link CKEDITOR.plugins.widget.definition#upcast} property.
+		 * This should not be changed.
+		 *
+		 * @member CKEDITOR.plugins.imagebase.imageWidgetDefinition
+		 * @property {String}
+		 */
+		definition.upcast = CKEDITOR.tools.objectKeys( definition.upcasts ).join( ',' );
+
+		return definition;
 	}
 
 	CKEDITOR.plugins.add( 'imagebase', {

--- a/plugins/imagebase/plugin.js
+++ b/plugins/imagebase/plugin.js
@@ -20,10 +20,11 @@
 		 *
 		 * Note that because the image widget is a type of a widget, this definition extends
 		 * {@link CKEDITOR.plugins.widget.definition}.
-		 * It adds several parts of image and implements the {@link CKEDITOR.plugins.widget.definition#upcast} callback.
-		 * This callback should not be overwritten.
+		 * It adds several parts of image and implements the basic version of
+		 * {@link CKEDITOR.plugins.widget.definition#upcast} callback.
 		 *
 		 * @abstract
+		 * @since 4.8.0
 		 * @class CKEDITOR.plugins.imagebase.imageWidgetDefinition
 		 * @mixins CKEDITOR.plugins.widget.definition
 		 */
@@ -92,10 +93,9 @@
 	 */
 	CKEDITOR.plugins.imagebase = {
 		/**
-		 * Registers a new widget definition based on passed options.
+		 * Registers a new widget based on passed definition.
 		 *
-		 * @since 4.8.0
-		 * @param {CKEDITOR.editor} editor Editor that will get the definition registered.
+		 * @param {CKEDITOR.editor} editor Editor that will get the widget registered.
 		 * @param {String} name Widget name.
 		 * @param {CKEDITOR.plugins.imagebase.imageWidgetDefinition} definition Widget's definition.
 		 */

--- a/plugins/imagebase/plugin.js
+++ b/plugins/imagebase/plugin.js
@@ -99,7 +99,7 @@
 		 * @param {String} name Widget name.
 		 * @param {CKEDITOR.plugins.imagebase.imageWidgetDefinition} definition Widget's definition.
 		 */
-		createWidget: function( editor, name, definition ) {
+		addImageWidget: function( editor, name, definition ) {
 			var widget = editor.widgets.add( name, createWidgetDefinition( editor, definition ) );
 
 			editor.addFeature( widget );

--- a/plugins/imagebase/plugin.js
+++ b/plugins/imagebase/plugin.js
@@ -1,0 +1,13 @@
+/**
+ * @license Copyright (c) 2003-2017, CKSource - Frederico Knabben. All rights reserved.
+ * For licensing, see LICENSE.md or http://ckeditor.com/license
+ */
+
+( function() {
+	'use strict';
+
+	CKEDITOR.plugins.add( 'imagebase', {
+		requires: 'widget'
+	} );
+}() );
+

--- a/plugins/imagebase/plugin.js
+++ b/plugins/imagebase/plugin.js
@@ -39,7 +39,7 @@
 				caption: {
 					selector: 'figcaption',
 					pathName: editor.lang.imagebase.pathNameCaption,
-					allowedContent: 'br em strong sub sup u s; a[!href,target]'
+					allowedContent: options.captionAllowedContent
 				}
 			},
 

--- a/plugins/imagebase/plugin.js
+++ b/plugins/imagebase/plugin.js
@@ -37,13 +37,11 @@
 				img: {
 					attributes: '!src,alt,width,height'
 				},
-				figure: {
-					classes: '!imagebase'
-				},
+				figure: true,
 				figcaption: true
 			},
 
-			requiredContent: 'figure(!imagebase)',
+			requiredContent: 'figure',
 
 			editables: {
 				caption: {

--- a/plugins/imagebase/plugin.js
+++ b/plugins/imagebase/plugin.js
@@ -22,8 +22,8 @@
 		}
 
 		/**
-		 * This is an abstract class that describes a definition of an image widget.
-		 * It is a return type of {@link CKEDITOR.plugins.imagebase#createWidget} method.
+		 * This is an abstract class that describes a definition of a basic image widget
+		 * creted by {@link CKEDITOR.plugins.imagebase#createWidget} method.
 		 *
 		 * Note that because the image widget is a type of a widget, this definition extends
 		 * {@link CKEDITOR.plugins.widget.definition}.
@@ -35,19 +35,11 @@
 		 * @mixins CKEDITOR.plugins.widget.definition
 		 */
 		return {
-			/**
-			 * @inheritdoc
-			 */
+
 			pathName: editor.lang.imagebase.pathName,
 
-			/**
-			 * @inheritdoc
-			 */
 			template: defaultTemplate,
 
-			/**
-			 * @inheritdoc
-			 */
 			allowedContent: {
 				img: {
 					attributes: '!src,alt,width,height'
@@ -58,14 +50,8 @@
 				figcaption: true
 			},
 
-			/**
-			 * @inheritdoc
-			 */
 			requiredContent: 'figure(!' + options.basicClass + ')',
 
-			/**
-			 * @inheritdoc
-			 */
 			editables: {
 				caption: {
 					selector: 'figcaption',
@@ -74,9 +60,6 @@
 				}
 			},
 
-			/**
-			 * @inheritdoc
-			 */
 			parts: {
 				image: 'img',
 				caption: 'figcaption'

--- a/plugins/imagebase/plugin.js
+++ b/plugins/imagebase/plugin.js
@@ -41,7 +41,7 @@
 				figcaption: true
 			},
 
-			requiredContent: 'figure',
+			requiredContent: 'figure; img[!src]',
 
 			editables: {
 				caption: {
@@ -58,7 +58,9 @@
 
 			upcasts: {
 				figure: function( element ) {
-					return element;
+					if ( element.find( 'img' ).length === 1 ) {
+						return element;
+					}
 				}
 			}
 		};

--- a/plugins/imagebase/plugin.js
+++ b/plugins/imagebase/plugin.js
@@ -21,9 +21,33 @@
 			return toApply.join( ',' );
 		}
 
+		/**
+		 * This is an abstract class that describes a definition of an image widget.
+		 * It is a return type of {@link CKEDITOR.plugins.imagebase#createWidget} method.
+		 *
+		 * Note that because the image widget is a type of a widget, this definition extends
+		 * {@link CKEDITOR.plugins.widget.definition}.
+		 * It adds several parts of image and implements the {@link CKEDITOR.plugins.widget.definition#upcast} callback.
+		 * This callback should not be overwritten.
+		 *
+		 * @abstract
+		 * @class CKEDITOR.plugins.imagebase.imageWidgetDefinition
+		 * @mixins CKEDITOR.plugins.widget.definition
+		 */
 		return {
+			/**
+			 * @inheritdoc
+			 */
 			pathName: editor.lang.imagebase.pathName,
+
+			/**
+			 * @inheritdoc
+			 */
 			template: defaultTemplate,
+
+			/**
+			 * @inheritdoc
+			 */
 			allowedContent: {
 				img: {
 					attributes: '!src,alt,width,height'
@@ -33,8 +57,15 @@
 				},
 				figcaption: true
 			},
+
+			/**
+			 * @inheritdoc
+			 */
 			requiredContent: 'figure(!' + options.basicClass + ')',
 
+			/**
+			 * @inheritdoc
+			 */
 			editables: {
 				caption: {
 					selector: 'figcaption',
@@ -43,11 +74,20 @@
 				}
 			},
 
+			/**
+			 * @inheritdoc
+			 */
 			parts: {
 				image: 'img',
 				caption: 'figcaption'
 			},
 
+			/**
+			 * Image widget definition overwrites the {@link CKEDITOR.plugins.widget.definition#upcast} property.
+			 * This should not be changed.
+			 *
+			 * @property {Function}
+			 */
 			upcast: function( element ) {
 				// http://dev.ckeditor.com/ticket/11110 Don't initialize on pasted fake objects.
 				if ( element.attributes[ 'data-cke-realelement' ] ) {
@@ -59,6 +99,11 @@
 				}
 			},
 
+			/**
+			 * Invokes user defined widget initialization method.
+			 *
+			 * @property {Function}
+			 */
 			init: function() {
 				if ( options.init ) {
 					options.init.call( this );
@@ -72,7 +117,29 @@
 		lang: 'en'
 	} );
 
+	/**
+	 * Namespace providing a set of helper functions for working with image widgets.
+	 *
+	 * @since 4.8.0
+	 * @singleton
+	 * @class CKEDITOR.plugins.imagebase
+	 */
 	CKEDITOR.plugins.imagebase = {
+		/**
+		 * Creates new image widget based on passed options.
+		 *
+		 * @since 4.8.0
+		 * @param {CKEDITOR.editor} editor Editor that owns the new widget.
+		 * @param {String} name Name of newly created widget.
+		 * @param {Object} options Widget's options.
+		 * @param {String} options.basicClass Primary class for widget's element, that allows to properly
+		 * identify the widget.
+		 * @param {String[]} options.additionalClasses Additional classes that could be applied to widget's
+		 * element.
+		 * @param {CKEDITOR.filter.allowedContentRules} options.captionAllowedContent Allowed content inside
+		 * image's caption.
+		 * @param {Function} options.init Widget's initialization method.
+		 */
 		createWidget: function( editor, name, options ) {
 			var widget = editor.widgets.add( name, createWidgetDefinition( editor, options ) );
 
@@ -80,4 +147,3 @@
 		}
 	};
 }() );
-

--- a/plugins/imagebase/plugin.js
+++ b/plugins/imagebase/plugin.js
@@ -58,14 +58,7 @@
 
 			upcasts: {
 				figure: function( element ) {
-					// http://dev.ckeditor.com/ticket/11110 Don't initialize on pasted fake objects.
-					if ( element.attributes[ 'data-cke-realelement' ] ) {
-						return;
-					}
-
-					if ( element.name === 'figure' ) {
-						return element;
-					}
+					return element;
 				}
 			}
 		};

--- a/plugins/imagebase/plugin.js
+++ b/plugins/imagebase/plugin.js
@@ -126,11 +126,11 @@
 	 */
 	CKEDITOR.plugins.imagebase = {
 		/**
-		 * Creates new image widget based on passed options.
+		 * Registers a new widget definition based on passed options.
 		 *
 		 * @since 4.8.0
-		 * @param {CKEDITOR.editor} editor Editor that owns the new widget.
-		 * @param {String} name Name of newly created widget.
+		 * @param {CKEDITOR.editor} editor Editor that will get the definition registered.
+		 * @param {String} name Widget name.
 		 * @param {Object} options Widget's options.
 		 * @param {String} options.basicClass Primary class for widget's element, that allows to properly
 		 * identify the widget.

--- a/plugins/imagebase/plugin.js
+++ b/plugins/imagebase/plugin.js
@@ -8,7 +8,7 @@
 
 	function createWidgetDefinition( editor, definition ) {
 		var defaultTemplate = new CKEDITOR.template(
-			'<figure class="{basicClass}">' +
+			'<figure>' +
 				'<img alt="" src="" />' +
 				'<figcaption>{captionPlaceholder}</figcaption>' +
 			'</figure>' ),
@@ -16,7 +16,7 @@
 
 		/**
 		 * This is an abstract class that describes a definition of a basic image widget
-		 * creted by {@link CKEDITOR.plugins.imagebase#addImageWidget} method.
+		 * created by {@link CKEDITOR.plugins.imagebase#addImageWidget} method.
 		 *
 		 * Note that because the image widget is a type of a widget, this definition extends
 		 * {@link CKEDITOR.plugins.widget.definition}.

--- a/plugins/imagebase/plugin.js
+++ b/plugins/imagebase/plugin.js
@@ -66,8 +66,9 @@
 		definition = CKEDITOR.tools.object.merge( baseDefinition, definition );
 
 		/**
-		 * Image widget definition overwrites the {@link CKEDITOR.plugins.widget.definition#upcast} property.
-		 * This should not be changed.
+		 * Image widget definition overrides {@link CKEDITOR.plugins.widget.definition#upcast} property.
+		 * It's automatically set to enumerate keys of {@link #upcasts}.
+		 * Avoid changes, unless you know what you're doing.
 		 *
 		 * @member CKEDITOR.plugins.imagebase.imageWidgetDefinition
 		 * @property {String}

--- a/plugins/imagebase/plugin.js
+++ b/plugins/imagebase/plugin.js
@@ -38,7 +38,7 @@
 			editables: {
 				caption: {
 					selector: 'figcaption',
-					pathName: editor.lang.imagebase.caption,
+					pathName: editor.lang.imagebase.pathNameCaption,
 					allowedContent: 'br em strong sub sup u s; a[!href,target]'
 				}
 			},

--- a/plugins/imagebase/plugin.js
+++ b/plugins/imagebase/plugin.js
@@ -16,7 +16,7 @@
 
 		/**
 		 * This is an abstract class that describes a definition of a basic image widget
-		 * creted by {@link CKEDITOR.plugins.imagebase#createWidget} method.
+		 * creted by {@link CKEDITOR.plugins.imagebase#addImageWidget} method.
 		 *
 		 * Note that because the image widget is a type of a widget, this definition extends
 		 * {@link CKEDITOR.plugins.widget.definition}.

--- a/plugins/imagebase/plugin.js
+++ b/plugins/imagebase/plugin.js
@@ -6,20 +6,13 @@
 ( function() {
 	'use strict';
 
-	function createWidgetDefinition( editor, options ) {
+	function createWidgetDefinition( editor, definition ) {
 		var defaultTemplate = new CKEDITOR.template(
 			'<figure class="{basicClass}">' +
 				'<img alt="" src="" />' +
 				'<figcaption>{captionPlaceholder}</figcaption>' +
-			'</figure>' );
-
-		function joinClasses( basicClass, additionalClasses ) {
-			var toApply = additionalClasses.slice();
-
-			toApply.unshift( basicClass );
-
-			return toApply.join( ',' );
-		}
+			'</figure>' ),
+			baseDefinition;
 
 		/**
 		 * This is an abstract class that describes a definition of a basic image widget
@@ -34,8 +27,7 @@
 		 * @class CKEDITOR.plugins.imagebase.imageWidgetDefinition
 		 * @mixins CKEDITOR.plugins.widget.definition
 		 */
-		return {
-
+		baseDefinition = {
 			pathName: editor.lang.imagebase.pathName,
 
 			template: defaultTemplate,
@@ -45,18 +37,18 @@
 					attributes: '!src,alt,width,height'
 				},
 				figure: {
-					classes: '!' + joinClasses( options.basicClass, options.additionalClasses )
+					classes: '!imagebase'
 				},
 				figcaption: true
 			},
 
-			requiredContent: 'figure(!' + options.basicClass + ')',
+			requiredContent: 'figure(!imagebase)',
 
 			editables: {
 				caption: {
 					selector: 'figcaption',
 					pathName: editor.lang.imagebase.pathNameCaption,
-					allowedContent: options.captionAllowedContent
+					allowedContent: 'br em strong sub sup u s; a[!href,target]'
 				}
 			},
 
@@ -77,22 +69,13 @@
 					return;
 				}
 
-				if ( element.name === 'figure' && element.hasClass( options.basicClass ) ) {
+				if ( element.name === 'figure' && element.hasClass( 'imagebase' ) ) {
 					return element;
-				}
-			},
-
-			/**
-			 * Invokes user defined widget initialization method.
-			 *
-			 * @property {Function}
-			 */
-			init: function() {
-				if ( options.init ) {
-					options.init.call( this );
 				}
 			}
 		};
+
+		return CKEDITOR.tools.object.merge( baseDefinition, definition );
 	}
 
 	CKEDITOR.plugins.add( 'imagebase', {
@@ -114,17 +97,10 @@
 		 * @since 4.8.0
 		 * @param {CKEDITOR.editor} editor Editor that will get the definition registered.
 		 * @param {String} name Widget name.
-		 * @param {Object} options Widget's options.
-		 * @param {String} options.basicClass Primary class for widget's element, that allows to properly
-		 * identify the widget.
-		 * @param {String[]} options.additionalClasses Additional classes that could be applied to widget's
-		 * element.
-		 * @param {CKEDITOR.filter.allowedContentRules} options.captionAllowedContent Allowed content inside
-		 * image's caption.
-		 * @param {Function} options.init Widget's initialization method.
+		 * @param {CKEDITOR.plugins.imagebase.imageWidgetDefinition} definition Widget's definition.
 		 */
-		createWidget: function( editor, name, options ) {
-			var widget = editor.widgets.add( name, createWidgetDefinition( editor, options ) );
+		createWidget: function( editor, name, definition ) {
+			var widget = editor.widgets.add( name, createWidgetDefinition( editor, definition ) );
 
 			editor.addFeature( widget );
 		}

--- a/plugins/imagebase/plugin.js
+++ b/plugins/imagebase/plugin.js
@@ -6,8 +6,78 @@
 ( function() {
 	'use strict';
 
+	function createWidgetDefinition( editor, options ) {
+		var defaultTemplate = new CKEDITOR.template(
+			'<figure class="{basicClass}">' +
+				'<img alt="" src="" />' +
+				'<figcaption>{captionPlaceholder}</figcaption>' +
+			'</figure>' );
+
+		function joinClasses( basicClass, additionalClasses ) {
+			var toApply = additionalClasses.slice();
+
+			toApply.unshift( basicClass );
+
+			return toApply.join( ',' );
+		}
+
+		return {
+			pathName: editor.lang.imagebase.pathName,
+			template: defaultTemplate,
+			allowedContent: {
+				img: {
+					attributes: '!src,alt,width,height'
+				},
+				figure: {
+					classes: '!' + joinClasses( options.basicClass, options.additionalClasses )
+				},
+				figcaption: true
+			},
+			requiredContent: 'figure(!' + options.basicClass + ')',
+
+			editables: {
+				caption: {
+					selector: 'figcaption',
+					pathName: editor.lang.imagebase.caption,
+					allowedContent: 'br em strong sub sup u s; a[!href,target]'
+				}
+			},
+
+			parts: {
+				image: 'img',
+				caption: 'figcaption'
+			},
+
+			upcast: function( element ) {
+				// http://dev.ckeditor.com/ticket/11110 Don't initialize on pasted fake objects.
+				if ( element.attributes[ 'data-cke-realelement' ] ) {
+					return;
+				}
+
+				if ( element.name === 'figure' && element.hasClass( options.basicClass ) ) {
+					return element;
+				}
+			},
+
+			init: function() {
+				if ( options.init ) {
+					options.init.call( this );
+				}
+			}
+		};
+	}
+
 	CKEDITOR.plugins.add( 'imagebase', {
-		requires: 'widget'
+		requires: 'widget',
+		lang: 'en'
 	} );
+
+	CKEDITOR.plugins.imagebase = {
+		createWidget: function( editor, name, options ) {
+			var widget = editor.widgets.add( name, createWidgetDefinition( editor, options ) );
+
+			editor.addFeature( widget );
+		}
+	};
 }() );
 

--- a/tests/plugins/easyimage/config.html
+++ b/tests/plugins/easyimage/config.html
@@ -1,0 +1,23 @@
+<div id="changedClass">
+	<figure class="customClass" id="customSideId">
+		<img src="../image2/_assets/foo.png" alt="fig1">
+		<figcaption>Changed class</figcaption>
+	</figure>
+
+	<figure>
+		<img src="../image2/_assets/foo.png" alt="fig2">
+		<figcaption>Figure without class</figcaption>
+	</figure>
+</div>
+
+<div id="expectedCustomSideClass">
+	<figure class="customClass customSideClass" id="customSideId">
+		<img alt="fig1" src="../image2/_assets/foo.png" />
+		<figcaption>Changed class</figcaption>
+	</figure>
+
+	<figure>
+		<img src="../image2/_assets/foo.png" alt="fig2">
+		<figcaption>Figure without class</figcaption>
+	</figure>
+</div>

--- a/tests/plugins/easyimage/config.js
+++ b/tests/plugins/easyimage/config.js
@@ -1,0 +1,49 @@
+/* bender-tags: editor,widget */
+/* bender-ckeditor-plugins: easyimage,toolbar */
+/* bender-include: ../widget/_helpers/tools.js */
+/* global widgetTestsTools */
+
+( function() {
+	'use strict';
+
+	bender.editors = {
+		classCustomized: {
+			config: {
+				// Widget is identified by id.
+				extraAllowedContent: 'figure[id]',
+				easyimage_class: 'customClass',
+				easyimage_sideClass: 'customSideClass'
+			}
+		}
+	};
+
+	bender.test( {
+		'test easyimage_class - changed': function() {
+			widgetTestsTools.assertWidget( {
+				count: 1,
+				widgetOffset: 0,
+				nameCreated: 'easyimage',
+				html: CKEDITOR.document.getById( 'changedClass' ).getHtml(),
+				bot: this.editorBots.classCustomized
+			} );
+		},
+
+		'test easyimage_sideClass - changed': function() {
+			var bot = this.editorBots.classCustomized;
+
+			bot.setData( CKEDITOR.document.getById( 'changedClass' ).getHtml(), function() {
+				var editor = bot.editor,
+					widgetInstance = widgetTestsTools.getWidgetById( editor, 'customSideId', true );
+
+				widgetInstance.focus();
+
+				// IE11 for some reasons needs to have the command state force refreshed, after focusing the widget with API only.
+				editor.commands.easyimageSide.refresh( editor, editor.elementPath() );
+
+				editor.execCommand( 'easyimageSide' );
+
+				assert.beautified.html( CKEDITOR.document.getById( 'expectedCustomSideClass' ).getHtml(), editor.getData() );
+			} );
+		}
+	} );
+} )();

--- a/tests/plugins/easyimage/manual/figuresnoclass.html
+++ b/tests/plugins/easyimage/manual/figuresnoclass.html
@@ -1,0 +1,21 @@
+
+<div id="classic">
+	<p>Both figures should become widgets:</p>
+	<figure class="easyimage">
+		<img src="../../image2/_assets/foo.png" alt="foo">
+		<figcaption>Test image</figcaption>
+	</figure>
+	<p>Figure two:</p>
+	<figure>
+		<img src="../../image2/_assets/foo.png" alt="foo">
+		<figcaption>Test image</figcaption>
+	</figure>
+</div>
+
+<script>
+	CKEDITOR.replace( 'classic', {
+		easyimage_class: null,
+		height: 500,
+		extraAllowedContent: 'figure(*)'
+	} );
+</script>

--- a/tests/plugins/easyimage/manual/figuresnoclass.md
+++ b/tests/plugins/easyimage/manual/figuresnoclass.md
@@ -1,0 +1,13 @@
+@bender-tags: 4.8.0, feature, config, 932
+@bender-ui: collapsed
+@bender-ckeditor-plugins: sourcearea, wysiwygarea, floatingspace, toolbar, easyimage, htmlwriter, elementspath
+
+`config.easyimage_class` customization
+
+1. Check if both figures become widgets.
+1. Click "Source" button to check output.
+
+## Expected
+
+* First `<figure>` element has `easyimage` class.
+* Second `<figure>` element has no class.

--- a/tests/plugins/easyimage/widget.html
+++ b/tests/plugins/easyimage/widget.html
@@ -7,4 +7,7 @@
 		<img src="../image2/_assets/foo.png" alt="fig2">
 		<figcaption>Figure without class</figcaption>
 	</figure>
+	<figure>
+		<figcaption>Figure without image</figcaption>
+	</figure>
 </div>

--- a/tests/plugins/easyimage/widget.html
+++ b/tests/plugins/easyimage/widget.html
@@ -1,0 +1,10 @@
+<div id="mixedFigures">
+	<figure class="easyimage">
+		<img src="../image2/_assets/foo.png" alt="fig1">
+		<figcaption>Figure with a easyimage class</figcaption>
+	</figure>
+	<figure>
+		<img src="../image2/_assets/foo.png" alt="fig2">
+		<figcaption>Figure without class</figcaption>
+	</figure>
+</div>

--- a/tests/plugins/easyimage/widget.js
+++ b/tests/plugins/easyimage/widget.js
@@ -1,0 +1,48 @@
+/* bender-tags: editor,widget */
+/* bender-ckeditor-plugins: easyimage,toolbar */
+
+( function() {
+	'use strict';
+
+	bender.editors = {
+		classic: {},
+
+		divarea: {
+			config: {
+				extraPlugins: 'divarea'
+			}
+		},
+
+		inline: {
+			creator: 'inline'
+		}
+	};
+
+	function assertUpcast( bot, data, widget ) {
+		var editor = bot.editor;
+
+		bot.setData( data, function() {
+			var widgets = editor.editable().find( '[data-widget="' + widget + '"]' );
+
+			assert.areSame( 1, widgets.count(), 'Widget is properly upcasted' );
+		} );
+	}
+
+	var widgetHtml = '<figure class="easyimage"><img src="../image2/_assets/foo.png" alt="foo"><figcaption>Test image</figcaption></figure>',
+		tests = {
+			tearDown: function() {
+				var currentDialog = CKEDITOR.dialog.getCurrent();
+
+				if ( currentDialog ) {
+					currentDialog.hide();
+				}
+			},
+
+			'test upcasting image widget': function( editor, bot ) {
+				assertUpcast( bot, widgetHtml + '<figure>Foo</figure>', 'easyimage' );
+			}
+		};
+
+	tests = bender.tools.createTestsForEditors( CKEDITOR.tools.objectKeys( bender.editors ), tests );
+	bender.test( tests );
+} )();

--- a/tests/plugins/easyimage/widget.js
+++ b/tests/plugins/easyimage/widget.js
@@ -1,5 +1,7 @@
 /* bender-tags: editor,widget */
 /* bender-ckeditor-plugins: easyimage,toolbar */
+/* bender-include: ../widget/_helpers/tools.js */
+/* global widgetTestsTools */
 
 ( function() {
 	'use strict';
@@ -15,33 +17,27 @@
 
 		inline: {
 			creator: 'inline'
+		},
+
+		// This instance upcasts all figures, despite figure[class] value.
+		classicAllFigures: {
+			config: {
+				easyimage_class: null
+			}
 		}
 	};
 
-	function assertUpcast( bot, data, widget ) {
-		var editor = bot.editor;
-
-		bot.setData( data, function() {
-			var widgets = editor.editable().find( '[data-widget="' + widget + '"]' );
-
-			assert.areSame( 1, widgets.count(), 'Widget is properly upcasted' );
-		} );
-	}
-
-	var widgetHtml = '<figure class="easyimage"><img src="../image2/_assets/foo.png" alt="foo"><figcaption>Test image</figcaption></figure>',
-		tests = {
-			tearDown: function() {
-				var currentDialog = CKEDITOR.dialog.getCurrent();
-
-				if ( currentDialog ) {
-					currentDialog.hide();
-				}
-			},
-
-			'test upcasting image widget': function( editor, bot ) {
-				assertUpcast( bot, widgetHtml + '<figure>Foo</figure>', 'easyimage' );
-			}
-		};
+	var tests = {
+		'test upcasting image widget': function( editor, bot ) {
+			widgetTestsTools.assertWidget( {
+				count: editor.name === 'classicAllFigures' ? 2 : 1,
+				widgetOffset: 0,
+				nameCreated: 'easyimage',
+				html: CKEDITOR.document.getById( 'mixedFigures' ).getHtml(),
+				bot: bot
+			} );
+		}
+	};
 
 	tests = bender.tools.createTestsForEditors( CKEDITOR.tools.objectKeys( bender.editors ), tests );
 	bender.test( tests );

--- a/tests/plugins/imagebase/imagebase.html
+++ b/tests/plugins/imagebase/imagebase.html
@@ -1,0 +1,11 @@
+<div id="upcastTest">
+	<figure>Foo</figure>
+
+	<div>
+		<img src="foo">
+	</div>
+
+	<figure>
+		<img src="foo">
+	</figure>
+</div>

--- a/tests/plugins/imagebase/imagebase.js
+++ b/tests/plugins/imagebase/imagebase.js
@@ -1,18 +1,10 @@
 /* bender-tags: editor,widget */
 /* bender-ckeditor-plugins: imagebase,toolbar */
+/* bender-include: ../widget/_helpers/tools.js */
+/* global widgetTestsTools */
 
 ( function() {
 	'use strict';
-
-	function assertUpcast( bot, data, widget ) {
-		var editor = bot.editor;
-
-		bot.setData( data, function() {
-			var widgets = editor.editable().find( '[data-widget="' + widget + '"]' );
-
-			assert.areSame( 1, widgets.count(), 'Widget is properly upcasted' );
-		} );
-	}
 
 	bender.editors = {
 		classic: {},
@@ -48,7 +40,14 @@
 
 		'test upcasting image widget': function( editor, bot ) {
 			assert.areSame( 'figure', editor.widgets.registered.testWidget.upcast );
-			assertUpcast( bot, '<figure>Foo</figure><div><img src="foo"></div><figure><img src="foo"></figure>', 'testWidget' );
+
+			widgetTestsTools.assertWidget( {
+				count: 1,
+				widgetOffset: 0,
+				nameCreated: 'testWidget',
+				html: CKEDITOR.document.getById( 'upcastTest' ).getHtml(),
+				bot: bot
+			} );
 		}
 	};
 

--- a/tests/plugins/imagebase/imagebase.js
+++ b/tests/plugins/imagebase/imagebase.js
@@ -1,0 +1,58 @@
+/* bender-tags: editor,widget */
+/* bender-ckeditor-plugins: imagebase,toolbar */
+
+( function() {
+	'use strict';
+
+	function assertUpcast( bot, data, widget ) {
+		var editor = bot.editor;
+
+		bot.setData( data, function() {
+			var widgets = editor.editable().find( '[data-widget="' + widget + '"]' );
+
+			assert.areSame( 1, widgets.count(), 'Widget is properly upcasted' );
+		} );
+	}
+
+
+	bender.editors = {
+		classic: {},
+
+		divarea: {
+			config: {
+				extraPlugins: 'divarea'
+			}
+		},
+
+		inline: {
+			creator: 'inline'
+		}
+	};
+
+	var tests = {
+		'test adding image widget': function( editor ) {
+			var expectedParts = {
+				caption: 'figcaption',
+				image: 'img',
+				loader: 'progress'
+			};
+
+			CKEDITOR.plugins.imagebase.addImageWidget( editor, 'testWidget', {
+				parts: {
+					loader: 'progress'
+				}
+			} );
+
+			objectAssert.ownsKeys( [ 'testWidget' ], editor.widgets.registered );
+			objectAssert.areDeepEqual( expectedParts, editor.widgets.registered.testWidget.parts );
+
+		},
+
+		'test upcasting image widget': function( editor, bot ) {
+			assertUpcast( bot, '<figure class="imagebase"></figure>', 'testWidget' );
+		}
+	};
+
+	tests = bender.tools.createTestsForEditors( CKEDITOR.tools.objectKeys( bender.editors ), tests );
+	bender.test( tests );
+} )();

--- a/tests/plugins/imagebase/imagebase.js
+++ b/tests/plugins/imagebase/imagebase.js
@@ -14,7 +14,6 @@
 		} );
 	}
 
-
 	bender.editors = {
 		classic: {},
 
@@ -45,7 +44,6 @@
 
 			objectAssert.ownsKeys( [ 'testWidget' ], editor.widgets.registered );
 			objectAssert.areDeepEqual( expectedParts, editor.widgets.registered.testWidget.parts );
-
 		},
 
 		'test upcasting image widget': function( editor, bot ) {

--- a/tests/plugins/imagebase/imagebase.js
+++ b/tests/plugins/imagebase/imagebase.js
@@ -49,7 +49,8 @@
 		},
 
 		'test upcasting image widget': function( editor, bot ) {
-			assertUpcast( bot, '<figure class="imagebase"></figure>', 'testWidget' );
+			assert.areSame( 'figure', editor.widgets.registered.testWidget.upcast );
+			assertUpcast( bot, '<figure>Foo</figure>', 'testWidget' );
 		}
 	};
 

--- a/tests/plugins/imagebase/imagebase.js
+++ b/tests/plugins/imagebase/imagebase.js
@@ -48,7 +48,7 @@
 
 		'test upcasting image widget': function( editor, bot ) {
 			assert.areSame( 'figure', editor.widgets.registered.testWidget.upcast );
-			assertUpcast( bot, '<figure>Foo</figure>', 'testWidget' );
+			assertUpcast( bot, '<figure>Foo</figure><div><img src="foo"></div><figure><img src="foo"></figure>', 'testWidget' );
 		}
 	};
 


### PR DESCRIPTION
## What is the purpose of this pull request?

New feature

## Does your PR contain necessary tests?

All patches which change the editor code must include tests. You can always read more
on [PR testing](http://docs.ckeditor.com/#!/guide/dev_contributing_code-section-tests),
[how to set the testing environment](http://docs.ckeditor.com/#!/guide/dev_tests) and
[how to create tests](http://docs.ckeditor.com/#!/guide/dev_tests-section-creating-your-own-test)
in the official CKEditor documentation.

### This PR contains

- [ ] Unit tests
- [ ] Manual tests

_coming soon_

## What changes did you make?

I've introduced new plugin, `imagebase`, which creates new image widget. This plugin could be used as a base for both `image2` and `easyimage` plugins.

Currently the implementation is very basic and it does not do much beyond just displaying image.
