### PR TITLE
Upload widget for Easy Image

### DIFF
--- a/plugins/cloudservices/plugin.js
+++ b/plugins/cloudservices/plugin.js
@@ -1,3 +1,8 @@
+/**
+ * @license Copyright (c) 2003-2017, CKSource - Frederico Knabben. All rights reserved.
+ * For licensing, see LICENSE.md or http://ckeditor.com/license
+ */
+
 ( function() {
 	'use strict';
 

--- a/plugins/cloudservices/plugin.js
+++ b/plugins/cloudservices/plugin.js
@@ -22,11 +22,11 @@
 			 * @class CKEDITOR.plugins.cloudservices.cloudServicesLoader
 			 * @extends CKEDITOR.fileTools.fileLoader
 			 */
-			function cloudServicesLoader( editor, fileOrData, fileName ) {
+			function CloudServicesLoader( editor, fileOrData, fileName ) {
 				FileLoader.call( this, editor, fileOrData, fileName );
 			}
 
-			cloudServicesLoader.prototype = CKEDITOR.tools.extend( {}, FileLoader.prototype );
+			CloudServicesLoader.prototype = CKEDITOR.tools.extend( {}, FileLoader.prototype );
 
 			/**
 			 * @inheritdoc
@@ -34,7 +34,7 @@
 			 * @param {Object} [additionalRequestParameters] Additional data that would be passed to the
 			 * {@link CKEDITOR.editor#fileUploadRequest} event.
 			 */
-			cloudServicesLoader.prototype.upload = function( url, additionalRequestParameters ) {
+			CloudServicesLoader.prototype.upload = function( url, additionalRequestParameters ) {
 				url = url || this.editor.config.cloudServices_url;
 
 				FileLoader.prototype.upload.call( this, url, additionalRequestParameters );
@@ -48,7 +48,7 @@
 			 * the {@link CKEDITOR.editor#fileUploadRequest} event.
 			*/
 
-			CKEDITOR.plugins.cloudservices.cloudServicesLoader = cloudServicesLoader;
+			CKEDITOR.plugins.cloudservices.cloudServicesLoader = CloudServicesLoader;
 		},
 
 		beforeInit: function( editor ) {

--- a/plugins/cloudservices/plugin.js
+++ b/plugins/cloudservices/plugin.js
@@ -1,0 +1,70 @@
+( function() {
+	'use strict';
+
+	CKEDITOR.plugins.add( 'cloudservices', {
+		requires: 'filetools',
+		onLoad: function() {
+			var FileLoader = CKEDITOR.fileTools.fileLoader;
+
+			/**
+			 * Dedicated uploader for [Cloud Services](https://ckeditor.com/ckeditor-cloud-services/).
+			 *
+			 * @since 4.8.0
+			 * @class CKEDITOR.plugins.cloudservices.fileLoader
+			 * @extends CKEDITOR.fileTools.fileLoader
+			 */
+			function CloudSericesLoader( editor, fileOrData, fileName ) {
+				FileLoader.call( this, editor, fileOrData, fileName );
+			}
+
+			CloudSericesLoader.prototype = CKEDITOR.tools.extend( {}, FileLoader.prototype );
+
+			// CloudSericesLoader.prototype.attachRequestListeners = function() {
+			// 	FileLoader.prototype.attachRequestListeners.call( this );
+
+			// 	this.xhr.setRequestHeader( 'Authorization', this.editor.config.easyimage_token );
+			// };
+
+			CKEDITOR.plugins.cloudservices.fileLoader = CloudSericesLoader;
+		},
+
+		beforeInit: function( editor ) {
+			editor.on( 'fileUploadRequest', function( evt ) {
+				var fileLoader = evt.data.fileLoader,
+					reqData = evt.data.requestData;
+
+				if ( fileLoader instanceof CKEDITOR.plugins.cloudservices.fileLoader ) {
+					// Cloud Services expect file to be put as a "file" property.
+					reqData.file = reqData.upload;
+					delete reqData.upload;
+
+					// Add authorization token.
+					evt.data.fileLoader.xhr.setRequestHeader( 'Authorization', editor.config.easyimage_token );
+				}
+			}, null, null, 6 );
+
+			editor.on( 'fileUploadResponse', function( evt ) {
+				var fileLoader = evt.data.fileLoader,
+					xhr = fileLoader.xhr,
+					response;
+
+				if ( fileLoader instanceof CKEDITOR.plugins.cloudservices.fileLoader ) {
+					evt.stop();
+
+					try {
+						response = JSON.parse( xhr.responseText );
+
+						evt.data.response = response;
+					} catch ( e ) {
+						CKEDITOR.warn( 'filetools-response-error', { responseText: xhr.responseText } );
+					}
+				}
+			} );
+		}
+	} );
+
+	CKEDITOR.plugins.cloudservices = {
+		// Note this type is loaded on runtime.
+		fileLoader: null
+	};
+} )();

--- a/plugins/cloudservices/plugin.js
+++ b/plugins/cloudservices/plugin.js
@@ -21,9 +21,27 @@
 			 * @since 4.8.0
 			 * @class CKEDITOR.plugins.cloudservices.cloudServicesLoader
 			 * @extends CKEDITOR.fileTools.fileLoader
+			 * @constructor
+			 * @inheritdoc
+			 * @param {CKEDITOR.editor} editor The editor instance. Used only to get language data.
+			 * @param {Blob/String} fileOrData A [blob object](https://developer.mozilla.org/en/docs/Web/API/Blob) or a data
+			 * string encoded with Base64.
+			 * @param {String} [fileName] The file name. If not set and the second parameter is a file, then its name will be used.
+			 * If not set and the second parameter is a Base64 data string, then the file name will be created based on
+			 * the {@link CKEDITOR.config#fileTools_defaultFileName} option.
+			 * @param {String} [token] A token used for [Cloud Service](https://ckeditor.com/ckeditor-cloud-services/) request. If
+			 * skipped {@link CKEDITOR.config#cloudServices_token} will be used.
 			 */
-			function CloudServicesLoader( editor, fileOrData, fileName ) {
+			function CloudServicesLoader( editor, fileOrData, fileName, token ) {
 				FileLoader.call( this, editor, fileOrData, fileName );
+
+				/**
+				 * Custom [Cloud Service](https://ckeditor.com/ckeditor-cloud-services/) token.
+				 *
+				 * @property {String} custom_token
+				 * @member CKEDITOR.plugins.cloudservices.cloudServicesLoader
+				 */
+				this.customToken = token;
 			}
 
 			CloudServicesLoader.prototype = CKEDITOR.tools.extend( {}, FileLoader.prototype );
@@ -62,7 +80,7 @@
 					delete reqData.upload;
 
 					// Add authorization token.
-					evt.data.fileLoader.xhr.setRequestHeader( 'Authorization', editor.config.cloudServices_token );
+					evt.data.fileLoader.xhr.setRequestHeader( 'Authorization', fileLoader.customToken || editor.config.cloudServices_token );
 				}
 			}, null, null, 6 );
 

--- a/plugins/cloudservices/plugin.js
+++ b/plugins/cloudservices/plugin.js
@@ -7,25 +7,43 @@
 			var FileLoader = CKEDITOR.fileTools.fileLoader;
 
 			/**
-			 * Dedicated uploader for [Cloud Services](https://ckeditor.com/ckeditor-cloud-services/).
+			 * Dedicated uploader type for [Cloud Services](https://ckeditor.com/ckeditor-cloud-services/).
+			 *
+			 * Note that this type is defined in {@link CKEDITOR.pluginDefinition#onLoad plugin.onLoad} method, thus is
+			 * guaranteed to be available in dependent plugin's {@link CKEDITOR.pluginDefinition#beforeInit beforeInit},
+			 * {@link CKEDITOR.pluginDefinition#init init} and {@link CKEDITOR.pluginDefinition#afterInit} methods.
 			 *
 			 * @since 4.8.0
-			 * @class CKEDITOR.plugins.cloudservices.fileLoader
+			 * @class CKEDITOR.plugins.cloudservices.cloudServicesLoader
 			 * @extends CKEDITOR.fileTools.fileLoader
 			 */
-			function CloudSericesLoader( editor, fileOrData, fileName ) {
+			function cloudServicesLoader( editor, fileOrData, fileName ) {
 				FileLoader.call( this, editor, fileOrData, fileName );
 			}
 
-			CloudSericesLoader.prototype = CKEDITOR.tools.extend( {}, FileLoader.prototype );
+			cloudServicesLoader.prototype = CKEDITOR.tools.extend( {}, FileLoader.prototype );
 
-			// CloudSericesLoader.prototype.attachRequestListeners = function() {
-			// 	FileLoader.prototype.attachRequestListeners.call( this );
+			/**
+			 * @inheritdoc
+			 * @param {String} [url] The upload URL. If not provided {@link CKEDITOR.config#cloudServices_url} will be used.
+			 * @param {Object} [additionalRequestParameters] Additional data that would be passed to the
+			 * {@link CKEDITOR.editor#fileUploadRequest} event.
+			 */
+			cloudServicesLoader.prototype.upload = function( url, additionalRequestParameters ) {
+				url = url || this.editor.config.cloudServices_url;
 
-			// 	this.xhr.setRequestHeader( 'Authorization', this.editor.config.easyimage_token );
-			// };
+				FileLoader.prototype.upload.call( this, url, additionalRequestParameters );
+			};
 
-			CKEDITOR.plugins.cloudservices.fileLoader = CloudSericesLoader;
+			/**
+			 * @method loadAndUpload
+			 * @inheritdoc
+			 * @param {String} [url] The upload URL. If not provided {@link CKEDITOR.config#cloudServices_url} will be used.
+			 * @param {Object} [additionalRequestParameters] Additional parameters that would be passed to
+			 * the {@link CKEDITOR.editor#fileUploadRequest} event.
+			*/
+
+			CKEDITOR.plugins.cloudservices.cloudServicesLoader = cloudServicesLoader;
 		},
 
 		beforeInit: function( editor ) {
@@ -33,13 +51,13 @@
 				var fileLoader = evt.data.fileLoader,
 					reqData = evt.data.requestData;
 
-				if ( fileLoader instanceof CKEDITOR.plugins.cloudservices.fileLoader ) {
+				if ( fileLoader instanceof CKEDITOR.plugins.cloudservices.cloudServicesLoader ) {
 					// Cloud Services expect file to be put as a "file" property.
 					reqData.file = reqData.upload;
 					delete reqData.upload;
 
 					// Add authorization token.
-					evt.data.fileLoader.xhr.setRequestHeader( 'Authorization', editor.config.easyimage_token );
+					evt.data.fileLoader.xhr.setRequestHeader( 'Authorization', editor.config.cloudServices_token );
 				}
 			}, null, null, 6 );
 
@@ -48,7 +66,7 @@
 					xhr = fileLoader.xhr,
 					response;
 
-				if ( fileLoader instanceof CKEDITOR.plugins.cloudservices.fileLoader ) {
+				if ( fileLoader instanceof CKEDITOR.plugins.cloudservices.cloudServicesLoader ) {
 					evt.stop();
 
 					try {
@@ -65,6 +83,22 @@
 
 	CKEDITOR.plugins.cloudservices = {
 		// Note this type is loaded on runtime.
-		fileLoader: null
+		cloudServicesLoader: null
 	};
+
+	/**
+	 * Endpoint URL for [Cloud Services](https://ckeditor.com/ckeditor-cloud-services) uploads.
+	 *
+	 * @since 4.8.0
+	 * @cfg {String} [cloudServices_url='']
+	 * @member CKEDITOR.config
+	 */
+
+	/**
+	 * Token used for [Cloud Services](https://ckeditor.com/ckeditor-cloud-services) authentication.
+	 *
+	 * @since 4.8.0
+	 * @cfg {String} [cloudServices_token='']
+	 * @member CKEDITOR.config
+	 */
 } )();

--- a/plugins/cloudservices/plugin.js
+++ b/plugins/cloudservices/plugin.js
@@ -38,7 +38,7 @@
 				/**
 				 * Custom [Cloud Service](https://ckeditor.com/ckeditor-cloud-services/) token.
 				 *
-				 * @property {String} custom_token
+				 * @property {String} customToken
 				 * @member CKEDITOR.plugins.cloudservices.cloudServicesLoader
 				 */
 				this.customToken = token;

--- a/plugins/easyimage/plugin.js
+++ b/plugins/easyimage/plugin.js
@@ -105,6 +105,10 @@
 				allowedContent: {
 					figure: {
 						classes: config.easyimage_sideClass
+					},
+
+					img: {
+						attributes: '!src,srcset,alt,width,height'
 					}
 				},
 
@@ -166,7 +170,10 @@
 			},
 
 			onUploaded: function( upload ) {
-				this.replaceWith( '<img src="' + upload.responseData.response[ 'default' ] + '">' );
+				var srcset = CKEDITOR.plugins.easyimage._parseSrcSet( upload.responseData.response );
+
+				this.replaceWith( '<img src="' + upload.responseData.response[ 'default' ] + '" srcset="' +
+					srcset + '" sizes="100vw">' );
 			}
 		} );
 
@@ -217,6 +224,38 @@
 			editor.addContentsCss( plugin.path + 'styles/easyimage.css' );
 		}
 	}
+
+	/**
+	 * Namespace providing a set of helper functions for Easy Image plugin.
+	 *
+	 * @since 4.8.0
+	 * @singleton
+	 * @class CKEDITOR.plugins.easyimage
+	 */
+	CKEDITOR.plugins.easyimage = {
+		/**
+		 * Converts response from the server into proper `[srcset]` attribute.
+		 *
+		 * @since 4.8.0
+		 * @private
+		 * @param {Object} srcs Sources list to be parsed.
+		 * @returns {String} `img[srcset]` attribute.
+		 */
+		_parseSrcSet: function( srcs ) {
+			var srcset = [],
+				src;
+
+			for ( src in srcs ) {
+				if ( src === 'default' ) {
+					continue;
+				}
+
+				srcset.push( srcs[ src ] + ' ' + src + 'w' );
+			}
+
+			return srcset.join( ', ' );
+		}
+	};
 
 	CKEDITOR.plugins.add( 'easyimage', {
 		requires: 'imagebase,uploadwidget,contextmenu,dialog',

--- a/plugins/easyimage/plugin.js
+++ b/plugins/easyimage/plugin.js
@@ -141,20 +141,12 @@
 	}
 
 	function registerUploadWidget( editor ) {
-		var uploadUrl = CKEDITOR.fileTools.getUploadUrl( editor.config, 'easyimage' );
-
 		CKEDITOR.fileTools.addUploadWidget( editor, 'uploadeasyimage', {
 			supportedTypes: /image\/(jpeg|png|gif|bmp)/,
-
-			uploadUrl: uploadUrl,
 
 			loadMethod: 'loadAndUpload',
 
 			loaderType: CKEDITOR.plugins.cloudservices.cloudServicesLoader,
-
-			additionalRequestParameters: {
-				isEasyImage: true
-			},
 
 			fileToElement: function() {
 				var img = new CKEDITOR.dom.element( 'img' );

--- a/plugins/easyimage/plugin.js
+++ b/plugins/easyimage/plugin.js
@@ -321,20 +321,4 @@
 	 * @member CKEDITOR.config
 	 */
 	CKEDITOR.config.easyimage_sideClass = 'easyimage-side';
-
-	/**
-	 * The URL where images inserted by Easy Image plugin  should be uploaded.
-	 *
-	 * @since 4.8.0
-	 * @cfg {String} [easyimageUploadUrl='' (empty string = disabled)]
-	 * @member CKEDITOR.config
-	 */
-
-	/**
-	 * Token used for authorization while uploading images via Easy Image plugin.
-	 *
-	 * @since 4.8.0
-	 * @cfg {String} [easyimage_token='' (empty string = disabled)]
-	 * @member CKEDITOR.config
-	 */
 }() );

--- a/plugins/easyimage/plugin.js
+++ b/plugins/easyimage/plugin.js
@@ -144,7 +144,8 @@
 		CKEDITOR.fileTools.addUploadWidget( editor, 'uploadeasyimage', {
 			supportedTypes: /image\/(jpeg|png|gif|bmp)/,
 
-			loadMethod: 'loadAndUpload',
+			// Easy image uses only upload method, as is manually handled in onUploading function.
+			loadMethod: 'upload',
 
 			loaderType: CKEDITOR.plugins.cloudservices.cloudServicesLoader,
 

--- a/plugins/easyimage/plugin.js
+++ b/plugins/easyimage/plugin.js
@@ -150,6 +150,8 @@
 
 			loadMethod: 'loadAndUpload',
 
+			loaderType: CKEDITOR.plugins.cloudservices.fileLoader,
+
 			additionalRequestParameters: {
 				isEasyImage: true
 			},
@@ -175,86 +177,6 @@
 				this.replaceWith( '<img src="' + upload.responseData.response[ 'default' ] + '" srcset="' +
 					srcset + '" sizes="100vw">' );
 			}
-		} );
-
-		editor.on( 'fileUploadRequest', function( evt ) {
-			var requestData = evt.data.requestData;
-
-			if ( !requestData.isEasyImage ) {
-				return;
-			}
-
-			evt.data.requestData.file = evt.data.requestData.upload;
-			delete evt.data.requestData.upload;
-
-			// This property is used by fileUploadResponse callback to identify EI requests.
-			evt.data.fileLoader.isEasyImage = true;
-
-			evt.data.fileLoader.xhr.setRequestHeader( 'Authorization', editor.config.easyimage_token );
-		} );
-
-		editor.on( 'fileUploadResponse', function( evt ) {
-			var fileLoader = evt.data.fileLoader,
-				xhr = fileLoader.xhr,
-				response;
-
-			if ( !fileLoader.isEasyImage ) {
-				return;
-			}
-
-			evt.stop();
-
-			try {
-				response = JSON.parse( xhr.responseText );
-
-				evt.data.response = response;
-			} catch ( e ) {
-				CKEDITOR.warn( 'filetools-response-error', { responseText: xhr.responseText } );
-			}
-		} );
-
-		// Handle images which are not available in the dataTransfer.
-		// This means that we need to read them from the <img src="data:..."> elements.
-		editor.on( 'paste', function( evt ) {
-			var fileTools = CKEDITOR.fileTools;
-
-			// For performance reason do not parse data if it does not contain img tag and data attribute.
-			if ( !evt.data.dataValue.match( /<img[\s\S]+data:/i ) ) {
-				return;
-			}
-
-			var data = evt.data,
-				// Prevent XSS attacks.
-				tempDoc = document.implementation.createHTMLDocument( '' ),
-				temp = new CKEDITOR.dom.element( tempDoc.body ),
-				imgs, img, i;
-
-			// Without this isReadOnly will not works properly.
-			temp.data( 'cke-editable', 1 );
-
-			temp.appendHtml( data.dataValue );
-
-			imgs = temp.find( 'img' );
-
-			for ( i = 0; i < imgs.count(); i++ ) {
-				img = imgs.getItem( i );
-
-				// Image have to contain src=data:...
-				var isDataInSrc = img.getAttribute( 'src' ) && img.getAttribute( 'src' ).substring( 0, 5 ) == 'data:',
-					isRealObject = img.data( 'cke-realelement' ) === null;
-
-				// We are not uploading images in non-editable blocs and fake objects (http://dev.ckeditor.com/ticket/13003).
-				if ( isDataInSrc && isRealObject && !img.data( 'cke-upload-id' ) && !img.isReadOnly( 1 ) ) {
-					var loader = editor.uploadRepository.create( img.getAttribute( 'src' ) );
-					loader.upload( uploadUrl );
-
-					fileTools.markElement( img, 'uploadeasyimage', loader.id );
-
-					fileTools.bindNotifications( editor, loader );
-				}
-			}
-
-			data.dataValue = temp.getHtml();
 		} );
 	}
 
@@ -302,7 +224,7 @@
 	};
 
 	CKEDITOR.plugins.add( 'easyimage', {
-		requires: 'imagebase,uploadwidget,contextmenu,dialog',
+		requires: 'imagebase,uploadwidget,contextmenu,dialog,cloudservices',
 		lang: 'en',
 
 		onLoad: function() {

--- a/plugins/easyimage/plugin.js
+++ b/plugins/easyimage/plugin.js
@@ -150,7 +150,7 @@
 
 			loadMethod: 'loadAndUpload',
 
-			loaderType: CKEDITOR.plugins.cloudservices.fileLoader,
+			loaderType: CKEDITOR.plugins.cloudservices.cloudServicesLoader,
 
 			additionalRequestParameters: {
 				isEasyImage: true

--- a/plugins/easyimage/plugin.js
+++ b/plugins/easyimage/plugin.js
@@ -120,6 +120,23 @@
 							element.find( 'img' ).length === 1 ) {
 							return element;
 						}
+					},
+
+					// Upload widget creates bare img[srcset] elements, so we should also upcast them.
+					img: function( element )  {
+						if ( element.attributes.srcset ) {
+							var figure = new CKEDITOR.htmlParser.element( 'figure' );
+
+							if ( figureClass ) {
+								figure.attributes[ 'class' ] = figureClass;
+							}
+
+							element.wrapWith( figure );
+
+							return figure;
+						}
+
+						return false;
 					}
 				},
 

--- a/plugins/easyimage/plugin.js
+++ b/plugins/easyimage/plugin.js
@@ -184,6 +184,7 @@
 			var data = evt.data,
 				// Prevent XSS attacks.
 				tempDoc = document.implementation.createHTMLDocument( '' ),
+				widgetDef = editor.widgets.registered.uploadeasyimage,
 				temp = new CKEDITOR.dom.element( tempDoc.body ),
 				imgs, img, i;
 
@@ -203,7 +204,7 @@
 
 				// We are not uploading images in non-editable blocs and fake objects (http://dev.ckeditor.com/ticket/13003).
 				if ( isDataInSrc && isRealObject && !img.data( 'cke-upload-id' ) && !img.isReadOnly( 1 ) ) {
-					var loader = editor.uploadRepository.create( img.getAttribute( 'src' ) );
+					var loader = editor.uploadRepository.create( img.getAttribute( 'src' ), undefined, widgetDef.loaderType );
 					loader.upload();
 
 					fileTools.markElement( img, 'uploadeasyimage', loader.id );

--- a/plugins/easyimage/plugin.js
+++ b/plugins/easyimage/plugin.js
@@ -206,7 +206,7 @@
 				// We are not uploading images in non-editable blocs and fake objects (http://dev.ckeditor.com/ticket/13003).
 				if ( isDataInSrc && isRealObject && !img.data( 'cke-upload-id' ) && !img.isReadOnly( 1 ) ) {
 					var loader = editor.uploadRepository.create( img.getAttribute( 'src' ), undefined, widgetDef.loaderType );
-					loader.upload();
+					loader.upload( widgetDef.uploadUrl, widgetDef.additionalRequestParameters );
 
 					fileTools.markElement( img, 'uploadeasyimage', loader.id );
 

--- a/plugins/easyimage/plugin.js
+++ b/plugins/easyimage/plugin.js
@@ -261,4 +261,20 @@
 	 * @member CKEDITOR.config
 	 */
 	CKEDITOR.config.easyimage_sideClass = 'easyimage-side';
+
+	/**
+	 * The URL where images inserted by Easy Image plugin  should be uploaded.
+	 *
+	 * @since 4.8.0
+	 * @cfg {String} [easyimageUploadUrl='' (empty string = disabled)]
+	 * @member CKEDITOR.config
+	 */
+
+	/**
+	 * Token used for authorization while uploading images via Easy Image plugin.
+	 *
+	 * @since 4.8.0
+	 * @cfg {String} [easyimage_token='' (empty string = disabled)]
+	 * @member CKEDITOR.config
+	 */
 }() );

--- a/plugins/easyimage/plugin.js
+++ b/plugins/easyimage/plugin.js
@@ -170,6 +170,50 @@
 					srcset + '" sizes="100vw">' );
 			}
 		} );
+
+		// Handle images which are not available in the dataTransfer.
+		// This means that we need to read them from the <img src="data:..."> elements.
+		editor.on( 'paste', function( evt ) {
+			var fileTools = CKEDITOR.fileTools;
+
+			// For performance reason do not parse data if it does not contain img tag and data attribute.
+			if ( !evt.data.dataValue.match( /<img[\s\S]+data:/i ) ) {
+				return;
+			}
+
+			var data = evt.data,
+				// Prevent XSS attacks.
+				tempDoc = document.implementation.createHTMLDocument( '' ),
+				temp = new CKEDITOR.dom.element( tempDoc.body ),
+				imgs, img, i;
+
+			// Without this isReadOnly will not works properly.
+			temp.data( 'cke-editable', 1 );
+
+			temp.appendHtml( data.dataValue );
+
+			imgs = temp.find( 'img' );
+
+			for ( i = 0; i < imgs.count(); i++ ) {
+				img = imgs.getItem( i );
+
+				// Image have to contain src=data:...
+				var isDataInSrc = img.getAttribute( 'src' ) && img.getAttribute( 'src' ).substring( 0, 5 ) == 'data:',
+					isRealObject = img.data( 'cke-realelement' ) === null;
+
+				// We are not uploading images in non-editable blocs and fake objects (http://dev.ckeditor.com/ticket/13003).
+				if ( isDataInSrc && isRealObject && !img.data( 'cke-upload-id' ) && !img.isReadOnly( 1 ) ) {
+					var loader = editor.uploadRepository.create( img.getAttribute( 'src' ) );
+					loader.upload();
+
+					fileTools.markElement( img, 'uploadeasyimage', loader.id );
+
+					fileTools.bindNotifications( editor, loader );
+				}
+			}
+
+			data.dataValue = temp.getHtml();
+		} );
 	}
 
 	function loadStyles( editor, plugin ) {

--- a/plugins/easyimage/plugin.js
+++ b/plugins/easyimage/plugin.js
@@ -212,6 +212,50 @@
 				CKEDITOR.warn( 'filetools-response-error', { responseText: xhr.responseText } );
 			}
 		} );
+
+		// Handle images which are not available in the dataTransfer.
+		// This means that we need to read them from the <img src="data:..."> elements.
+		editor.on( 'paste', function( evt ) {
+			var fileTools = CKEDITOR.fileTools;
+
+			// For performance reason do not parse data if it does not contain img tag and data attribute.
+			if ( !evt.data.dataValue.match( /<img[\s\S]+data:/i ) ) {
+				return;
+			}
+
+			var data = evt.data,
+				// Prevent XSS attacks.
+				tempDoc = document.implementation.createHTMLDocument( '' ),
+				temp = new CKEDITOR.dom.element( tempDoc.body ),
+				imgs, img, i;
+
+			// Without this isReadOnly will not works properly.
+			temp.data( 'cke-editable', 1 );
+
+			temp.appendHtml( data.dataValue );
+
+			imgs = temp.find( 'img' );
+
+			for ( i = 0; i < imgs.count(); i++ ) {
+				img = imgs.getItem( i );
+
+				// Image have to contain src=data:...
+				var isDataInSrc = img.getAttribute( 'src' ) && img.getAttribute( 'src' ).substring( 0, 5 ) == 'data:',
+					isRealObject = img.data( 'cke-realelement' ) === null;
+
+				// We are not uploading images in non-editable blocs and fake objects (http://dev.ckeditor.com/ticket/13003).
+				if ( isDataInSrc && isRealObject && !img.data( 'cke-upload-id' ) && !img.isReadOnly( 1 ) ) {
+					var loader = editor.uploadRepository.create( img.getAttribute( 'src' ) );
+					loader.upload( uploadUrl );
+
+					fileTools.markElement( img, 'uploadeasyimage', loader.id );
+
+					fileTools.bindNotifications( editor, loader );
+				}
+			}
+
+			data.dataValue = temp.getHtml();
+		} );
 	}
 
 	function loadStyles( editor, plugin ) {

--- a/plugins/easyimage/samples/easyimage.html
+++ b/plugins/easyimage/samples/easyimage.html
@@ -110,7 +110,7 @@ function getToken( callback ) {
 getToken( function( token ) {
 	CKEDITOR.replace( 'editor', {
 		extraPlugins: 'easyimage',
-		imageUploadUrl: 'https://files.cke-cs.com/upload/',
+		easyimageUploadUrl: 'https://files.cke-cs.com/upload/',
 		easyimage_token: token,
 		height: 500
 	} );

--- a/plugins/easyimage/samples/easyimage.html
+++ b/plugins/easyimage/samples/easyimage.html
@@ -110,8 +110,8 @@ function getToken( callback ) {
 getToken( function( token ) {
 	CKEDITOR.replace( 'editor', {
 		extraPlugins: 'easyimage',
-		easyimageUploadUrl: 'https://files.cke-cs.com/upload/',
-		easyimage_token: token,
+		cloudServices_url: 'https://files.cke-cs.com/upload/',
+		cloudServices_token: token,
 		height: 500
 	} );
 } );

--- a/plugins/easyimage/samples/easyimage.html
+++ b/plugins/easyimage/samples/easyimage.html
@@ -72,9 +72,48 @@ For licensing, see LICENSE.md or http://ckeditor.com/license
 	</div>
 </footer>
 <script>
-CKEDITOR.replace( 'editor', {
-	extraPlugins: 'easyimage',
-	height: 500
+var CLOUD_SERVICES_TOKEN_URL = 'https://j2sns7jmy0.execute-api.eu-central-1.amazonaws.com/prod/token';
+// Stolen from https://github.com/ckeditor/ckeditor5-easy-image/blob/42fbc4b8ed8b020f559da0a5a499e0a604ea0baf/tests/_utils/gettoken.js
+function getToken( callback ) {
+	function uid() {
+		var uuid = 'e'; // Make sure that id does not start with number.
+
+		for ( var i = 0; i < 8; i++ ) {
+			uuid += Math.floor( ( 1 + Math.random() ) * 0x10000 ).toString( 16 ).substring( 1 );
+		}
+
+		return uuid;
+	}
+
+	var xhr = new XMLHttpRequest(),
+		userId = uid();
+
+	xhr.open( 'GET', CLOUD_SERVICES_TOKEN_URL + '?user.id=' + userId );
+
+	xhr.onload = function() {
+		if ( xhr.status >= 200 && xhr.status < 300 ) {
+			var response = JSON.parse( xhr.responseText );
+
+			callback( response.token );
+		} else {
+			console.error( xhr.status );
+		}
+	};
+
+	xhr.onerror = function( error ) {
+		console.error( error );
+	}
+
+	xhr.send( null );
+}
+
+getToken( function( token ) {
+	CKEDITOR.replace( 'editor', {
+		extraPlugins: 'easyimage',
+		imageUploadUrl: 'https://files.cke-cs.com/upload/',
+		easyimage_token: token,
+		height: 500
+	} );
 } );
 </script>
 

--- a/plugins/filetools/plugin.js
+++ b/plugins/filetools/plugin.js
@@ -148,9 +148,11 @@
 		 * @param {String} fileName See {@link CKEDITOR.fileTools.fileLoader}.
 		 * @returns {CKEDITOR.fileTools.fileLoader} The created file loader instance.
 		 */
-		create: function( fileOrData, fileName ) {
+		create: function( fileOrData, fileName, loaderType ) {
+			loaderType = loaderType || FileLoader;
+
 			var id = this.loaders.length,
-				loader = new FileLoader( this.editor, fileOrData, fileName );
+				loader = new loaderType( this.editor, fileOrData, fileName );
 
 			loader.id = id;
 			this.loaders[ id ] = loader;

--- a/plugins/filetools/plugin.js
+++ b/plugins/filetools/plugin.js
@@ -146,6 +146,8 @@
 		 *
 		 * @param {Blob/String} fileOrData See {@link CKEDITOR.fileTools.fileLoader}.
 		 * @param {String} fileName See {@link CKEDITOR.fileTools.fileLoader}.
+		 * @param {Function} [loaderType] Loader type to be created. If skipped the default {@link CKEDITOR.fileTools.fileLoader}
+		 * type will be used.
 		 * @returns {CKEDITOR.fileTools.fileLoader} The created file loader instance.
 		 */
 		create: function( fileOrData, fileName, loaderType ) {

--- a/plugins/uploadwidget/plugin.js
+++ b/plugins/uploadwidget/plugin.js
@@ -364,6 +364,12 @@
 			 */
 
 			/**
+			 * Loader type that should be used for creating fileTools requests.
+			 *
+			 * @property {Function} [loaderType]
+			 */
+
+			/**
 			 * An object containing additional data that should be passed to the function defined by {@link #loadMethod}.
 			 *
 			 * @property {Object} [additionalRequestParameters]

--- a/plugins/uploadwidget/plugin.js
+++ b/plugins/uploadwidget/plugin.js
@@ -188,7 +188,7 @@
 					// No def.supportedTypes means all types are supported.
 					if ( !def.supportedTypes || fileTools.isTypeSupported( file, def.supportedTypes ) ) {
 						var el = def.fileToElement( file ),
-							loader = uploads.create( file );
+							loader = uploads.create( file, undefined, def.loaderType );
 
 						if ( el ) {
 							loader[ loadMethod ]( def.uploadUrl, def.additionalRequestParameters );

--- a/tests/plugins/cloudservices/unit.js
+++ b/tests/plugins/cloudservices/unit.js
@@ -1,0 +1,73 @@
+/* @bender-ckeditor-plugins: cloudservices */
+
+bender.editor = {
+	config: {
+		cloudServices_url: 'cs_url',
+		cloudServices_token: 'cs_token'
+	}
+};
+
+var mockBase64 = 'data:image/gif;base64,R0lGODlhDgAOAIAAAAAAAP///yH5BAAAAAAALAAAAAAOAA4AAAIMhI+py+0Po5y02qsKADs=';
+
+bender.test( {
+	setUp: function() {
+		this.cloudservices = CKEDITOR.plugins.cloudservices;
+	},
+
+	'test plugin exposes loader': function() {
+		assert.isInstanceOf( Function, this.cloudservices.cloudSericesLoader, 'cloudServicesLoader property type' );
+	},
+
+	'test loader uses config url/token': function() {
+		var instance = new this.cloudservices.cloudSericesLoader( this.editor, mockBase64 ),
+			// Stub loader.xhr methods before it's actually called.
+			listener = this.editor.once( 'fileUploadRequest', this.commonRequestListener, null, null, 0 );
+
+		try {
+			instance.upload();
+
+			// Make sure that configured URL has been requested.
+			sinon.assert.calledWithExactly( instance.xhr.open, 'POST', 'cs_url', true );
+
+			// Make sure that proper header has been added.
+			sinon.assert.calledWithExactly( instance.xhr.setRequestHeader, 'Authorization', 'cs_token' );
+
+			assert.areSame( 1, instance.xhr.send.callCount, 'Call count' );
+		} catch ( e ) {
+			// Propagate.
+			throw e;
+		} finally {
+			// Always remove listener.
+			listener.removeListener();
+		}
+	},
+
+	'test loader allows url overriding': function() {
+		var instance = new this.cloudservices.cloudSericesLoader( this.editor, mockBase64 ),
+			// Stub loader.xhr methods before it's actually called.
+			listener = this.editor.once( 'fileUploadRequest', this.commonRequestListener, null, null, 0 );
+
+		try {
+			instance.upload( 'my_custom_url' );
+
+			sinon.assert.calledWithExactly( instance.xhr.open, 'POST', 'my_custom_url', true );
+
+			assert.areSame( 1, instance.xhr.send.callCount, 'Call count' );
+		} catch ( e ) {
+			// Propagate.
+			throw e;
+		} finally {
+			// Always remove listener.
+			listener.removeListener();
+		}
+	},
+
+	// Common fileUploadRequest listener reused by tests.
+	commonRequestListener: function( evt ) {
+		var loader = evt.data.fileLoader;
+
+		sinon.stub( loader.xhr, 'open' );
+		sinon.stub( loader.xhr, 'send' );
+		sinon.stub( loader.xhr, 'setRequestHeader' );
+	}
+} );

--- a/tests/plugins/cloudservices/unit.js
+++ b/tests/plugins/cloudservices/unit.js
@@ -15,11 +15,11 @@ bender.test( {
 	},
 
 	'test plugin exposes loader': function() {
-		assert.isInstanceOf( Function, this.cloudservices.cloudSericesLoader, 'cloudServicesLoader property type' );
+		assert.isInstanceOf( Function, this.cloudservices.cloudServicesLoader, 'cloudServicesLoader property type' );
 	},
 
 	'test loader uses config url/token': function() {
-		var instance = new this.cloudservices.cloudSericesLoader( this.editor, mockBase64 ),
+		var instance = new this.cloudservices.cloudServicesLoader( this.editor, mockBase64 ),
 			// Stub loader.xhr methods before it's actually called.
 			listener = this.editor.once( 'fileUploadRequest', this.commonRequestListener, null, null, 0 );
 
@@ -43,7 +43,7 @@ bender.test( {
 	},
 
 	'test loader allows url overriding': function() {
-		var instance = new this.cloudservices.cloudSericesLoader( this.editor, mockBase64 ),
+		var instance = new this.cloudservices.cloudServicesLoader( this.editor, mockBase64 ),
 			// Stub loader.xhr methods before it's actually called.
 			listener = this.editor.once( 'fileUploadRequest', this.commonRequestListener, null, null, 0 );
 

--- a/tests/plugins/cloudservices/unit.js
+++ b/tests/plugins/cloudservices/unit.js
@@ -62,6 +62,26 @@ bender.test( {
 		}
 	},
 
+	'test loader allows token overriding': function() {
+		var instance = new this.cloudservices.cloudServicesLoader( this.editor, mockBase64, null, 'different_token' ),
+			// Stub loader.xhr methods before it's actually called.
+			listener = this.editor.once( 'fileUploadRequest', this.commonRequestListener, null, null, 0 );
+
+		try {
+			instance.upload();
+
+			sinon.assert.calledWithExactly( instance.xhr.setRequestHeader, 'Authorization', 'different_token' );
+
+			assert.areSame( 1, instance.xhr.send.callCount, 'Call count' );
+		} catch ( e ) {
+			// Propagate.
+			throw e;
+		} finally {
+			// Always remove listener.
+			listener.removeListener();
+		}
+	},
+
 	// Common fileUploadRequest listener reused by tests.
 	commonRequestListener: function( evt ) {
 		var loader = evt.data.fileLoader;

--- a/tests/plugins/easyimage/tools.js
+++ b/tests/plugins/easyimage/tools.js
@@ -1,0 +1,30 @@
+/* bender-tags: editor,widget */
+/* bender-ckeditor-plugins: easyimage,toolbar */
+
+( function() {
+	'use strict';
+
+	bender.editor = true;
+
+	var tools;
+
+	bender.test( {
+		setUp: function() {
+			tools = CKEDITOR.plugins.easyimage;
+		},
+
+		'test _parseSrcSet function': function() {
+			var srcs = {
+					100: 'https://test/100',
+					243: 'https://tests/243',
+					404: 'http://tests/404',
+					600: 'http://tests/600'
+				},
+				srcset = 'https://test/100 100w, https://tests/243 243w, http://tests/404 404w, http://tests/600 600w';
+
+			srcs[ 'default' ] = 'http://test/default';
+
+			assert.areSame( srcset, tools._parseSrcSet( srcs ) );
+		}
+	} );
+} )();

--- a/tests/plugins/easyimage/uploadwidget.js
+++ b/tests/plugins/easyimage/uploadwidget.js
@@ -4,9 +4,9 @@
 /* bender-include: %BASE_PATH%/plugins/uploadfile/_helpers/waitForImage.js */
 /* global pasteFiles, waitForImage */
 
-'use strict';
-
 ( function() {
+	'use strict';
+
 	var uploadCount, loadAndUploadCount, resumeAfter, tests,
 		IMG_URL = '%BASE_PATH%_assets/logo.png',
 		DATA_IMG = 'data:',
@@ -50,6 +50,8 @@
 
 	CKEDITOR.on( 'instanceCreated', function() {
 		if ( !CKEDITOR.plugins.cloudservices.cloudServicesLoader.restore ) {
+			// Because of #1068 we can't provide loaderType directly. Instead we just replace cloudServicesLoader
+			// with our loader stub that is going to be customized in init method.
 			sinon.stub( CKEDITOR.plugins.cloudservices, 'cloudServicesLoader', CKEDITOR.fileTools.fileLoader );
 		}
 	} );
@@ -66,6 +68,8 @@
 
 			resumeAfter = bender.tools.resumeAfter;
 
+			// This tests suite could be made much prettier, it would require #1068 to be resolved. Then you
+			// could just use LoaderStub type with stubbed methods, rather than overwrite base FileLoader type.
 			CKEDITOR.fileTools.fileLoader.prototype.loadAndUpload = function() {
 				loadAndUploadCount++;
 
@@ -80,7 +84,8 @@
 				this.responseData = CKEDITOR.tools.clone( responseData );
 			};
 
-			// Further hacking, now stub can be safely removed, as it's used only in plugin.init, which has already been called.
+			// Now stub can be safely removed, as it's used only in plugin.init, which has already been called,
+			// this workaround could be removed once #1068 is fixed.
 			if ( CKEDITOR.plugins.cloudservices.cloudServicesLoader.restore ) {
 				CKEDITOR.plugins.cloudservices.cloudServicesLoader.restore();
 			}

--- a/tests/plugins/easyimage/uploadwidget.js
+++ b/tests/plugins/easyimage/uploadwidget.js
@@ -1,0 +1,446 @@
+/* bender-tags: editor,clipboard,widget */
+/* bender-ckeditor-plugins: easyimage,toolbar, */
+/* bender-include: %BASE_PATH%/plugins/clipboard/_helpers/pasting.js */
+/* bender-include: %BASE_PATH%/plugins/uploadfile/_helpers/waitForImage.js */
+/* global pasteFiles, waitForImage */
+
+'use strict';
+
+( function() {
+	var uploadCount, loadAndUploadCount, lastUploadUrl, resumeAfter, tests,
+		IMG_URL = '%BASE_PATH%_assets/logo.png',
+		DATA_IMG = 'data:',
+		BLOB_IMG = 'blob:';
+
+	bender.editors = {
+		classic: {
+			name: 'classic',
+			config: {
+				easyimageUploadUrl: 'http://foo/upload',
+				// Disable pasteFilter on Webkits (pasteFilter defaults semantic-text on Webkits).
+				pasteFilter: null
+			}
+		},
+
+		divarea: {
+			name: 'divarea',
+			config: {
+				extraPlugins: 'divarea',
+				easyimageUploadUrl: 'http://foo/upload',
+				// Disable pasteFilter on Webkits (pasteFilter defaults semantic-text on Webkits).
+				pasteFilter: null
+			}
+		},
+
+		inline: {
+			name: 'inline',
+			creator: 'inline',
+			config: {
+				easyimageUploadUrl: 'http://foo/upload',
+				// Disable pasteFilter on Webkits (pasteFilter defaults semantic-text on Webkits).
+				pasteFilter: null
+			}
+		}
+	};
+
+	function assertUploadingWidgets( editor, expectedSrc ) {
+		var widgets = editor.editable().find( 'img[data-widget="uploadeasyimage"]' ),
+			widget, i;
+
+		assert.areSame( 1, widgets.count(), 'Expected widgets count should be 1' );
+
+		for ( i = 0; i < widgets.count(); i++ ) {
+			widget = widgets.getItem( i );
+			assert.areSame( '0', widget.getAttribute( 'data-cke-upload-id' ) );
+			assert.areSame( expectedSrc, widget.getAttribute( 'src' ).substring( 0, 5 ) );
+		}
+	}
+
+	tests = {
+		init: function() {
+			var responseData = {
+				response: {
+					100: IMG_URL,
+					200: IMG_URL
+				}
+			};
+
+			responseData[ 'default' ] = IMG_URL;
+			resumeAfter = bender.tools.resumeAfter;
+
+			CKEDITOR.fileTools.fileLoader.prototype.loadAndUpload = function( url ) {
+				loadAndUploadCount++;
+				lastUploadUrl = url;
+
+				this.responseData = CKEDITOR.tools.clone( responseData );
+			};
+
+			CKEDITOR.fileTools.fileLoader.prototype.load = function() {};
+
+			CKEDITOR.fileTools.fileLoader.prototype.upload = function( url ) {
+				uploadCount++;
+				lastUploadUrl = url;
+
+				this.responseData = CKEDITOR.tools.clone( responseData );
+			};
+		},
+
+		setUp: function() {
+			if ( !CKEDITOR.plugins.clipboard.isFileApiSupported ) {
+				assert.ignore();
+			}
+
+			var editorName;
+
+			uploadCount = 0;
+			loadAndUploadCount = 0;
+
+			for ( editorName in this.editors ) {
+				// Clear upload repository.
+				this.editors[ editorName ].uploadRepository.loaders = [];
+			}
+
+			if ( CKEDITOR.fileTools.bindNotifications.reset ) {
+				CKEDITOR.fileTools.bindNotifications.reset();
+			}
+		},
+
+		'test classic with easyimage (integration test)': function( editor ) {
+			pasteFiles( editor, [ bender.tools.getTestPngFile() ] );
+
+			assertUploadingWidgets( editor, DATA_IMG );
+			assert.areSame( '', editor.getData(), 'getData on loading.' );
+
+			var loader = editor.uploadRepository.loaders[ 0 ];
+
+			loader.data = bender.tools.pngBase64;
+			loader.uploadTotal = 10;
+			loader.changeStatus( 'uploading' );
+
+			assertUploadingWidgets( editor, BLOB_IMG );
+			assert.areSame( '', editor.getData(), 'getData on uploading.' );
+
+			var image = editor.editable().find( 'img[data-widget="uploadeasyimage"]' ).getItem( 0 );
+
+			waitForImage( image, function() {
+				loader.url = IMG_URL;
+				loader.changeStatus( 'uploaded' );
+
+				assert.sameData( '<p><img alt="" src="' + IMG_URL + '" /></p>', editor.getData() );
+				assert.areSame( 1, editor.editable().find( 'img[data-widget="image"]' ).count() );
+
+				assert.areSame( 1, loadAndUploadCount );
+				assert.areSame( 0, uploadCount );
+				assert.areSame( 'http://foo/upload', lastUploadUrl );
+			} );
+		},
+
+		'test paste img as html (integration test)': function( editor, bot ) {
+			bot.setData( '', function() {
+				pasteFiles( editor, [], '<p>x<img src="' + bender.tools.pngBase64 + '">x</p>' );
+
+				assertUploadingWidgets( editor, DATA_IMG );
+				assert.areSame( '<p>xx</p>', editor.getData(), 'getData on loading.' );
+
+				var loader = editor.uploadRepository.loaders[ 0 ];
+
+				loader.data = bender.tools.pngBase64;
+				loader.changeStatus( 'uploading' );
+
+				assertUploadingWidgets( editor, BLOB_IMG );
+				assert.areSame( '<p>xx</p>', editor.getData(), 'getData on uploading.' );
+
+				var image = editor.editable().find( 'img[data-widget="uploadeasyimage"]' ).getItem( 0 );
+
+				waitForImage( image, function() {
+					loader.url = IMG_URL;
+					loader.changeStatus( 'uploaded' );
+
+					assert.sameData( '<p>x<img alt="" src="' + IMG_URL + '" />x</p>', editor.getData() );
+					assert.areSame( 1, editor.editable().find( 'img[data-widget="image"]' ).count() );
+
+					assert.areSame( 0, loadAndUploadCount );
+					assert.areSame( 1, uploadCount );
+					assert.areSame( 'http://foo/upload', lastUploadUrl );
+				} );
+			} );
+		},
+
+		'test supportedTypes png': function( editor, bot ) {
+			bot.setData( '', function() {
+				resumeAfter( editor, 'paste', function() {
+					assertUploadingWidgets( editor, DATA_IMG );
+				} );
+
+				pasteFiles( editor, [ { name: 'test.png', type: 'image/png' } ] );
+
+				wait();
+			} );
+		},
+
+		'test supportedTypes jpg': function( editor, bot ) {
+			bot.setData( '', function() {
+				resumeAfter( editor, 'paste', function() {
+					assertUploadingWidgets( editor, DATA_IMG );
+				} );
+
+				pasteFiles( editor, [ { name: 'test.jpg', type: 'image/jpeg' } ] );
+
+				wait();
+			} );
+		},
+
+		'test supportedTypes gif': function( editor, bot ) {
+			bot.setData( '', function() {
+				resumeAfter( editor, 'paste', function() {
+					assertUploadingWidgets( editor, DATA_IMG );
+				} );
+
+				pasteFiles( editor, [ { name: 'test.gif', type: 'image/gif' } ] );
+
+				wait();
+			} );
+		},
+
+		'test supportedTypes bmp': function( editor, bot ) {
+			bot.setData( '', function() {
+				resumeAfter( editor, 'paste', function() {
+					assertUploadingWidgets( editor, DATA_IMG );
+				} );
+
+				pasteFiles( editor, [ { name: 'test.bmp', type: 'image/bmp' } ] );
+
+				wait();
+			} );
+		},
+
+		'test not supportedTypes tiff': function( editor, bot ) {
+			bot.setData( '', function() {
+				resumeAfter( editor, 'paste', function() {
+					assert.areSame( 0, editor.editable().find( 'img[data-widget="uploadeasyimage"]' ).count() );
+				} );
+
+				pasteFiles( editor, [ { name: 'test.tiff', type: 'image/tiff' } ] );
+
+				wait();
+			} );
+		},
+
+		'test paste single image': function( editor ) {
+			resumeAfter( editor, 'paste', function( evt ) {
+				var img = CKEDITOR.dom.element.createFromHtml( evt.data.dataValue );
+
+				assert.areSame( '0', img.getAttribute( 'data-cke-upload-id' ) );
+				assert.areSame( 'uploadeasyimage', img.getAttribute( 'data-widget' ) );
+
+				assert.areSame( 0, loadAndUploadCount );
+				assert.areSame( 1, uploadCount );
+			} );
+
+			editor.fire( 'paste', {
+				dataValue: '<img src="' + bender.tools.pngBase64 + '">'
+			} );
+
+			wait();
+		},
+
+		'test paste nested image': function( editor ) {
+			resumeAfter( editor, 'paste', function( evt ) {
+				var imgs = CKEDITOR.dom.element.createFromHtml( evt.data.dataValue ).find( 'img[data-widget="uploadeasyimage"]' ),
+					img, i;
+
+				assert.areSame( 2, imgs.count(), 'Expected imgs count should be 2' );
+
+				for ( i = 0; i < imgs.count(); i++ ) {
+					img = imgs.getItem( i );
+					assert.areSame( i + '', img.getAttribute( 'data-cke-upload-id' ) );
+				}
+
+				assert.areSame( 0, loadAndUploadCount );
+				assert.areSame( 2, uploadCount );
+			} );
+
+			editor.fire( 'paste', {
+				dataValue: '<div>x<img src="' + bender.tools.pngBase64 + '">x' +
+							'<p>x<img src="' + bender.tools.pngBase64 + '">x</p></div>'
+			} );
+
+			wait();
+		},
+
+		'test paste no image': function( editor ) {
+			resumeAfter( editor, 'paste', function( evt ) {
+				assert.areSame( 'foo', evt.data.dataValue );
+
+				assert.areSame( 0, loadAndUploadCount );
+				assert.areSame( 0, uploadCount );
+			} );
+
+			editor.fire( 'paste', {
+				dataValue: 'foo'
+			} );
+
+			wait();
+		},
+
+		'test paste no data in image': function( editor ) {
+			resumeAfter( editor, 'paste', function( evt ) {
+				var img = CKEDITOR.dom.element.createFromHtml( evt.data.dataValue );
+
+				assert.isNull( img.getAttribute( 'data-cke-upload-id' ) );
+				assert.isNull( img.getAttribute( 'data-widget' ) );
+
+				assert.areSame( 0, loadAndUploadCount );
+				assert.areSame( 0, uploadCount );
+			} );
+
+			editor.fire( 'paste', {
+				dataValue: '<img src="' + IMG_URL + '">'
+			} );
+
+			wait();
+		},
+
+		'test paste image already marked': function( editor ) {
+			var uploads = editor.uploadRepository;
+
+			resumeAfter( editor, 'paste', function( evt ) {
+				var img = CKEDITOR.dom.element.createFromHtml( evt.data.dataValue );
+
+				assert.areSame( '0', img.getAttribute( 'data-cke-upload-id' ) );
+				assert.areSame( 'uploadeasyimage', img.getAttribute( 'data-widget' ) );
+
+				assert.areSame( 0, loadAndUploadCount );
+				assert.areSame( 0, uploadCount );
+			} );
+
+			// Fill upload repository.
+			uploads.create( bender.tools.getTestPngFile() );
+
+			editor.fire( 'paste', {
+				dataValue: '<img src="' + bender.tools.pngBase64 + '" data-widget="uploadeasyimage" data-cke-upload-id="0">'
+			} );
+
+			wait();
+		},
+
+		'test omit images in non contentEditable': function( editor ) {
+			resumeAfter( editor, 'paste', function( evt ) {
+				var img = CKEDITOR.dom.element.createFromHtml( evt.data.dataValue ).findOne( 'img' );
+
+				assert.isNull( img.getAttribute( 'data-cke-upload-id' ) );
+				assert.isNull( img.getAttribute( 'data-widget' ) );
+
+				assert.areSame( 0, loadAndUploadCount );
+				assert.areSame( 0, uploadCount );
+			} );
+
+			editor.fire( 'paste', {
+				dataValue:
+					'<div contentEditable="false">' +
+						'<img src="' + bender.tools.pngBase64 + '">' +
+					'</div>'
+			} );
+
+			wait();
+		},
+
+		'test handle images in nested editable': function( editor ) {
+			resumeAfter( editor, 'paste', function( evt ) {
+				var img = CKEDITOR.dom.element.createFromHtml( evt.data.dataValue ).findOne( 'img' );
+
+				assert.areSame( '0', img.getAttribute( 'data-cke-upload-id' ) );
+				assert.areSame( 'uploadeasyimage', img.getAttribute( 'data-widget' ) );
+
+				assert.areSame( 0, loadAndUploadCount );
+				assert.areSame( 1, uploadCount );
+			} );
+
+			editor.fire( 'paste', {
+				dataValue:
+					'<div contentEditable="false">' +
+						'<div contentEditable="true">' +
+							'<img src="' + bender.tools.pngBase64 + '">' +
+						'</div>' +
+					'</div>'
+			} );
+
+			wait();
+		},
+
+		'test handle images in nested editable using cke-editable': function( editor ) {
+			resumeAfter( editor, 'paste', function( evt ) {
+				var img = CKEDITOR.dom.element.createFromHtml( evt.data.dataValue ).findOne( 'img' );
+
+				assert.areSame( '0', img.getAttribute( 'data-cke-upload-id' ) );
+				assert.areSame( 'uploadeasyimage', img.getAttribute( 'data-widget' ) );
+
+				assert.areSame( 0, loadAndUploadCount );
+				assert.areSame( 1, uploadCount );
+			} );
+
+			editor.fire( 'paste', {
+				dataValue:
+					'<div contentEditable="false">' +
+						'<div data-cke-editable="1">' +
+							'<img src="' + bender.tools.pngBase64 + '">' +
+						'</div>' +
+					'</div>'
+			} );
+
+			wait();
+		},
+
+		'test bindNotifications when paste image': function( editor ) {
+			CKEDITOR.fileTools.bindNotifications = sinon.spy();
+
+			resumeAfter( editor, 'paste', function() {
+				var spy = CKEDITOR.fileTools.bindNotifications;
+				assert.areSame( 1, spy.callCount );
+				assert.isTrue( spy.calledWith( editor ) );
+				assert.areSame( bender.tools.pngBase64, spy.firstCall.args[ 1 ].data );
+			} );
+
+			editor.fire( 'paste', {
+				dataValue: '<img src="' + bender.tools.pngBase64 + '">'
+			} );
+
+			wait();
+		},
+
+		'test XSS attack': function( editor ) {
+			window.attacked = sinon.spy();
+
+			editor.fire( 'paste', {
+				dataValue: '<img src="x" onerror="window.attacked();">' + bender.tools.pngBase64
+			} );
+
+			editor.once( 'afterPaste', function() {
+				resume( function() {
+					assert.areSame( 0, window.attacked.callCount );
+				} );
+			} );
+
+			wait();
+		},
+
+		'test prevent upload fake elements (http://dev.ckeditor.com/ticket/13003)': function( editor ) {
+			var createspy = sinon.spy( editor.uploadRepository, 'create' );
+
+			editor.fire( 'paste', {
+				dataValue: '<img src="data:image/gif;base64,aw==" alt="nothing" data-cke-realelement="some" />'
+			} );
+
+			editor.once( 'afterPaste', function() {
+				resume( function() {
+					assert.isTrue( createspy.notCalled );
+				} );
+			} );
+
+			wait();
+		}
+	};
+
+	tests = bender.tools.createTestsForEditors( CKEDITOR.tools.objectKeys( bender.editors ), tests );
+	bender.test( tests );
+} )();

--- a/tests/plugins/easyimage/uploadwidget.js
+++ b/tests/plugins/easyimage/uploadwidget.js
@@ -69,11 +69,10 @@
 
 			CKEDITOR.plugins.cloudservices.cloudServicesLoader.prototype.load = function() {};
 
-			CKEDITOR.plugins.cloudservices.cloudServicesLoader.prototype.upload = function() {
+			sinon.stub( CKEDITOR.plugins.cloudservices.cloudServicesLoader.prototype, 'upload', function() {
 				uploadCount++;
-
 				this.responseData = CKEDITOR.tools.clone( responseData );
-			};
+			} );
 		},
 
 		setUp: function() {
@@ -93,6 +92,10 @@
 
 			if ( CKEDITOR.fileTools.bindNotifications.reset ) {
 				CKEDITOR.fileTools.bindNotifications.reset();
+			}
+
+			if ( CKEDITOR.plugins.cloudservices.cloudServicesLoader.prototype.upload.reset ) {
+				CKEDITOR.plugins.cloudservices.cloudServicesLoader.prototype.upload.reset();
 			}
 		},
 
@@ -424,6 +427,30 @@
 				resume( function() {
 					assert.isTrue( createspy.notCalled );
 				} );
+			} );
+
+			wait();
+		},
+
+		'test cloudservices URL can be customized': function( editor ) {
+			var originalUploadUrl = editor.widgets.registered.uploadeasyimage.uploadUrl,
+				loader;
+
+			// Upload widget might have an uploadUrl changed in definition, allowing for upload URL customization.
+			editor.widgets.registered.uploadeasyimage.uploadUrl = 'https://customDomain.localhost/endpoint';
+
+			resumeAfter( editor, 'paste', function() {
+				// Restore original value.
+				editor.widgets.registered.uploadeasyimage.uploadUrl = originalUploadUrl;
+
+				loader = editor.uploadRepository.loaders[ 0 ];
+
+				sinon.assert.calledWith( loader.upload, 'https://customDomain.localhost/endpoint' );
+				assert.isTrue( true );
+			} );
+
+			editor.fire( 'paste', {
+				dataValue: '<img src="' + bender.tools.pngBase64 + '">'
 			} );
 
 			wait();

--- a/tests/plugins/easyimage/uploadwidget.js
+++ b/tests/plugins/easyimage/uploadwidget.js
@@ -53,11 +53,11 @@
 			var responseData = {
 				response: {
 					100: IMG_URL,
-					200: IMG_URL,
-					default: IMG_URL
+					200: IMG_URL
 				}
 			};
 
+			responseData.response[ 'default' ] = IMG_URL;
 			resumeAfter = bender.tools.resumeAfter;
 
 			// Approach taken from tests/plugins/uploadwidget/uploadwidget.js test.

--- a/tests/plugins/easyimage/uploadwidget.js
+++ b/tests/plugins/easyimage/uploadwidget.js
@@ -16,7 +16,7 @@
 		classic: {
 			name: 'classic',
 			config: {
-				easyimageUploadUrl: 'http://foo/upload',
+				cloudServices_url: 'http://foo/upload',
 				// Disable pasteFilter on Webkits (pasteFilter defaults semantic-text on Webkits).
 				pasteFilter: null
 			}
@@ -26,7 +26,7 @@
 			name: 'divarea',
 			config: {
 				extraPlugins: 'divarea',
-				easyimageUploadUrl: 'http://foo/upload',
+				cloudServices_url: 'http://foo/upload',
 				// Disable pasteFilter on Webkits (pasteFilter defaults semantic-text on Webkits).
 				pasteFilter: null
 			}
@@ -36,7 +36,7 @@
 			name: 'inline',
 			creator: 'inline',
 			config: {
-				easyimageUploadUrl: 'http://foo/upload',
+				cloudServices_url: 'http://foo/upload',
 				// Disable pasteFilter on Webkits (pasteFilter defaults semantic-text on Webkits).
 				pasteFilter: null
 			}
@@ -56,16 +56,22 @@
 		}
 	}
 
+	CKEDITOR.on( 'instanceCreated', function() {
+		if ( !CKEDITOR.plugins.cloudservices.cloudServicesLoader.restore ) {
+			sinon.stub( CKEDITOR.plugins.cloudservices, 'cloudServicesLoader', CKEDITOR.fileTools.fileLoader );
+		}
+	} );
+
 	tests = {
 		init: function() {
 			var responseData = {
 				response: {
 					100: IMG_URL,
-					200: IMG_URL
+					200: IMG_URL,
+					default: IMG_URL
 				}
 			};
 
-			responseData[ 'default' ] = IMG_URL;
 			resumeAfter = bender.tools.resumeAfter;
 
 			CKEDITOR.fileTools.fileLoader.prototype.loadAndUpload = function( url ) {
@@ -83,6 +89,11 @@
 
 				this.responseData = CKEDITOR.tools.clone( responseData );
 			};
+
+			// Further hacking, now stub can be safely removed, as it's used only in plugin.init, which has already been called.
+			if ( CKEDITOR.plugins.cloudservices.cloudServicesLoader.restore ) {
+				CKEDITOR.plugins.cloudservices.cloudServicesLoader.restore();
+			}
 		},
 
 		setUp: function() {

--- a/tests/plugins/easyimage/uploadwidget.js
+++ b/tests/plugins/easyimage/uploadwidget.js
@@ -10,36 +10,28 @@
 	var uploadCount, loadAndUploadCount, resumeAfter, tests,
 		IMG_URL = '%BASE_PATH%_assets/logo.png',
 		DATA_IMG = 'data:',
-		BLOB_IMG = 'blob:';
+		BLOB_IMG = 'blob:',
+		commonConfig = {
+			cloudServices_url: 'http://foo/upload',
+			// Disable pasteFilter on Webkits (pasteFilter defaults semantic-text on Webkits).
+			pasteFilter: null
+		};
 
 	bender.editors = {
 		classic: {
 			name: 'classic',
-			config: {
-				cloudServices_url: 'http://foo/upload',
-				// Disable pasteFilter on Webkits (pasteFilter defaults semantic-text on Webkits).
-				pasteFilter: null
-			}
+			config: commonConfig
 		},
 
 		divarea: {
 			name: 'divarea',
-			config: {
-				extraPlugins: 'divarea',
-				cloudServices_url: 'http://foo/upload',
-				// Disable pasteFilter on Webkits (pasteFilter defaults semantic-text on Webkits).
-				pasteFilter: null
-			}
+			config: CKEDITOR.tools.extend( { extraPlugins: 'divarea' }, commonConfig )
 		},
 
 		inline: {
 			name: 'inline',
 			creator: 'inline',
-			config: {
-				cloudServices_url: 'http://foo/upload',
-				// Disable pasteFilter on Webkits (pasteFilter defaults semantic-text on Webkits).
-				pasteFilter: null
-			}
+			config: commonConfig
 		}
 	};
 

--- a/tests/plugins/easyimage/uploadwidget.js
+++ b/tests/plugins/easyimage/uploadwidget.js
@@ -120,8 +120,8 @@
 				assert.sameData( '<p><img alt="" src="' + IMG_URL + '" /></p>', editor.getData() );
 				assert.areSame( 1, editor.editable().find( 'img[data-widget="image"]' ).count() );
 
-				assert.areSame( 1, loadAndUploadCount );
-				assert.areSame( 0, uploadCount );
+				assert.areSame( 0, loadAndUploadCount );
+				assert.areSame( 1, uploadCount );
 			} );
 		},
 

--- a/tests/plugins/easyimage/uploadwidget.js
+++ b/tests/plugins/easyimage/uploadwidget.js
@@ -48,14 +48,6 @@
 		}
 	}
 
-	CKEDITOR.on( 'instanceCreated', function() {
-		if ( !CKEDITOR.plugins.cloudservices.cloudServicesLoader.restore ) {
-			// Because of #1068 we can't provide loaderType directly. Instead we just replace cloudServicesLoader
-			// with our loader stub that is going to be customized in init method.
-			sinon.stub( CKEDITOR.plugins.cloudservices, 'cloudServicesLoader', CKEDITOR.fileTools.fileLoader );
-		}
-	} );
-
 	tests = {
 		init: function() {
 			var responseData = {
@@ -68,27 +60,20 @@
 
 			resumeAfter = bender.tools.resumeAfter;
 
-			// This tests suite could be made much prettier, it would require #1068 to be resolved. Then you
-			// could just use LoaderStub type with stubbed methods, rather than overwrite base FileLoader type.
-			CKEDITOR.fileTools.fileLoader.prototype.loadAndUpload = function() {
+			// Approach taken from tests/plugins/uploadwidget/uploadwidget.js test.
+			CKEDITOR.plugins.cloudservices.cloudServicesLoader.prototype.loadAndUpload = function() {
 				loadAndUploadCount++;
 
 				this.responseData = CKEDITOR.tools.clone( responseData );
 			};
 
-			CKEDITOR.fileTools.fileLoader.prototype.load = function() {};
+			CKEDITOR.plugins.cloudservices.cloudServicesLoader.prototype.load = function() {};
 
-			CKEDITOR.fileTools.fileLoader.prototype.upload = function() {
+			CKEDITOR.plugins.cloudservices.cloudServicesLoader.prototype.upload = function() {
 				uploadCount++;
 
 				this.responseData = CKEDITOR.tools.clone( responseData );
 			};
-
-			// Now stub can be safely removed, as it's used only in plugin.init, which has already been called,
-			// this workaround could be removed once #1068 is fixed.
-			if ( CKEDITOR.plugins.cloudservices.cloudServicesLoader.restore ) {
-				CKEDITOR.plugins.cloudservices.cloudServicesLoader.restore();
-			}
 		},
 
 		setUp: function() {

--- a/tests/plugins/easyimage/uploadwidget.js
+++ b/tests/plugins/easyimage/uploadwidget.js
@@ -11,6 +11,9 @@
 		IMG_URL = '%BASE_PATH%_assets/logo.png',
 		DATA_IMG = 'data:',
 		BLOB_IMG = 'blob:',
+		WIDGET_HTML = '<figure class="easyimage">' +
+				'<img src="' + IMG_URL + '" srcset="' + IMG_URL + ' 100w, ' + IMG_URL + ' 200w" />' +
+			'</figure>',
 		commonConfig = {
 			cloudServices_url: 'http://foo/upload',
 			// Disable pasteFilter on Webkits (pasteFilter defaults semantic-text on Webkits).
@@ -120,8 +123,8 @@
 				loader.url = IMG_URL;
 				loader.changeStatus( 'uploaded' );
 
-				assert.sameData( '<p><img alt="" src="' + IMG_URL + '" /></p>', editor.getData() );
-				assert.areSame( 1, editor.editable().find( 'img[data-widget="image"]' ).count() );
+				assert.sameData( WIDGET_HTML, editor.getData() );
+				assert.areSame( 1, editor.editable().find( '[data-widget="easyimage"]' ).count(), 'dupa' );
 
 				assert.areSame( 0, loadAndUploadCount );
 				assert.areSame( 1, uploadCount );
@@ -149,8 +152,9 @@
 					loader.url = IMG_URL;
 					loader.changeStatus( 'uploaded' );
 
-					assert.sameData( '<p>x<img alt="" src="' + IMG_URL + '" />x</p>', editor.getData() );
-					assert.areSame( 1, editor.editable().find( 'img[data-widget="image"]' ).count() );
+					assert.sameData( '<p>x</p>' + WIDGET_HTML + '<p>x</p>',
+					editor.getData() );
+					assert.areSame( 1, editor.editable().find( '[data-widget="easyimage"]' ).count() );
 
 					assert.areSame( 0, loadAndUploadCount );
 					assert.areSame( 1, uploadCount );

--- a/tests/plugins/easyimage/uploadwidget.js
+++ b/tests/plugins/easyimage/uploadwidget.js
@@ -7,7 +7,7 @@
 'use strict';
 
 ( function() {
-	var uploadCount, loadAndUploadCount, lastUploadUrl, resumeAfter, tests,
+	var uploadCount, loadAndUploadCount, resumeAfter, tests,
 		IMG_URL = '%BASE_PATH%_assets/logo.png',
 		DATA_IMG = 'data:',
 		BLOB_IMG = 'blob:';
@@ -74,18 +74,16 @@
 
 			resumeAfter = bender.tools.resumeAfter;
 
-			CKEDITOR.fileTools.fileLoader.prototype.loadAndUpload = function( url ) {
+			CKEDITOR.fileTools.fileLoader.prototype.loadAndUpload = function() {
 				loadAndUploadCount++;
-				lastUploadUrl = url;
 
 				this.responseData = CKEDITOR.tools.clone( responseData );
 			};
 
 			CKEDITOR.fileTools.fileLoader.prototype.load = function() {};
 
-			CKEDITOR.fileTools.fileLoader.prototype.upload = function( url ) {
+			CKEDITOR.fileTools.fileLoader.prototype.upload = function() {
 				uploadCount++;
-				lastUploadUrl = url;
 
 				this.responseData = CKEDITOR.tools.clone( responseData );
 			};
@@ -142,7 +140,6 @@
 
 				assert.areSame( 1, loadAndUploadCount );
 				assert.areSame( 0, uploadCount );
-				assert.areSame( 'http://foo/upload', lastUploadUrl );
 			} );
 		},
 
@@ -172,7 +169,6 @@
 
 					assert.areSame( 0, loadAndUploadCount );
 					assert.areSame( 1, uploadCount );
-					assert.areSame( 'http://foo/upload', lastUploadUrl );
 				} );
 			} );
 		},

--- a/tests/plugins/easyimage/uploadwidget.js
+++ b/tests/plugins/easyimage/uploadwidget.js
@@ -472,7 +472,7 @@
 
 			LoaderSubclass.prototype = CKEDITOR.tools.extend( {}, CloudServicesLoader.prototype );
 
-			// Upload widget might have an uploadUrl changed in definition, allowing for upload URL customization.
+			// Upload widget might have a loaderType changed in definition, allowing for loader type customization.
 			uploadEasyImageDef.loaderType = LoaderSubclass;
 
 			resumeAfter( editor, 'paste', function() {

--- a/tests/plugins/easyimage/widget.html
+++ b/tests/plugins/easyimage/widget.html
@@ -11,3 +11,8 @@
 		<figcaption>Figure without image</figcaption>
 	</figure>
 </div>
+
+<div id="mixedImgs">
+	<img src="../image2/_assets/foo.png" srcset="../image2/_assets/foo.png 100w, ../image2/_assets/foo.png 200w" alt="fig1">
+	<img src="../image2/_assets/foo.png" alt="fig1">
+</div>

--- a/tests/plugins/easyimage/widget.js
+++ b/tests/plugins/easyimage/widget.js
@@ -28,13 +28,34 @@
 	};
 
 	var tests = {
-		'test upcasting image widget': function( editor, bot ) {
+		'test upcasting image widget (figure)': function( editor, bot ) {
 			widgetTestsTools.assertWidget( {
 				count: editor.name === 'classicAllFigures' ? 2 : 1,
 				widgetOffset: 0,
 				nameCreated: 'easyimage',
 				html: CKEDITOR.document.getById( 'mixedFigures' ).getHtml(),
 				bot: bot
+			} );
+		},
+
+		'test upcasting image widget (img)': function( editor, bot ) {
+			widgetTestsTools.assertWidget( {
+				count: 1,
+				widgetOffset: 0,
+				nameCreated: 'easyimage',
+				html: CKEDITOR.document.getById( 'mixedImgs' ).getHtml(),
+				bot: bot,
+				assertCreated: function( widget ) {
+					var element = widget.element;
+
+					assert.areSame( 'figure', element.getName(), 'img is wrapped in figure' );
+
+					if ( editor.name !== 'classicAllFigures' ) {
+						assert.isTrue( element.hasClass( 'easyimage' ), 'figure has appropriate class' );
+					} else {
+						assert.isFalse( element.hasClass( 'easyimage' ), 'figure does not have class' );
+					}
+				}
 			} );
 		}
 	};

--- a/tests/plugins/filetools/filetools.js
+++ b/tests/plugins/filetools/filetools.js
@@ -133,6 +133,15 @@
 			assert.isUndefined( repository.loaders[ 2 ] );
 		},
 
+		'test UploadRepository.create allows changing fileLoader type': function() {
+			function CustomType() {
+			}
+
+			var repository = this.editor.uploadRepository,
+				loader = repository.create( { name: 'name' }, undefined, CustomType );
+
+			assert.isInstanceOf( CustomType, loader, 'Returned loader type' );
+		},
 
 		'test UploadRepository instanceCreated event': function() {
 			var repository = this.editor.uploadRepository,

--- a/tests/plugins/uploadfile/_helpers/waitForImage.js
+++ b/tests/plugins/uploadfile/_helpers/waitForImage.js
@@ -5,7 +5,7 @@ function waitForImage( image, callback ) {
 	if ( CKEDITOR.env.ie ) {
 		wait( callback, 100 );
 	} else {
-		image.on( 'load', function() {
+		image.once( 'load', function() {
 			resume( callback );
 		} );
 		wait();

--- a/tests/plugins/uploadwidget/uploadwidget.js
+++ b/tests/plugins/uploadwidget/uploadwidget.js
@@ -507,6 +507,28 @@
 			wait();
 		},
 
+		'test custom def.loaderType': function() {
+			var editor = mockEditorForPaste(),
+				uploadStub = sinon.stub();
+
+			function CustomLoaderType() {
+				this.upload = uploadStub;
+			}
+
+			addTestUploadWidget( editor, 'loadMethodLoad', {
+				loaderType: CustomLoaderType,
+				loadMethod: 'upload'
+			} );
+
+			resumeAfter( editor, 'paste', function() {
+				assert.areSame( 1, uploadStub.callCount, 'CustomLoaderType.upload call count' );
+			} );
+
+			pasteFiles( editor, [ bender.tools.getTestPngFile( 'test1.png' ) ] );
+
+			wait();
+		},
+
 		'test paste multiple files': function() {
 			var editor = mockEditorForPaste();
 

--- a/tests/plugins/uploadwidget/uploadwidget.js
+++ b/tests/plugins/uploadwidget/uploadwidget.js
@@ -515,7 +515,7 @@
 				this.upload = uploadStub;
 			}
 
-			addTestUploadWidget( editor, 'loadMethodLoad', {
+			addTestUploadWidget( editor, 'customLoaderType', {
 				loaderType: CustomLoaderType,
 				loadMethod: 'upload'
 			} );


### PR DESCRIPTION
## What is the purpose of this pull request?

New feature

## Does your PR contain necessary tests?

All patches which change the editor code must include tests. You can always read more
on [PR testing](http://docs.ckeditor.com/#!/guide/dev_contributing_code-section-tests),
[how to set the testing environment](http://docs.ckeditor.com/#!/guide/dev_tests) and
[how to create tests](http://docs.ckeditor.com/#!/guide/dev_tests-section-creating-your-own-test)
in the official CKEditor documentation.

### This PR contains

- [x] Unit tests
- [ ] Manual tests

## What changes did you make?

I've introduced upload widget for easy image, based on existing `uploadimage` widget.

Currently information about easy image is passed as additional request parameters to `fileUploadRequest` and `fileLoader`'s property to `fileUploadResponse`. Additionally there is some code duplication between `uploadimage` and current widget (especially whole handling of pasting images, which is just copied).

There is also WIP `[srcset]` support, waiting for dedicated image plugin to be fully functional.