### PR TITLE
Button group wrapping in inline tootlbar

### DIFF
--- a/plugins/inlinetoolbar/plugin.js
+++ b/plugins/inlinetoolbar/plugin.js
@@ -25,7 +25,6 @@
 			triangleHeight: 10
 		} );
 		CKEDITOR.ui.balloonPanel.call( this, editor, definition );
-
 		/**
 		 * Listeners registered by this toolbar view.
 		 *

--- a/plugins/inlinetoolbar/plugin.js
+++ b/plugins/inlinetoolbar/plugin.js
@@ -145,7 +145,6 @@
 				var output = [],
 					isStarted = false;
 				for ( var menuItem in items ) {
-
 					if ( items[ menuItem ] instanceof CKEDITOR.ui.richCombo ) {
 						if ( isStarted ) {
 							isStarted = false;

--- a/plugins/inlinetoolbar/plugin.js
+++ b/plugins/inlinetoolbar/plugin.js
@@ -150,12 +150,12 @@
 				CKEDITOR.tools.array.forEach( keys, function( itemKey ) {
 
 					// If next element to render is richCombo and we have already opened group we have to close it.
-					if ( items[ itemKey ] instanceof CKEDITOR.ui.richCombo && groupStarted ) {
+					if ( CKEDITOR.ui.richCombo && items[ itemKey ] instanceof CKEDITOR.ui.richCombo && groupStarted ) {
 						groupStarted = false;
 						output.push( '</span>' );
 
 					// If we have closed group and element that is not richBox we have to open group.
-					} else if ( !( items[ itemKey ] instanceof CKEDITOR.ui.richCombo ) && !groupStarted ) {
+					} else if ( !( CKEDITOR.ui.richCombo && items[ itemKey ] instanceof CKEDITOR.ui.richCombo ) && !groupStarted ) {
 						groupStarted = true;
 						output.push( '<span class="cke_toolgroup">' );
 					}

--- a/plugins/inlinetoolbar/plugin.js
+++ b/plugins/inlinetoolbar/plugin.js
@@ -25,6 +25,7 @@
 			triangleHeight: 10
 		} );
 		CKEDITOR.ui.balloonPanel.call( this, editor, definition );
+
 		/**
 		 * Listeners registered by this toolbar view.
 		 *
@@ -143,22 +144,28 @@
 			 */
 			CKEDITOR.ui.inlineToolbarView.prototype.renderItems = function( items ) {
 				var output = [],
-					keys = CKEDITOR.tools.objectKeys( items );
+					keys = CKEDITOR.tools.objectKeys( items ),
+					groupStarted = false;
 
-				CKEDITOR.tools.array.forEach( keys, function( itemKey, keyIndex ) {
-					if ( items[ itemKey ] instanceof CKEDITOR.ui.richCombo || keyIndex === 0 ) {
-						// Button group should be open on the beginning, and for each rich combo.
-						if ( keyIndex !== 0 ) {
-							output.push( '</span>' );
-						}
+				CKEDITOR.tools.array.forEach( keys, function( itemKey ) {
 
+					//if next element to render is richCombo and we have already opened group we have to close it.
+					if ( items[ itemKey ] instanceof CKEDITOR.ui.richCombo  && groupStarted ) {
+						groupStarted = false;
+						output.push( '</span>' );
+
+					//if we have closed group and element that is not richBox we have to open group
+					} else if ( !( items[ itemKey ] instanceof CKEDITOR.ui.richCombo ) && !groupStarted ) {
+						groupStarted = true;
 						output.push( '<span class="cke_toolgroup">' );
 					}
 
+					//Now we can render element
 					items[ itemKey ].render( this.editor, output );
 				}, this );
 
-				if ( keys.length ) {
+				// We have to check if last group is closed
+				if ( groupStarted ) {
 					output.push( '</span>' );
 				}
 

--- a/plugins/inlinetoolbar/plugin.js
+++ b/plugins/inlinetoolbar/plugin.js
@@ -149,22 +149,22 @@
 
 				CKEDITOR.tools.array.forEach( keys, function( itemKey ) {
 
-					//if next element to render is richCombo and we have already opened group we have to close it.
-					if ( items[ itemKey ] instanceof CKEDITOR.ui.richCombo  && groupStarted ) {
+					// If next element to render is richCombo and we have already opened group we have to close it.
+					if ( items[ itemKey ] instanceof CKEDITOR.ui.richCombo && groupStarted ) {
 						groupStarted = false;
 						output.push( '</span>' );
 
-					//if we have closed group and element that is not richBox we have to open group
+					// If we have closed group and element that is not richBox we have to open group.
 					} else if ( !( items[ itemKey ] instanceof CKEDITOR.ui.richCombo ) && !groupStarted ) {
 						groupStarted = true;
 						output.push( '<span class="cke_toolgroup">' );
 					}
 
-					//Now we can render element
+					// Now we can render element.
 					items[ itemKey ].render( this.editor, output );
 				}, this );
 
-				// We have to check if last group is closed
+				// We have to check if last group is closed.
 				if ( groupStarted ) {
 					output.push( '</span>' );
 				}

--- a/plugins/inlinetoolbar/plugin.js
+++ b/plugins/inlinetoolbar/plugin.js
@@ -142,9 +142,25 @@
 			 * @param {CKEDITOR.ui.button[]/CKEDITOR.ui.richCombo[]} items Array of UI elements objects.
 			 */
 			CKEDITOR.ui.inlineToolbarView.prototype.renderItems = function( items ) {
-				var output = [];
+				var output = [],
+					isStarted = false;
 				for ( var menuItem in items ) {
+
+					if ( items[ menuItem ] instanceof CKEDITOR.ui.richCombo ) {
+						if ( isStarted ) {
+							isStarted = false;
+							output.push( '</span>' );
+						}
+					} else {
+						if ( !isStarted ) {
+							output.push( '<span class="cke_toolgroup">' );
+							isStarted = true;
+						}
+					}
 					items[ menuItem ].render( this.editor, output );
+				}
+				if ( isStarted ) {
+					output.push( '</span>' );
 				}
 				this.parts.content.setHtml( output.join( '' ) );
 			};

--- a/plugins/inlinetoolbar/skins/kama/inlinetoolbar.css
+++ b/plugins/inlinetoolbar/skins/kama/inlinetoolbar.css
@@ -13,7 +13,7 @@ For licensing, see LICENSE.md or http://ckeditor.com/license
 .cke_balloon.cke_inlinetoolbar .cke_balloon_content
 {
 	min-height: 10px;
-	padding: 3px;
+	padding: 3px 3px 3px 9px;
 }
 
 /* side: [ bottom, top ] */
@@ -64,4 +64,10 @@ For licensing, see LICENSE.md or http://ckeditor.com/license
 .cke_balloon.cke_inlinetoolbar .cke_balloon_triangle_outer.cke_balloon_triangle_align_hcenter
 {
 	margin-left: -10px;
+}
+
+.cke_balloon.cke_inlinetoolbar .cke_toolgroup,
+.cke_balloon.cke_inlinetoolbar .cke_combo_button
+{
+	margin-bottom: 0px;
 }

--- a/plugins/inlinetoolbar/skins/moono-lisa/inlinetoolbar.css
+++ b/plugins/inlinetoolbar/skins/moono-lisa/inlinetoolbar.css
@@ -12,7 +12,7 @@ For licensing, see LICENSE.md or http://ckeditor.com/license
 .cke_balloon.cke_inlinetoolbar .cke_balloon_content
 {
 	min-height: 10px;
-	padding: 3px;
+	padding: 3px 9px 3px 9px;
 }
 
 /* side: [ bottom, top ] */
@@ -58,4 +58,10 @@ For licensing, see LICENSE.md or http://ckeditor.com/license
 .cke_balloon.cke_inlinetoolbar .cke_balloon_triangle_outer.cke_balloon_triangle_align_hcenter
 {
 	margin-left: -10px;
+}
+
+.cke_balloon.cke_inlinetoolbar .cke_toolgroup,
+.cke_balloon.cke_inlinetoolbar .cke_combo
+{
+	margin-bottom: 0px;
 }

--- a/plugins/inlinetoolbar/skins/moono-lisa/inlinetoolbar.css
+++ b/plugins/inlinetoolbar/skins/moono-lisa/inlinetoolbar.css
@@ -12,7 +12,7 @@ For licensing, see LICENSE.md or http://ckeditor.com/license
 .cke_balloon.cke_inlinetoolbar .cke_balloon_content
 {
 	min-height: 10px;
-	padding: 3px 9px 3px 9px;
+	padding: 3px 4px 3px 9px;
 }
 
 /* side: [ bottom, top ] */
@@ -66,7 +66,13 @@ For licensing, see LICENSE.md or http://ckeditor.com/license
 	margin-bottom: 0px;
 }
 
+.cke_balloon.cke_inlinetoolbar .cke_combo
+{
+	margin-right: 2px;
+}
+
 .cke_balloon.cke_inlinetoolbar span:last-child a:last-child::after,
-.cke_balloon.cke_inlinetoolbar span:last-child::after {
+.cke_balloon.cke_inlinetoolbar span:last-child::after
+{
 	border-right: 0px;
 }

--- a/plugins/inlinetoolbar/skins/moono-lisa/inlinetoolbar.css
+++ b/plugins/inlinetoolbar/skins/moono-lisa/inlinetoolbar.css
@@ -65,3 +65,8 @@ For licensing, see LICENSE.md or http://ckeditor.com/license
 {
 	margin-bottom: 0px;
 }
+
+.cke_balloon.cke_inlinetoolbar span:last-child a:last-child::after,
+.cke_balloon.cke_inlinetoolbar span:last-child::after {
+	border-right: 0px;
+}

--- a/plugins/inlinetoolbar/skins/moono/inlinetoolbar.css
+++ b/plugins/inlinetoolbar/skins/moono/inlinetoolbar.css
@@ -14,7 +14,7 @@ For licensing, see LICENSE.md or http://ckeditor.com/license
 .cke_balloon.cke_inlinetoolbar .cke_balloon_content
 {
 	min-height: 10px;
-	padding: 3px;
+	padding: 3px 3px 3px 9px;
 }
 
 /* side: [ bottom, top ] */
@@ -62,4 +62,10 @@ For licensing, see LICENSE.md or http://ckeditor.com/license
 .cke_balloon.cke_inlinetoolbar .cke_balloon_triangle_outer.cke_balloon_triangle_align_hcenter
 {
 	margin-left: -10px;
+}
+
+.cke_balloon.cke_inlinetoolbar .cke_toolgroup,
+.cke_balloon.cke_inlinetoolbar .cke_combo_button
+{
+	margin-bottom: 0px;
 }

--- a/tests/plugins/inlinetoolbar/buttons.js
+++ b/tests/plugins/inlinetoolbar/buttons.js
@@ -31,7 +31,7 @@
 			assert.isUndefined( panel.getItem( 'cut' ), 'The button should be deleted.' );
 		},
 
-		'test group wrapping': function() {
+		'test buuton group wrapping': function() {
 			var panel = new CKEDITOR.ui.inlineToolbar( this.editor );
 			panel.addItems( {
 				cut: new CKEDITOR.ui.button( {
@@ -41,6 +41,74 @@
 			} );
 			panel._view.renderItems( panel._items );
 			assert.isNotNull( panel._view.parts.content.findOne( '.cke_toolgroup' ), 'Button should be wrapped in group' );
+		},
+
+		'test group wrapping ommiting checkbox': function() {
+			var panel = new CKEDITOR.ui.inlineToolbar( this.editor );
+			panel.addItems( {
+				rich: new CKEDITOR.ui.richCombo( {
+					className: 'richCombo',
+					panel: {
+						css: [],
+						multiSelect: false
+					},
+					init: function() {},
+					onClick: function() {},
+					onRender: function() {}
+				} )
+			} );
+			panel._view.renderItems( panel._items );
+			assert.isNull( panel._view.parts.content.findOne( '.cke_toolgroup' ), 'Checkbox should not be wrapped in group' );
+		},
+
+		'test group wrapping ommiting checkbox at the beggining': function() {
+			var panel = new CKEDITOR.ui.inlineToolbar( this.editor );
+			panel.addItems( {
+				rich: new CKEDITOR.ui.richCombo( {
+					className: 'richCombo',
+					panel: {
+						css: [],
+						multiSelect: false
+					},
+					init: function() {},
+					onClick: function() {},
+					onRender: function() {}
+				} ),
+				cut: new CKEDITOR.ui.button( {
+					label: 'test',
+					command: 'cut'
+				} )
+			} );
+			panel._view.renderItems( panel._items );
+			assert.areEqual( 1, panel._view.parts.content.find( '.cke_toolgroup' ).count(), 'There should be only one toolgroup' );
+			assert.isNull( panel._view.parts.content.findOne( '.cke_toolgroup' ).findOne( '.richCombo' ), 'Rich combo should not be inside toolgroup' );
+
+		},
+
+		'test mixed group': function() {
+			var panel = new CKEDITOR.ui.inlineToolbar( this.editor );
+			panel.addItems( {
+				test: new CKEDITOR.ui.button( {
+					label: 'test',
+					command: 'cut'
+				} ),
+				rich: new CKEDITOR.ui.richCombo( {
+					className: 'richCombo',
+					panel: {
+						css: [],
+						multiSelect: false
+					},
+					init: function() {},
+					onClick: function() {},
+					onRender: function() {}
+				} ),
+				cut: new CKEDITOR.ui.button( {
+					label: 'test',
+					command: 'cut'
+				} )
+			} );
+			panel._view.renderItems( panel._items );
+			assert.areEqual( 2, panel._view.parts.content.find( '.cke_toolgroup' ).count(), 'There should be two toolgroups' );
 		}
 	} );
 } )();

--- a/tests/plugins/inlinetoolbar/buttons.js
+++ b/tests/plugins/inlinetoolbar/buttons.js
@@ -31,7 +31,7 @@
 			assert.isUndefined( panel.getItem( 'cut' ), 'The button should be deleted.' );
 		},
 
-		'test buuton group wrapping': function() {
+		'test button group wrapping': function() {
 			var panel = new CKEDITOR.ui.inlineToolbar( this.editor );
 			panel.addItems( {
 				cut: new CKEDITOR.ui.button( {
@@ -43,7 +43,7 @@
 			assert.isNotNull( panel._view.parts.content.findOne( '.cke_toolgroup' ), 'Button should be wrapped in group' );
 		},
 
-		'test group wrapping ommiting checkbox': function() {
+		'test group wrapping omitting rich combo': function() {
 			var panel = new CKEDITOR.ui.inlineToolbar( this.editor );
 			panel.addItems( {
 				rich: new CKEDITOR.ui.richCombo( {
@@ -61,7 +61,7 @@
 			assert.isNull( panel._view.parts.content.findOne( '.cke_toolgroup' ), 'Checkbox should not be wrapped in group' );
 		},
 
-		'test group wrapping ommiting checkbox at the beggining': function() {
+		'test group wrapping omiting rich combo at the beginning': function() {
 			var panel = new CKEDITOR.ui.inlineToolbar( this.editor );
 			panel.addItems( {
 				rich: new CKEDITOR.ui.richCombo( {

--- a/tests/plugins/inlinetoolbar/buttons.js
+++ b/tests/plugins/inlinetoolbar/buttons.js
@@ -1,5 +1,5 @@
 /* bender-tags: inlinetoolbar */
-/* bender-ckeditor-plugins: inlinetoolbar,button */
+/* bender-ckeditor-plugins: inlinetoolbar,button,richcombo */
 
 ( function() {
 	'use strict';
@@ -16,8 +16,8 @@
 				} )
 			} );
 			assert.isInstanceOf( CKEDITOR.ui.button, panel.getItem( 'cut' ), 'Registered button type.' );
-
 		},
+
 		'test removing buttion': function() {
 			var panel = new CKEDITOR.ui.inlineToolbar( this.editor );
 			panel.addItems( {
@@ -29,7 +29,18 @@
 			assert.isInstanceOf( CKEDITOR.ui.button, panel.getItem( 'cut' ), 'Registered button type.' );
 			panel.deleteItem( 'cut' );
 			assert.isUndefined( panel.getItem( 'cut' ), 'The button should be deleted.' );
+		},
 
+		'test group wrapping': function() {
+			var panel = new CKEDITOR.ui.inlineToolbar( this.editor );
+			panel.addItems( {
+				cut: new CKEDITOR.ui.button( {
+					label: 'test',
+					command: 'cut'
+				} )
+			} );
+			panel._view.renderItems( panel._items );
+			assert.isNotNull( panel._view.parts.content.findOne( '.cke_toolgroup' ), 'Button should be wrapped in group' );
 		}
 	} );
 } )();

--- a/tests/plugins/inlinetoolbar/manual/kama.html
+++ b/tests/plugins/inlinetoolbar/manual/kama.html
@@ -49,7 +49,11 @@
 					command: 'bold'
 				} ),
 				language: evt.editor.ui.create('Language'),
-				Styles: evt.editor.ui.create( 'Styles' )
+				Styles: evt.editor.ui.create( 'Styles' ),
+				italic: new CKEDITOR.ui.button( {
+					label: 'test',
+					command: 'italic'
+				} )
 			} );
 			panel.create( this );
 		} );

--- a/tests/plugins/inlinetoolbar/manual/moono-lisa.html
+++ b/tests/plugins/inlinetoolbar/manual/moono-lisa.html
@@ -49,7 +49,11 @@
 					command: 'bold'
 				} ),
 				language: evt.editor.ui.create('Language'),
-				Styles: evt.editor.ui.create( 'Styles' )
+				Styles: evt.editor.ui.create( 'Styles' ),
+				italic: new CKEDITOR.ui.button( {
+					label: 'test',
+					command: 'italic'
+				} )
 			} );
 			panel.create( this );
 		} );

--- a/tests/plugins/inlinetoolbar/manual/moono.html
+++ b/tests/plugins/inlinetoolbar/manual/moono.html
@@ -49,7 +49,11 @@
 					command: 'bold'
 				} ),
 				language: evt.editor.ui.create('Language'),
-				Styles: evt.editor.ui.create( 'Styles' )
+				Styles: evt.editor.ui.create( 'Styles' ),
+				italic: new CKEDITOR.ui.button( {
+					label: 'test',
+					command: 'italic'
+				} )
 			} );
 			panel.create( this );
 		} );

--- a/tests/plugins/inlinetoolbar/view.js
+++ b/tests/plugins/inlinetoolbar/view.js
@@ -28,7 +28,7 @@
 
 			view.renderItems( items );
 
-			assert.areSame( 'aabb', view.parts.content.getHtml() );
+			assert.areSame( '<span class="cke_toolgroup">aabb</span>', view.parts.content.getHtml() );
 		},
 
 		'test inlineToolbarView.render empty list': function() {


### PR DESCRIPTION
## What is the purpose of this pull request?

Automatic wrapping buttons to groups in inline toolbar

## Does your PR contain necessary tests?

All patches which change the editor code must include tests. You can always read more
on [PR testing](http://docs.ckeditor.com/#!/guide/dev_contributing_code-section-tests),
[how to set the testing environment](http://docs.ckeditor.com/#!/guide/dev_tests) and
[how to create tests](http://docs.ckeditor.com/#!/guide/dev_tests-section-creating-your-own-test)
in the official CKEditor documentation.

### This PR contains

- [X] Unit tests
- [X] Manual tests

## What changes did you make?

I added wrapping buttons in to groups. Manual tests for skins are updated and CSS files are updated.
