### PR TITLE
Allow to use custom fileLoader in uploadRepository.create and upload widget

### DIFF
--- a/plugins/filetools/plugin.js
+++ b/plugins/filetools/plugin.js
@@ -148,9 +148,11 @@
 		 * @param {String} fileName See {@link CKEDITOR.fileTools.fileLoader}.
 		 * @returns {CKEDITOR.fileTools.fileLoader} The created file loader instance.
 		 */
-		create: function( fileOrData, fileName ) {
+		create: function( fileOrData, fileName, loaderType ) {
+			loaderType = loaderType || FileLoader;
+
 			var id = this.loaders.length,
-				loader = new FileLoader( this.editor, fileOrData, fileName );
+				loader = new loaderType( this.editor, fileOrData, fileName );
 
 			loader.id = id;
 			this.loaders[ id ] = loader;

--- a/plugins/filetools/plugin.js
+++ b/plugins/filetools/plugin.js
@@ -146,6 +146,8 @@
 		 *
 		 * @param {Blob/String} fileOrData See {@link CKEDITOR.fileTools.fileLoader}.
 		 * @param {String} fileName See {@link CKEDITOR.fileTools.fileLoader}.
+		 * @param {Function} [loaderType] Loader type to be created. If skipped the default {@link CKEDITOR.fileTools.fileLoader}
+		 * type will be used.
 		 * @returns {CKEDITOR.fileTools.fileLoader} The created file loader instance.
 		 */
 		create: function( fileOrData, fileName, loaderType ) {

--- a/plugins/uploadwidget/plugin.js
+++ b/plugins/uploadwidget/plugin.js
@@ -364,6 +364,12 @@
 			 */
 
 			/**
+			 * Loader type that should be used for creating fileTools requests.
+			 *
+			 * @property {Function} [loaderType]
+			 */
+
+			/**
 			 * An object containing additional data that should be passed to the function defined by {@link #loadMethod}.
 			 *
 			 * @property {Object} [additionalRequestParameters]

--- a/plugins/uploadwidget/plugin.js
+++ b/plugins/uploadwidget/plugin.js
@@ -188,7 +188,7 @@
 					// No def.supportedTypes means all types are supported.
 					if ( !def.supportedTypes || fileTools.isTypeSupported( file, def.supportedTypes ) ) {
 						var el = def.fileToElement( file ),
-							loader = uploads.create( file );
+							loader = uploads.create( file, undefined, def.loaderType );
 
 						if ( el ) {
 							loader[ loadMethod ]( def.uploadUrl, def.additionalRequestParameters );

--- a/tests/plugins/filetools/filetools.js
+++ b/tests/plugins/filetools/filetools.js
@@ -133,6 +133,15 @@
 			assert.isUndefined( repository.loaders[ 2 ] );
 		},
 
+		'test UploadRepository.create allows changing fileLoader type': function() {
+			function CustomType() {
+			}
+
+			var repository = this.editor.uploadRepository,
+				loader = repository.create( { name: 'name' }, undefined, CustomType );
+
+			assert.isInstanceOf( CustomType, loader, 'Returned loader type' );
+		},
 
 		'test UploadRepository instanceCreated event': function() {
 			var repository = this.editor.uploadRepository,

--- a/tests/plugins/uploadwidget/uploadwidget.js
+++ b/tests/plugins/uploadwidget/uploadwidget.js
@@ -507,6 +507,28 @@
 			wait();
 		},
 
+		'test custom def.loaderType': function() {
+			var editor = mockEditorForPaste(),
+				uploadStub = sinon.stub();
+
+			function CustomLoaderType() {
+				this.upload = uploadStub;
+			}
+
+			addTestUploadWidget( editor, 'loadMethodLoad', {
+				loaderType: CustomLoaderType,
+				loadMethod: 'upload'
+			} );
+
+			resumeAfter( editor, 'paste', function() {
+				assert.areSame( 1, uploadStub.callCount, 'CustomLoaderType.upload call count' );
+			} );
+
+			pasteFiles( editor, [ bender.tools.getTestPngFile( 'test1.png' ) ] );
+
+			wait();
+		},
+
 		'test paste multiple files': function() {
 			var editor = mockEditorForPaste();
 

--- a/tests/plugins/uploadwidget/uploadwidget.js
+++ b/tests/plugins/uploadwidget/uploadwidget.js
@@ -515,7 +515,7 @@
 				this.upload = uploadStub;
 			}
 
-			addTestUploadWidget( editor, 'loadMethodLoad', {
+			addTestUploadWidget( editor, 'customLoaderType', {
 				loaderType: CustomLoaderType,
 				loadMethod: 'upload'
 			} );


### PR DESCRIPTION
Allow to use custom fileLoader in uploadRepository.create and upload widget

## What is the purpose of this pull request?

New feature

### This PR contains

- [x] Unit tests
- [ ] Manual tests - it's an API change, so I'm adding only unit tests

## What changes did you make?

* A new argument in [`uploadRepository.create`](http://docs.ckeditor.test/#!/api/CKEDITOR.fileTools.uploadRepository-method-create) allowing to use custom loader type.
* Added `loaderType` property in the [`CKEDITOR.fileTools.uploadWidgetDefinition`](https://docs.ckeditor.com/ckeditor4/docs/#!/api/CKEDITOR.fileTools.uploadWidgetDefinition).

Now that we have more than one loaders (Cloud Services loader has been added in recent PR), we need a way to customize loader used by a given feature.

That way we'll be able to easily change where widgets are uploaded, etc.