### PR TITLE
Balloon panel API change

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -32,6 +32,7 @@ Fixed Issues:
 API Changes:
 
 * [#1097](https://github.com/ckeditor/ckeditor-dev/issues/1097): Widget [`upcast`](https://docs.ckeditor.com/ckeditor4/docs/#!/api/CKEDITOR.plugins.widget.definition-property-upcast) methods are now called in the [widget definition's](https://docs.ckeditor.com/ckeditor4/docs/#!/api/CKEDITOR.plugins.widget-property-definition) context.
+* [#1118](https://github.com/ckeditor/ckeditor-dev/issues/1118): Added `show` option in [`balloonPanel.attach`](https://docs.ckeditor.com/ckeditor4/docs/#!/api/CKEDITOR.ui.balloonPanel-method-attach) method, allowing to attach a hidden [Balloon Panel](http://ckeditor.com/addon/balloonpanel) instance.
 
 Other Changes:
 

--- a/plugins/balloonpanel/plugin.js
+++ b/plugins/balloonpanel/plugin.js
@@ -392,8 +392,7 @@
 				}
 
 				options = CKEDITOR.tools.extend( options, {
-					show: true,
-					focusElement: undefined
+					show: true
 				} );
 
 				if ( options.show === true ) {

--- a/plugins/balloonpanel/plugin.js
+++ b/plugins/balloonpanel/plugin.js
@@ -320,10 +320,13 @@
 		 *
 		 * @method attach
 		 * @param {CKEDITOR.dom.element} element The element to which the panel is attached.
-		 * @param {CKEDITOR.dom.element/Boolean} [focusElement] The element to be focused after the panel
+		 * @param {Object} options Ballonpanel focus and show options
+		 * @param {CKEDITOR.dom.element/Boolean} [options.focusElement] The element to be focused after the panel
 		 * is attached. By default the `panel` property of {@link #parts} will be focused. You might specify the element
 		 * to be focused by passing any {@link CKEDITOR.dom.element} instance.
 		 * You can also prevent changing focus at all by setting it to `false`.
+		 * Balloonpanel still support old API where focusElement was second param of attach method.
+		 * @param {Boolean} options.show Param defines if we want to show balloonpanel after attach.
 		 */
 		attach: ( function() {
 			var winGlobal, frame, editable, isInline;
@@ -383,8 +386,18 @@
 				left: 'right'
 			};
 
-			return function( element, focusElement ) {
-				this.show();
+			return function( element, options ) {
+				var focusElement;
+				// Support for old API.
+				if ( options instanceof CKEDITOR.dom.element || typeof options === 'boolean' || typeof options === 'undefined' ) {
+					focusElement = options;
+					this.show();
+				} else {
+					if ( options.show ) {
+						this.show();
+					}
+					focusElement = options.focusElement;
+				}
 
 				this.fire( 'attach' );
 

--- a/plugins/balloonpanel/plugin.js
+++ b/plugins/balloonpanel/plugin.js
@@ -326,7 +326,7 @@
 		 * to be focused by passing any {@link CKEDITOR.dom.element} instance.
 		 * You can also prevent changing focus at all by setting it to `false`.
 		 * Balloonpanel still support old API where focusElement was second param of attach method.
-		 * @param {Boolean} options.show Param defines if we want to show balloonpanel after attach.
+		 * @param {Boolean} [options.show] Param defines if we want to show balloonpanel after attach. By default panel will show.
 		 */
 		attach: ( function() {
 			var winGlobal, frame, editable, isInline;
@@ -393,7 +393,7 @@
 					focusElement = options;
 					this.show();
 				} else {
-					if ( options.show ) {
+					if ( options.show === true || typeof options.show === 'undefined' ) {
 						this.show();
 					}
 					focusElement = options.focusElement;

--- a/plugins/balloonpanel/plugin.js
+++ b/plugins/balloonpanel/plugin.js
@@ -320,9 +320,9 @@
 		 *
 		 * @method attach
 		 * @param {CKEDITOR.dom.element} element The element to which the panel is attached.
-		 * @param {Object/CKEDITOR.dom.element/Boolean} [options] **Since 4.8.0** this parameter works as options object.
+		 * @param {Object/CKEDITOR.dom.element/Boolean} [options] **Since 4.8.0** this parameter works as `options` object.
 		 *
-		 * If CKEDITOR.dom.element/Boolean instance is given this parameter acts as a options.focusElement.
+		 * If `{@link CKEDITOR.dom.element}/Boolean` instance is given this parameter acts as a `options.focusElement`.
 		 * @param {CKEDITOR.dom.element/Boolean} [options.focusElement] The element to be focused after the panel
 		 * is attached. By default the `panel` property of {@link #parts} will be focused. You might specify the element
 		 * to be focused by passing any {@link CKEDITOR.dom.element} instance.

--- a/plugins/balloonpanel/plugin.js
+++ b/plugins/balloonpanel/plugin.js
@@ -387,7 +387,7 @@
 			};
 
 			return function( element, options ) {
-				if ( options instanceof CKEDITOR.dom.element || typeof options === 'boolean' || typeof options === 'undefined' ) {
+				if ( options instanceof CKEDITOR.dom.element || !options ) {
 					options = { focusElement: options };
 				}
 

--- a/plugins/balloonpanel/plugin.js
+++ b/plugins/balloonpanel/plugin.js
@@ -321,7 +321,8 @@
 		 * @method attach
 		 * @param {CKEDITOR.dom.element} element The element to which the panel is attached.
 		 * @param {Object/CKEDITOR.dom.element/Boolean} [options] **Since 4.8.0** this parameter works as options object.
-		 * Balloonpanel still support old API where `CKEDITOR.dom.element/Boolean` will be used as `options.focusElement`.
+		 *
+		 * If CKEDITOR.dom.element/Boolean instance is given this parameter acts as a options.focusElement.
 		 * @param {CKEDITOR.dom.element/Boolean} [options.focusElement] The element to be focused after the panel
 		 * is attached. By default the `panel` property of {@link #parts} will be focused. You might specify the element
 		 * to be focused by passing any {@link CKEDITOR.dom.element} instance.

--- a/plugins/balloonpanel/plugin.js
+++ b/plugins/balloonpanel/plugin.js
@@ -320,13 +320,13 @@
 		 *
 		 * @method attach
 		 * @param {CKEDITOR.dom.element} element The element to which the panel is attached.
-		 * @param {Object} options Ballonpanel focus and show options
+		 * @param {Object/CKEDITOR.dom.element/Boolean} [options] **Since 4.8.0** this parameter works as options object.
+		 * Balloonpanel still support old API where `CKEDITOR.dom.element/Boolean` will be used as `options.focusElement`.
 		 * @param {CKEDITOR.dom.element/Boolean} [options.focusElement] The element to be focused after the panel
 		 * is attached. By default the `panel` property of {@link #parts} will be focused. You might specify the element
 		 * to be focused by passing any {@link CKEDITOR.dom.element} instance.
 		 * You can also prevent changing focus at all by setting it to `false`.
-		 * Balloonpanel still support old API where focusElement was second param of attach method.
-		 * @param {Boolean} [options.show] Param defines if we want to show balloonpanel after attach. By default panel will show.
+		 * @param {Boolean} [options.show=true] Param defines if we want to show balloonpanel after attach.
 		 */
 		attach: ( function() {
 			var winGlobal, frame, editable, isInline;
@@ -387,16 +387,17 @@
 			};
 
 			return function( element, options ) {
-				var focusElement;
-				// Support for old API.
 				if ( options instanceof CKEDITOR.dom.element || typeof options === 'boolean' || typeof options === 'undefined' ) {
-					focusElement = options;
+					options = { focusElement: options };
+				}
+
+				options = CKEDITOR.tools.extend( options, {
+					show: true,
+					focusElement: undefined
+				} );
+
+				if ( options.show === true ) {
 					this.show();
-				} else {
-					if ( options.show === true || typeof options.show === 'undefined' ) {
-						this.show();
-					}
-					focusElement = options.focusElement;
 				}
 
 				this.fire( 'attach' );
@@ -487,8 +488,8 @@
 				this.setTriangle( triangleRelativePosition[ minDifferenceAlignment[ 0 ] ], minDifferenceAlignment[ 1 ] );
 
 				// Set focus to proper element.
-				if ( focusElement !== false ) {
-					( focusElement || this.parts.panel ).focus();
+				if ( options.focusElement !== false ) {
+					( options.focusElement || this.parts.panel ).focus();
 				}
 			};
 		} )(),

--- a/tests/plugins/balloonpanel/balloonpanel.js
+++ b/tests/plugins/balloonpanel/balloonpanel.js
@@ -149,15 +149,46 @@
 			assert.isTrue( doc.getActive().equals( panelElement ), 'Panel element is focused' );
 
 			// Giving focus element explicitly.
-			panel.attach( strong, closeElement );
+			panel.attach( strong, { focusElement: closeElement } );
 			assert.isTrue( doc.getActive().equals( closeElement ), 'Close element is focused' );
 
 			// Blur focused element, so the body will be focused.
 			closeElement.$.blur();
 
 			// Ensure that focus is not changed when giving false.
-			panel.attach( strong, false );
+			panel.attach( strong, { focusElement: false } );
 			assert.isTrue( doc.getActive().equals( doc.getBody() ), 'Focus remains on body element' );
+		},
+		'test panel show option': function() {
+			var panel = new CKEDITOR.ui.balloonPanel( bender.editor, {
+				title: 'Test panel #3'
+			} ),
+				strong = bender.editor.document.findOne( 'strong' ),
+				showEvent = false;
+
+			panel.addShowListener( function() {
+				showEvent = true;
+				return {
+					removeListener: function() {
+						showEvent = false;
+					}
+				};
+			} );
+
+
+			panel.attach( strong, { show: false } );
+			assert.isFalse( showEvent, 'Event show should not be fired when show param is false.' );
+
+			panel.attach( strong, { show: true } );
+			assert.isTrue( showEvent, 'Event show should be fired when show param is true.' );
+			panel.hide();
+			assert.isFalse( showEvent, 'After hide showElement should be false' );
+
+			panel.attach( strong, {} );
+			assert.isTrue( showEvent, 'Event show should be fired when show param is undefined.' );
+			panel.hide();
+
+			panels.push( panel );
 		},
 
 		'test panel destroy': function() {

--- a/tests/plugins/balloonpanel/balloonpanel.js
+++ b/tests/plugins/balloonpanel/balloonpanel.js
@@ -159,41 +159,38 @@
 			panel.attach( strong, { focusElement: false } );
 			assert.isTrue( doc.getActive().equals( doc.getBody() ), 'Focus remains on body element' );
 		},
+
 		'test panel show option': function() {
 			var panel = new CKEDITOR.ui.balloonPanel( bender.editor, {
-				title: 'Test panel #3'
-			} ),
+					title: 'Test panel #4'
+				} ),
 				strong = bender.editor.document.findOne( 'strong' ),
-				showEvent = false;
-
-			panel.addShowListener( function() {
-				showEvent = true;
-				return {
-					removeListener: function() {
-						showEvent = false;
-					}
+				showListener = sinon.stub(),
+				resetState = function() {
+					showListener.reset();
+					panel.hide();
 				};
-			} );
+
+			panel.addShowListener( showListener );
+			panels.push( panel );
 
 
 			panel.attach( strong, { show: false } );
-			assert.isFalse( showEvent, 'Event show should not be fired when show param is false.' );
+			assert.isFalse( showListener.called, 'Event show should not be fired when show param is false.' );
+			resetState();
 
 			panel.attach( strong, { show: true } );
-			assert.isTrue( showEvent, 'Event show should be fired when show param is true.' );
-			panel.hide();
-			assert.isFalse( showEvent, 'After hide showElement should be false' );
+			assert.isTrue( showListener.called, 'Event show should be fired when show param is true.' );
+			resetState();
 
 			panel.attach( strong, {} );
-			assert.isTrue( showEvent, 'Event show should be fired when show param is undefined.' );
-			panel.hide();
-
-			panels.push( panel );
+			assert.isTrue( showListener.called, 'Event show should be fired when show param is undefined.' );
+			resetState();
 		},
 
 		'test panel destroy': function() {
 			var panel = new CKEDITOR.ui.balloonPanel( bender.editor, {
-				title: 'Test panel #4'
+				title: 'Test panel #5'
 			} );
 
 			panels.push( panel );

--- a/tests/plugins/balloonpanel/balloonpanel.js
+++ b/tests/plugins/balloonpanel/balloonpanel.js
@@ -186,6 +186,10 @@
 			panel.attach( strong, {} );
 			assert.isTrue( showListener.called, 'Event show should be fired when show param is undefined.' );
 			resetState();
+
+			panel.attach( strong, null );
+			assert.isTrue( showListener.called, 'Event show should be fired when show param is null.' );
+			resetState();
 		},
 
 		'test panel destroy': function() {


### PR DESCRIPTION
## What is the purpose of this pull request?

New feature

### This PR contains

- [X] Unit tests
- [ ] Manual tests

## What changes did you make?

Balloon panel still support old API in `attach` method but now We are able to give options param:
```
{
    focusElement: CKEDITOR.dom.element/Boolean
    show: Boolean
}
```
Thanks to this we can attach balloon panel without showing it.

Closes #1118