### PR TITLE
Easy image upload refactoring

### DIFF
--- a/plugins/easyimage/plugin.js
+++ b/plugins/easyimage/plugin.js
@@ -194,7 +194,7 @@
 				// We are not uploading images in non-editable blocs and fake objects (http://dev.ckeditor.com/ticket/13003).
 				if ( isDataInSrc && isRealObject && !img.data( 'cke-upload-id' ) && !img.isReadOnly( 1 ) ) {
 					var loader = editor.uploadRepository.create( img.getAttribute( 'src' ), undefined, widgetDef.loaderType );
-					loader.upload();
+					loader.upload( widgetDef.uploadUrl, widgetDef.additionalRequestParameters );
 
 					fileTools.markElement( img, 'uploadeasyimage', loader.id );
 

--- a/plugins/easyimage/plugin.js
+++ b/plugins/easyimage/plugin.js
@@ -132,7 +132,8 @@
 		CKEDITOR.fileTools.addUploadWidget( editor, 'uploadeasyimage', {
 			supportedTypes: /image\/(jpeg|png|gif|bmp)/,
 
-			loadMethod: 'loadAndUpload',
+			// Easy image uses only upload method, as is manually handled in onUploading function.
+			loadMethod: 'upload',
 
 			loaderType: CKEDITOR.plugins.cloudservices.cloudServicesLoader,
 

--- a/plugins/easyimage/plugin.js
+++ b/plugins/easyimage/plugin.js
@@ -129,20 +129,12 @@
 	}
 
 	function registerUploadWidget( editor ) {
-		var uploadUrl = CKEDITOR.fileTools.getUploadUrl( editor.config, 'easyimage' );
-
 		CKEDITOR.fileTools.addUploadWidget( editor, 'uploadeasyimage', {
 			supportedTypes: /image\/(jpeg|png|gif|bmp)/,
-
-			uploadUrl: uploadUrl,
 
 			loadMethod: 'loadAndUpload',
 
 			loaderType: CKEDITOR.plugins.cloudservices.cloudServicesLoader,
-
-			additionalRequestParameters: {
-				isEasyImage: true
-			},
 
 			fileToElement: function() {
 				var img = new CKEDITOR.dom.element( 'img' );

--- a/plugins/easyimage/plugin.js
+++ b/plugins/easyimage/plugin.js
@@ -158,6 +158,50 @@
 					srcset + '" sizes="100vw">' );
 			}
 		} );
+
+		// Handle images which are not available in the dataTransfer.
+		// This means that we need to read them from the <img src="data:..."> elements.
+		editor.on( 'paste', function( evt ) {
+			var fileTools = CKEDITOR.fileTools;
+
+			// For performance reason do not parse data if it does not contain img tag and data attribute.
+			if ( !evt.data.dataValue.match( /<img[\s\S]+data:/i ) ) {
+				return;
+			}
+
+			var data = evt.data,
+				// Prevent XSS attacks.
+				tempDoc = document.implementation.createHTMLDocument( '' ),
+				temp = new CKEDITOR.dom.element( tempDoc.body ),
+				imgs, img, i;
+
+			// Without this isReadOnly will not works properly.
+			temp.data( 'cke-editable', 1 );
+
+			temp.appendHtml( data.dataValue );
+
+			imgs = temp.find( 'img' );
+
+			for ( i = 0; i < imgs.count(); i++ ) {
+				img = imgs.getItem( i );
+
+				// Image have to contain src=data:...
+				var isDataInSrc = img.getAttribute( 'src' ) && img.getAttribute( 'src' ).substring( 0, 5 ) == 'data:',
+					isRealObject = img.data( 'cke-realelement' ) === null;
+
+				// We are not uploading images in non-editable blocs and fake objects (http://dev.ckeditor.com/ticket/13003).
+				if ( isDataInSrc && isRealObject && !img.data( 'cke-upload-id' ) && !img.isReadOnly( 1 ) ) {
+					var loader = editor.uploadRepository.create( img.getAttribute( 'src' ) );
+					loader.upload();
+
+					fileTools.markElement( img, 'uploadeasyimage', loader.id );
+
+					fileTools.bindNotifications( editor, loader );
+				}
+			}
+
+			data.dataValue = temp.getHtml();
+		} );
 	}
 
 	function loadStyles( editor, plugin ) {

--- a/plugins/easyimage/plugin.js
+++ b/plugins/easyimage/plugin.js
@@ -172,6 +172,7 @@
 			var data = evt.data,
 				// Prevent XSS attacks.
 				tempDoc = document.implementation.createHTMLDocument( '' ),
+				widgetDef = editor.widgets.registered.uploadeasyimage,
 				temp = new CKEDITOR.dom.element( tempDoc.body ),
 				imgs, img, i;
 
@@ -191,7 +192,7 @@
 
 				// We are not uploading images in non-editable blocs and fake objects (http://dev.ckeditor.com/ticket/13003).
 				if ( isDataInSrc && isRealObject && !img.data( 'cke-upload-id' ) && !img.isReadOnly( 1 ) ) {
-					var loader = editor.uploadRepository.create( img.getAttribute( 'src' ) );
+					var loader = editor.uploadRepository.create( img.getAttribute( 'src' ), undefined, widgetDef.loaderType );
 					loader.upload();
 
 					fileTools.markElement( img, 'uploadeasyimage', loader.id );

--- a/plugins/easyimage/plugin.js
+++ b/plugins/easyimage/plugin.js
@@ -138,7 +138,7 @@
 
 			loadMethod: 'loadAndUpload',
 
-			loaderType: CKEDITOR.plugins.cloudservices.fileLoader,
+			loaderType: CKEDITOR.plugins.cloudservices.cloudServicesLoader,
 
 			additionalRequestParameters: {
 				isEasyImage: true

--- a/plugins/easyimage/plugin.js
+++ b/plugins/easyimage/plugin.js
@@ -138,6 +138,8 @@
 
 			loadMethod: 'loadAndUpload',
 
+			loaderType: CKEDITOR.plugins.cloudservices.fileLoader,
+
 			additionalRequestParameters: {
 				isEasyImage: true
 			},
@@ -163,86 +165,6 @@
 				this.replaceWith( '<img src="' + upload.responseData.response[ 'default' ] + '" srcset="' +
 					srcset + '" sizes="100vw">' );
 			}
-		} );
-
-		editor.on( 'fileUploadRequest', function( evt ) {
-			var requestData = evt.data.requestData;
-
-			if ( !requestData.isEasyImage ) {
-				return;
-			}
-
-			evt.data.requestData.file = evt.data.requestData.upload;
-			delete evt.data.requestData.upload;
-
-			// This property is used by fileUploadResponse callback to identify EI requests.
-			evt.data.fileLoader.isEasyImage = true;
-
-			evt.data.fileLoader.xhr.setRequestHeader( 'Authorization', editor.config.easyimage_token );
-		} );
-
-		editor.on( 'fileUploadResponse', function( evt ) {
-			var fileLoader = evt.data.fileLoader,
-				xhr = fileLoader.xhr,
-				response;
-
-			if ( !fileLoader.isEasyImage ) {
-				return;
-			}
-
-			evt.stop();
-
-			try {
-				response = JSON.parse( xhr.responseText );
-
-				evt.data.response = response;
-			} catch ( e ) {
-				CKEDITOR.warn( 'filetools-response-error', { responseText: xhr.responseText } );
-			}
-		} );
-
-		// Handle images which are not available in the dataTransfer.
-		// This means that we need to read them from the <img src="data:..."> elements.
-		editor.on( 'paste', function( evt ) {
-			var fileTools = CKEDITOR.fileTools;
-
-			// For performance reason do not parse data if it does not contain img tag and data attribute.
-			if ( !evt.data.dataValue.match( /<img[\s\S]+data:/i ) ) {
-				return;
-			}
-
-			var data = evt.data,
-				// Prevent XSS attacks.
-				tempDoc = document.implementation.createHTMLDocument( '' ),
-				temp = new CKEDITOR.dom.element( tempDoc.body ),
-				imgs, img, i;
-
-			// Without this isReadOnly will not works properly.
-			temp.data( 'cke-editable', 1 );
-
-			temp.appendHtml( data.dataValue );
-
-			imgs = temp.find( 'img' );
-
-			for ( i = 0; i < imgs.count(); i++ ) {
-				img = imgs.getItem( i );
-
-				// Image have to contain src=data:...
-				var isDataInSrc = img.getAttribute( 'src' ) && img.getAttribute( 'src' ).substring( 0, 5 ) == 'data:',
-					isRealObject = img.data( 'cke-realelement' ) === null;
-
-				// We are not uploading images in non-editable blocs and fake objects (http://dev.ckeditor.com/ticket/13003).
-				if ( isDataInSrc && isRealObject && !img.data( 'cke-upload-id' ) && !img.isReadOnly( 1 ) ) {
-					var loader = editor.uploadRepository.create( img.getAttribute( 'src' ) );
-					loader.upload( uploadUrl );
-
-					fileTools.markElement( img, 'uploadeasyimage', loader.id );
-
-					fileTools.bindNotifications( editor, loader );
-				}
-			}
-
-			data.dataValue = temp.getHtml();
 		} );
 	}
 
@@ -290,7 +212,7 @@
 	};
 
 	CKEDITOR.plugins.add( 'easyimage', {
-		requires: 'image2,uploadwidget,contextmenu,dialog',
+		requires: 'image2,uploadwidget,contextmenu,dialog,cloudservices',
 		lang: 'en',
 
 		onLoad: function() {

--- a/plugins/easyimage/samples/easyimage.html
+++ b/plugins/easyimage/samples/easyimage.html
@@ -110,8 +110,8 @@ function getToken( callback ) {
 getToken( function( token ) {
 	CKEDITOR.replace( 'editor', {
 		extraPlugins: 'easyimage',
-		easyimageUploadUrl: 'https://files.cke-cs.com/upload/',
-		easyimage_token: token,
+		cloudServices_url: 'https://files.cke-cs.com/upload/',
+		cloudServices_token: token,
 		height: 500
 	} );
 } );

--- a/tests/plugins/easyimage/uploadwidget.js
+++ b/tests/plugins/easyimage/uploadwidget.js
@@ -4,9 +4,9 @@
 /* bender-include: %BASE_PATH%/plugins/uploadfile/_helpers/waitForImage.js */
 /* global pasteFiles, waitForImage */
 
-'use strict';
-
 ( function() {
+	'use strict';
+
 	var uploadCount, loadAndUploadCount, resumeAfter, tests,
 		IMG_URL = '%BASE_PATH%_assets/logo.png',
 		DATA_IMG = 'data:',
@@ -50,6 +50,8 @@
 
 	CKEDITOR.on( 'instanceCreated', function() {
 		if ( !CKEDITOR.plugins.cloudservices.cloudServicesLoader.restore ) {
+			// Because of #1068 we can't provide loaderType directly. Instead we just replace cloudServicesLoader
+			// with our loader stub that is going to be customized in init method.
 			sinon.stub( CKEDITOR.plugins.cloudservices, 'cloudServicesLoader', CKEDITOR.fileTools.fileLoader );
 		}
 	} );
@@ -66,6 +68,8 @@
 
 			resumeAfter = bender.tools.resumeAfter;
 
+			// This tests suite could be made much prettier, it would require #1068 to be resolved. Then you
+			// could just use LoaderStub type with stubbed methods, rather than overwrite base FileLoader type.
 			CKEDITOR.fileTools.fileLoader.prototype.loadAndUpload = function() {
 				loadAndUploadCount++;
 
@@ -80,7 +84,8 @@
 				this.responseData = CKEDITOR.tools.clone( responseData );
 			};
 
-			// Further hacking, now stub can be safely removed, as it's used only in plugin.init, which has already been called.
+			// Now stub can be safely removed, as it's used only in plugin.init, which has already been called,
+			// this workaround could be removed once #1068 is fixed.
 			if ( CKEDITOR.plugins.cloudservices.cloudServicesLoader.restore ) {
 				CKEDITOR.plugins.cloudservices.cloudServicesLoader.restore();
 			}

--- a/tests/plugins/easyimage/uploadwidget.js
+++ b/tests/plugins/easyimage/uploadwidget.js
@@ -69,11 +69,10 @@
 
 			CKEDITOR.plugins.cloudservices.cloudServicesLoader.prototype.load = function() {};
 
-			CKEDITOR.plugins.cloudservices.cloudServicesLoader.prototype.upload = function() {
+			sinon.stub( CKEDITOR.plugins.cloudservices.cloudServicesLoader.prototype, 'upload', function() {
 				uploadCount++;
-
 				this.responseData = CKEDITOR.tools.clone( responseData );
-			};
+			} );
 		},
 
 		setUp: function() {
@@ -93,6 +92,10 @@
 
 			if ( CKEDITOR.fileTools.bindNotifications.reset ) {
 				CKEDITOR.fileTools.bindNotifications.reset();
+			}
+
+			if ( CKEDITOR.plugins.cloudservices.cloudServicesLoader.prototype.upload.reset ) {
+				CKEDITOR.plugins.cloudservices.cloudServicesLoader.prototype.upload.reset();
 			}
 		},
 
@@ -424,6 +427,30 @@
 				resume( function() {
 					assert.isTrue( createspy.notCalled );
 				} );
+			} );
+
+			wait();
+		},
+
+		'test cloudservices URL can be customized': function( editor ) {
+			var originalUploadUrl = editor.widgets.registered.uploadeasyimage.uploadUrl,
+				loader;
+
+			// Upload widget might have an uploadUrl changed in definition, allowing for upload URL customization.
+			editor.widgets.registered.uploadeasyimage.uploadUrl = 'https://customDomain.localhost/endpoint';
+
+			resumeAfter( editor, 'paste', function() {
+				// Restore original value.
+				editor.widgets.registered.uploadeasyimage.uploadUrl = originalUploadUrl;
+
+				loader = editor.uploadRepository.loaders[ 0 ];
+
+				sinon.assert.calledWith( loader.upload, 'https://customDomain.localhost/endpoint' );
+				assert.isTrue( true );
+			} );
+
+			editor.fire( 'paste', {
+				dataValue: '<img src="' + bender.tools.pngBase64 + '">'
 			} );
 
 			wait();

--- a/tests/plugins/easyimage/uploadwidget.js
+++ b/tests/plugins/easyimage/uploadwidget.js
@@ -53,11 +53,11 @@
 			var responseData = {
 				response: {
 					100: IMG_URL,
-					200: IMG_URL,
-					default: IMG_URL
+					200: IMG_URL
 				}
 			};
 
+			responseData.response[ 'default' ] = IMG_URL;
 			resumeAfter = bender.tools.resumeAfter;
 
 			// Approach taken from tests/plugins/uploadwidget/uploadwidget.js test.

--- a/tests/plugins/easyimage/uploadwidget.js
+++ b/tests/plugins/easyimage/uploadwidget.js
@@ -16,7 +16,7 @@
 		classic: {
 			name: 'classic',
 			config: {
-				easyimageUploadUrl: 'http://foo/upload',
+				cloudServices_url: 'http://foo/upload',
 				// Disable pasteFilter on Webkits (pasteFilter defaults semantic-text on Webkits).
 				pasteFilter: null
 			}
@@ -26,7 +26,7 @@
 			name: 'divarea',
 			config: {
 				extraPlugins: 'divarea',
-				easyimageUploadUrl: 'http://foo/upload',
+				cloudServices_url: 'http://foo/upload',
 				// Disable pasteFilter on Webkits (pasteFilter defaults semantic-text on Webkits).
 				pasteFilter: null
 			}
@@ -36,7 +36,7 @@
 			name: 'inline',
 			creator: 'inline',
 			config: {
-				easyimageUploadUrl: 'http://foo/upload',
+				cloudServices_url: 'http://foo/upload',
 				// Disable pasteFilter on Webkits (pasteFilter defaults semantic-text on Webkits).
 				pasteFilter: null
 			}
@@ -56,16 +56,22 @@
 		}
 	}
 
+	CKEDITOR.on( 'instanceCreated', function() {
+		if ( !CKEDITOR.plugins.cloudservices.cloudServicesLoader.restore ) {
+			sinon.stub( CKEDITOR.plugins.cloudservices, 'cloudServicesLoader', CKEDITOR.fileTools.fileLoader );
+		}
+	} );
+
 	tests = {
 		init: function() {
 			var responseData = {
 				response: {
 					100: IMG_URL,
-					200: IMG_URL
+					200: IMG_URL,
+					default: IMG_URL
 				}
 			};
 
-			responseData[ 'default' ] = IMG_URL;
 			resumeAfter = bender.tools.resumeAfter;
 
 			CKEDITOR.fileTools.fileLoader.prototype.loadAndUpload = function( url ) {
@@ -83,6 +89,11 @@
 
 				this.responseData = CKEDITOR.tools.clone( responseData );
 			};
+
+			// Further hacking, now stub can be safely removed, as it's used only in plugin.init, which has already been called.
+			if ( CKEDITOR.plugins.cloudservices.cloudServicesLoader.restore ) {
+				CKEDITOR.plugins.cloudservices.cloudServicesLoader.restore();
+			}
 		},
 
 		setUp: function() {

--- a/tests/plugins/easyimage/uploadwidget.js
+++ b/tests/plugins/easyimage/uploadwidget.js
@@ -10,36 +10,28 @@
 	var uploadCount, loadAndUploadCount, resumeAfter, tests,
 		IMG_URL = '%BASE_PATH%_assets/logo.png',
 		DATA_IMG = 'data:',
-		BLOB_IMG = 'blob:';
+		BLOB_IMG = 'blob:',
+		commonConfig = {
+			cloudServices_url: 'http://foo/upload',
+			// Disable pasteFilter on Webkits (pasteFilter defaults semantic-text on Webkits).
+			pasteFilter: null
+		};
 
 	bender.editors = {
 		classic: {
 			name: 'classic',
-			config: {
-				cloudServices_url: 'http://foo/upload',
-				// Disable pasteFilter on Webkits (pasteFilter defaults semantic-text on Webkits).
-				pasteFilter: null
-			}
+			config: commonConfig
 		},
 
 		divarea: {
 			name: 'divarea',
-			config: {
-				extraPlugins: 'divarea',
-				cloudServices_url: 'http://foo/upload',
-				// Disable pasteFilter on Webkits (pasteFilter defaults semantic-text on Webkits).
-				pasteFilter: null
-			}
+			config: CKEDITOR.tools.extend( { extraPlugins: 'divarea' }, commonConfig )
 		},
 
 		inline: {
 			name: 'inline',
 			creator: 'inline',
-			config: {
-				cloudServices_url: 'http://foo/upload',
-				// Disable pasteFilter on Webkits (pasteFilter defaults semantic-text on Webkits).
-				pasteFilter: null
-			}
+			config: commonConfig
 		}
 	};
 

--- a/tests/plugins/easyimage/uploadwidget.js
+++ b/tests/plugins/easyimage/uploadwidget.js
@@ -120,8 +120,8 @@
 				assert.sameData( '<p><img alt="" src="' + IMG_URL + '" /></p>', editor.getData() );
 				assert.areSame( 1, editor.editable().find( 'img[data-widget="image"]' ).count() );
 
-				assert.areSame( 1, loadAndUploadCount );
-				assert.areSame( 0, uploadCount );
+				assert.areSame( 0, loadAndUploadCount );
+				assert.areSame( 1, uploadCount );
 			} );
 		},
 

--- a/tests/plugins/easyimage/uploadwidget.js
+++ b/tests/plugins/easyimage/uploadwidget.js
@@ -48,14 +48,6 @@
 		}
 	}
 
-	CKEDITOR.on( 'instanceCreated', function() {
-		if ( !CKEDITOR.plugins.cloudservices.cloudServicesLoader.restore ) {
-			// Because of #1068 we can't provide loaderType directly. Instead we just replace cloudServicesLoader
-			// with our loader stub that is going to be customized in init method.
-			sinon.stub( CKEDITOR.plugins.cloudservices, 'cloudServicesLoader', CKEDITOR.fileTools.fileLoader );
-		}
-	} );
-
 	tests = {
 		init: function() {
 			var responseData = {
@@ -68,27 +60,20 @@
 
 			resumeAfter = bender.tools.resumeAfter;
 
-			// This tests suite could be made much prettier, it would require #1068 to be resolved. Then you
-			// could just use LoaderStub type with stubbed methods, rather than overwrite base FileLoader type.
-			CKEDITOR.fileTools.fileLoader.prototype.loadAndUpload = function() {
+			// Approach taken from tests/plugins/uploadwidget/uploadwidget.js test.
+			CKEDITOR.plugins.cloudservices.cloudServicesLoader.prototype.loadAndUpload = function() {
 				loadAndUploadCount++;
 
 				this.responseData = CKEDITOR.tools.clone( responseData );
 			};
 
-			CKEDITOR.fileTools.fileLoader.prototype.load = function() {};
+			CKEDITOR.plugins.cloudservices.cloudServicesLoader.prototype.load = function() {};
 
-			CKEDITOR.fileTools.fileLoader.prototype.upload = function() {
+			CKEDITOR.plugins.cloudservices.cloudServicesLoader.prototype.upload = function() {
 				uploadCount++;
 
 				this.responseData = CKEDITOR.tools.clone( responseData );
 			};
-
-			// Now stub can be safely removed, as it's used only in plugin.init, which has already been called,
-			// this workaround could be removed once #1068 is fixed.
-			if ( CKEDITOR.plugins.cloudservices.cloudServicesLoader.restore ) {
-				CKEDITOR.plugins.cloudservices.cloudServicesLoader.restore();
-			}
 		},
 
 		setUp: function() {

--- a/tests/plugins/easyimage/uploadwidget.js
+++ b/tests/plugins/easyimage/uploadwidget.js
@@ -7,7 +7,7 @@
 'use strict';
 
 ( function() {
-	var uploadCount, loadAndUploadCount, lastUploadUrl, resumeAfter, tests,
+	var uploadCount, loadAndUploadCount, resumeAfter, tests,
 		IMG_URL = '%BASE_PATH%_assets/logo.png',
 		DATA_IMG = 'data:',
 		BLOB_IMG = 'blob:';
@@ -74,18 +74,16 @@
 
 			resumeAfter = bender.tools.resumeAfter;
 
-			CKEDITOR.fileTools.fileLoader.prototype.loadAndUpload = function( url ) {
+			CKEDITOR.fileTools.fileLoader.prototype.loadAndUpload = function() {
 				loadAndUploadCount++;
-				lastUploadUrl = url;
 
 				this.responseData = CKEDITOR.tools.clone( responseData );
 			};
 
 			CKEDITOR.fileTools.fileLoader.prototype.load = function() {};
 
-			CKEDITOR.fileTools.fileLoader.prototype.upload = function( url ) {
+			CKEDITOR.fileTools.fileLoader.prototype.upload = function() {
 				uploadCount++;
-				lastUploadUrl = url;
 
 				this.responseData = CKEDITOR.tools.clone( responseData );
 			};
@@ -142,7 +140,6 @@
 
 				assert.areSame( 1, loadAndUploadCount );
 				assert.areSame( 0, uploadCount );
-				assert.areSame( 'http://foo/upload', lastUploadUrl );
 			} );
 		},
 
@@ -172,7 +169,6 @@
 
 					assert.areSame( 0, loadAndUploadCount );
 					assert.areSame( 1, uploadCount );
-					assert.areSame( 'http://foo/upload', lastUploadUrl );
 				} );
 			} );
 		},

--- a/tests/plugins/easyimage/uploadwidget.js
+++ b/tests/plugins/easyimage/uploadwidget.js
@@ -472,7 +472,7 @@
 
 			LoaderSubclass.prototype = CKEDITOR.tools.extend( {}, CloudServicesLoader.prototype );
 
-			// Upload widget might have an uploadUrl changed in definition, allowing for upload URL customization.
+			// Upload widget might have a loaderType changed in definition, allowing for loader type customization.
 			uploadEasyImageDef.loaderType = LoaderSubclass;
 
 			resumeAfter( editor, 'paste', function() {

--- a/tests/plugins/uploadfile/_helpers/waitForImage.js
+++ b/tests/plugins/uploadfile/_helpers/waitForImage.js
@@ -5,7 +5,7 @@ function waitForImage( image, callback ) {
 	if ( CKEDITOR.env.ie ) {
 		wait( callback, 100 );
 	} else {
-		image.on( 'load', function() {
+		image.once( 'load', function() {
 			resume( callback );
 		} );
 		wait();


### PR DESCRIPTION
## What is the purpose of this pull request?

Other, refactoring of other PR.

## Does your PR contain necessary tests?

All patches which change the editor code must include tests. You can always read more
on [PR testing](http://docs.ckeditor.com/#!/guide/dev_contributing_code-section-tests),
[how to set the testing environment](http://docs.ckeditor.com/#!/guide/dev_tests) and
[how to create tests](http://docs.ckeditor.com/#!/guide/dev_tests-section-creating-your-own-test)
in the official CKEditor documentation.

### This PR contains

- [x] Unit tests
- [x] Manual tests

## What changes did you make?

This PR adds some fixes to #1052, the general idea was to simplify it and extract cloud-service (backend) stuff to a separate plugin.

There were already quite a few changes, many of which has been already fixed in #1062 and #1066.

Summary for this PR:

* [`uploadUrl`](https://github.com/ckeditor/ckeditor-dev/blob/de017b395220ebaba8136ef7650d54dd035b5411/plugins/easyimage/plugin.js#L137) is now optional, as the plugin uses CloudService loader which automatically picks up URL from the config.
* [`loadMethod`](https://github.com/ckeditor/ckeditor-dev/blob/de017b395220ebaba8136ef7650d54dd035b5411/plugins/easyimage/plugin.js?utf8=%E2%9C%93#L139) is now changed to upload. Since you proposed a more modern approach with object URL - I think it's fine, however we need a followup ticket to keep track of data allocated with it. See TP#3131.
* Removed `fileUploadResponse`, `fileUploadRequest` as they're no longer needed (fixed in #1062, #1066).
* [paste listener](https://github.com/ckeditor/ckeditor-dev/blob/4c7e90d472cc1490df1963c6eb158914e8fefbe4/plugins/easyimage/plugin.js#L206) for `uploadeasyimage` widget uses widget definition at a time of paste event to avoid #1068. Though still I'm not happy that it's a copy pasta of a listener from `imageupload` plugin, we need to combine it. See TP#3132.
* Config options `easyimageUploadUrl`, `easyimage_token` have been renamed to `cloudServices_url`, `cloudServices_token` respectively.
* Corrected [`responseData` structure](https://github.com/ckeditor/ckeditor-dev/blob/4c7e90d472cc1490df1963c6eb158914e8fefbe4/tests/plugins/easyimage/uploadwidget.js?utf8=%E2%9C%93#L61-L66) in unit tests.

There's one issue that latest FF is extremely unstable, that's something that we need to investigate in a followup ticket.

Once this is merged, I'll just give a final check to #1052 and that will be it in terms of uploading.