### PR TITLE
Fix unit test failing in Edge 16

### DIFF
--- a/tests/plugins/indent/indent.js
+++ b/tests/plugins/indent/indent.js
@@ -3,11 +3,38 @@
 ( function() {
 	'use strict';
 
-	var enterModeAbbr = {};
+	var editorCounter = 0,
+		enterModeAbbr = {},
+		editorsCache = {},
+		editors;
 
 	enterModeAbbr[ CKEDITOR.ENTER_P ] = 'P';
 	enterModeAbbr[ CKEDITOR.ENTER_BR ] = 'BR';
 	enterModeAbbr[ CKEDITOR.ENTER_DIV ] = 'DIV';
+
+	function createEditor( editorName, callback ) {
+		var editorConfig = editors[ editorName ];
+
+		editorCounter++;
+		editorConfig.name = editorConfig.name + editorCounter;
+		editorConfig.config = CKEDITOR.tools.extend( {}, editorConfig.config, {
+			indentOffset: 10,
+			indentUnit: 'px',
+			autoParagraph: true,
+			plugins: 'toolbar,list,indentlist,indentblock,undo'
+		} );
+
+		if ( CKEDITOR.env.edge && CKEDITOR.env.version >= 16 ) {
+			bender.editorBot.create( editorConfig, callback );
+		} else if ( editorsCache[ editorName ] ) {
+			callback( editorsCache[ editorName ] );
+		} else {
+			bender.editorBot.create( editorConfig, function( bot ) {
+				editorsCache[ editorName ] = bot;
+				callback( bot );
+			} );
+		}
+	}
 
 	function createIndentOutdentTester( editor, html ) {
 		html && bender.tools.setHtmlWithSelection( editor, html );
@@ -64,7 +91,7 @@
 		};
 	}
 
-	bender.editors = {
+	editors = {
 		enterBR: {
 			name: 'test_enterBR',
 			config: {
@@ -134,572 +161,642 @@
 		}
 	};
 
-	bender.editorsConfig = {
-		indentOffset: 10,
-		indentUnit: 'px',
-		autoParagraph: true,
-		plugins: 'toolbar,list,indentlist,indentblock,undo'
-	};
-
 	bender.test( {
 		'test block': function() {
-			var t = createIndentOutdentTester( this.editors.enterP, '<p>x^</p>' );
+			createEditor( 'enterP', function( bot ) {
+				var t = createIndentOutdentTester( bot.editor, '<p>x^</p>' );
 
-			t.s( 2, 0 );
-			t.i( '<p style="margin-left:10px;">x^</p>',														'Indent it once.' );
-			t.s( 2, 2 );
-			t.i( '<p style="margin-left:20px;">x^</p>',														'Indent it twice.' );
-			t.s( 2, 2 );
-			t.o( '<p style="margin-left:10px;">x^</p>',														'Outdent it back.' );
-			t.s( 2, 2 );
-			t.o( '<p>x^</p>',																				'Outdent it back again.' );
-			t.s( 2, 0 );
-			t.o( '<p>x^</p>',																				'Remaining at minimum intent level.' );
-			t.s( 2, 0 );
+				t.s( 2, 0 );
+				t.i( '<p style="margin-left:10px;">x^</p>',														'Indent it once.' );
+				t.s( 2, 2 );
+				t.i( '<p style="margin-left:20px;">x^</p>',														'Indent it twice.' );
+				t.s( 2, 2 );
+				t.o( '<p style="margin-left:10px;">x^</p>',														'Outdent it back.' );
+				t.s( 2, 2 );
+				t.o( '<p>x^</p>',																				'Outdent it back again.' );
+				t.s( 2, 0 );
+				t.o( '<p>x^</p>',																				'Remaining at minimum intent level.' );
+				t.s( 2, 0 );
+			} );
 		},
 
 		'test block (cross-sel between blocks)': function() {
-			var t = createIndentOutdentTester( this.editors.enterP, '<p>xx[x</p><p>yy]y</p>' );
+			createEditor( 'enterP', function( bot ) {
+				var t = createIndentOutdentTester( bot.editor, '<p>xx[x</p><p>yy]y</p>' );
 
-			t.s( 2, 0 );
-			t.i( '<p style="margin-left:10px;">xx[x</p><p style="margin-left:10px;">yy]y</p>',				'Indent it once.' );
-			t.s( 2, 2 );
-			t.i( '<p style="margin-left:20px;">xx[x</p><p style="margin-left:20px;">yy]y</p>',				'Indent it twice.' );
-			t.s( 2, 2 );
-			t.o( '<p style="margin-left:10px;">xx[x</p><p style="margin-left:10px;">yy]y</p>',				'Outdent it back.' );
-			t.s( 2, 2 );
-			t.o( '<p>xx[x</p><p>yy]y</p>',																	'Outdent it back again.' );
-			t.s( 2, 0 );
-			t.o( '<p>xx[x</p><p>yy]y</p>',																	'Remaining at minimum intent level.' );
-			t.s( 2, 0 );
+				t.s( 2, 0 );
+				t.i( '<p style="margin-left:10px;">xx[x</p><p style="margin-left:10px;">yy]y</p>',				'Indent it once.' );
+				t.s( 2, 2 );
+				t.i( '<p style="margin-left:20px;">xx[x</p><p style="margin-left:20px;">yy]y</p>',				'Indent it twice.' );
+				t.s( 2, 2 );
+				t.o( '<p style="margin-left:10px;">xx[x</p><p style="margin-left:10px;">yy]y</p>',				'Outdent it back.' );
+				t.s( 2, 2 );
+				t.o( '<p>xx[x</p><p>yy]y</p>',																	'Outdent it back again.' );
+				t.s( 2, 0 );
+				t.o( '<p>xx[x</p><p>yy]y</p>',																	'Remaining at minimum intent level.' );
+				t.s( 2, 0 );
+			} );
 		},
 
 		// This might be similar to #2
 		'test list (first li element, indent full list)': function() {
-			var t = createIndentOutdentTester( this.editors.enterP, '<ul><li>x^</li><li>y</li></ul>' );
+			createEditor( 'enterP', function( bot ) {
+				var t = createIndentOutdentTester( bot.editor, '<ul><li>x^</li><li>y</li></ul>' );
 
-			t.s( 2, 2 );
-			t.i( '<ul style="margin-left:10px;"><li>x^</li><li>y</li></ul>',								'Indent it once.' );
-			t.s( 2, 2 );
-			t.i( '<ul style="margin-left:20px;"><li>x^</li><li>y</li></ul>',								'Indent it twice.' );
-			t.s( 2, 2 );
-			t.o( '<ul style="margin-left:10px;"><li>x^</li><li>y</li></ul>',								'Outdent it back.' );
-			t.s( 2, 2 );
-			t.o( '<ul><li>x^</li><li>y</li></ul>',															'Outdent it back again.' );
-			t.s( 2, 2 );
-			t.o( '<p>x^</p><ul><li>y</li></ul>',															'Extract paragraph from list element.' );
-			t.s( 2, 0 );
+				t.s( 2, 2 );
+				t.i( '<ul style="margin-left:10px;"><li>x^</li><li>y</li></ul>',								'Indent it once.' );
+				t.s( 2, 2 );
+				t.i( '<ul style="margin-left:20px;"><li>x^</li><li>y</li></ul>',								'Indent it twice.' );
+				t.s( 2, 2 );
+				t.o( '<ul style="margin-left:10px;"><li>x^</li><li>y</li></ul>',								'Outdent it back.' );
+				t.s( 2, 2 );
+				t.o( '<ul><li>x^</li><li>y</li></ul>',															'Outdent it back again.' );
+				t.s( 2, 2 );
+				t.o( '<p>x^</p><ul><li>y</li></ul>',															'Extract paragraph from list element.' );
+				t.s( 2, 0 );
+			} );
 		},
 
 		'test list (next li element, nesting lists)': function() {
-			var t = createIndentOutdentTester( this.editors.enterP, '<ul><li>x</li><li>y^</li></ul>' );
+			createEditor( 'enterP', function( bot ) {
+				var t = createIndentOutdentTester( bot.editor, '<ul><li>x</li><li>y^</li></ul>' );
 
-			t.s( 2, 2 );
-			t.i( '<ul><li>x<ul><li>y^</li></ul></li></ul>',													'First indent is nesting.' );
-			t.s( 2, 2 );
-			t.i( '<ul><li>x<ul style="margin-left:10px;"><li>y^</li></ul></li></ul>',						'Second indent is margin.' );
-			t.s( 2, 2 );
-			t.i( '<ul><li>x<ul style="margin-left:20px;"><li>y^</li></ul></li></ul>',						'Third indent is margin.' );
-			t.s( 2, 2 );
-			t.o( '<ul><li>x<ul style="margin-left:10px;"><li>y^</li></ul></li></ul>',						'Outdent margin back.' );
-			t.s( 2, 2 );
-			t.o( '<ul><li>x<ul><li>y^</li></ul></li></ul>',													'Outdent margin back.' );
-			t.s( 2, 2 );
-			t.o( '<ul><li>x</li><li>y^</li></ul>',															'Outdent nesting back.' );
-			t.s( 2, 2 );
-			t.o( '<ul><li>x</li></ul><p>y^</p>',															'Extract paragraph from list element.' );
-			t.s( 2, 0 );
+				t.s( 2, 2 );
+				t.i( '<ul><li>x<ul><li>y^</li></ul></li></ul>',													'First indent is nesting.' );
+				t.s( 2, 2 );
+				t.i( '<ul><li>x<ul style="margin-left:10px;"><li>y^</li></ul></li></ul>',						'Second indent is margin.' );
+				t.s( 2, 2 );
+				t.i( '<ul><li>x<ul style="margin-left:20px;"><li>y^</li></ul></li></ul>',						'Third indent is margin.' );
+				t.s( 2, 2 );
+				t.o( '<ul><li>x<ul style="margin-left:10px;"><li>y^</li></ul></li></ul>',						'Outdent margin back.' );
+				t.s( 2, 2 );
+				t.o( '<ul><li>x<ul><li>y^</li></ul></li></ul>',													'Outdent margin back.' );
+				t.s( 2, 2 );
+				t.o( '<ul><li>x</li><li>y^</li></ul>',															'Outdent nesting back.' );
+				t.s( 2, 2 );
+				t.o( '<ul><li>x</li></ul><p>y^</p>',															'Extract paragraph from list element.' );
+				t.s( 2, 0 );
+			} );
 		},
 
 		'test list (nesting multiple li elements)': function() {
-			var t = createIndentOutdentTester( this.editors.enterP, '<ul><li>x</li><li>y[y</li><li>z]z</li></ul>' );
+			createEditor( 'enterP', function( bot ) {
+				var t = createIndentOutdentTester( bot.editor, '<ul><li>x</li><li>y[y</li><li>z]z</li></ul>' );
 
-			t.s( 2, 2 );
-			t.i( '<ul><li>x<ul><li>y[y</li><li>z]z</li></ul></li></ul>',									'First indent is nesting two elements.' );
-			t.s( 2, 2 );
-			t.i( '<ul><li>x<ul style="margin-left:10px;"><li>y[y</li><li>z]z</li></ul></li></ul>',			'Second indent is margin to nested list.' );
-			t.s( 2, 2 );
-			t.o( '<ul><li>x<ul><li>y[y</li><li>z]z</li></ul></li></ul>',									'Outdent margin back.' );
-			t.s( 2, 2 );
-			t.o( '<ul><li>x</li><li>y[y</li><li>z]z</li></ul>',												'Outdent nesting back.' );
-			t.s( 2, 2 );
-			t.o( '<ul><li>x</li></ul><p>y[y</p><p>z]z</p>',													'Extract paragraphs from selected elements.' );
-			t.s( 2, 0 );
+				t.s( 2, 2 );
+				t.i( '<ul><li>x<ul><li>y[y</li><li>z]z</li></ul></li></ul>',									'First indent is nesting two elements.' );
+				t.s( 2, 2 );
+				t.i( '<ul><li>x<ul style="margin-left:10px;"><li>y[y</li><li>z]z</li></ul></li></ul>',			'Second indent is margin to nested list.' );
+				t.s( 2, 2 );
+				t.o( '<ul><li>x<ul><li>y[y</li><li>z]z</li></ul></li></ul>',									'Outdent margin back.' );
+				t.s( 2, 2 );
+				t.o( '<ul><li>x</li><li>y[y</li><li>z]z</li></ul>',												'Outdent nesting back.' );
+				t.s( 2, 2 );
+				t.o( '<ul><li>x</li></ul><p>y[y</p><p>z]z</p>',													'Extract paragraphs from selected elements.' );
+				t.s( 2, 0 );
+			} );
 		},
 
 		'test list (cross-sel, nesting nested li elements)': function() {
-			var t = createIndentOutdentTester( this.editors.enterP, '<ul><li>x</li><li>x[x<ol><li>y]y</li></ol></li><li>x</li></ul>' );
+			createEditor( 'enterP', function( bot ) {
+				var t = createIndentOutdentTester( bot.editor, '<ul><li>x</li><li>x[x<ol><li>y]y</li></ol></li><li>x</li></ul>' );
 
-			t.s( 2, 2 );
-			t.i( '<ul><li>x<ul><li>x[x<ol><li>y]y</li></ol></li></ul></li><li>x</li></ul>',					'First indent creates 2nd level nesting.' );
-			t.s( 2, 2 );
-			t.i( '<ul><li>x<ul style="margin-left:10px;"><li>x[x<ol><li>y]y</li></ol></li></ul></li><li>x</li></ul>',
-																											'Second indent is margin to 1st level nested list.' );
-			t.s( 2, 2 );
-			t.o( '<ul><li>x<ul><li>x[x<ol><li>y]y</li></ol></li></ul></li><li>x</li></ul>',					'Outdent margin back.' );
-			t.s( 2, 2 );
-			t.o( '<ul><li>x</li><li>x[x<ol><li>y]y</li></ol></li><li>x</li></ul>',							'Outdent nesting back.' );
-			t.s( 2, 2 );
-			t.o( '<ul><li>x</li></ul><p>x[x</p><ol><li>y]y</li></ol><ul><li>x</li></ul>',					'Extract paragraphs.' );
-			t.s( 2, 0 );
+				t.s( 2, 2 );
+				t.i( '<ul><li>x<ul><li>x[x<ol><li>y]y</li></ol></li></ul></li><li>x</li></ul>',					'First indent creates 2nd level nesting.' );
+				t.s( 2, 2 );
+				t.i( '<ul><li>x<ul style="margin-left:10px;"><li>x[x<ol><li>y]y</li></ol></li></ul></li><li>x</li></ul>',
+																												'Second indent is margin to 1st level nested list.' );
+				t.s( 2, 2 );
+				t.o( '<ul><li>x<ul><li>x[x<ol><li>y]y</li></ol></li></ul></li><li>x</li></ul>',					'Outdent margin back.' );
+				t.s( 2, 2 );
+				t.o( '<ul><li>x</li><li>x[x<ol><li>y]y</li></ol></li><li>x</li></ul>',							'Outdent nesting back.' );
+				t.s( 2, 2 );
+				t.o( '<ul><li>x</li></ul><p>x[x</p><ol><li>y]y</li></ol><ul><li>x</li></ul>',					'Extract paragraphs.' );
+				t.s( 2, 0 );
+			} );
 		},
 
 		'test list (cross-sel, selection start hooked in first li)': function() {
-			var t = createIndentOutdentTester( this.editors.enterP, '<ul><li>x[x</li><li>xx<ol><li>y]y</li></ol></li><li>x</li></ul>' );
+			createEditor( 'enterP', function( bot ) {
+				var t = createIndentOutdentTester( bot.editor, '<ul><li>x[x</li><li>xx<ol><li>y]y</li></ol></li><li>x</li></ul>' );
 
-			t.s( 2, 2 );
-			t.i( '<ul style="margin-left:10px;"><li>x[x</li><li>xx<ol><li>y]y</li></ol></li><li>x</li></ul>',
-																											'First indent increases margin.' );
-			t.s( 2, 2 );
-			t.i( '<ul style="margin-left:20px;"><li>x[x</li><li>xx<ol><li>y]y</li></ol></li><li>x</li></ul>',
-																											'Second indent increases margin.' );
-			t.s( 2, 2 );
-			t.o( '<ul style="margin-left:10px;"><li>x[x</li><li>xx<ol><li>y]y</li></ol></li><li>x</li></ul>',
-																											'First outdent reduces margin.' );
-			t.s( 2, 2 );
-			t.o( '<ul><li>x[x</li><li>xx<ol><li>y]y</li></ol></li><li>x</li></ul>',							'Second outdent reduces margin.' );
-			t.s( 2, 2 );
-			t.o( '<p>x[x</p><p>xx</p><ol><li>y]y</li></ol><ul><li>x</li></ul>',								'Extract paragraphs.' );
-			t.s( 2, 0 );
+				t.s( 2, 2 );
+				t.i( '<ul style="margin-left:10px;"><li>x[x</li><li>xx<ol><li>y]y</li></ol></li><li>x</li></ul>',
+																												'First indent increases margin.' );
+				t.s( 2, 2 );
+				t.i( '<ul style="margin-left:20px;"><li>x[x</li><li>xx<ol><li>y]y</li></ol></li><li>x</li></ul>',
+																												'Second indent increases margin.' );
+				t.s( 2, 2 );
+				t.o( '<ul style="margin-left:10px;"><li>x[x</li><li>xx<ol><li>y]y</li></ol></li><li>x</li></ul>',
+																												'First outdent reduces margin.' );
+				t.s( 2, 2 );
+				t.o( '<ul><li>x[x</li><li>xx<ol><li>y]y</li></ol></li><li>x</li></ul>',							'Second outdent reduces margin.' );
+				t.s( 2, 2 );
+				t.o( '<p>x[x</p><p>xx</p><ol><li>y]y</li></ol><ul><li>x</li></ul>',								'Extract paragraphs.' );
+				t.s( 2, 0 );
+			} );
 		},
 
 		'test list (cross-sel between two li elements)': function() {
-			var t = createIndentOutdentTester( this.editors.enterP, '<ul><li>x[x</li><li>y]y</li></ul>' );
+			createEditor( 'enterP', function( bot ) {
+				var t = createIndentOutdentTester( bot.editor, '<ul><li>x[x</li><li>y]y</li></ul>' );
 
-			t.s( 2, 2 );
-			t.i( '<ul style="margin-left:10px;"><li>x[x</li><li>y]y</li></ul>',								'Indent it once.' );
-			t.s( 2, 2 );
-			t.i( '<ul style="margin-left:20px;"><li>x[x</li><li>y]y</li></ul>',								'Indent it twice.' );
-			t.s( 2, 2 );
-			t.o( '<ul style="margin-left:10px;"><li>x[x</li><li>y]y</li></ul>',								'Outdent it back.' );
-			t.s( 2, 2 );
-			t.o( '<ul><li>x[x</li><li>y]y</li></ul>',														'Outdent it back again.' );
-			t.s( 2, 2 );
-			t.o( '<p>x[x</p><p>y]y</p>',																	'Extract paragraph from list element.' );
-			t.s( 2, 0 );
+				t.s( 2, 2 );
+				t.i( '<ul style="margin-left:10px;"><li>x[x</li><li>y]y</li></ul>',								'Indent it once.' );
+				t.s( 2, 2 );
+				t.i( '<ul style="margin-left:20px;"><li>x[x</li><li>y]y</li></ul>',								'Indent it twice.' );
+				t.s( 2, 2 );
+				t.o( '<ul style="margin-left:10px;"><li>x[x</li><li>y]y</li></ul>',								'Outdent it back.' );
+				t.s( 2, 2 );
+				t.o( '<ul><li>x[x</li><li>y]y</li></ul>',														'Outdent it back again.' );
+				t.s( 2, 2 );
+				t.o( '<p>x[x</p><p>y]y</p>',																	'Extract paragraph from list element.' );
+				t.s( 2, 0 );
+			} );
 		},
 
 		// Entire test is freaky. See #1 above.
 		'test list (outer-sel#2, sel hooked in sibling blocks)': function() {
-			var t = createIndentOutdentTester( this.editors.enterP, '<p>[x</p><ul><li>x</li><li>y</li></ul><p>x]</p>' );
+			createEditor( 'enterP', function( bot ) {
+				var t = createIndentOutdentTester( bot.editor, '<p>[x</p><ul><li>x</li><li>y</li></ul><p>x]</p>' );
 
-			t.s( 2, 0 );
-			t.i( '<p style="margin-left:10px;">[x</p><ul><li><p style="margin-left:10px;">x</p></li><li><p style="margin-left:10px;">y</p></li></ul><p style="margin-left:10px;">x]</p>',
-																											'Indent it once.' );
-			t.s( 2, 2 );
-			t.i( '<p style="margin-left:20px;">[x</p><ul><li><p style="margin-left:20px;">x</p></li><li><p style="margin-left:20px;">y</p></li></ul><p style="margin-left:20px;">x]</p>',
-																											'Indent it twice.' );
-			t.s( 2, 2 );
-			t.o( '<p style="margin-left:10px;">[x</p><ul><li><p style="margin-left:10px;">x</p></li><li><p style="margin-left:10px;">y</p></li></ul><p style="margin-left:10px;">x]</p>',
-																											'Outdent it back.' );
-			t.s( 2, 2 );
-			t.o( '<p>[x</p><ul><li><p>x</p></li><li><p>y</p></li></ul><p>x]</p>',							'Outdent it back again.' );
-			t.s( 2, 0 );
+				t.s( 2, 0 );
+				t.i( '<p style="margin-left:10px;">[x</p><ul><li><p style="margin-left:10px;">x</p></li><li><p style="margin-left:10px;">y</p></li></ul><p style="margin-left:10px;">x]</p>',
+																												'Indent it once.' );
+				t.s( 2, 2 );
+				t.i( '<p style="margin-left:20px;">[x</p><ul><li><p style="margin-left:20px;">x</p></li><li><p style="margin-left:20px;">y</p></li></ul><p style="margin-left:20px;">x]</p>',
+																												'Indent it twice.' );
+				t.s( 2, 2 );
+				t.o( '<p style="margin-left:10px;">[x</p><ul><li><p style="margin-left:10px;">x</p></li><li><p style="margin-left:10px;">y</p></li></ul><p style="margin-left:10px;">x]</p>',
+																												'Outdent it back.' );
+				t.s( 2, 2 );
+				t.o( '<p>[x</p><ul><li><p>x</p></li><li><p>y</p></li></ul><p>x]</p>',							'Outdent it back again.' );
+				t.s( 2, 0 );
+			} );
 		},
 
 		'test list (outer-sel#3, mixed sel block->list)': function() {
-			var t = createIndentOutdentTester( this.editors.enterP, '<p>x[x</p><ul><li>x]</li><li>y</li></ul>' );
+			createEditor( 'enterP', function( bot ) {
+				var t = createIndentOutdentTester( bot.editor, '<p>x[x</p><ul><li>x]</li><li>y</li></ul>' );
 
-			t.s( 2, 0 );
-			t.i( '<p style="margin-left:10px;">x[x</p><ul><li><p style="margin-left:10px;">x]</p></li><li>y</li></ul>',
-																											'Indent it once.' );
-			t.s( 2, 2 );
-			t.i( '<p style="margin-left:20px;">x[x</p><ul><li><p style="margin-left:20px;">x]</p></li><li>y</li></ul>',
-																											'Indent it twice.' );
-			t.s( 2, 2 );
-			t.o( '<p style="margin-left:10px;">x[x</p><ul><li><p style="margin-left:10px;">x]</p></li><li>y</li></ul>',
-																											'Outdent it back.' );
-			t.s( 2, 2 );
-			t.o( '<p>x[x</p><ul><li><p>x]</p></li><li>y</li></ul>',											'Outdent it back again.' );
-			t.s( 2, 0 );
+				t.s( 2, 0 );
+				t.i( '<p style="margin-left:10px;">x[x</p><ul><li><p style="margin-left:10px;">x]</p></li><li>y</li></ul>',
+																												'Indent it once.' );
+				t.s( 2, 2 );
+				t.i( '<p style="margin-left:20px;">x[x</p><ul><li><p style="margin-left:20px;">x]</p></li><li>y</li></ul>',
+																												'Indent it twice.' );
+				t.s( 2, 2 );
+				t.o( '<p style="margin-left:10px;">x[x</p><ul><li><p style="margin-left:10px;">x]</p></li><li>y</li></ul>',
+																												'Outdent it back.' );
+				t.s( 2, 2 );
+				t.o( '<p>x[x</p><ul><li><p>x]</p></li><li>y</li></ul>',											'Outdent it back again.' );
+				t.s( 2, 0 );
+			} );
 		},
 
 		'test list (outer-sel#3, mixed sel list->block)': function() {
-			var t = createIndentOutdentTester( this.editors.enterP, '<ul><li>x</li><li>[y</li></ul><p>x]x</p>' );
+			createEditor( 'enterP', function( bot ) {
+				var t = createIndentOutdentTester( bot.editor, '<ul><li>x</li><li>[y</li></ul><p>x]x</p>' );
 
-			t.s( 2, 2 );
-			t.i( '<ul><li>x<ul><li>[y</li></ul></li></ul><p>x]x</p>',										'Indent it once.' );
-			t.s( 2, 2 );
-			t.i( '<ul><li>x<ul style="margin-left:10px;"><li>[y</li></ul></li></ul><p>x]x</p>',				'Indent it twice.' );
-			t.s( 2, 2 );
-			t.o( '<ul><li>x<ul><li>[y</li></ul></li></ul><p>x]x</p>',										'Outdent it back.' );
-			t.s( 2, 2 );
-			t.o( '<ul><li>x</li><li>[y</li></ul><p>x]x</p>',												'Outdent it back again.' );
-			t.s( 2, 2 );
+				t.s( 2, 2 );
+				t.i( '<ul><li>x<ul><li>[y</li></ul></li></ul><p>x]x</p>',										'Indent it once.' );
+				t.s( 2, 2 );
+				t.i( '<ul><li>x<ul style="margin-left:10px;"><li>[y</li></ul></li></ul><p>x]x</p>',				'Indent it twice.' );
+				t.s( 2, 2 );
+				t.o( '<ul><li>x<ul><li>[y</li></ul></li></ul><p>x]x</p>',										'Outdent it back.' );
+				t.s( 2, 2 );
+				t.o( '<ul><li>x</li><li>[y</li></ul><p>x]x</p>',												'Outdent it back again.' );
+				t.s( 2, 2 );
+			} );
 		},
 
 		'test list (first li in nested list)': function() {
-			var t = createIndentOutdentTester( this.editors.enterP, '<ul><li><ol><li>x^</li></ol></li><li>y</li></ul>' );
+			createEditor( 'enterP', function( bot ) {
+				var t = createIndentOutdentTester( bot.editor, '<ul><li><ol><li>x^</li></ol></li><li>y</li></ul>' );
 
-			t.s( 2, 2 );
-			t.i( '<ul><li><ol style="margin-left:10px;"><li>x^</li></ol></li><li>y</li></ul>',				'Indent it once.' );
-			t.s( 2, 2 );
-			t.i( '<ul><li><ol style="margin-left:20px;"><li>x^</li></ol></li><li>y</li></ul>',				'Indent it twice.' );
-			t.s( 2, 2 );
-			t.o( '<ul><li><ol style="margin-left:10px;"><li>x^</li></ol></li><li>y</li></ul>',				'Outdent it back.' );
-			t.s( 2, 2 );
-			t.o( '<ul><li><ol><li>x^</li></ol></li><li>y</li></ul>',										'Outdent it back again.' );
-			t.s( 2, 2 );
-			t.o( '<ul><li>&nbsp;</li><li>x^</li><li>y</li></ul>',											'Collapse the inner list.' );
-			t.s( 2, 2 );
+				t.s( 2, 2 );
+				t.i( '<ul><li><ol style="margin-left:10px;"><li>x^</li></ol></li><li>y</li></ul>',				'Indent it once.' );
+				t.s( 2, 2 );
+				t.i( '<ul><li><ol style="margin-left:20px;"><li>x^</li></ol></li><li>y</li></ul>',				'Indent it twice.' );
+				t.s( 2, 2 );
+				t.o( '<ul><li><ol style="margin-left:10px;"><li>x^</li></ol></li><li>y</li></ul>',				'Outdent it back.' );
+				t.s( 2, 2 );
+				t.o( '<ul><li><ol><li>x^</li></ol></li><li>y</li></ul>',										'Outdent it back again.' );
+				t.s( 2, 2 );
+				t.o( '<ul><li>&nbsp;</li><li>x^</li><li>y</li></ul>',											'Collapse the inner list.' );
+				t.s( 2, 2 );
+			} );
 		},
 
 		'test list (first li in nested list, same type)': function() {
-			var t = createIndentOutdentTester( this.editors.enterP, '<ul><li><ul><li>x^</li></ul></li><li>y</li></ul>' );
+			createEditor( 'enterP', function( bot ) {
+				var t = createIndentOutdentTester( bot.editor, '<ul><li><ul><li>x^</li></ul></li><li>y</li></ul>' );
 
-			t.s( 2, 2 );
-			t.i( '<ul><li><ul style="margin-left:10px;"><li>x^</li></ul></li><li>y</li></ul>',				'Indent it once.' );
-			t.s( 2, 2 );
-			t.i( '<ul><li><ul style="margin-left:20px;"><li>x^</li></ul></li><li>y</li></ul>',				'Indent it twice.' );
-			t.s( 2, 2 );
-			t.o( '<ul><li><ul style="margin-left:10px;"><li>x^</li></ul></li><li>y</li></ul>',				'Outdent it back.' );
-			t.s( 2, 2 );
-			t.o( '<ul><li><ul><li>x^</li></ul></li><li>y</li></ul>',										'Outdent it back again.' );
-			t.s( 2, 2 );
-			t.o( '<ul><li>&nbsp;</li><li>x^</li><li>y</li></ul>',											'Collapse the inner list.' );
-			t.s( 2, 2 );
+				t.s( 2, 2 );
+				t.i( '<ul><li><ul style="margin-left:10px;"><li>x^</li></ul></li><li>y</li></ul>',				'Indent it once.' );
+				t.s( 2, 2 );
+				t.i( '<ul><li><ul style="margin-left:20px;"><li>x^</li></ul></li><li>y</li></ul>',				'Indent it twice.' );
+				t.s( 2, 2 );
+				t.o( '<ul><li><ul style="margin-left:10px;"><li>x^</li></ul></li><li>y</li></ul>',				'Outdent it back.' );
+				t.s( 2, 2 );
+				t.o( '<ul><li><ul><li>x^</li></ul></li><li>y</li></ul>',										'Outdent it back again.' );
+				t.s( 2, 2 );
+				t.o( '<ul><li>&nbsp;</li><li>x^</li><li>y</li></ul>',											'Collapse the inner list.' );
+				t.s( 2, 2 );
+			} );
 		},
 
 		'test list (first li in nested list, cross-sel between lists)': function() {
-			var t = createIndentOutdentTester( this.editors.enterP, '<ul><li><ol><li>x[x</li></ol></li><li>y]y</li></ul>' );
+			createEditor( 'enterP', function( bot ) {
+				var t = createIndentOutdentTester( bot.editor, '<ul><li><ol><li>x[x</li></ol></li><li>y]y</li></ul>' );
 
-			t.s( 2, 2 );
-			t.i( '<ul><li><ol style="margin-left:10px;"><li>x[x</li></ol></li><li>y]y</li></ul>',			'Indent it once.' );
-			t.s( 2, 2 );
-			t.i( '<ul><li><ol style="margin-left:20px;"><li>x[x</li></ol></li><li>y]y</li></ul>',			'Indent it twice.' );
-			t.s( 2, 2 );
-			t.o( '<ul><li><ol style="margin-left:10px;"><li>x[x</li></ol></li><li>y]y</li></ul>',			'Outdent it back.' );
-			t.s( 2, 2 );
-			t.o( '<ul><li><ol><li>x[x</li></ol></li><li>y]y</li></ul>',										'Outdent it back again.' );
-			t.s( 2, 2 );
-			t.o( /<ol><li>x\[x<\/li><\/ol><p>y\]y<\/p>/,													'Collapse the outer list.' );
-			t.s( 2, 2 );
+				t.s( 2, 2 );
+				t.i( '<ul><li><ol style="margin-left:10px;"><li>x[x</li></ol></li><li>y]y</li></ul>',			'Indent it once.' );
+				t.s( 2, 2 );
+				t.i( '<ul><li><ol style="margin-left:20px;"><li>x[x</li></ol></li><li>y]y</li></ul>',			'Indent it twice.' );
+				t.s( 2, 2 );
+				t.o( '<ul><li><ol style="margin-left:10px;"><li>x[x</li></ol></li><li>y]y</li></ul>',			'Outdent it back.' );
+				t.s( 2, 2 );
+				t.o( '<ul><li><ol><li>x[x</li></ol></li><li>y]y</li></ul>',										'Outdent it back again.' );
+				t.s( 2, 2 );
+				t.o( /<ol><li>x\[x<\/li><\/ol><p>y\]y<\/p>/,													'Collapse the outer list.' );
+				t.s( 2, 2 );
+			} );
 		},
 
 		'test table': function() {
-			var t = createIndentOutdentTester( this.editors.enterP, '<table><tbody><tr><td>y^</td><td></td></tr></tbody></table>' );
+			createEditor( 'enterP', function( bot ) {
+				var t = createIndentOutdentTester( bot.editor, '<table><tbody><tr><td>y^</td><td></td></tr></tbody></table>' );
 
-			t.s( 2, 0 );
-			t.i( '<table><tbody><tr><td><p style="margin-left:10px;">y^</p></td><td>&nbsp;</td></tr></tbody></table>',
-																											'Indent it once.' );
-			t.s( 2, 2 );
-			t.i( '<table><tbody><tr><td><p style="margin-left:20px;">y^</p></td><td>&nbsp;</td></tr></tbody></table>',
-																											'Indent it twice.' );
-			t.s( 2, 2 );
-			t.o( '<table><tbody><tr><td><p style="margin-left:10px;">y^</p></td><td>&nbsp;</td></tr></tbody></table>',
-																											'Outdent it back.' );
-			t.s( 2, 2 );
-			t.o( '<table><tbody><tr><td><p>y^</p></td><td>&nbsp;</td></tr></tbody></table>',
-																											'Outdent it back again.' );
-			t.s( 2, 0 );
+				t.s( 2, 0 );
+				t.i( '<table><tbody><tr><td><p style="margin-left:10px;">y^</p></td><td>&nbsp;</td></tr></tbody></table>',
+																												'Indent it once.' );
+				t.s( 2, 2 );
+				t.i( '<table><tbody><tr><td><p style="margin-left:20px;">y^</p></td><td>&nbsp;</td></tr></tbody></table>',
+																												'Indent it twice.' );
+				t.s( 2, 2 );
+				t.o( '<table><tbody><tr><td><p style="margin-left:10px;">y^</p></td><td>&nbsp;</td></tr></tbody></table>',
+																												'Outdent it back.' );
+				t.s( 2, 2 );
+				t.o( '<table><tbody><tr><td><p>y^</p></td><td>&nbsp;</td></tr></tbody></table>',
+																												'Outdent it back again.' );
+				t.s( 2, 0 );
+			} );
 		},
 
 		'test table (outer-sel between sibling blocks)': function() {
-			var t = createIndentOutdentTester( this.editors.enterP, '<p>[x</p><table><tbody><tr><td>y</td><td></td></tr></tbody></table><p>z]</p>' );
+			createEditor( 'enterP', function( bot ) {
+				var t = createIndentOutdentTester( bot.editor, '<p>[x</p><table><tbody><tr><td>y</td><td></td></tr></tbody></table><p>z]</p>' );
 
-			t.s( 2, 0 );
-			t.i( '<p style="margin-left:10px;">[x</p><table><tbody><tr><td><p style="margin-left:10px;">y</p></td>' +
-				'<td style="margin-left:10px;">&nbsp;</td></tr></tbody></table><p style="margin-left:10px;">z]</p>',
-																											'Indent it once.' );
-			t.s( 2, 2 );
-			t.i( '<p style="margin-left:20px;">[x</p><table><tbody><tr><td><p style="margin-left:20px;">y</p></td>' +
-				'<td style="margin-left:20px;">&nbsp;</td></tr></tbody></table><p style="margin-left:20px;">z]</p>',
-																											'Indent it twice.' );
-			t.s( 2, 2 );
-			t.o( '<p style="margin-left:10px;">[x</p><table><tbody><tr><td><p style="margin-left:10px;">y</p></td>' +
-				'<td style="margin-left:10px;">&nbsp;</td></tr></tbody></table><p style="margin-left:10px;">z]</p>',
-																											'Outdent it back.' );
-			t.s( 2, 2 );
-			t.o( '<p>[x</p><table><tbody><tr><td><p>y</p></td><td>&nbsp;</td></tr></tbody></table><p>z]</p>',
-																											'Outdent it back again.' );
-			t.s( 2, 0 );
+				t.s( 2, 0 );
+				t.i( '<p style="margin-left:10px;">[x</p><table><tbody><tr><td><p style="margin-left:10px;">y</p></td>' +
+					'<td style="margin-left:10px;">&nbsp;</td></tr></tbody></table><p style="margin-left:10px;">z]</p>',
+																												'Indent it once.' );
+				t.s( 2, 2 );
+				t.i( '<p style="margin-left:20px;">[x</p><table><tbody><tr><td><p style="margin-left:20px;">y</p></td>' +
+					'<td style="margin-left:20px;">&nbsp;</td></tr></tbody></table><p style="margin-left:20px;">z]</p>',
+																												'Indent it twice.' );
+				t.s( 2, 2 );
+				t.o( '<p style="margin-left:10px;">[x</p><table><tbody><tr><td><p style="margin-left:10px;">y</p></td>' +
+					'<td style="margin-left:10px;">&nbsp;</td></tr></tbody></table><p style="margin-left:10px;">z]</p>',
+																												'Outdent it back.' );
+				t.s( 2, 2 );
+				t.o( '<p>[x</p><table><tbody><tr><td><p>y</p></td><td>&nbsp;</td></tr></tbody></table><p>z]</p>',
+																												'Outdent it back again.' );
+				t.s( 2, 0 );
+			} );
 		},
 
 		'test div': function() {
-			var t = createIndentOutdentTester( this.editors.enterP, '<div>x^</div>' );
+			createEditor( 'enterP', function( bot ) {
+				var t = createIndentOutdentTester( bot.editor, '<div>x^</div>' );
 
-			t.s( 2, 0 );
-			t.i( '<div style="margin-left:10px;">x^</div>',													'Indent it once.' );
-			t.s( 2, 2 );
-			t.i( '<div style="margin-left:20px;">x^</div>',													'Indent it twice.' );
-			t.s( 2, 2 );
-			t.o( '<div style="margin-left:10px;">x^</div>',													'Outdent it back.' );
-			t.s( 2, 2 );
-			t.o( '<div>x^</div>',																			'Outdent it back again.' );
-			t.s( 2, 0 );
-			t.o( '<div>x^</div>',																			'Remaining at minimum intent level.' );
-			t.s( 2, 0 );
+				t.s( 2, 0 );
+				t.i( '<div style="margin-left:10px;">x^</div>',													'Indent it once.' );
+				t.s( 2, 2 );
+				t.i( '<div style="margin-left:20px;">x^</div>',													'Indent it twice.' );
+				t.s( 2, 2 );
+				t.o( '<div style="margin-left:10px;">x^</div>',													'Outdent it back.' );
+				t.s( 2, 2 );
+				t.o( '<div>x^</div>',																			'Outdent it back again.' );
+				t.s( 2, 0 );
+				t.o( '<div>x^</div>',																			'Remaining at minimum intent level.' );
+				t.s( 2, 0 );
+			} );
 		},
 
 		'test div (indent nested div)': function() {
-			var t = createIndentOutdentTester( this.editors.enterP, '<div><div>x^</div></div>' );
+			createEditor( 'enterP', function( bot ) {
+				var t = createIndentOutdentTester( bot.editor, '<div><div>x^</div></div>' );
 
-			t.s( 2, 0 );
-			t.i( '<div><div style="margin-left:10px;">x^</div></div>',										'Indent it once.' );
-			t.s( 2, 2 );
-			t.i( '<div><div style="margin-left:20px;">x^</div></div>',										'Indent it twice.' );
-			t.s( 2, 2 );
-			t.o( '<div><div style="margin-left:10px;">x^</div></div>',										'Outdent it back.' );
-			t.s( 2, 2 );
-			t.o( '<div><div>x^</div></div>',																'Outdent it back again.' );
-			t.s( 2, 0 );
-			t.o( '<div><div>x^</div></div>',																'Remaining at minimum intent level.' );
-			t.s( 2, 0 );
+				t.s( 2, 0 );
+				t.i( '<div><div style="margin-left:10px;">x^</div></div>',										'Indent it once.' );
+				t.s( 2, 2 );
+				t.i( '<div><div style="margin-left:20px;">x^</div></div>',										'Indent it twice.' );
+				t.s( 2, 2 );
+				t.o( '<div><div style="margin-left:10px;">x^</div></div>',										'Outdent it back.' );
+				t.s( 2, 2 );
+				t.o( '<div><div>x^</div></div>',																'Outdent it back again.' );
+				t.s( 2, 0 );
+				t.o( '<div><div>x^</div></div>',																'Remaining at minimum intent level.' );
+				t.s( 2, 0 );
+			} );
 		},
 
 		'test div (indent nested div, cross-sel between divs)': function() {
-			var t = createIndentOutdentTester( this.editors.enterP, '<div>x[x<div>y]y</div></div>' );
+			createEditor( 'enterP', function( bot ) {
+				var t = createIndentOutdentTester( bot.editor, '<div>x[x<div>y]y</div></div>' );
 
-			t.s( 2, 0 );
-			t.i( '<div><p style="margin-left:10px;">x[x</p><div style="margin-left:10px;">y]y</div></div>', 'Indent it once.' );
-			t.s( 2, 2 );
-			t.i( '<div><p style="margin-left:20px;">x[x</p><div style="margin-left:20px;">y]y</div></div>', 'Indent it twice.' );
-			t.s( 2, 2 );
-			t.o( '<div><p style="margin-left:10px;">x[x</p><div style="margin-left:10px;">y]y</div></div>', 'Outdent it back.' );
-			t.s( 2, 2 );
-			t.o( '<div><p>x[x</p><div>y]y</div></div>',														'Outdent it back again.' );
-			t.s( 2, 0 );
-			t.o( '<div><p>x[x</p><div>y]y</div></div>',														'Remaining at minimum intent level.' );
-			t.s( 2, 0 );
+				t.s( 2, 0 );
+				t.i( '<div><p style="margin-left:10px;">x[x</p><div style="margin-left:10px;">y]y</div></div>', 'Indent it once.' );
+				t.s( 2, 2 );
+				t.i( '<div><p style="margin-left:20px;">x[x</p><div style="margin-left:20px;">y]y</div></div>', 'Indent it twice.' );
+				t.s( 2, 2 );
+				t.o( '<div><p style="margin-left:10px;">x[x</p><div style="margin-left:10px;">y]y</div></div>', 'Outdent it back.' );
+				t.s( 2, 2 );
+				t.o( '<div><p>x[x</p><div>y]y</div></div>',														'Outdent it back again.' );
+				t.s( 2, 0 );
+				t.o( '<div><p>x[x</p><div>y]y</div></div>',														'Remaining at minimum intent level.' );
+				t.s( 2, 0 );
+			} );
 		},
 
 		'test deflist': function() {
-			var t = createIndentOutdentTester( this.editors.enterP, '<dl><dt>x^</dt><dd>y</dd></dl>' );
+			createEditor( 'enterP', function( bot ) {
+				var t = createIndentOutdentTester( bot.editor, '<dl><dt>x^</dt><dd>y</dd></dl>' );
 
-			t.s( 2, 0 );
-			t.i( '<dl style="margin-left:10px;"><dt>x^</dt><dd>y</dd></dl>',								'Indent it once.' );
-			t.s( 2, 2 );
-			t.i( '<dl style="margin-left:20px;"><dt>x^</dt><dd>y</dd></dl>',								'Indent it twice.' );
-			t.s( 2, 2 );
-			t.o( '<dl style="margin-left:10px;"><dt>x^</dt><dd>y</dd></dl>',								'Outdent it back.' );
-			t.s( 2, 2 );
-			t.o( '<dl><dt>x^</dt><dd>y</dd></dl>',															'Outdent it back again.' );
-			t.s( 2, 0 );
-			t.o( '<dl><dt>x^</dt><dd>y</dd></dl>',															'Remaining at minimum intent level.' );
-			t.s( 2, 0 );
+				t.s( 2, 0 );
+				t.i( '<dl style="margin-left:10px;"><dt>x^</dt><dd>y</dd></dl>',								'Indent it once.' );
+				t.s( 2, 2 );
+				t.i( '<dl style="margin-left:20px;"><dt>x^</dt><dd>y</dd></dl>',								'Indent it twice.' );
+				t.s( 2, 2 );
+				t.o( '<dl style="margin-left:10px;"><dt>x^</dt><dd>y</dd></dl>',								'Outdent it back.' );
+				t.s( 2, 2 );
+				t.o( '<dl><dt>x^</dt><dd>y</dd></dl>',															'Outdent it back again.' );
+				t.s( 2, 0 );
+				t.o( '<dl><dt>x^</dt><dd>y</dd></dl>',															'Remaining at minimum intent level.' );
+				t.s( 2, 0 );
+			} );
 		},
 
 		'test deflist (cross-sel)': function() {
-			var t = createIndentOutdentTester( this.editors.enterP, '<dl><dt>x[x</dt><dd>y]y</dd></dl>' );
+			createEditor( 'enterP', function( bot ) {
+				var t = createIndentOutdentTester( bot.editor, '<dl><dt>x[x</dt><dd>y]y</dd></dl>' );
 
-			t.s( 2, 0 );
-			t.i( '<dl style="margin-left:10px;"><dt>x[x</dt><dd>y]y</dd></dl>',								'Indent it once.' );
-			t.s( 2, 2 );
-			t.i( '<dl style="margin-left:20px;"><dt>x[x</dt><dd>y]y</dd></dl>',								'Indent it twice.' );
-			t.s( 2, 2 );
-			t.o( '<dl style="margin-left:10px;"><dt>x[x</dt><dd>y]y</dd></dl>',								'Outdent it back.' );
-			t.s( 2, 2 );
-			t.o( '<dl><dt>x[x</dt><dd>y]y</dd></dl>',														'Outdent it back again.' );
-			t.s( 2, 0 );
-			t.o( '<dl><dt>x[x</dt><dd>y]y</dd></dl>',														'Remaining at minimum intent level.' );
-			t.s( 2, 0 );
+				t.s( 2, 0 );
+				t.i( '<dl style="margin-left:10px;"><dt>x[x</dt><dd>y]y</dd></dl>',								'Indent it once.' );
+				t.s( 2, 2 );
+				t.i( '<dl style="margin-left:20px;"><dt>x[x</dt><dd>y]y</dd></dl>',								'Indent it twice.' );
+				t.s( 2, 2 );
+				t.o( '<dl style="margin-left:10px;"><dt>x[x</dt><dd>y]y</dd></dl>',								'Outdent it back.' );
+				t.s( 2, 2 );
+				t.o( '<dl><dt>x[x</dt><dd>y]y</dd></dl>',														'Outdent it back again.' );
+				t.s( 2, 0 );
+				t.o( '<dl><dt>x[x</dt><dd>y]y</dd></dl>',														'Remaining at minimum intent level.' );
+				t.s( 2, 0 );
+			} );
 		},
 
 		'test indent classes': function() {
-			var t = createIndentOutdentTester( this.editors.indentClasses, '<p>x^</p>' );
+			createEditor( 'indentClasses', function( bot ) {
+				var t = createIndentOutdentTester( bot.editor, '<p>x^</p>' );
 
-			t.s( 2, 0 );
-			t.i( '<p class="1st">x^</p>',																	'Indent it once.' );
-			t.s( 2, 2 );
-			t.i( '<p class="2nd">x^</p>',																	'Indent it again.' );
-			t.s( 0, 2 );
-			t.i( '<p class="2nd">x^</p>',																	'Can\'t indent any further.' );
-			t.s( 0, 2 );
-			t.o( '<p class="1st">x^</p>',																	'Outdent it once.' );
-			t.s( 2, 2 );
-			t.o( '<p>x^</p>',																				'Outdent it again.' );
-			t.s( 2, 0 );
+				t.s( 2, 0 );
+				t.i( '<p class="1st">x^</p>',																	'Indent it once.' );
+				t.s( 2, 2 );
+				t.i( '<p class="2nd">x^</p>',																	'Indent it again.' );
+				t.s( 0, 2 );
+				t.i( '<p class="2nd">x^</p>',																	'Can\'t indent any further.' );
+				t.s( 0, 2 );
+				t.o( '<p class="1st">x^</p>',																	'Outdent it once.' );
+				t.s( 2, 2 );
+				t.o( '<p>x^</p>',																				'Outdent it again.' );
+				t.s( 2, 0 );
+			} );
 		},
 
 		'test indent classes - list': function() {
-			var t = createIndentOutdentTester( this.editors.indentClasses, '<ul><li>x</li><li>y^</li></ul>' );
+			createEditor( 'indentClasses', function( bot ) {
+				var t = createIndentOutdentTester( bot.editor, '<ul><li>x</li><li>y^</li></ul>' );
 
-			t.s( 2, 2 );
-			t.i( '<ul><li>x<ul><li>y^</li></ul></li></ul>',													'Indent it once.' );
-			t.s( 2, 2 );
-			t.i( '<ul><li>x<ul class="1st"><li>y^</li></ul></li></ul>',										'Indent it again.' );
-			t.s( 2, 2 );
-			t.i( '<ul><li>x<ul class="2nd"><li>y^</li></ul></li></ul>',										'Indent it again.' );
-			t.s( 0, 2 );
-			t.i( '<ul><li>x<ul class="2nd"><li>y^</li></ul></li></ul>',										'Can\'t indent any further.' );
-			t.s( 0, 2 );
-			t.o( '<ul><li>x<ul class="1st"><li>y^</li></ul></li></ul>',										'Outdent it once.' );
-			t.s( 2, 2 );
-			t.o( '<ul><li>x<ul><li>y^</li></ul></li></ul>',													'Outdent it again.' );
-			t.s( 2, 2 );
-			t.o( '<ul><li>x</li><li>y^</li></ul>',															'Outdent it again.' );
-			t.s( 2, 2 );
-			t.o( '<ul><li>x</li></ul><p>y^</p>',															'Extract paragraph.' );
-			t.s( 2, 0 );
+				t.s( 2, 2 );
+				t.i( '<ul><li>x<ul><li>y^</li></ul></li></ul>',													'Indent it once.' );
+				t.s( 2, 2 );
+				t.i( '<ul><li>x<ul class="1st"><li>y^</li></ul></li></ul>',										'Indent it again.' );
+				t.s( 2, 2 );
+				t.i( '<ul><li>x<ul class="2nd"><li>y^</li></ul></li></ul>',										'Indent it again.' );
+				t.s( 0, 2 );
+				t.i( '<ul><li>x<ul class="2nd"><li>y^</li></ul></li></ul>',										'Can\'t indent any further.' );
+				t.s( 0, 2 );
+				t.o( '<ul><li>x<ul class="1st"><li>y^</li></ul></li></ul>',										'Outdent it once.' );
+				t.s( 2, 2 );
+				t.o( '<ul><li>x<ul><li>y^</li></ul></li></ul>',													'Outdent it again.' );
+				t.s( 2, 2 );
+				t.o( '<ul><li>x</li><li>y^</li></ul>',															'Outdent it again.' );
+				t.s( 2, 2 );
+				t.o( '<ul><li>x</li></ul><p>y^</p>',															'Extract paragraph.' );
+				t.s( 2, 0 );
+			} );
 		},
 
 		'test indent units': function() {
-			var t = createIndentOutdentTester( this.editors.indentUnit, '<p>x^</p>' );
+			createEditor( 'indentUnit', function( bot ) {
+				var t = createIndentOutdentTester( bot.editor, '<p>x^</p>' );
 
-			t.s( 2, 0 );
-			t.i( '<p style="margin-left:10em;">x^</p>',														'Indent it once.' );
-			t.s( 2, 2 );
-			t.i( '<p style="margin-left:20em;">x^</p>',														'Indent it twice.' );
-			t.s( 2, 2 );
-			t.o( '<p style="margin-left:10em;">x^</p>',														'Outdent it back.' );
-			t.s( 2, 2 );
-			t.o( '<p>x^</p>',																				'Outdent it back again.' );
-			t.s( 2, 0 );
-			t.o( '<p>x^</p>',																				'Remaining at minimum intent level.' );
-			t.s( 2, 0 );
+				t.s( 2, 0 );
+				t.i( '<p style="margin-left:10em;">x^</p>',														'Indent it once.' );
+				t.s( 2, 2 );
+				t.i( '<p style="margin-left:20em;">x^</p>',														'Indent it twice.' );
+				t.s( 2, 2 );
+				t.o( '<p style="margin-left:10em;">x^</p>',														'Outdent it back.' );
+				t.s( 2, 2 );
+				t.o( '<p>x^</p>',																				'Outdent it back again.' );
+				t.s( 2, 0 );
+				t.o( '<p>x^</p>',																				'Remaining at minimum intent level.' );
+				t.s( 2, 0 );
+			} );
 		},
 
 		'test indent lists-only: states, indent block': function() {
-			var t = createIndentOutdentTester( this.editors.indentList, '<p>fo^o</p><ul><li>x</li><li>y</li></ul>' );
+			createEditor( 'indentList', function( bot ) {
+				var t = createIndentOutdentTester( bot.editor, '<p>fo^o</p><ul><li>x</li><li>y</li></ul>' );
 
-			t.s( 0, 0 );
-			t.i( '<p>fo^o</p><ul><li>x</li><li>y</li></ul>',												'Cannot indent blocks.' );
-			t.s( 0, 0 );
+				t.s( 0, 0 );
+				t.i( '<p>fo^o</p><ul><li>x</li><li>y</li></ul>',												'Cannot indent blocks.' );
+				t.s( 0, 0 );
+			} );
 		},
 
 		'test indent lists-only: states, indent block (#2)': function() {
-			var t = createIndentOutdentTester( this.editors.indentList, '<ul><li>x^</li><li>y</li></ul>' );
+			createEditor( 'indentList', function( bot ) {
+				var t = createIndentOutdentTester( bot.editor, '<ul><li>x^</li><li>y</li></ul>' );
 
-			t.s( 0, 2 );
-			t.i( '<ul><li>x^</li><li>y</li></ul>',															'Cannot indent blocks.' );
-			t.s( 0, 2 );
-			t.o( '<p>x^</p><ul><li>y</li></ul>',															'Collapse the list into paragraph.' );
-			t.s( 0, 0 );
+				t.s( 0, 2 );
+				t.i( '<ul><li>x^</li><li>y</li></ul>',															'Cannot indent blocks.' );
+				t.s( 0, 2 );
+				t.o( '<p>x^</p><ul><li>y</li></ul>',															'Collapse the list into paragraph.' );
+				t.s( 0, 0 );
+			} );
 		},
 
 		'test indent lists-only: states, nested list': function() {
-			var t = createIndentOutdentTester( this.editors.indentList, '<ul><li>x</li><li>y^</li></ul>' );
+			createEditor( 'indentList', function( bot ) {
+				var t = createIndentOutdentTester( bot.editor, '<ul><li>x</li><li>y^</li></ul>' );
 
-			t.s( 2, 2 );
-			t.i( '<ul><li>x<ul><li>y^</li></ul></li></ul>',													'Can nest lists.' );
-			t.s( 0, 2 );
-			t.o( '<ul><li>x</li><li>y^</li></ul>',															'Can outdent nested lists.' );
-			t.s( 2, 2 );
+				t.s( 2, 2 );
+				t.i( '<ul><li>x<ul><li>y^</li></ul></li></ul>',													'Can nest lists.' );
+				t.s( 0, 2 );
+				t.o( '<ul><li>x</li><li>y^</li></ul>',															'Can outdent nested lists.' );
+				t.s( 2, 2 );
+			} );
 		},
 
 		'test indent lists-only: selections, start in list, cross': function() {
-			var t = createIndentOutdentTester( this.editors.indentList, '<p>foo</p><ul><li>[x</li><li>y]</li></ul>' );
+			createEditor( 'indentList', function( bot ) {
+				var t = createIndentOutdentTester( bot.editor, '<p>foo</p><ul><li>[x</li><li>y]</li></ul>' );
 
-			t.s( 0, 2 );
-			t.o( '<p>foo</p><p>[x</p><p>y]</p>',															'Collapse list when cross-selection.' );
-			t.s( 0, 0 );
+				t.s( 0, 2 );
+				t.o( '<p>foo</p><p>[x</p><p>y]</p>',															'Collapse list when cross-selection.' );
+				t.s( 0, 0 );
+			} );
 		},
 
 		'test indent lists-only: selections, start in block': function() {
-			var t = createIndentOutdentTester( this.editors.indentList, '<p>fo[o</p><ul><li>x</li><li>y]</li></ul>' );
+			createEditor( 'indentList', function( bot ) {
+				var t = createIndentOutdentTester( bot.editor, '<p>fo[o</p><ul><li>x</li><li>y]</li></ul>' );
 
-			t.s( 0, 0,																						'Path is in block. Nothing to do for indentlist.' );
+				t.s( 0, 0,																						'Path is in block. Nothing to do for indentlist.' );
+			} );
 		},
 
 		'test indent lists-only: selections, start in list element': function() {
-			var t = createIndentOutdentTester( this.editors.indentList, '<ul><li>x</li><li>[y</li></ul><p>fo]o</p>' );
+			createEditor( 'indentList', function( bot ) {
+				var t = createIndentOutdentTester( bot.editor, '<ul><li>x</li><li>[y</li></ul><p>fo]o</p>' );
 
-			t.s( 2, 2,																						'Can indent and outdent since path is in list.' );
-			t.i( '<ul><li>x<ul><li>[y</li></ul></li></ul><p>fo]o</p>',										'Indent list once.' );
-			t.s( 0, 2,																						'Cannot indent again - first element of a list.' );
-			t.o( '<ul><li>x</li><li>[y</li></ul><p>fo]o</p>',												'Outdent list once.' );
-			t.s( 2, 2,																						'Can indent and outdent since path is in list.' );
-			t.o( '<ul><li>x</li></ul><p>[y</p><p>fo]o</p>',													'Outdented and collapsed list element.' );
-			t.s( 0, 0 );
+				t.s( 2, 2,																						'Can indent and outdent since path is in list.' );
+				t.i( '<ul><li>x<ul><li>[y</li></ul></li></ul><p>fo]o</p>',										'Indent list once.' );
+				t.s( 0, 2,																						'Cannot indent again - first element of a list.' );
+				t.o( '<ul><li>x</li><li>[y</li></ul><p>fo]o</p>',												'Outdent list once.' );
+				t.s( 2, 2,																						'Can indent and outdent since path is in list.' );
+				t.o( '<ul><li>x</li></ul><p>[y</p><p>fo]o</p>',													'Outdented and collapsed list element.' );
+				t.s( 0, 0 );
+			} );
 		},
 
 		'test indent lists-only: margins': function() {
-			var t = createIndentOutdentTester( this.editors.indentList, '<ul style="margin-left:10px;"><li>x</li><li>^y</li></ul>' );
+			createEditor( 'indentList', function( bot ) {
+				var t = createIndentOutdentTester( bot.editor, '<ul style="margin-left:10px;"><li>x</li><li>^y</li></ul>' );
 
-			t.s( 2, 2 );
-			t.i( '<ul style="margin-left:10px;"><li>x<ul><li>^y</li></ul></li></ul>',						'Indent list once. Don\'t touch list margin.' );
-			t.s( 0, 2 );
-			t.o( '<ul style="margin-left:10px;"><li>x</li><li>^y</li></ul>',								'Outdent nested list. Don\'t touch parents list margin.' );
-			t.s( 2, 2 );
-			t.o( '<ul style="margin-left:10px;"><li>x</li></ul><p>^y</p>',									'Collapse list despite of margin if not first element.' );
-			t.s( 0, 0 );
+				t.s( 2, 2 );
+				t.i( '<ul style="margin-left:10px;"><li>x<ul><li>^y</li></ul></li></ul>',						'Indent list once. Don\'t touch list margin.' );
+				t.s( 0, 2 );
+				t.o( '<ul style="margin-left:10px;"><li>x</li><li>^y</li></ul>',								'Outdent nested list. Don\'t touch parents list margin.' );
+				t.s( 2, 2 );
+				t.o( '<ul style="margin-left:10px;"><li>x</li></ul><p>^y</p>',									'Collapse list despite of margin if not first element.' );
+				t.s( 0, 0 );
+			} );
 		},
 
 		'test indent block-only: paragraph': function() {
-			var t = createIndentOutdentTester( this.editors.indentBlock, '<p>fo[o</p><ul><li>x]</li><li>y</li></ul>' );
+			createEditor( 'indentBlock', function( bot ) {
+				var t = createIndentOutdentTester( bot.editor, '<p>fo[o</p><ul><li>x]</li><li>y</li></ul>' );
 
-			t.s( 2, 0 );
-			t.i( '<p style="margin-left:10px;">fo[o</p><ul><li><p style="margin-left:10px;">x]</p></li><li>y</li></ul>',							'Create indented paragraphs.' );
-			t.s( 2, 2 );
-			t.o( '<p>fo[o</p><ul><li><p>x]</p></li><li>y</li></ul>',										'Outdent paragraphs.' );
-			t.s( 2, 0 );
+				t.s( 2, 0 );
+				t.i( '<p style="margin-left:10px;">fo[o</p><ul><li><p style="margin-left:10px;">x]</p></li><li>y</li></ul>',							'Create indented paragraphs.' );
+				t.s( 2, 2 );
+				t.o( '<p>fo[o</p><ul><li><p>x]</p></li><li>y</li></ul>',										'Outdent paragraphs.' );
+				t.s( 2, 0 );
+			} );
 		},
 
 		'test ENTER_BR': function() {
-			var t = createIndentOutdentTester( this.editors.enterBR, 'f^oo' );
+			createEditor( 'enterBR', function( bot ) {
+				var t = createIndentOutdentTester( bot.editor, 'f^oo' );
 
-			t.s( 2, 0 );
-			t.i( '<div style="margin-left:10px;">f^oo</div>',												'Indent entire block.' );
-			t.s( 2, 2 );
-			t.i( '<div style="margin-left:20px;">f^oo</div>',												'Indent entire block twice.' );
-			t.s( 2, 2 );
-			t.o( '<div style="margin-left:10px;">f^oo</div>',												'Outdent entire block.' );
-			t.s( 2, 2 );
-			t.o( '<div>f^oo</div>',																			'Outdent entire block again.' );
-			t.s( 2, 0 );
+				t.s( 2, 0 );
+				t.i( '<div style="margin-left:10px;">f^oo</div>',												'Indent entire block.' );
+				t.s( 2, 2 );
+				t.i( '<div style="margin-left:20px;">f^oo</div>',												'Indent entire block twice.' );
+				t.s( 2, 2 );
+				t.o( '<div style="margin-left:10px;">f^oo</div>',												'Outdent entire block.' );
+				t.s( 2, 2 );
+				t.o( '<div>f^oo</div>',																			'Outdent entire block again.' );
+				t.s( 2, 0 );
+			} );
 		},
 
 		'test ENTER_BR (#2)': function() {
-			var t = createIndentOutdentTester( this.editors.enterBR, 'x<ul><li>y^</li></ul>z' );
+			createEditor( 'enterBR', function( bot ) {
+				var t = createIndentOutdentTester( bot.editor, 'x<ul><li>y^</li></ul>z' );
 
-			t.s( 2, 2 );
-			t.o( /xy\^(<br \/>)?z/,																			'Collapse entire list.' );
-			t.s( 2, 0 );
+				t.s( 2, 2 );
+				t.o( /xy\^(<br \/>)?z/,																			'Collapse entire list.' );
+				t.s( 2, 0 );
+			} );
 		},
 
 		'test ENTER_BR with indent classes': function() {
-			var t = createIndentOutdentTester( this.editors.indentClassesBR, 'f^oo' );
+			createEditor( 'indentClassesBR', function( bot ) {
+				var t = createIndentOutdentTester( bot.editor, 'f^oo' );
 
-			t.s( 2, 0 );
-			t.i( '<div class="1st">f^oo</div>',																'Indent entire block.' );
-			t.s( 2, 2 );
-			t.i( '<div class="2nd">f^oo</div>',																'Indent entire block twice.' );
-			t.s( 0, 2 );
-			t.o( '<div class="1st">f^oo</div>',																'Outdent entire block.' );
-			t.s( 2, 2 );
-			t.o( '<div>f^oo</div>',																			'Outdent entire block again.' );
-			t.s( 2, 0 );
+				t.s( 2, 0 );
+				t.i( '<div class="1st">f^oo</div>',																'Indent entire block.' );
+				t.s( 2, 2 );
+				t.i( '<div class="2nd">f^oo</div>',																'Indent entire block twice.' );
+				t.s( 0, 2 );
+				t.o( '<div class="1st">f^oo</div>',																'Outdent entire block.' );
+				t.s( 2, 2 );
+				t.o( '<div>f^oo</div>',																			'Outdent entire block again.' );
+				t.s( 2, 0 );
+			} );
 		},
 
 		'test undo manager': function() {
-			var t = createIndentOutdentTester( this.editors.enterP, '<ul><li>x</li><li>y^</li></ul>' );
+			createEditor( 'enterP', function( bot ) {
+				var t = createIndentOutdentTester( bot.editor, '<ul><li>x</li><li>y^</li></ul>' );
 
-			// We'd love to have undoManager clean for this test - this editor is shared with
-			// other tests.
-			this.editors.enterP.resetUndo();
+				// Reset undo as startupData is just '<p>&nbsp;</p>' and also undo may be affected by previous tests.
+				bot.editor.resetUndo();
 
-			t.i( '<ul><li>x<ul><li>y^</li></ul></li></ul>',													'Indent entire list.' );
-			t.i( '<ul><li>x<ul style="margin-left:10px;"><li>y^</li></ul></li></ul>',						'Indent entire list twice.' );
-			t.u( '<ul><li>x<ul><li>y^</li></ul></li></ul>',													'Undo once.' );
-			t.u( '<ul><li>x</li><li>y^</li></ul>',															'Undo twice.' );
-			t.u( '<ul><li>x</li><li>y^</li></ul>',															'Undo - nothing more can be undone.' );
-			t.r( '<ul><li>x<ul><li>y^</li></ul></li></ul>',													'Redo once.' );
-			t.r( '<ul><li>x<ul style="margin-left:10px;"><li>y^</li></ul></li></ul>',						'Redo twice.' );
-			t.r( '<ul><li>x<ul style="margin-left:10px;"><li>y^</li></ul></li></ul>',						'Redo - nothing more can be redone.' );
+				t.i( '<ul><li>x<ul><li>y^</li></ul></li></ul>',													'Indent entire list.' );
+				t.i( '<ul><li>x<ul style="margin-left:10px;"><li>y^</li></ul></li></ul>',						'Indent entire list twice.' );
+				t.u( '<ul><li>x<ul><li>y^</li></ul></li></ul>',													'Undo once.' );
+				t.u( '<ul><li>x</li><li>y^</li></ul>',															'Undo twice.' );
+				t.u( '<ul><li>x</li><li>y^</li></ul>',															'Undo - nothing more can be undone.' );
+				t.r( '<ul><li>x<ul><li>y^</li></ul></li></ul>',													'Redo once.' );
+				t.r( '<ul><li>x<ul style="margin-left:10px;"><li>y^</li></ul></li></ul>',						'Redo twice.' );
+				t.r( '<ul><li>x<ul style="margin-left:10px;"><li>y^</li></ul></li></ul>',						'Redo - nothing more can be redone.' );
+			} );
 		},
 
 		'test keystrokes - paragraph': function() {
-			var t = createIndentOutdentTester( this.editors.enterP, '<p>x^</p>' );
+			createEditor( 'enterP', function( bot ) {
+				var t = createIndentOutdentTester( bot.editor, '<p>x^</p>' );
 
-			t.ki( '<p>x^</p>',																				'Keystrokes indent lists only.' );
-			t.ko( '<p>x^</p>',																				'Keystrokes outdent lists only.' );
+				t.ki( '<p>x^</p>',																				'Keystrokes indent lists only.' );
+				t.ko( '<p>x^</p>',																				'Keystrokes outdent lists only.' );
+			} );
 		},
 
 		'test keystrokes - list, non-first element': function() {
-			var t = createIndentOutdentTester( this.editors.enterP, '<ul><li>x</li><li>y^</li></ul>' );
+			createEditor( 'enterP', function( bot ) {
+				var t = createIndentOutdentTester( bot.editor, '<ul><li>x</li><li>y^</li></ul>' );
 
-			t.ki( '<ul><li>x<ul><li>y^</li></ul></li></ul>',												'Nest list once.' );
-			t.ki( '<ul><li>x<ul><li>y^</li></ul></li></ul>',												'Cannot indent list more.' );
-			t.ko( '<ul><li>x</li><li>y^</li></ul>',															'Outdent list once.' );
-			t.ko( '<ul><li>x</li></ul><p>y^</p>',															'Collapse list.' );
-			t.ko( '<ul><li>x</li></ul><p>y^</p>',															'Cannot outdent any more.' );
+				t.ki( '<ul><li>x<ul><li>y^</li></ul></li></ul>',												'Nest list once.' );
+				t.ki( '<ul><li>x<ul><li>y^</li></ul></li></ul>',												'Cannot indent list more.' );
+				t.ko( '<ul><li>x</li><li>y^</li></ul>',															'Outdent list once.' );
+				t.ko( '<ul><li>x</li></ul><p>y^</p>',															'Collapse list.' );
+				t.ko( '<ul><li>x</li></ul><p>y^</p>',															'Cannot outdent any more.' );
+			} );
 		},
 
 		'test keystrokes - list, first element': function() {
-			var t = createIndentOutdentTester( this.editors.indentList, '<ul><li>x^</li></ul>' );
+			createEditor( 'indentList', function( bot ) {
+				var t = createIndentOutdentTester( bot.editor, '<ul><li>x^</li></ul>' );
 
-			t.ki( '<ul><li>x^</li></ul>',																	'Indentlist doesn\'t indent entire lists.' );
-			t.ko( '<p>x^</p>',																				'Indentlist collapses entire lists.' );
+				t.ki( '<ul><li>x^</li></ul>',																	'Indentlist doesn\'t indent entire lists.' );
+				t.ko( '<p>x^</p>',																				'Indentlist collapses entire lists.' );
+			} );
 		},
 
 		'test indent next to inline non-editable': function() {
@@ -708,19 +805,21 @@
 				assert.ignore();
 			}
 
-			var t1 = createIndentOutdentTester( this.editors.enterP, '<p><span contenteditable="false">xxx</span>^</p>' );
+			createEditor( 'enterP', function( bot ) {
+				var t1 = createIndentOutdentTester( bot.editor, '<p><span contenteditable="false">xxx</span>^</p>' );
 
-			t1.s( 2, 0 );
-			t1.i( '<p style="margin-left:10px;"><span contenteditable="false">xxx</span>^</p>',				'Indent it once.' );
-			t1.s( 2, 2 );
+				t1.s( 2, 0 );
+				t1.i( '<p style="margin-left:10px;"><span contenteditable="false">xxx</span>^</p>',				'Indent it once.' );
+				t1.s( 2, 2 );
 
-			var t2 = createIndentOutdentTester( this.editors.enterP, '<p>a<span contenteditable="false">bb</span>c^</p>' );
+				var t2 = createIndentOutdentTester( bot.editor, '<p>a<span contenteditable="false">bb</span>c^</p>' );
 
-			t2.s( 2, 0 );
-			t2.i( '<p style="margin-left:10px;">a<span contenteditable="false">bb</span>c^</p>',			'Indent it once.' );
-			t2.s( 2, 2 );
-			t2.u( '<p>a<span contenteditable="false">bb</span>c^</p>',										'Undo once.' );
-			t2.s( 2, 0 );
+				t2.s( 2, 0 );
+				t2.i( '<p style="margin-left:10px;">a<span contenteditable="false">bb</span>c^</p>',			'Indent it once.' );
+				t2.s( 2, 2 );
+				t2.u( '<p>a<span contenteditable="false">bb</span>c^</p>',										'Undo once.' );
+				t2.s( 2, 0 );
+			} );
 		}
 	} );
 } )();

--- a/tests/plugins/list/list.js
+++ b/tests/plugins/list/list.js
@@ -1,23 +1,32 @@
 /* bender-tags: editor */
 /* bender-ckeditor-plugins: list,justify,bidi,table,forms,toolbar */
 
-bender.editor = {
-	config: {
-		enterMode: CKEDITOR.ENTER_P
+// Use two editor instances as there are some issues on Edge 16+ when single instance is used.
+bender.editors = {
+	editor1: {
+		config: {
+			enterMode: CKEDITOR.ENTER_P
+		},
+		allowedForTests: 'li{margin-right}[type]; ul[lang]; ol{font-size}; dl dt dd'
 	},
-	allowedForTests: 'li{margin-right}[type]; ul[lang]; ol{font-size}; dl dt dd'
+	editor2: {
+		config: {
+			enterMode: CKEDITOR.ENTER_P
+		},
+		allowedForTests: 'li{margin-right}[type]; ul[lang]; ol{font-size}; dl dt dd'
+	}
 };
 
 bender.test( {
-	supportForSelectFullList: function() {
+	supportForSelectFullList: function( editor ) {
 		// With full selection, it will break inline in old IEs.
-		return !( this.editor.elementMode == CKEDITOR.ELEMENT_MODE_INLINE &&
+		return !( editor.elementMode == CKEDITOR.ELEMENT_MODE_INLINE &&
 			CKEDITOR.env.ie && CKEDITOR.env.version < 9 );
 	},
 
 	// Test list creation.
 	'test apply list': function() {
-		var bot = this.editorBot;
+		var bot = this.editorBots.editor1;
 
 		bot.setHtmlWithSelection( '[<p>foo<br />bar</p><p>baz</p>]' );
 		bot.execCommand( 'numberedlist' );
@@ -28,7 +37,7 @@ bender.test( {
 
 	// https://dev.ckeditor.com/ticket/3940
 	'test create list in table': function() {
-		var bot = this.editorBot;
+		var bot = this.editorBots.editor1;
 		bender.tools.testInputOut( 'create_list_table', function( input, expected ) {
 			bot.setHtmlWithSelection( input );
 			bot.execCommand( 'numberedlist' );
@@ -37,7 +46,7 @@ bender.test( {
 	},
 
 	'test apply list ( with justify style)': function() {
-		var bot = this.editorBot;
+		var bot = this.editorBots.editor1;
 
 		bot.setHtmlWithSelection( '<p>[foo</p><p style="text-align:center;">bar</p><p style="text-align:right;">baz]</p>' );
 		bot.execCommand( 'numberedlist' );
@@ -49,7 +58,7 @@ bender.test( {
 	},
 
 	'test apply list (with text direction)': function() {
-		var bot = this.editorBot;
+		var bot = this.editorBots.editor1;
 
 		bot.setHtmlWithSelection( '[<p dir="rtl">foo</p><p dir="rtl">bar</p><p dir="rtl">baz</p>]' );
 		bot.execCommand( 'numberedlist' );
@@ -62,7 +71,7 @@ bender.test( {
 
 	// https://dev.ckeditor.com/ticket/7657
 	'test apply list (with block styles)': function() {
-		var bot = this.editorBot;
+		var bot = this.editorBots.editor1;
 		bot.setHtmlWithSelection( '[<p dir="rtl">Item 1</p><p dir="rtl" style="margin-right: 40px;">Item 2</p><p dir="rtl" style="margin-right: 80px;">Item 3</p>]' );
 		bot.execCommand( 'bulletedlist' );
 		assert.areSame( '<ul dir="rtl"><li>item 1</li><li style="margin-right:40px;">item 2</li><li style="margin-right:80px;">item 3</li></ul>', bot.getData( true ) );
@@ -70,14 +79,14 @@ bender.test( {
 
 	// Test list removal.
 	'test remove list': function() {
-		var bot = this.editorBot;
+		var bot = this.editorBots.editor1;
 
 		bot.setHtmlWithSelection( '<ol><li>^text</li></ol>' );
 		bot.execCommand( 'numberedlist' );
 		assert.areSame( '<p>text</p>', bot.getData( false, true ) );
 
 		// With full selection, it will break inline in old IEs.
-		if ( this.supportForSelectFullList() ) {
+		if ( this.supportForSelectFullList( bot.editor ) ) {
 			bot.setHtmlWithSelection( '[<ol><li>text</li></ol>]' );
 			bot.execCommand( 'numberedlist' );
 			assert.areSame( '<p>text</p>', bot.getData( false, true ) );
@@ -91,7 +100,7 @@ bender.test( {
 
 	// (https://dev.ckeditor.com/ticket/6715)
 	'test remove list (inside table)': function() {
-		var bot = this.editorBot;
+		var bot = this.editorBots.editor1;
 		bot.setHtmlWithSelection( '<table><tr><td><ol><li>[item 1</li><li>item 2]</li></ol></td></tr></table>' );
 		bot.execCommand( 'numberedlist' );
 		assert.areSame( '<table><tbody><tr><td><p>item 1</p><p>item 2</p></td></tr></tbody></table>', bot.getData( false, true ) );
@@ -99,7 +108,7 @@ bender.test( {
 
 	// (https://dev.ckeditor.com/ticket/7645)
 	'test remove list (with input)': function() {
-		var bot = this.editorBot;
+		var bot = this.editorBots.editor1;
 		bot.setHtmlWithSelection( '<ol><li><input name="name" type="checkbox">[item1</li><li>item2]</li></ol>' );
 		bot.execCommand( 'numberedlist' );
 		assert.isMatching( /<p><input name="name" type="checkbox" (value="on" )?\/>item1<\/p><p>item2<\/p>/, bot.getData( true ) );
@@ -109,7 +118,7 @@ bender.test( {
 	 *  Test merge newlist with previous list. (https://dev.ckeditor.com/ticket/3820)
 	 */
 	'test create list with merge': function() {
-		var bot = this.editorBot;
+		var bot = this.editorBots.editor2;
 		bot.setHtmlWithSelection( '<ul><li>bullet line 1</li><li>bullet line 2</li></ul><p>^second line</p>' );
 		bot.execCommand( 'bulletedlist' );
 		assert.areSame( '<ul><li>bullet line 1</li><li>bullet line 2</li><li>second line</li></ul>', bot.getData( 1 ) );
@@ -119,7 +128,7 @@ bender.test( {
 	 * Test switch list type with custom bullet attributes. (https://dev.ckeditor.com/ticket/4950)
 	 */
 	'test switch list type (with custom bullet)': function() {
-		var bot = this.editorBot;
+		var bot = this.editorBots.editor2;
 		bot.setHtmlWithSelection( '<ol><li type="square">[item1</li><li type="square">item2</li><li type="square">item3]</li></ol> ' );
 		bot.execCommand( 'bulletedlist' );
 		assert.areSame( '<ul><li type="square">item1</li><li type="square">item2</li><li type="square">item3</li></ul>', bot.getData( 1 ) );
@@ -127,7 +136,7 @@ bender.test( {
 
 	// https://dev.ckeditor.com/ticket/7290
 	'test switch list type (inside definition list)': function() {
-		var bot = this.editorBot;
+		var bot = this.editorBots.editor2;
 		bender.tools.testInputOut( 'switch_list_dl', function( source, expected ) {
 			bot.setHtmlWithSelection( source );
 			bot.execCommand( 'numberedlist' );
@@ -138,7 +147,7 @@ bender.test( {
 
 	// https://dev.ckeditor.com/ticket/6059
 	'test switch list type keeps text direction': function() {
-		var bot = this.editorBot;
+		var bot = this.editorBots.editor2;
 		bot.setHtmlWithSelection( '[<ol dir="rtl" lang="en"><li>line 1</li><li>line 2</li></ol>]' );
 		bot.execCommand( 'bulletedlist' );
 		assert.areSame( '<ul dir="rtl" lang="en"><li>line 1</li><li>line 2</li></ul>', bot.getData( true ) );
@@ -146,17 +155,18 @@ bender.test( {
 
 	// https://dev.ckeditor.com/ticket/8997
 	'test change list type keep styles on sub list': function() {
-		if ( !this.supportForSelectFullList() )
-			assert.ignore();
+		var bot = this.editorBots.editor2;
 
-		var bot = this.editorBot;
+		if ( !this.supportForSelectFullList( bot.editor ) ) {
+			assert.ignore();
+		}
 		bot.setHtmlWithSelection( '[<ul style="font-size:16px;"><li>foo<ul style="font-size:22px;"><li>bar</li></ul></li></ul>]' );
 		bot.execCommand( 'numberedlist' );
 		assert.areSame( '<ol style="font-size:16px;"><li>foo<ol style="font-size:22px;"><li>bar</li></ol></li></ol>', bot.getData( true ) );
 	},
 
 	'test create list with merge below (with direction)': function() {
-		var bot = this.editorBot;
+		var bot = this.editorBots.editor2;
 
 		// LTR
 		bot.setHtmlWithSelection( '<p>^ltr</p><ol dir="rtl"><li>rtl</li></ol>' );
@@ -170,7 +180,7 @@ bender.test( {
 	},
 
 	'test create list with merge above (with direction)': function() {
-		var bot = this.editorBot;
+		var bot = this.editorBots.editor2;
 
 		bot.setHtmlWithSelection( '<ol dir="rtl"><li>rtl</li></ol><p>^ltr</p>' );
 		bot.execCommand( 'numberedlist' );
@@ -189,7 +199,7 @@ bender.test( {
 	},
 
 	'test single list type active inside of nested list': function() {
-		var ed = this.editor, bot = this.editorBot;
+		var bot = this.editorBots.editor2, ed = bot.editor;
 		bot.setHtmlWithSelection( '<ol><li>item1<ul><li>^item2</li></ul></li></ol>' );
 		var nList = ed.getCommand( 'numberedlist' ), bList = ed.getCommand( 'bulletedlist' );
 		assert.areSame( CKEDITOR.TRISTATE_OFF, nList.state, 'check numbered list inactive' );
@@ -198,7 +208,7 @@ bender.test( {
 	},
 
 	'test inactive when list is out of block limit': function() {
-		var ed = this.editor, bot = this.editorBot;
+		var bot = this.editorBots.editor2, ed = bot.editor;
 		bot.setHtmlWithSelection( '<ul><li><table><tr><td>^foo</td></tr></table></li></ul>' );
 		var bList = ed.getCommand( 'bulletedlist' );
 		assert.areSame( CKEDITOR.TRISTATE_OFF, bList.state, 'check numbered list inactive' );


### PR DESCRIPTION
## What is the purpose of this pull request?

Other: fixing tests failing on newest Edge (version 16). Closes #945.

## Does your PR contain necessary tests?

All patches which change the editor code must include tests. You can always read more
on [PR testing](http://docs.ckeditor.com/#!/guide/dev_contributing_code-section-tests),
[how to set the testing environment](http://docs.ckeditor.com/#!/guide/dev_tests) and
[how to create tests](http://docs.ckeditor.com/#!/guide/dev_tests-section-creating-your-own-test)
in the official CKEditor documentation.

### This PR contains

- [ ] Unit tests
- [ ] Manual tests

Tests are not needed as this PR is fixing tests only.

## What changes did you make?

As stated in #945, the browser behaviour seems quite random. The troublesome test when executed alone or as a first test works fine.  I also tried to check which preceding test may affect it, commenting out one after another. I found a few which when enabled causes the behaviour, however when those tests and only the troublesome one were enabled, again it worked fine (so tests in between where needed to trigger the issue). I also checked if timeout or clearing editor contents in-between test helps, but it doesn't.

It seems there is some issue with many tests operating on lists running in the same editor instance. My proposition for a workaround is to:

* `tests/plugins/indent/indent.js` - run each test in newly created editor instance (as it significantly increases test execution time it will only work this way in Edge, in other browsers it will reuse already created instances).
* `tests/plugins/list/list.js` - instead of one there are two editor instances created. All tests before troublesome one uses first instance and the rest second one.

The above fixes works and all tests now passes in Edge 16, I think it is sufficient for now. However, if we encounter similar behaviour in the future it will definitely require more detailed look.