### PR TITLE
Cloud Services file loader

### DIFF
--- a/plugins/cloudservices/plugin.js
+++ b/plugins/cloudservices/plugin.js
@@ -1,3 +1,8 @@
+/**
+ * @license Copyright (c) 2003-2017, CKSource - Frederico Knabben. All rights reserved.
+ * For licensing, see LICENSE.md or http://ckeditor.com/license
+ */
+
 ( function() {
 	'use strict';
 

--- a/plugins/cloudservices/plugin.js
+++ b/plugins/cloudservices/plugin.js
@@ -22,11 +22,11 @@
 			 * @class CKEDITOR.plugins.cloudservices.cloudServicesLoader
 			 * @extends CKEDITOR.fileTools.fileLoader
 			 */
-			function cloudServicesLoader( editor, fileOrData, fileName ) {
+			function CloudServicesLoader( editor, fileOrData, fileName ) {
 				FileLoader.call( this, editor, fileOrData, fileName );
 			}
 
-			cloudServicesLoader.prototype = CKEDITOR.tools.extend( {}, FileLoader.prototype );
+			CloudServicesLoader.prototype = CKEDITOR.tools.extend( {}, FileLoader.prototype );
 
 			/**
 			 * @inheritdoc
@@ -34,7 +34,7 @@
 			 * @param {Object} [additionalRequestParameters] Additional data that would be passed to the
 			 * {@link CKEDITOR.editor#fileUploadRequest} event.
 			 */
-			cloudServicesLoader.prototype.upload = function( url, additionalRequestParameters ) {
+			CloudServicesLoader.prototype.upload = function( url, additionalRequestParameters ) {
 				url = url || this.editor.config.cloudServices_url;
 
 				FileLoader.prototype.upload.call( this, url, additionalRequestParameters );
@@ -48,7 +48,7 @@
 			 * the {@link CKEDITOR.editor#fileUploadRequest} event.
 			*/
 
-			CKEDITOR.plugins.cloudservices.cloudServicesLoader = cloudServicesLoader;
+			CKEDITOR.plugins.cloudservices.cloudServicesLoader = CloudServicesLoader;
 		},
 
 		beforeInit: function( editor ) {

--- a/plugins/cloudservices/plugin.js
+++ b/plugins/cloudservices/plugin.js
@@ -1,0 +1,70 @@
+( function() {
+	'use strict';
+
+	CKEDITOR.plugins.add( 'cloudservices', {
+		requires: 'filetools',
+		onLoad: function() {
+			var FileLoader = CKEDITOR.fileTools.fileLoader;
+
+			/**
+			 * Dedicated uploader for [Cloud Services](https://ckeditor.com/ckeditor-cloud-services/).
+			 *
+			 * @since 4.8.0
+			 * @class CKEDITOR.plugins.cloudservices.fileLoader
+			 * @extends CKEDITOR.fileTools.fileLoader
+			 */
+			function CloudSericesLoader( editor, fileOrData, fileName ) {
+				FileLoader.call( this, editor, fileOrData, fileName );
+			}
+
+			CloudSericesLoader.prototype = CKEDITOR.tools.extend( {}, FileLoader.prototype );
+
+			// CloudSericesLoader.prototype.attachRequestListeners = function() {
+			// 	FileLoader.prototype.attachRequestListeners.call( this );
+
+			// 	this.xhr.setRequestHeader( 'Authorization', this.editor.config.easyimage_token );
+			// };
+
+			CKEDITOR.plugins.cloudservices.fileLoader = CloudSericesLoader;
+		},
+
+		beforeInit: function( editor ) {
+			editor.on( 'fileUploadRequest', function( evt ) {
+				var fileLoader = evt.data.fileLoader,
+					reqData = evt.data.requestData;
+
+				if ( fileLoader instanceof CKEDITOR.plugins.cloudservices.fileLoader ) {
+					// Cloud Services expect file to be put as a "file" property.
+					reqData.file = reqData.upload;
+					delete reqData.upload;
+
+					// Add authorization token.
+					evt.data.fileLoader.xhr.setRequestHeader( 'Authorization', editor.config.easyimage_token );
+				}
+			}, null, null, 6 );
+
+			editor.on( 'fileUploadResponse', function( evt ) {
+				var fileLoader = evt.data.fileLoader,
+					xhr = fileLoader.xhr,
+					response;
+
+				if ( fileLoader instanceof CKEDITOR.plugins.cloudservices.fileLoader ) {
+					evt.stop();
+
+					try {
+						response = JSON.parse( xhr.responseText );
+
+						evt.data.response = response;
+					} catch ( e ) {
+						CKEDITOR.warn( 'filetools-response-error', { responseText: xhr.responseText } );
+					}
+				}
+			} );
+		}
+	} );
+
+	CKEDITOR.plugins.cloudservices = {
+		// Note this type is loaded on runtime.
+		fileLoader: null
+	};
+} )();

--- a/plugins/cloudservices/plugin.js
+++ b/plugins/cloudservices/plugin.js
@@ -21,9 +21,27 @@
 			 * @since 4.8.0
 			 * @class CKEDITOR.plugins.cloudservices.cloudServicesLoader
 			 * @extends CKEDITOR.fileTools.fileLoader
+			 * @constructor
+			 * @inheritdoc
+			 * @param {CKEDITOR.editor} editor The editor instance. Used only to get language data.
+			 * @param {Blob/String} fileOrData A [blob object](https://developer.mozilla.org/en/docs/Web/API/Blob) or a data
+			 * string encoded with Base64.
+			 * @param {String} [fileName] The file name. If not set and the second parameter is a file, then its name will be used.
+			 * If not set and the second parameter is a Base64 data string, then the file name will be created based on
+			 * the {@link CKEDITOR.config#fileTools_defaultFileName} option.
+			 * @param {String} [token] A token used for [Cloud Service](https://ckeditor.com/ckeditor-cloud-services/) request. If
+			 * skipped {@link CKEDITOR.config#cloudServices_token} will be used.
 			 */
-			function CloudServicesLoader( editor, fileOrData, fileName ) {
+			function CloudServicesLoader( editor, fileOrData, fileName, token ) {
 				FileLoader.call( this, editor, fileOrData, fileName );
+
+				/**
+				 * Custom [Cloud Service](https://ckeditor.com/ckeditor-cloud-services/) token.
+				 *
+				 * @property {String} custom_token
+				 * @member CKEDITOR.plugins.cloudservices.cloudServicesLoader
+				 */
+				this.customToken = token;
 			}
 
 			CloudServicesLoader.prototype = CKEDITOR.tools.extend( {}, FileLoader.prototype );
@@ -62,7 +80,7 @@
 					delete reqData.upload;
 
 					// Add authorization token.
-					evt.data.fileLoader.xhr.setRequestHeader( 'Authorization', editor.config.cloudServices_token );
+					evt.data.fileLoader.xhr.setRequestHeader( 'Authorization', fileLoader.customToken || editor.config.cloudServices_token );
 				}
 			}, null, null, 6 );
 

--- a/plugins/cloudservices/plugin.js
+++ b/plugins/cloudservices/plugin.js
@@ -7,25 +7,43 @@
 			var FileLoader = CKEDITOR.fileTools.fileLoader;
 
 			/**
-			 * Dedicated uploader for [Cloud Services](https://ckeditor.com/ckeditor-cloud-services/).
+			 * Dedicated uploader type for [Cloud Services](https://ckeditor.com/ckeditor-cloud-services/).
+			 *
+			 * Note that this type is defined in {@link CKEDITOR.pluginDefinition#onLoad plugin.onLoad} method, thus is
+			 * guaranteed to be available in dependent plugin's {@link CKEDITOR.pluginDefinition#beforeInit beforeInit},
+			 * {@link CKEDITOR.pluginDefinition#init init} and {@link CKEDITOR.pluginDefinition#afterInit} methods.
 			 *
 			 * @since 4.8.0
-			 * @class CKEDITOR.plugins.cloudservices.fileLoader
+			 * @class CKEDITOR.plugins.cloudservices.cloudServicesLoader
 			 * @extends CKEDITOR.fileTools.fileLoader
 			 */
-			function CloudSericesLoader( editor, fileOrData, fileName ) {
+			function cloudServicesLoader( editor, fileOrData, fileName ) {
 				FileLoader.call( this, editor, fileOrData, fileName );
 			}
 
-			CloudSericesLoader.prototype = CKEDITOR.tools.extend( {}, FileLoader.prototype );
+			cloudServicesLoader.prototype = CKEDITOR.tools.extend( {}, FileLoader.prototype );
 
-			// CloudSericesLoader.prototype.attachRequestListeners = function() {
-			// 	FileLoader.prototype.attachRequestListeners.call( this );
+			/**
+			 * @inheritdoc
+			 * @param {String} [url] The upload URL. If not provided {@link CKEDITOR.config#cloudServices_url} will be used.
+			 * @param {Object} [additionalRequestParameters] Additional data that would be passed to the
+			 * {@link CKEDITOR.editor#fileUploadRequest} event.
+			 */
+			cloudServicesLoader.prototype.upload = function( url, additionalRequestParameters ) {
+				url = url || this.editor.config.cloudServices_url;
 
-			// 	this.xhr.setRequestHeader( 'Authorization', this.editor.config.easyimage_token );
-			// };
+				FileLoader.prototype.upload.call( this, url, additionalRequestParameters );
+			};
 
-			CKEDITOR.plugins.cloudservices.fileLoader = CloudSericesLoader;
+			/**
+			 * @method loadAndUpload
+			 * @inheritdoc
+			 * @param {String} [url] The upload URL. If not provided {@link CKEDITOR.config#cloudServices_url} will be used.
+			 * @param {Object} [additionalRequestParameters] Additional parameters that would be passed to
+			 * the {@link CKEDITOR.editor#fileUploadRequest} event.
+			*/
+
+			CKEDITOR.plugins.cloudservices.cloudServicesLoader = cloudServicesLoader;
 		},
 
 		beforeInit: function( editor ) {
@@ -33,13 +51,13 @@
 				var fileLoader = evt.data.fileLoader,
 					reqData = evt.data.requestData;
 
-				if ( fileLoader instanceof CKEDITOR.plugins.cloudservices.fileLoader ) {
+				if ( fileLoader instanceof CKEDITOR.plugins.cloudservices.cloudServicesLoader ) {
 					// Cloud Services expect file to be put as a "file" property.
 					reqData.file = reqData.upload;
 					delete reqData.upload;
 
 					// Add authorization token.
-					evt.data.fileLoader.xhr.setRequestHeader( 'Authorization', editor.config.easyimage_token );
+					evt.data.fileLoader.xhr.setRequestHeader( 'Authorization', editor.config.cloudServices_token );
 				}
 			}, null, null, 6 );
 
@@ -48,7 +66,7 @@
 					xhr = fileLoader.xhr,
 					response;
 
-				if ( fileLoader instanceof CKEDITOR.plugins.cloudservices.fileLoader ) {
+				if ( fileLoader instanceof CKEDITOR.plugins.cloudservices.cloudServicesLoader ) {
 					evt.stop();
 
 					try {
@@ -65,6 +83,22 @@
 
 	CKEDITOR.plugins.cloudservices = {
 		// Note this type is loaded on runtime.
-		fileLoader: null
+		cloudServicesLoader: null
 	};
+
+	/**
+	 * Endpoint URL for [Cloud Services](https://ckeditor.com/ckeditor-cloud-services) uploads.
+	 *
+	 * @since 4.8.0
+	 * @cfg {String} [cloudServices_url='']
+	 * @member CKEDITOR.config
+	 */
+
+	/**
+	 * Token used for [Cloud Services](https://ckeditor.com/ckeditor-cloud-services) authentication.
+	 *
+	 * @since 4.8.0
+	 * @cfg {String} [cloudServices_token='']
+	 * @member CKEDITOR.config
+	 */
 } )();

--- a/plugins/cloudservices/plugin.js
+++ b/plugins/cloudservices/plugin.js
@@ -38,7 +38,7 @@
 				/**
 				 * Custom [Cloud Service](https://ckeditor.com/ckeditor-cloud-services/) token.
 				 *
-				 * @property {String} custom_token
+				 * @property {String} customToken
 				 * @member CKEDITOR.plugins.cloudservices.cloudServicesLoader
 				 */
 				this.customToken = token;

--- a/tests/plugins/cloudservices/unit.js
+++ b/tests/plugins/cloudservices/unit.js
@@ -1,0 +1,73 @@
+/* @bender-ckeditor-plugins: cloudservices */
+
+bender.editor = {
+	config: {
+		cloudServices_url: 'cs_url',
+		cloudServices_token: 'cs_token'
+	}
+};
+
+var mockBase64 = 'data:image/gif;base64,R0lGODlhDgAOAIAAAAAAAP///yH5BAAAAAAALAAAAAAOAA4AAAIMhI+py+0Po5y02qsKADs=';
+
+bender.test( {
+	setUp: function() {
+		this.cloudservices = CKEDITOR.plugins.cloudservices;
+	},
+
+	'test plugin exposes loader': function() {
+		assert.isInstanceOf( Function, this.cloudservices.cloudSericesLoader, 'cloudServicesLoader property type' );
+	},
+
+	'test loader uses config url/token': function() {
+		var instance = new this.cloudservices.cloudSericesLoader( this.editor, mockBase64 ),
+			// Stub loader.xhr methods before it's actually called.
+			listener = this.editor.once( 'fileUploadRequest', this.commonRequestListener, null, null, 0 );
+
+		try {
+			instance.upload();
+
+			// Make sure that configured URL has been requested.
+			sinon.assert.calledWithExactly( instance.xhr.open, 'POST', 'cs_url', true );
+
+			// Make sure that proper header has been added.
+			sinon.assert.calledWithExactly( instance.xhr.setRequestHeader, 'Authorization', 'cs_token' );
+
+			assert.areSame( 1, instance.xhr.send.callCount, 'Call count' );
+		} catch ( e ) {
+			// Propagate.
+			throw e;
+		} finally {
+			// Always remove listener.
+			listener.removeListener();
+		}
+	},
+
+	'test loader allows url overriding': function() {
+		var instance = new this.cloudservices.cloudSericesLoader( this.editor, mockBase64 ),
+			// Stub loader.xhr methods before it's actually called.
+			listener = this.editor.once( 'fileUploadRequest', this.commonRequestListener, null, null, 0 );
+
+		try {
+			instance.upload( 'my_custom_url' );
+
+			sinon.assert.calledWithExactly( instance.xhr.open, 'POST', 'my_custom_url', true );
+
+			assert.areSame( 1, instance.xhr.send.callCount, 'Call count' );
+		} catch ( e ) {
+			// Propagate.
+			throw e;
+		} finally {
+			// Always remove listener.
+			listener.removeListener();
+		}
+	},
+
+	// Common fileUploadRequest listener reused by tests.
+	commonRequestListener: function( evt ) {
+		var loader = evt.data.fileLoader;
+
+		sinon.stub( loader.xhr, 'open' );
+		sinon.stub( loader.xhr, 'send' );
+		sinon.stub( loader.xhr, 'setRequestHeader' );
+	}
+} );

--- a/tests/plugins/cloudservices/unit.js
+++ b/tests/plugins/cloudservices/unit.js
@@ -15,11 +15,11 @@ bender.test( {
 	},
 
 	'test plugin exposes loader': function() {
-		assert.isInstanceOf( Function, this.cloudservices.cloudSericesLoader, 'cloudServicesLoader property type' );
+		assert.isInstanceOf( Function, this.cloudservices.cloudServicesLoader, 'cloudServicesLoader property type' );
 	},
 
 	'test loader uses config url/token': function() {
-		var instance = new this.cloudservices.cloudSericesLoader( this.editor, mockBase64 ),
+		var instance = new this.cloudservices.cloudServicesLoader( this.editor, mockBase64 ),
 			// Stub loader.xhr methods before it's actually called.
 			listener = this.editor.once( 'fileUploadRequest', this.commonRequestListener, null, null, 0 );
 
@@ -43,7 +43,7 @@ bender.test( {
 	},
 
 	'test loader allows url overriding': function() {
-		var instance = new this.cloudservices.cloudSericesLoader( this.editor, mockBase64 ),
+		var instance = new this.cloudservices.cloudServicesLoader( this.editor, mockBase64 ),
 			// Stub loader.xhr methods before it's actually called.
 			listener = this.editor.once( 'fileUploadRequest', this.commonRequestListener, null, null, 0 );
 

--- a/tests/plugins/cloudservices/unit.js
+++ b/tests/plugins/cloudservices/unit.js
@@ -62,6 +62,26 @@ bender.test( {
 		}
 	},
 
+	'test loader allows token overriding': function() {
+		var instance = new this.cloudservices.cloudServicesLoader( this.editor, mockBase64, null, 'different_token' ),
+			// Stub loader.xhr methods before it's actually called.
+			listener = this.editor.once( 'fileUploadRequest', this.commonRequestListener, null, null, 0 );
+
+		try {
+			instance.upload();
+
+			sinon.assert.calledWithExactly( instance.xhr.setRequestHeader, 'Authorization', 'different_token' );
+
+			assert.areSame( 1, instance.xhr.send.callCount, 'Call count' );
+		} catch ( e ) {
+			// Propagate.
+			throw e;
+		} finally {
+			// Always remove listener.
+			listener.removeListener();
+		}
+	},
+
 	// Common fileUploadRequest listener reused by tests.
 	commonRequestListener: function( evt ) {
 		var loader = evt.data.fileLoader;


### PR DESCRIPTION
New feature


- [x] Unit tests
- [ ] Manual tests - this is strictly an API PR, thus I skipped manual test


Reuses logic proposed in #1052, but extracts [Code Services](https://ckeditor.com/ckeditor-cloud-services) handing into a separate type.

So far it's only a loader type, integration with the [UploadRepository](https://docs.ckeditor.com/ckeditor4/docs/#!/api/CKEDITOR.fileTools.uploadRepository) or UploadWidget will be added in a followup PR.