### PR TITLE
t/1061 Fixing basepathglobal unit test on Safari

### DIFF
--- a/tests/core/ckeditor/basepathglobal.js
+++ b/tests/core/ckeditor/basepathglobal.js
@@ -10,7 +10,7 @@
 		folderPath = path + testDir.slice( 0, testDir.lastIndexOf( '/' ) ),
 		expectedEditorPath = '/apps/ckeditor/',
 		query = CKEDITOR.timestamp ? '?t=' + CKEDITOR.timestamp : '',
-		secondDomainName = 'sub.ckeditor.dev',
+		secondDomainName = window.location.hostname,
 		port = window.location.port;
 
 


### PR DESCRIPTION
## What is the purpose of this pull request?

Fixing failing test `/tests/core/ckeditor/basepathglobal` on Safari.

## What changes did you make?

The reason for failing test was setting `sub.ckeditor.dev` as a current domain. So if, the test was running from other domain was failed. Now, I'm checking current domain.

---

Closes: #1061 


