### PR TITLE
#1094 Upcast method invoked only for specified element

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -26,6 +26,7 @@ Fixed Issues:
 * [#877](https://github.com/ckeditor/ckeditor-dev/issues/877): Fixed: Lists with custom bullets with exotic characters crashes editor when [pasted from Word](http://ckeditor.com/addon/pastefromword).
 * [#605](https://github.com/ckeditor/ckeditor-dev/issues/605): Fixed: Inline widgets do not preserve trailing spaces.
 * [#1008](https://github.com/ckeditor/ckeditor-dev/issues/1008): Fixed: Shorthand hex colors from [colorButton_colors](https://docs.ckeditor.com/ckeditor4/docs/#!/api/CKEDITOR.config-cfg-colorButton_colors) are not correctly highlighted in [Color Button](http://ckeditor.com/addon/colorbutton) _text color_ / _background color_ panel.
+* [#1094](https://github.com/ckeditor/ckeditor-dev/issues/1094): Fixed: Widget definition [`upcats`](https://docs.ckeditor.com/ckeditor4/docs/#!/api/CKEDITOR.plugins.widget.definition-property-upcasts) methods are called for every element.
 
 Other Changes:
 

--- a/plugins/widget/plugin.js
+++ b/plugins/widget/plugin.js
@@ -1957,18 +1957,31 @@
 
 	function addWidgetProcessors( widgetsRepo, widgetDef ) {
 		var upcast = widgetDef.upcast,
-			upcasts,
 			priority = widgetDef.upcastPriority || 10;
+
+		function multipleUpcastsHandler( element, data ) {
+			var upcasts = widgetDef.upcast.split( ',' ),
+				upcast,
+				i;
+
+			for ( i = 0; i < upcasts.length; i++ ) {
+				upcast = upcasts[ i ];
+
+				if ( upcast === element.name ) {
+					return widgetDef.upcasts[ upcast ].call( this, element, data );
+				}
+			}
+
+			return false;
+		}
 
 		if ( !upcast )
 			return;
 
 		// Multiple upcasts defined in string.
 		if ( typeof upcast == 'string' ) {
-			upcasts = upcast.split( ',' );
-			while ( upcasts.length ) {
-				addUpcast( widgetDef.upcasts[ upcasts.pop() ], widgetDef.name, priority );
-			}
+			// This handler ensures that upcast method is fired only for appropriate element (#1094).
+			addUpcast( multipleUpcastsHandler, widgetDef.name, priority );
 		}
 		// Single rule which is automatically activated.
 		else {

--- a/tests/plugins/widget/definition.js
+++ b/tests/plugins/widget/definition.js
@@ -71,20 +71,20 @@
 
 				var widgetDef = {
 					upcasts: {
-						up1: function( el ) {
+						b: function( el ) {
 							return el.name == 'b';
 						},
-						up2: function( el ) {
+						i: function( el ) {
 							return el.name == 'i';
 						},
-						up3: function( el ) {
+						u: function( el ) {
 							return el.name == 'u';
 						}
 					}
 				};
 
 				editor.once( 'widgetDefinition', function( evt ) {
-					evt.data.upcast = 'up1,up2';
+					evt.data.upcast = 'b,i';
 				} );
 
 				editor.widgets.add( 'testup1', widgetDef );

--- a/tests/plugins/widget/widgetapi.js
+++ b/tests/plugins/widget/widgetapi.js
@@ -795,6 +795,24 @@
 				assert.areSame( '&nbsp;', widget.data.nbsp );
 				assert.areSame( '\u00a0', widget.data.nbspu );
 			} );
+		},
+
+		// #1094
+		'test upcasts methods are invoked only for specified elements': function() {
+			var editor = this.editor,
+				spy = sinon.spy();
+
+			editor.widgets.add( 'upcastelement', {
+				upcasts: {
+					del: spy
+				},
+				upcast: 'del'
+			} );
+
+			this.editorBot.setData( '<p><b>Foo</b><del>Bar</del></p>', function() {
+				assert.areSame( 1, spy.callCount, 'Upcast was called only once' );
+				assert.areSame( 'del', spy.getCall( 0 ).args[ 0 ].name, 'Upcast was called on del element' );
+			} );
 		}
 	} );
 } )();


### PR DESCRIPTION
## What is the purpose of this pull request?

Bug fix

## Does your PR contain necessary tests?

All patches which change the editor code must include tests. You can always read more
on [PR testing](http://docs.ckeditor.com/#!/guide/dev_contributing_code-section-tests),
[how to set the testing environment](http://docs.ckeditor.com/#!/guide/dev_tests) and
[how to create tests](http://docs.ckeditor.com/#!/guide/dev_tests-section-creating-your-own-test)
in the official CKEditor documentation.

### This PR contains

- [x] Unit tests
- [ ] Manual tests

## What changes did you make?

I've introduced `multipleUpcastsHandler`, which fires appropriate upcast method for appropriate elements.

Closes #1094 
