### PR TITLE
Update sample for inline toolbar

### DIFF
--- a/plugins/inlinetoolbar/samples/inlinetoolbar.html
+++ b/plugins/inlinetoolbar/samples/inlinetoolbar.html
@@ -18,7 +18,7 @@ For licensing, see LICENSE.md or http://ckeditor.com/license
 		<div class="grid-container">
 			<div class="content grid-width-100">
 				<p>
-					To run inline toolbar please click button <b>Test inline toolbar</b>
+					To run inline toolbar please click <strong>Test inline toolbar</strong> button.
 				</p>
 			</div>
 		</div>
@@ -28,9 +28,7 @@ For licensing, see LICENSE.md or http://ckeditor.com/license
 			<div class="grid-width-100">
 				<button id="test-inline-toolbar">Test inline toolbar</button>
 				<div id="editor">
-					<p>foo</p>
-
-					<p>bar</p>
+					<p><img alt="CKEditor logo" src="../../../samples/img/logo.png" /></p>
 
 					<p>foo</p>
 
@@ -78,12 +76,52 @@ For licensing, see LICENSE.md or http://ckeditor.com/license
 
 					<p>bar</p>
 
-					<p>foo</p>
-
-					<p>bar</p>
-
 				</div>
 			</div>
+		</div>
+	</div>
+
+	<div class="grid-container">
+		<div class="content grid-width-100">
+			<section id="sample-customize">
+				<h2>Customize Your Editor</h2>
+				<p>Modular build and <a href="http://docs.ckeditor.com/#!/guide/dev_configuration">numerous configuration options</a> give you nearly endless possibilities to customize CKEditor. Replace the content of your <code><a href="../config.js">config.js</a></code> file with the following code and refresh this page (<strong>remember to clear the browser cache</strong>)!</p>
+		<pre class="cm-s-neo CodeMirror"><code><span style="padding-right: 0.1px;"><span class="cm-variable">CKEDITOR</span>.<span class="cm-property">editorConfig</span> <span class="cm-operator">=</span> <span class="cm-keyword">function</span>( <span class="cm-def">config</span> ) {</span>
+<span style="padding-right: 0.1px;"><span class="cm-tab">	</span><span class="cm-variable-2">config</span>.<span class="cm-property">language</span> <span class="cm-operator">=</span> <span class="cm-string">'es'</span>;</span>
+<span style="padding-right: 0.1px;"><span class="cm-tab">	</span><span class="cm-variable-2">config</span>.<span class="cm-property">uiColor</span> <span class="cm-operator">=</span> <span class="cm-string">'#F7B42C'</span>;</span>
+<span style="padding-right: 0.1px;"><span class="cm-tab">	</span><span class="cm-variable-2">config</span>.<span class="cm-property">height</span> <span class="cm-operator">=</span> <span class="cm-number">300</span>;</span>
+<span style="padding-right: 0.1px;"><span class="cm-tab">	</span><span class="cm-variable-2">config</span>.<span class="cm-property">toolbarCanCollapse</span> <span class="cm-operator">=</span> <span class="cm-atom">true</span>;</span>
+<span style="padding-right: 0.1px;">};</span></code></pre>
+			</section>
+
+			<section>
+				<h2>Toolbar Configuration</h2>
+				<p>If you want to reorder toolbar buttons or remove some of them, check <a href="toolbarconfigurator/index.html">this handy tool</a>!</p>
+			</section>
+
+			<section>
+				<h2>More Samples!</h2>
+				<p>Visit the <a href="http://sdk.ckeditor.com">CKEditor SDK</a> for a huge collection of samples showcasing editor features, with source code readily available to copy and use in your own implementation.</p>
+			</section>
+
+			<section>
+				<h2>Developer's Guide</h2>
+				<p>The most important resource for all developers working with CKEditor, integrating it with their websites and applications, and customizing to their needs. You can start from here:</p>
+				<ul>
+					<li><a href="http://docs.ckeditor.com/#!/guide/dev_installation">Getting Started</a> &ndash; Explains most crucial editor concepts and practices as well as the installation process and integration with your website.</li>
+					<li><a href="http://docs.ckeditor.com/#!/guide/dev_advanced_installation">Advanced Installation Concepts</a> &ndash; Describes how to upgrade, install additional components (plugins, skins), or create a custom build.</li>
+				</ul>
+					<p>When you have the basics sorted out, feel free to browse some more advanced sections like:</p>
+				<ul>
+					<li><a href="http://docs.ckeditor.com/#!/guide/dev_features">Functionality Overview</a> &ndash; Descriptions and samples of various editor features.</li>
+					<li><a href="http://docs.ckeditor.com/#!/guide/plugin_sdk_intro">Plugin SDK</a>, <a href="http://docs.ckeditor.com/#!/guide/widget_sdk_intro">Widget SDK</a>, and <a href="http://docs.ckeditor.com/#!/guide/skin_sdk_intro">Skin SDK</a> &ndash; Useful when you want to create your own editor components.</li>
+				</ul>
+			</section>
+
+			<section>
+				<h2>CKEditor JavaScript API</h2>
+				<p>CKEditor boasts a rich <a href="http://docs.ckeditor.com/#!/api">JavaScript API</a> that you can use to adjust the editor to your needs and integrate it with your website or application.</p>
+			</section>
 		</div>
 	</div>
 </main>

--- a/plugins/inlinetoolbar/samples/inlinetoolbar.html
+++ b/plugins/inlinetoolbar/samples/inlinetoolbar.html
@@ -18,7 +18,7 @@ For licensing, see LICENSE.md or http://ckeditor.com/license
 		<div class="grid-container">
 			<div class="content grid-width-100">
 				<p>
-					To run inline toolbar please click <strong>Test inline toolbar</strong> button.
+					To show Inline Toolbar select any fragment of the editor. Inline toolbar will appear, pointing at the last selected elemnt.
 				</p>
 			</div>
 		</div>
@@ -26,7 +26,6 @@ For licensing, see LICENSE.md or http://ckeditor.com/license
 	<div class="adjoined-bottom">
 		<div class="grid-container">
 			<div class="grid-width-100">
-				<button id="test-inline-toolbar">Test inline toolbar</button>
 				<div id="editor">
 					<p><img alt="CKEditor logo" src="../../../samples/img/logo.png" /></p>
 

--- a/plugins/inlinetoolbar/samples/inlinetoolbar.html
+++ b/plugins/inlinetoolbar/samples/inlinetoolbar.html
@@ -13,43 +13,12 @@ For licensing, see LICENSE.md or http://ckeditor.com/license
 	<link rel="stylesheet" href="../../../samples/toolbarconfigurator/lib/codemirror/neo.css">
 </head>
 <body id="main">
-
-<nav class="navigation-a">
-	<div class="grid-container">
-		<ul class="navigation-a-left grid-width-70">
-			<li><a href="http://ckeditor.com">Project Homepage</a></li>
-			<li><a href="https://github.com/ckeditor/ckeditor-dev/issues">I found a bug</a></li>
-			<li><a href="http://github.com/ckeditor/ckeditor-dev" class="icon-pos-right icon-navigation-a-github">Fork CKEditor on GitHub</a></li>
-		</ul>
-		<ul class="navigation-a-right grid-width-30">
-			<li><a href="http://ckeditor.com/blog-list">CKEditor Blog</a></li>
-		</ul>
-	</div>
-</nav>
-
-<header class="header-a">
-	<div class="grid-container">
-		<h1 class="header-a-logo grid-width-30">
-			<a href="index.html"><img src="../../../samples/img/logo.png" alt="CKEditor Sample"></a>
-		</h1>
-
-		<nav class="navigation-b grid-width-70">
-			<ul>
-				<li><a href="index.html" class="button-a button-a-background">Start</a></li>
-				<li><a href="toolbarconfigurator/index.html" class="button-a">Toolbar configurator <span class="balloon-a balloon-a-nw">Edit your toolbar now!</span></a></li>
-			</ul>
-		</nav>
-	</div>
-</header>
-
 <main>
 	<div class="adjoined-top">
 		<div class="grid-container">
 			<div class="content grid-width-100">
-				<h1>Congratulations!</h1>
 				<p>
-					If you can see CKEditor below, it means that the installation succeeded.
-					To run inlinetoolbar demo plese click invisible button next to the IFrame button.
+					To run inline toolbar please click button <b>Test inline toolbar</b>
 				</p>
 			</div>
 		</div>
@@ -57,7 +26,7 @@ For licensing, see LICENSE.md or http://ckeditor.com/license
 	<div class="adjoined-bottom">
 		<div class="grid-container">
 			<div class="grid-width-100">
-				<button id="test-inline-toolbar">TEST INLINE TOOLBAR</button>
+				<button id="test-inline-toolbar">Test inline toolbar</button>
 				<div id="editor">
 					<p>foo</p>
 
@@ -115,50 +84,6 @@ For licensing, see LICENSE.md or http://ckeditor.com/license
 
 				</div>
 			</div>
-		</div>
-	</div>
-
-	<div class="grid-container">
-		<div class="content grid-width-100">
-			<section id="sample-customize">
-				<h2>Customize Your Editor</h2>
-				<p>Modular build and <a href="http://docs.ckeditor.com/#!/guide/dev_configuration">numerous configuration options</a> give you nearly endless possibilities to customize CKEditor. Replace the content of your <code><a href="../config.js">config.js</a></code> file with the following code and refresh this page (<strong>remember to clear the browser cache</strong>)!</p>
-		<pre class="cm-s-neo CodeMirror"><code><span style="padding-right: 0.1px;"><span class="cm-variable">CKEDITOR</span>.<span class="cm-property">editorConfig</span> <span class="cm-operator">=</span> <span class="cm-keyword">function</span>( <span class="cm-def">config</span> ) {</span>
-<span style="padding-right: 0.1px;"><span class="cm-tab">	</span><span class="cm-variable-2">config</span>.<span class="cm-property">language</span> <span class="cm-operator">=</span> <span class="cm-string">'es'</span>;</span>
-<span style="padding-right: 0.1px;"><span class="cm-tab">	</span><span class="cm-variable-2">config</span>.<span class="cm-property">uiColor</span> <span class="cm-operator">=</span> <span class="cm-string">'#F7B42C'</span>;</span>
-<span style="padding-right: 0.1px;"><span class="cm-tab">	</span><span class="cm-variable-2">config</span>.<span class="cm-property">height</span> <span class="cm-operator">=</span> <span class="cm-number">300</span>;</span>
-<span style="padding-right: 0.1px;"><span class="cm-tab">	</span><span class="cm-variable-2">config</span>.<span class="cm-property">toolbarCanCollapse</span> <span class="cm-operator">=</span> <span class="cm-atom">true</span>;</span>
-<span style="padding-right: 0.1px;">};</span></code></pre>
-			</section>
-
-			<section>
-				<h2>Toolbar Configuration</h2>
-				<p>If you want to reorder toolbar buttons or remove some of them, check <a href="toolbarconfigurator/index.html">this handy tool</a>!</p>
-			</section>
-
-			<section>
-				<h2>More Samples!</h2>
-				<p>Visit the <a href="http://sdk.ckeditor.com">CKEditor SDK</a> for a huge collection of samples showcasing editor features, with source code readily available to copy and use in your own implementation.</p>
-			</section>
-
-			<section>
-				<h2>Developer's Guide</h2>
-				<p>The most important resource for all developers working with CKEditor, integrating it with their websites and applications, and customizing to their needs. You can start from here:</p>
-				<ul>
-					<li><a href="http://docs.ckeditor.com/#!/guide/dev_installation">Getting Started</a> &ndash; Explains most crucial editor concepts and practices as well as the installation process and integration with your website.</li>
-					<li><a href="http://docs.ckeditor.com/#!/guide/dev_advanced_installation">Advanced Installation Concepts</a> &ndash; Describes how to upgrade, install additional components (plugins, skins), or create a custom build.</li>
-				</ul>
-					<p>When you have the basics sorted out, feel free to browse some more advanced sections like:</p>
-				<ul>
-					<li><a href="http://docs.ckeditor.com/#!/guide/dev_features">Functionality Overview</a> &ndash; Descriptions and samples of various editor features.</li>
-					<li><a href="http://docs.ckeditor.com/#!/guide/plugin_sdk_intro">Plugin SDK</a>, <a href="http://docs.ckeditor.com/#!/guide/widget_sdk_intro">Widget SDK</a>, and <a href="http://docs.ckeditor.com/#!/guide/skin_sdk_intro">Skin SDK</a> &ndash; Useful when you want to create your own editor components.</li>
-				</ul>
-			</section>
-
-			<section>
-				<h2>CKEditor JavaScript API</h2>
-				<p>CKEditor boasts a rich <a href="http://docs.ckeditor.com/#!/api">JavaScript API</a> that you can use to adjust the editor to your needs and integrate it with your website or application.</p>
-			</section>
 		</div>
 	</div>
 </main>

--- a/plugins/inlinetoolbar/samples/js/sample.js
+++ b/plugins/inlinetoolbar/samples/js/sample.js
@@ -20,7 +20,7 @@ CKEDITOR.on( 'instanceReady', function( e ) {
 			var img = editor.editable().findOne( 'img' );
 			if ( img ) {
 				var panel = new CKEDITOR.ui.inlineToolbar( editor );
-				panel.addUIElements( {
+				panel.addItems( {
 					iamge: new CKEDITOR.ui.button( {
 						label: editor.lang.common.image,
 						command: 'image',

--- a/plugins/inlinetoolbar/samples/js/sample.js
+++ b/plugins/inlinetoolbar/samples/js/sample.js
@@ -12,6 +12,8 @@ if ( CKEDITOR.env.ie && CKEDITOR.env.version < 9 )
 // unless user specified own height.
 CKEDITOR.config.height = 150;
 CKEDITOR.config.width = 'auto';
+CKEDITOR.config.customConfig = '';
+CKEDITOR.config.plugins = 'sourcearea,wysiwygarea,basicstyles,toolbar,undo,image,list,blockquote,table';
 CKEDITOR.config.extraPlugins = 'inlinetoolbar';
 CKEDITOR.on( 'instanceReady', function( e ) {
 	var editor = e.editor;

--- a/plugins/inlinetoolbar/samples/js/sample.js
+++ b/plugins/inlinetoolbar/samples/js/sample.js
@@ -10,41 +10,37 @@ if ( CKEDITOR.env.ie && CKEDITOR.env.version < 9 )
 
 // The trick to keep the editor in the sample quite small
 // unless user specified own height.
-CKEDITOR.config.height = 150;
+CKEDITOR.config.height = 200;
 CKEDITOR.config.width = 'auto';
 CKEDITOR.config.customConfig = '';
-CKEDITOR.config.plugins = 'sourcearea,wysiwygarea,basicstyles,toolbar,undo,image,list,blockquote,table';
+CKEDITOR.config.plugins = 'sourcearea,wysiwygarea,basicstyles,toolbar,undo,image,link,list,blockquote,table,resize,elementspath';
 CKEDITOR.config.extraPlugins = 'inlinetoolbar';
 CKEDITOR.on( 'instanceReady', function( e ) {
 	var editor = e.editor;
-	editor.addCommand( 'testInlineToolbar', {
-		exec: function( editor ) {
-			var img = editor.editable().findOne( 'img' );
-			if ( img ) {
-				var panel = new CKEDITOR.ui.inlineToolbar( editor );
-				panel.addItems( {
-					iamge: new CKEDITOR.ui.button( {
-						label: editor.lang.common.image,
-						command: 'image',
-						toolbar: 'insert,10'
-					} ),
-					image2: new CKEDITOR.ui.button( {
-						label: editor.lang.common.image,
-						command: 'image',
-						toolbar: 'insert,10'
-					} ),
-					imag3: new CKEDITOR.ui.button( {
-						label: editor.lang.common.image,
-						command: 'image',
-						toolbar: 'insert,10'
-					} )
-				} );
-				panel.create( img );
-			}
-		}
+
+	var panel = new CKEDITOR.ui.inlineToolbar( editor );
+
+	panel.addItems( {
+		bold: new CKEDITOR.ui.button( {
+			command: 'bold'
+		} ),
+		underline: new CKEDITOR.ui.button( {
+			command: 'underline'
+		} ),
+		link: new CKEDITOR.ui.button( {
+			command: 'link'
+		} ),
+		unlink: new CKEDITOR.ui.button( {
+			command: 'unlink'
+		} )
 	} );
-	document.getElementById( 'test-inline-toolbar' ).addEventListener( 'click', function() {
-		editor.execCommand( 'testInlineToolbar' );
+
+	editor.on( 'selectionChange', function( evt ) {
+		var lastElement = evt.data.path.lastElement;
+
+		if ( lastElement ) {
+			panel.create( lastElement );
+		}
 	} );
 } );
 

--- a/plugins/inlinetoolbar/samples/js/sample.js
+++ b/plugins/inlinetoolbar/samples/js/sample.js
@@ -42,6 +42,10 @@ CKEDITOR.on( 'instanceReady', function( e ) {
 			panel.create( lastElement );
 		}
 	} );
+
+	editor.on( 'mode', function() {
+		panel._view.hide();
+	} );
 } );
 
 var initSample = ( function() {


### PR DESCRIPTION
Refreshed description of inline toolbar sample file in `plugins/inlinetoolbar/samples/`.
