### PR TITLE
Custom upcasting for image widget

### DIFF
--- a/plugins/easyimage/plugin.js
+++ b/plugins/easyimage/plugin.js
@@ -105,14 +105,11 @@
 
 			requiredContent: 'figure(!' + config.easyimage_class + ')',
 
-			upcast: function( element ) {
-				// http://dev.ckeditor.com/ticket/11110 Don't initialize on pasted fake objects.
-				if ( element.attributes[ 'data-cke-realelement' ] ) {
-					return;
-				}
-
-				if ( element.name === 'figure' && element.hasClass( config.easyimage_class ) ) {
-					return element;
+			upcasts: {
+				figure: function( element ) {
+					if ( element.hasClass( config.easyimage_class ) ) {
+						return element;
+					}
 				}
 			},
 

--- a/plugins/imagebase/plugin.js
+++ b/plugins/imagebase/plugin.js
@@ -59,19 +59,35 @@
 			},
 
 			/**
+			 * @inheritdoc
+			 * @property {Object} upcasts
+			 * @property {Function} upcasts.figure
+			 */
+
+			/**
 			 * Image widget definition overwrites the {@link CKEDITOR.plugins.widget.definition#upcast} property.
-			 * This should not be changed.
+			 * This method allows to upcast many different elements using callbacks defined in the
+			 * {@link CKEDITOR.plugins.imagebase.imageWidgetDefinition#upcasts} property, applying some additional
+			 * checkings.
+			 *
+			 * This method should not be changed.
 			 *
 			 * @property {Function}
 			 */
 			upcast: function( element ) {
+				var upcasts = definition.upcasts || {
+					figure: function() {
+						return true;
+					}
+				};
+
 				// http://dev.ckeditor.com/ticket/11110 Don't initialize on pasted fake objects.
 				if ( element.attributes[ 'data-cke-realelement' ] ) {
 					return;
 				}
 
-				if ( element.name === 'figure' && element.hasClass( 'imagebase' ) ) {
-					return element;
+				if ( upcasts[ element.name ] ) {
+					return upcasts[ element.name ]( element );
 				}
 			}
 		};

--- a/tests/plugins/imagebase/imagebase.js
+++ b/tests/plugins/imagebase/imagebase.js
@@ -16,16 +16,24 @@
 
 
 	bender.editors = {
-		classic: {},
+		classic: {
+			config: {
+				extraAllowedContent: 'figure img'
+			}
+		},
 
 		divarea: {
 			config: {
-				extraPlugins: 'divarea'
+				extraPlugins: 'divarea',
+				extraAllowedContent: 'figure img'
 			}
 		},
 
 		inline: {
-			creator: 'inline'
+			creator: 'inline',
+			config: {
+				extraAllowedContent: 'figure img'
+			}
 		}
 	};
 
@@ -48,8 +56,20 @@
 
 		},
 
-		'test upcasting image widget': function( editor, bot ) {
-			assertUpcast( bot, '<figure class="imagebase"></figure>', 'testWidget' );
+		'test default upcast': function( editor, bot ) {
+			assertUpcast( bot, '<figure></figure>', 'testWidget' );
+		},
+
+		'test custom upcast': function( editor, bot ) {
+			CKEDITOR.plugins.imagebase.addImageWidget( editor, 'customUpcastWidget', {
+				upcasts: {
+					img: function( element ) {
+						return element;
+					}
+				}
+			} );
+
+			assertUpcast( bot, '<img src="test" />', 'customUpcastWidget' );
 		}
 	};
 


### PR DESCRIPTION
## What is the purpose of this pull request?

New feature for new feature

## Does your PR contain necessary tests?

All patches which change the editor code must include tests. You can always read more
on [PR testing](http://docs.ckeditor.com/#!/guide/dev_contributing_code-section-tests),
[how to set the testing environment](http://docs.ckeditor.com/#!/guide/dev_tests) and
[how to create tests](http://docs.ckeditor.com/#!/guide/dev_tests-section-creating-your-own-test)
in the official CKEditor documentation.

### This PR contains

- [x] Unit tests
- [ ] Manual tests

## What changes did you make?

I've created custom `upcast` menu for image widgets created by `imagebase` plugin, which loops through all functions passed in `upcasts` property and does additional checks (at the moment it checks only if the element is not a fake object) before upcasting.
