### PR TITLE
[WIP] upload widget for Easy Image

### DIFF
--- a/plugins/easyimage/plugin.js
+++ b/plugins/easyimage/plugin.js
@@ -8,6 +8,11 @@
 
 	var stylesLoaded = false;
 
+	// jscs:disable maximumLineLength
+	// Black rectangle which is shown before image is loaded.
+	var loadingImage = 'data:image/gif;base64,R0lGODlhDgAOAIAAAAAAAP///yH5BAAAAAAALAAAAAAOAA4AAAIMhI+py+0Po5y02qsKADs=';
+	// jscs:enable maximumLineLength
+
 	function addCommands( editor ) {
 		function isSideImage( widget ) {
 			return widget.element.hasClass( editor.config.easyimage_sideClass );
@@ -124,26 +129,51 @@
 	}
 
 	function registerUploadWidget( editor ) {
-		editor.on( 'widgetDefinition', function( evt ) {
-			if ( evt.data.name !== 'uploadimage' ) {
-				return;
+		var uploadUrl = CKEDITOR.fileTools.getUploadUrl( editor.config, 'easyimage' );
+
+		CKEDITOR.fileTools.addUploadWidget( editor, 'uploadeasyimage', {
+			supportedTypes: /image\/(jpeg|png|gif|bmp)/,
+
+			uploadUrl: uploadUrl,
+
+			loadMethod: 'loadAndUpload',
+
+			additionalRequestParameters: {
+				isEasyImage: true
+			},
+
+			fileToElement: function() {
+				var img = new CKEDITOR.dom.element( 'img' );
+				img.setAttribute( 'src', loadingImage );
+				return img;
+			},
+
+			parts: {
+				img: 'img'
+			},
+
+			onUploading: function( upload ) {
+				// Show the image during the upload.
+				this.parts.img.setAttribute( 'src', URL.createObjectURL( upload.file ) );
+			},
+
+			onUploaded: function( upload ) {
+				this.replaceWith( '<img src="' + upload.responseData.response[ 'default' ] + '">' );
 			}
-
-			evt.data.onUploaded = function( upload ) {
-				var $img = this.parts.img.$,
-					width = $img.naturalWidth,
-					height = $img.naturalHeight;
-
-				// Set width and height to prevent blinking.
-				this.replaceWith( '<img src="' + upload.responseData.url[ 'default' ] + '" ' +
-					'width="' + width + '" ' +
-					'height="' + height + '">' );
-			};
 		} );
 
 		editor.on( 'fileUploadRequest', function( evt ) {
+			var requestData = evt.data.requestData;
+
+			if ( !requestData.isEasyImage ) {
+				return;
+			}
+
 			evt.data.requestData.file = evt.data.requestData.upload;
 			delete evt.data.requestData.upload;
+
+			// This property is used by fileUploadResponse callback to identify EI requests.
+			evt.data.fileLoader.isEasyImage = true;
 
 			evt.data.fileLoader.xhr.setRequestHeader( 'Authorization', editor.config.easyimage_token );
 		} );
@@ -151,15 +181,18 @@
 		editor.on( 'fileUploadResponse', function( evt ) {
 			var fileLoader = evt.data.fileLoader,
 				xhr = fileLoader.xhr,
-				data = evt.data,
 				response;
+
+			if ( !fileLoader.isEasyImage ) {
+				return;
+			}
 
 			evt.stop();
 
 			try {
 				response = JSON.parse( xhr.responseText );
 
-				data.url = response;
+				evt.data.response = response;
 			} catch ( e ) {
 				CKEDITOR.warn( 'filetools-response-error', { responseText: xhr.responseText } );
 			}
@@ -178,7 +211,7 @@
 	}
 
 	CKEDITOR.plugins.add( 'easyimage', {
-		requires: 'image2,uploadimage,contextmenu,dialog',
+		requires: 'image2,uploadwidget,contextmenu,dialog',
 		lang: 'en',
 
 		onLoad: function() {

--- a/plugins/easyimage/plugin.js
+++ b/plugins/easyimage/plugin.js
@@ -107,7 +107,7 @@
 				return;
 			}
 
-			evt.data.allowedContent.figure.classes += ',!' + editor.config.easyimage_class + ',' +
+			evt.data.allowedContent.figure.classes += ', img[srcset], !' + editor.config.easyimage_class + ',' +
 				editor.config.easyimage_sideClass;
 
 			// Block default image dialog.
@@ -158,7 +158,10 @@
 			},
 
 			onUploaded: function( upload ) {
-				this.replaceWith( '<img src="' + upload.responseData.response[ 'default' ] + '">' );
+				var srcset = CKEDITOR.plugins.easyimage._parseSrcSet( upload.responseData.response );
+
+				this.replaceWith( '<img src="' + upload.responseData.response[ 'default' ] + '" srcset="' +
+					srcset + '" sizes="100vw">' );
 			}
 		} );
 
@@ -209,6 +212,38 @@
 			editor.addContentsCss( plugin.path + 'styles/easyimage.css' );
 		}
 	}
+
+	/**
+	 * Namespace providing a set of helper functions for Easy Image plugin.
+	 *
+	 * @since 4.8.0
+	 * @singleton
+	 * @class CKEDITOR.plugins.easyimage
+	 */
+	CKEDITOR.plugins.easyimage = {
+		/**
+		 * Converts response from the server into proper `[srcset]` attribute.
+		 *
+		 * @since 4.8.0
+		 * @private
+		 * @param {Object} srcs Sources list to be parsed.
+		 * @returns {String} `img[srcset]` attribute.
+		 */
+		_parseSrcSet: function( srcs ) {
+			var srcset = [],
+				src;
+
+			for ( src in srcs ) {
+				if ( src === 'default' ) {
+					continue;
+				}
+
+				srcset.push( srcs[ src ] + ' ' + src + 'w' );
+			}
+
+			return srcset.join( ', ' );
+		}
+	};
 
 	CKEDITOR.plugins.add( 'easyimage', {
 		requires: 'image2,uploadwidget,contextmenu,dialog',

--- a/plugins/easyimage/plugin.js
+++ b/plugins/easyimage/plugin.js
@@ -200,6 +200,50 @@
 				CKEDITOR.warn( 'filetools-response-error', { responseText: xhr.responseText } );
 			}
 		} );
+
+		// Handle images which are not available in the dataTransfer.
+		// This means that we need to read them from the <img src="data:..."> elements.
+		editor.on( 'paste', function( evt ) {
+			var fileTools = CKEDITOR.fileTools;
+
+			// For performance reason do not parse data if it does not contain img tag and data attribute.
+			if ( !evt.data.dataValue.match( /<img[\s\S]+data:/i ) ) {
+				return;
+			}
+
+			var data = evt.data,
+				// Prevent XSS attacks.
+				tempDoc = document.implementation.createHTMLDocument( '' ),
+				temp = new CKEDITOR.dom.element( tempDoc.body ),
+				imgs, img, i;
+
+			// Without this isReadOnly will not works properly.
+			temp.data( 'cke-editable', 1 );
+
+			temp.appendHtml( data.dataValue );
+
+			imgs = temp.find( 'img' );
+
+			for ( i = 0; i < imgs.count(); i++ ) {
+				img = imgs.getItem( i );
+
+				// Image have to contain src=data:...
+				var isDataInSrc = img.getAttribute( 'src' ) && img.getAttribute( 'src' ).substring( 0, 5 ) == 'data:',
+					isRealObject = img.data( 'cke-realelement' ) === null;
+
+				// We are not uploading images in non-editable blocs and fake objects (http://dev.ckeditor.com/ticket/13003).
+				if ( isDataInSrc && isRealObject && !img.data( 'cke-upload-id' ) && !img.isReadOnly( 1 ) ) {
+					var loader = editor.uploadRepository.create( img.getAttribute( 'src' ) );
+					loader.upload( uploadUrl );
+
+					fileTools.markElement( img, 'uploadeasyimage', loader.id );
+
+					fileTools.bindNotifications( editor, loader );
+				}
+			}
+
+			data.dataValue = temp.getHtml();
+		} );
 	}
 
 	function loadStyles( editor, plugin ) {

--- a/plugins/easyimage/plugin.js
+++ b/plugins/easyimage/plugin.js
@@ -250,4 +250,20 @@
 	 * @member CKEDITOR.config
 	 */
 	CKEDITOR.config.easyimage_sideClass = 'easyimage-side';
+
+	/**
+	 * The URL where images inserted by Easy Image plugin  should be uploaded.
+	 *
+	 * @since 4.8.0
+	 * @cfg {String} [easyimageUploadUrl='' (empty string = disabled)]
+	 * @member CKEDITOR.config
+	 */
+
+	/**
+	 * Token used for authorization while uploading images via Easy Image plugin.
+	 *
+	 * @since 4.8.0
+	 * @cfg {String} [easyimage_token='' (empty string = disabled)]
+	 * @member CKEDITOR.config
+	 */
 }() );

--- a/plugins/easyimage/samples/easyimage.html
+++ b/plugins/easyimage/samples/easyimage.html
@@ -110,7 +110,7 @@ function getToken( callback ) {
 getToken( function( token ) {
 	CKEDITOR.replace( 'editor', {
 		extraPlugins: 'easyimage',
-		imageUploadUrl: 'https://files.cke-cs.com/upload/',
+		easyimageUploadUrl: 'https://files.cke-cs.com/upload/',
 		easyimage_token: token,
 		height: 500
 	} );

--- a/plugins/easyimage/samples/easyimage.html
+++ b/plugins/easyimage/samples/easyimage.html
@@ -72,9 +72,48 @@ For licensing, see LICENSE.md or http://ckeditor.com/license
 	</div>
 </footer>
 <script>
-CKEDITOR.replace( 'editor', {
-	extraPlugins: 'easyimage',
-	height: 500
+var CLOUD_SERVICES_TOKEN_URL = 'https://j2sns7jmy0.execute-api.eu-central-1.amazonaws.com/prod/token';
+// Stolen from https://github.com/ckeditor/ckeditor5-easy-image/blob/42fbc4b8ed8b020f559da0a5a499e0a604ea0baf/tests/_utils/gettoken.js
+function getToken( callback ) {
+	function uid() {
+		var uuid = 'e'; // Make sure that id does not start with number.
+
+		for ( var i = 0; i < 8; i++ ) {
+			uuid += Math.floor( ( 1 + Math.random() ) * 0x10000 ).toString( 16 ).substring( 1 );
+		}
+
+		return uuid;
+	}
+
+	var xhr = new XMLHttpRequest(),
+		userId = uid();
+
+	xhr.open( 'GET', CLOUD_SERVICES_TOKEN_URL + '?user.id=' + userId );
+
+	xhr.onload = function() {
+		if ( xhr.status >= 200 && xhr.status < 300 ) {
+			var response = JSON.parse( xhr.responseText );
+
+			callback( response.token );
+		} else {
+			console.error( xhr.status );
+		}
+	};
+
+	xhr.onerror = function( error ) {
+		console.error( error );
+	}
+
+	xhr.send( null );
+}
+
+getToken( function( token ) {
+	CKEDITOR.replace( 'editor', {
+		extraPlugins: 'easyimage',
+		imageUploadUrl: 'https://files.cke-cs.com/upload/',
+		easyimage_token: token,
+		height: 500
+	} );
 } );
 </script>
 

--- a/tests/plugins/easyimage/tools.js
+++ b/tests/plugins/easyimage/tools.js
@@ -1,0 +1,30 @@
+/* bender-tags: editor,widget */
+/* bender-ckeditor-plugins: easyimage,toolbar */
+
+( function() {
+	'use strict';
+
+	bender.editor = true;
+
+	var tools;
+
+	bender.test( {
+		setUp: function() {
+			tools = CKEDITOR.plugins.easyimage;
+		},
+
+		'test _parseSrcSet function': function() {
+			var srcs = {
+					100: 'https://test/100',
+					243: 'https://tests/243',
+					404: 'http://tests/404',
+					600: 'http://tests/600'
+				},
+				srcset = 'https://test/100 100w, https://tests/243 243w, http://tests/404 404w, http://tests/600 600w';
+
+			srcs[ 'default' ] = 'http://test/default';
+
+			assert.areSame( srcset, tools._parseSrcSet( srcs ) );
+		}
+	} );
+} )();

--- a/tests/plugins/easyimage/uploadwidget.js
+++ b/tests/plugins/easyimage/uploadwidget.js
@@ -1,0 +1,446 @@
+/* bender-tags: editor,clipboard,widget */
+/* bender-ckeditor-plugins: easyimage,toolbar, */
+/* bender-include: %BASE_PATH%/plugins/clipboard/_helpers/pasting.js */
+/* bender-include: %BASE_PATH%/plugins/uploadfile/_helpers/waitForImage.js */
+/* global pasteFiles, waitForImage */
+
+'use strict';
+
+( function() {
+	var uploadCount, loadAndUploadCount, lastUploadUrl, resumeAfter, tests,
+		IMG_URL = '%BASE_PATH%_assets/logo.png',
+		DATA_IMG = 'data:',
+		BLOB_IMG = 'blob:';
+
+	bender.editors = {
+		classic: {
+			name: 'classic',
+			config: {
+				easyimageUploadUrl: 'http://foo/upload',
+				// Disable pasteFilter on Webkits (pasteFilter defaults semantic-text on Webkits).
+				pasteFilter: null
+			}
+		},
+
+		divarea: {
+			name: 'divarea',
+			config: {
+				extraPlugins: 'divarea',
+				easyimageUploadUrl: 'http://foo/upload',
+				// Disable pasteFilter on Webkits (pasteFilter defaults semantic-text on Webkits).
+				pasteFilter: null
+			}
+		},
+
+		inline: {
+			name: 'inline',
+			creator: 'inline',
+			config: {
+				easyimageUploadUrl: 'http://foo/upload',
+				// Disable pasteFilter on Webkits (pasteFilter defaults semantic-text on Webkits).
+				pasteFilter: null
+			}
+		}
+	};
+
+	function assertUploadingWidgets( editor, expectedSrc ) {
+		var widgets = editor.editable().find( 'img[data-widget="uploadeasyimage"]' ),
+			widget, i;
+
+		assert.areSame( 1, widgets.count(), 'Expected widgets count should be 1' );
+
+		for ( i = 0; i < widgets.count(); i++ ) {
+			widget = widgets.getItem( i );
+			assert.areSame( '0', widget.getAttribute( 'data-cke-upload-id' ) );
+			assert.areSame( expectedSrc, widget.getAttribute( 'src' ).substring( 0, 5 ) );
+		}
+	}
+
+	tests = {
+		init: function() {
+			var responseData = {
+				response: {
+					100: IMG_URL,
+					200: IMG_URL
+				}
+			};
+
+			responseData[ 'default' ] = IMG_URL;
+			resumeAfter = bender.tools.resumeAfter;
+
+			CKEDITOR.fileTools.fileLoader.prototype.loadAndUpload = function( url ) {
+				loadAndUploadCount++;
+				lastUploadUrl = url;
+
+				this.responseData = CKEDITOR.tools.clone( responseData );
+			};
+
+			CKEDITOR.fileTools.fileLoader.prototype.load = function() {};
+
+			CKEDITOR.fileTools.fileLoader.prototype.upload = function( url ) {
+				uploadCount++;
+				lastUploadUrl = url;
+
+				this.responseData = CKEDITOR.tools.clone( responseData );
+			};
+		},
+
+		setUp: function() {
+			if ( !CKEDITOR.plugins.clipboard.isFileApiSupported ) {
+				assert.ignore();
+			}
+
+			var editorName;
+
+			uploadCount = 0;
+			loadAndUploadCount = 0;
+
+			for ( editorName in this.editors ) {
+				// Clear upload repository.
+				this.editors[ editorName ].uploadRepository.loaders = [];
+			}
+
+			if ( CKEDITOR.fileTools.bindNotifications.reset ) {
+				CKEDITOR.fileTools.bindNotifications.reset();
+			}
+		},
+
+		'test classic with easyimage (integration test)': function( editor ) {
+			pasteFiles( editor, [ bender.tools.getTestPngFile() ] );
+
+			assertUploadingWidgets( editor, DATA_IMG );
+			assert.areSame( '', editor.getData(), 'getData on loading.' );
+
+			var loader = editor.uploadRepository.loaders[ 0 ];
+
+			loader.data = bender.tools.pngBase64;
+			loader.uploadTotal = 10;
+			loader.changeStatus( 'uploading' );
+
+			assertUploadingWidgets( editor, BLOB_IMG );
+			assert.areSame( '', editor.getData(), 'getData on uploading.' );
+
+			var image = editor.editable().find( 'img[data-widget="uploadeasyimage"]' ).getItem( 0 );
+
+			waitForImage( image, function() {
+				loader.url = IMG_URL;
+				loader.changeStatus( 'uploaded' );
+
+				assert.sameData( '<p><img alt="" src="' + IMG_URL + '" /></p>', editor.getData() );
+				assert.areSame( 1, editor.editable().find( 'img[data-widget="image"]' ).count() );
+
+				assert.areSame( 1, loadAndUploadCount );
+				assert.areSame( 0, uploadCount );
+				assert.areSame( 'http://foo/upload', lastUploadUrl );
+			} );
+		},
+
+		'test paste img as html (integration test)': function( editor, bot ) {
+			bot.setData( '', function() {
+				pasteFiles( editor, [], '<p>x<img src="' + bender.tools.pngBase64 + '">x</p>' );
+
+				assertUploadingWidgets( editor, DATA_IMG );
+				assert.areSame( '<p>xx</p>', editor.getData(), 'getData on loading.' );
+
+				var loader = editor.uploadRepository.loaders[ 0 ];
+
+				loader.data = bender.tools.pngBase64;
+				loader.changeStatus( 'uploading' );
+
+				assertUploadingWidgets( editor, BLOB_IMG );
+				assert.areSame( '<p>xx</p>', editor.getData(), 'getData on uploading.' );
+
+				var image = editor.editable().find( 'img[data-widget="uploadeasyimage"]' ).getItem( 0 );
+
+				waitForImage( image, function() {
+					loader.url = IMG_URL;
+					loader.changeStatus( 'uploaded' );
+
+					assert.sameData( '<p>x<img alt="" src="' + IMG_URL + '" />x</p>', editor.getData() );
+					assert.areSame( 1, editor.editable().find( 'img[data-widget="image"]' ).count() );
+
+					assert.areSame( 0, loadAndUploadCount );
+					assert.areSame( 1, uploadCount );
+					assert.areSame( 'http://foo/upload', lastUploadUrl );
+				} );
+			} );
+		},
+
+		'test supportedTypes png': function( editor, bot ) {
+			bot.setData( '', function() {
+				resumeAfter( editor, 'paste', function() {
+					assertUploadingWidgets( editor, DATA_IMG );
+				} );
+
+				pasteFiles( editor, [ { name: 'test.png', type: 'image/png' } ] );
+
+				wait();
+			} );
+		},
+
+		'test supportedTypes jpg': function( editor, bot ) {
+			bot.setData( '', function() {
+				resumeAfter( editor, 'paste', function() {
+					assertUploadingWidgets( editor, DATA_IMG );
+				} );
+
+				pasteFiles( editor, [ { name: 'test.jpg', type: 'image/jpeg' } ] );
+
+				wait();
+			} );
+		},
+
+		'test supportedTypes gif': function( editor, bot ) {
+			bot.setData( '', function() {
+				resumeAfter( editor, 'paste', function() {
+					assertUploadingWidgets( editor, DATA_IMG );
+				} );
+
+				pasteFiles( editor, [ { name: 'test.gif', type: 'image/gif' } ] );
+
+				wait();
+			} );
+		},
+
+		'test supportedTypes bmp': function( editor, bot ) {
+			bot.setData( '', function() {
+				resumeAfter( editor, 'paste', function() {
+					assertUploadingWidgets( editor, DATA_IMG );
+				} );
+
+				pasteFiles( editor, [ { name: 'test.bmp', type: 'image/bmp' } ] );
+
+				wait();
+			} );
+		},
+
+		'test not supportedTypes tiff': function( editor, bot ) {
+			bot.setData( '', function() {
+				resumeAfter( editor, 'paste', function() {
+					assert.areSame( 0, editor.editable().find( 'img[data-widget="uploadeasyimage"]' ).count() );
+				} );
+
+				pasteFiles( editor, [ { name: 'test.tiff', type: 'image/tiff' } ] );
+
+				wait();
+			} );
+		},
+
+		'test paste single image': function( editor ) {
+			resumeAfter( editor, 'paste', function( evt ) {
+				var img = CKEDITOR.dom.element.createFromHtml( evt.data.dataValue );
+
+				assert.areSame( '0', img.getAttribute( 'data-cke-upload-id' ) );
+				assert.areSame( 'uploadeasyimage', img.getAttribute( 'data-widget' ) );
+
+				assert.areSame( 0, loadAndUploadCount );
+				assert.areSame( 1, uploadCount );
+			} );
+
+			editor.fire( 'paste', {
+				dataValue: '<img src="' + bender.tools.pngBase64 + '">'
+			} );
+
+			wait();
+		},
+
+		'test paste nested image': function( editor ) {
+			resumeAfter( editor, 'paste', function( evt ) {
+				var imgs = CKEDITOR.dom.element.createFromHtml( evt.data.dataValue ).find( 'img[data-widget="uploadeasyimage"]' ),
+					img, i;
+
+				assert.areSame( 2, imgs.count(), 'Expected imgs count should be 2' );
+
+				for ( i = 0; i < imgs.count(); i++ ) {
+					img = imgs.getItem( i );
+					assert.areSame( i + '', img.getAttribute( 'data-cke-upload-id' ) );
+				}
+
+				assert.areSame( 0, loadAndUploadCount );
+				assert.areSame( 2, uploadCount );
+			} );
+
+			editor.fire( 'paste', {
+				dataValue: '<div>x<img src="' + bender.tools.pngBase64 + '">x' +
+							'<p>x<img src="' + bender.tools.pngBase64 + '">x</p></div>'
+			} );
+
+			wait();
+		},
+
+		'test paste no image': function( editor ) {
+			resumeAfter( editor, 'paste', function( evt ) {
+				assert.areSame( 'foo', evt.data.dataValue );
+
+				assert.areSame( 0, loadAndUploadCount );
+				assert.areSame( 0, uploadCount );
+			} );
+
+			editor.fire( 'paste', {
+				dataValue: 'foo'
+			} );
+
+			wait();
+		},
+
+		'test paste no data in image': function( editor ) {
+			resumeAfter( editor, 'paste', function( evt ) {
+				var img = CKEDITOR.dom.element.createFromHtml( evt.data.dataValue );
+
+				assert.isNull( img.getAttribute( 'data-cke-upload-id' ) );
+				assert.isNull( img.getAttribute( 'data-widget' ) );
+
+				assert.areSame( 0, loadAndUploadCount );
+				assert.areSame( 0, uploadCount );
+			} );
+
+			editor.fire( 'paste', {
+				dataValue: '<img src="' + IMG_URL + '">'
+			} );
+
+			wait();
+		},
+
+		'test paste image already marked': function( editor ) {
+			var uploads = editor.uploadRepository;
+
+			resumeAfter( editor, 'paste', function( evt ) {
+				var img = CKEDITOR.dom.element.createFromHtml( evt.data.dataValue );
+
+				assert.areSame( '0', img.getAttribute( 'data-cke-upload-id' ) );
+				assert.areSame( 'uploadeasyimage', img.getAttribute( 'data-widget' ) );
+
+				assert.areSame( 0, loadAndUploadCount );
+				assert.areSame( 0, uploadCount );
+			} );
+
+			// Fill upload repository.
+			uploads.create( bender.tools.getTestPngFile() );
+
+			editor.fire( 'paste', {
+				dataValue: '<img src="' + bender.tools.pngBase64 + '" data-widget="uploadeasyimage" data-cke-upload-id="0">'
+			} );
+
+			wait();
+		},
+
+		'test omit images in non contentEditable': function( editor ) {
+			resumeAfter( editor, 'paste', function( evt ) {
+				var img = CKEDITOR.dom.element.createFromHtml( evt.data.dataValue ).findOne( 'img' );
+
+				assert.isNull( img.getAttribute( 'data-cke-upload-id' ) );
+				assert.isNull( img.getAttribute( 'data-widget' ) );
+
+				assert.areSame( 0, loadAndUploadCount );
+				assert.areSame( 0, uploadCount );
+			} );
+
+			editor.fire( 'paste', {
+				dataValue:
+					'<div contentEditable="false">' +
+						'<img src="' + bender.tools.pngBase64 + '">' +
+					'</div>'
+			} );
+
+			wait();
+		},
+
+		'test handle images in nested editable': function( editor ) {
+			resumeAfter( editor, 'paste', function( evt ) {
+				var img = CKEDITOR.dom.element.createFromHtml( evt.data.dataValue ).findOne( 'img' );
+
+				assert.areSame( '0', img.getAttribute( 'data-cke-upload-id' ) );
+				assert.areSame( 'uploadeasyimage', img.getAttribute( 'data-widget' ) );
+
+				assert.areSame( 0, loadAndUploadCount );
+				assert.areSame( 1, uploadCount );
+			} );
+
+			editor.fire( 'paste', {
+				dataValue:
+					'<div contentEditable="false">' +
+						'<div contentEditable="true">' +
+							'<img src="' + bender.tools.pngBase64 + '">' +
+						'</div>' +
+					'</div>'
+			} );
+
+			wait();
+		},
+
+		'test handle images in nested editable using cke-editable': function( editor ) {
+			resumeAfter( editor, 'paste', function( evt ) {
+				var img = CKEDITOR.dom.element.createFromHtml( evt.data.dataValue ).findOne( 'img' );
+
+				assert.areSame( '0', img.getAttribute( 'data-cke-upload-id' ) );
+				assert.areSame( 'uploadeasyimage', img.getAttribute( 'data-widget' ) );
+
+				assert.areSame( 0, loadAndUploadCount );
+				assert.areSame( 1, uploadCount );
+			} );
+
+			editor.fire( 'paste', {
+				dataValue:
+					'<div contentEditable="false">' +
+						'<div data-cke-editable="1">' +
+							'<img src="' + bender.tools.pngBase64 + '">' +
+						'</div>' +
+					'</div>'
+			} );
+
+			wait();
+		},
+
+		'test bindNotifications when paste image': function( editor ) {
+			CKEDITOR.fileTools.bindNotifications = sinon.spy();
+
+			resumeAfter( editor, 'paste', function() {
+				var spy = CKEDITOR.fileTools.bindNotifications;
+				assert.areSame( 1, spy.callCount );
+				assert.isTrue( spy.calledWith( editor ) );
+				assert.areSame( bender.tools.pngBase64, spy.firstCall.args[ 1 ].data );
+			} );
+
+			editor.fire( 'paste', {
+				dataValue: '<img src="' + bender.tools.pngBase64 + '">'
+			} );
+
+			wait();
+		},
+
+		'test XSS attack': function( editor ) {
+			window.attacked = sinon.spy();
+
+			editor.fire( 'paste', {
+				dataValue: '<img src="x" onerror="window.attacked();">' + bender.tools.pngBase64
+			} );
+
+			editor.once( 'afterPaste', function() {
+				resume( function() {
+					assert.areSame( 0, window.attacked.callCount );
+				} );
+			} );
+
+			wait();
+		},
+
+		'test prevent upload fake elements (http://dev.ckeditor.com/ticket/13003)': function( editor ) {
+			var createspy = sinon.spy( editor.uploadRepository, 'create' );
+
+			editor.fire( 'paste', {
+				dataValue: '<img src="data:image/gif;base64,aw==" alt="nothing" data-cke-realelement="some" />'
+			} );
+
+			editor.once( 'afterPaste', function() {
+				resume( function() {
+					assert.isTrue( createspy.notCalled );
+				} );
+			} );
+
+			wait();
+		}
+	};
+
+	tests = bender.tools.createTestsForEditors( CKEDITOR.tools.objectKeys( bender.editors ), tests );
+	bender.test( tests );
+} )();


### PR DESCRIPTION
## What is the purpose of this pull request?

New feature

## Does your PR contain necessary tests?

All patches which change the editor code must include tests. You can always read more
on [PR testing](http://docs.ckeditor.com/#!/guide/dev_contributing_code-section-tests),
[how to set the testing environment](http://docs.ckeditor.com/#!/guide/dev_tests) and
[how to create tests](http://docs.ckeditor.com/#!/guide/dev_tests-section-creating-your-own-test)
in the official CKEditor documentation.

### This PR contains

- [x] Unit tests
- [ ] Manual tests

## What changes did you make?

I've introduced upload widget for easy image, based on existing `uploadimage` widget.

Currently information about easy image is passed as additional request parameters to `fileUploadRequest` and `fileLoader`'s property to `fileUploadResponse`. Additionally there is some code duplication between `uploadimage` and current widget (especially whole handling of pasting images, which is just copied).

There is also WIP `[srcset]` support, waiting for dedicated image plugin to be fully functional.