### PR TITLE
T/1070 Failing test /tests/core/htmldataprocessor on Chrome 62+

### DIFF
--- a/tests/_benderjs/ckeditor/static/tools.js
+++ b/tests/_benderjs/ckeditor/static/tools.js
@@ -92,10 +92,10 @@
 			 */
 			linux: navigator.userAgent.toLowerCase().indexOf( 'linux' ) !== -1,
 
-			/**
-			 * Check whether current environment is running in Opera.
+			/*
+			 * Whether current environment is Opera browser.
 			 */
-			opera: ( navigator.userAgent.toLowerCase().indexOf( ' opr/' ) >= 0 )
+			opera: navigator.userAgent.toLowerCase().indexOf( ' opr/' ) !== -1
 		},
 
 		fixHtml: function( html, stripLineBreaks, toLowerCase ) {

--- a/tests/_benderjs/ckeditor/static/tools.js
+++ b/tests/_benderjs/ckeditor/static/tools.js
@@ -90,7 +90,12 @@
 			/*
 			 * Whether current OS is a Linux environment.
 			 */
-			linux: navigator.userAgent.toLowerCase().indexOf( 'linux' ) !== -1
+			linux: navigator.userAgent.toLowerCase().indexOf( 'linux' ) !== -1,
+
+			/**
+			 * Check whether current environment is running in Opera.
+			 */
+			opera: ( navigator.userAgent.toLowerCase().indexOf( ' opr/' ) >= 0 )
 		},
 
 		fixHtml: function( html, stripLineBreaks, toLowerCase ) {

--- a/tests/core/htmldataprocessor.js
+++ b/tests/core/htmldataprocessor.js
@@ -1323,8 +1323,8 @@
 
 	addXssTC( tcs, 'iframe with src=javascript 3',
 		'<p><iframe src="   jAvAsCrIpT:window.parent.%xss%;"></iframe></p>',
-		// Only WebKit (except Chrome version >= 62) removes preceding spaces in the attribute.
-		'<p><iframe src="' + ( CKEDITOR.env.chrome || !CKEDITOR.env.webkit ? '   ' : '' ) + 'javascript:window.parent.%xss%;"></iframe></p>' ); // jshint ignore:line
+		// Only Safari and Opera removes preceding spaces in the attribute.
+		'<p><iframe src="' + ( bender.tools.env.opera || CKEDITOR.env.safari ? '' : '   ' ) + 'javascript:window.parent.%xss%;"></iframe></p>' ); // jshint ignore:line
 
 	// The `src="&#10;&#106;javascript:..."` is treated as some different protocol in few browsers.
 	// IE8 treats it as an URL and opens it which reloads the whole page.

--- a/tests/core/htmldataprocessor.js
+++ b/tests/core/htmldataprocessor.js
@@ -1323,7 +1323,7 @@
 
 	addXssTC( tcs, 'iframe with src=javascript 3',
 		'<p><iframe src="   jAvAsCrIpT:window.parent.%xss%;"></iframe></p>',
-		// Only Safari and Opera removes preceding spaces in the attribute.
+		// Only Safari and Opera removes preceding spaces in the attribute (#1070).
 		'<p><iframe src="' + ( bender.tools.env.opera || CKEDITOR.env.safari ? '' : '   ' ) + 'javascript:window.parent.%xss%;"></iframe></p>' ); // jshint ignore:line
 
 	// The `src="&#10;&#106;javascript:..."` is treated as some different protocol in few browsers.

--- a/tests/core/htmldataprocessor.js
+++ b/tests/core/htmldataprocessor.js
@@ -1323,8 +1323,8 @@
 
 	addXssTC( tcs, 'iframe with src=javascript 3',
 		'<p><iframe src="   jAvAsCrIpT:window.parent.%xss%;"></iframe></p>',
-		// Only WebKit removes preceding spaces in the attribute.
-		'<p><iframe src="' + ( CKEDITOR.env.webkit ? '' : '   ' ) + 'javascript:window.parent.%xss%;"></iframe></p>' ); // jshint ignore:line
+		// Only WebKit (except Chrome version >= 62) removes preceding spaces in the attribute.
+		'<p><iframe src="' + ( CKEDITOR.env.chrome || !CKEDITOR.env.webkit ? '   ' : '' ) + 'javascript:window.parent.%xss%;"></iframe></p>' ); // jshint ignore:line
 
 	// The `src="&#10;&#106;javascript:..."` is treated as some different protocol in few browsers.
 	// IE8 treats it as an URL and opens it which reloads the whole page.


### PR DESCRIPTION
## What is the purpose of this pull request?

Fixing failing test `/tests/core/htmldataprocessor`

## What changes did you make?

A new version of Chrome 62 does not remove preceding spaces in attributes. I modified a condition a little.

---

Closes #1070 
