### PR TITLE
Link feature for imagebase

### DIFF
--- a/plugins/easyimage/plugin.js
+++ b/plugins/easyimage/plugin.js
@@ -163,6 +163,8 @@
 			widgetDefinition.allowedContent.figure.classes = '!' + figureClass + ',' + widgetDefinition.allowedContent.figure.classes;
 		}
 
+		widgetDefinition = CKEDITOR.plugins.imagebase.addFeature( 'link', widgetDefinition );
+
 		CKEDITOR.plugins.imagebase.addImageWidget( editor, 'easyimage', widgetDefinition );
 	}
 
@@ -288,7 +290,7 @@
 	};
 
 	CKEDITOR.plugins.add( 'easyimage', {
-		requires: 'imagebase,uploadwidget,contextmenu,dialog,cloudservices',
+		requires: 'imagebase,uploadwidget,contextmenu,dialog,cloudservices,link',
 		lang: 'en',
 
 		onLoad: function() {

--- a/plugins/easyimage/plugin.js
+++ b/plugins/easyimage/plugin.js
@@ -163,7 +163,7 @@
 			widgetDefinition.allowedContent.figure.classes = '!' + figureClass + ',' + widgetDefinition.allowedContent.figure.classes;
 		}
 
-		widgetDefinition = CKEDITOR.plugins.imagebase.addFeature( 'link', widgetDefinition );
+		widgetDefinition = CKEDITOR.plugins.imagebase.addFeature( editor, 'link', widgetDefinition );
 
 		CKEDITOR.plugins.imagebase.addImageWidget( editor, 'easyimage', widgetDefinition );
 	}

--- a/plugins/easyimage/plugin.js
+++ b/plugins/easyimage/plugin.js
@@ -163,7 +163,9 @@
 			widgetDefinition.allowedContent.figure.classes = '!' + figureClass + ',' + widgetDefinition.allowedContent.figure.classes;
 		}
 
-		widgetDefinition = CKEDITOR.plugins.imagebase.addFeature( editor, 'link', widgetDefinition );
+		if ( editor.plugins.link ) {
+			widgetDefinition = CKEDITOR.plugins.imagebase.addFeature( editor, 'link', widgetDefinition );
+		}
 
 		CKEDITOR.plugins.imagebase.addImageWidget( editor, 'easyimage', widgetDefinition );
 	}
@@ -290,7 +292,7 @@
 	};
 
 	CKEDITOR.plugins.add( 'easyimage', {
-		requires: 'imagebase,uploadwidget,contextmenu,dialog,cloudservices,link',
+		requires: 'imagebase,contextmenu,dialog,cloudservices',
 		lang: 'en',
 
 		onLoad: function() {

--- a/plugins/easyimage/plugin.js
+++ b/plugins/easyimage/plugin.js
@@ -292,7 +292,7 @@
 	};
 
 	CKEDITOR.plugins.add( 'easyimage', {
-		requires: 'imagebase,contextmenu,dialog,cloudservices',
+		requires: 'imagebase,uploadwidget,contextmenu,dialog,cloudservices',
 		lang: 'en',
 
 		onLoad: function() {

--- a/plugins/easyimage/plugin.js
+++ b/plugins/easyimage/plugin.js
@@ -303,6 +303,11 @@
 			loadStyles( editor, this );
 			addCommands( editor );
 			addMenuItems( editor );
+		},
+
+		// Widget must be registered after init in case that link plugin is dynamically loaded e.g. via
+		// `config.extraPlugins`.
+		afterInit: function( editor ) {
 			registerWidget( editor );
 			registerUploadWidget( editor );
 		}

--- a/plugins/easyimage/plugin.js
+++ b/plugins/easyimage/plugin.js
@@ -125,7 +125,7 @@
 				upcasts: {
 					figure: function( element ) {
 						if ( ( !figureClass || element.hasClass( figureClass ) ) &&
-							element.find( 'img' ).length === 1 ) {
+							element.find( 'img', true ).length === 1 ) {
 							return element;
 						}
 					}

--- a/plugins/imagebase/plugin.js
+++ b/plugins/imagebase/plugin.js
@@ -40,18 +40,6 @@
 		return link;
 	}
 
-	function deleteLink( img ) {
-		var link = img.getAscendant( 'a' );
-
-		if ( !link ) {
-			return;
-		}
-
-		img.replace( link );
-
-		return img;
-	}
-
 	function getLinkData( widget ) {
 		return CKEDITOR.plugins.link.parseLinkAttributes( widget.editor, widget.parts.link );
 	}
@@ -161,8 +149,7 @@
 
 				// Unlink was invoked.
 				if ( link === null ) {
-					deleteLink( img );
-
+					this.parts.link.remove( true );
 					this.parts.link = null;
 				} else {
 					var linkElement = createLink( editor, img, link );

--- a/plugins/imagebase/plugin.js
+++ b/plugins/imagebase/plugin.js
@@ -71,7 +71,8 @@
 				editor.on( 'dialogShow', function( evt ) {
 					var widget = getFocusedWidget( editor ),
 						dialog = evt.data,
-						displayTextField;
+						displayTextField,
+						okListener;
 
 					if ( !isLinkable( widget ) || dialog._.name !== 'link' ) {
 						return;
@@ -82,7 +83,7 @@
 					dialog.setupContent( widget.data.link || {} );
 					displayTextField.hide();
 
-					dialog.once( 'ok', function( evt ) {
+					okListener = dialog.once( 'ok', function( evt ) {
 						if ( !isLinkable( widget ) ) {
 							return;
 						}
@@ -96,6 +97,7 @@
 					}, null, null, 9 );
 
 					dialog.once( 'hide', function() {
+						okListener.removeListener();
 						displayTextField.show();
 					} );
 				} );

--- a/plugins/imagebase/plugin.js
+++ b/plugins/imagebase/plugin.js
@@ -35,6 +35,10 @@
 		return img;
 	}
 
+	function getLinkData( widget ) {
+		return CKEDITOR.plugins.link.parseLinkAttributes( widget.parts.link );
+	}
+
 	var featuresDefinitions = {
 		link: {
 			allowedContent: {
@@ -119,6 +123,11 @@
 			data: function( evt ) {
 				var link = evt.data.link,
 					img = this.element.findOne( 'img' );
+
+				// Widget is inited with link, so let's set appropriate data.
+				if ( typeof link === 'undefined' && this.parts.link ) {
+					this.setData( 'link', getLinkData( this ) );
+				}
 
 				if ( typeof link === 'undefined' ) {
 					return;

--- a/plugins/imagebase/plugin.js
+++ b/plugins/imagebase/plugin.js
@@ -57,7 +57,7 @@
 
 			setUp: function( editor ) {
 				if ( !editor.plugins.link ) {
-					// All of listeners registered later on make only when link plugin is loaded.
+					// All of listeners registered later on make only sense when link plugin is loaded.
 					return;
 				}
 

--- a/plugins/imagebase/plugin.js
+++ b/plugins/imagebase/plugin.js
@@ -286,7 +286,7 @@
 		 * with fields needed by feature.
 		 */
 		addFeature: function( editor, name, definition ) {
-			var featureDefinition = featuresDefinitions[ name ];
+			var featureDefinition = CKEDITOR.tools.clone( featuresDefinitions[ name ] );
 
 			function mergeMethods( oldOne, newOne ) {
 				if ( !oldOne && !newOne ) {

--- a/plugins/imagebase/plugin.js
+++ b/plugins/imagebase/plugin.js
@@ -36,7 +36,7 @@
 	}
 
 	function getLinkData( widget ) {
-		return CKEDITOR.plugins.link.parseLinkAttributes( widget.parts.link );
+		return CKEDITOR.plugins.link.parseLinkAttributes( widget.editor, widget.parts.link );
 	}
 
 	var featuresDefinitions = {

--- a/plugins/imagebase/plugin.js
+++ b/plugins/imagebase/plugin.js
@@ -89,6 +89,8 @@
 						return;
 					}
 
+					evt.stop();
+
 					widget.setData( 'link', null );
 
 					// Selection (which is fake) may not change if unlinked image in focused widget,
@@ -104,9 +106,11 @@
 						return;
 					}
 
+					evt.stop();
+
 					// Note that widget may be wrapped in a link, which
 					// does not belong to that widget (http://dev.ckeditor.com/ticket/11814).
-					this.setState( widget.data.link ? CKEDITOR.TRISTATE_OFF : CKEDITOR.TRISTATE_DISABLED );
+					this.setState( widget.parts.link ? CKEDITOR.TRISTATE_OFF : CKEDITOR.TRISTATE_DISABLED );
 
 					evt.cancel();
 				} );
@@ -123,8 +127,10 @@
 				// Unlink was invoked.
 				if ( link === null ) {
 					unwrapFromLink( img );
+
+					this.parts.link = null;
 				} else {
-					wrapInLink( img, link );
+					this.parts.link = wrapInLink( img, link );
 				}
 			}
 		}

--- a/plugins/imagebase/plugin.js
+++ b/plugins/imagebase/plugin.js
@@ -204,7 +204,7 @@
 
 			upcasts: {
 				figure: function( element ) {
-					if ( element.find( 'img' ).length === 1 ) {
+					if ( element.find( 'img', true ).length === 1 ) {
 						return element;
 					}
 				}

--- a/plugins/imagebase/plugin.js
+++ b/plugins/imagebase/plugin.js
@@ -56,6 +56,10 @@
 			},
 
 			setUp: function( editor ) {
+				if ( !editor.plugins.link ) {
+					return;
+				}
+
 				editor.on( 'dialogShow', function( evt ) {
 					var widget = getFocusedWidget( editor ),
 						dialog = evt.data,

--- a/plugins/imagebase/plugin.js
+++ b/plugins/imagebase/plugin.js
@@ -11,7 +11,7 @@
 	}
 
 	function isLinkable( widget ) {
-		return widget && widget.widgetFeatures && CKEDITOR.tools.array.indexOf( widget.widgetFeatures, 'link' ) !== -1;
+		return widget && widget.features && CKEDITOR.tools.array.indexOf( widget.features, 'link' ) !== -1;
 	}
 
 	function addLinkAttributes( editor, linkElement, linkData ) {
@@ -203,9 +203,9 @@
 			/**
 			 * The array containing names of features added to this widget's definition.
 			 *
-			 * @property {String[]} widgetFeatures
+			 * @property {String[]} features
 			 */
-			widgetFeatures: [],
+			features: [],
 
 			editables: {
 				caption: {
@@ -316,11 +316,11 @@
 
 			ret = CKEDITOR.tools.object.merge( definition, featureDefinition );
 
-			if ( !CKEDITOR.tools.isArray( ret.widgetFeatures ) ) {
-				ret.widgetFeatures = [];
+			if ( !CKEDITOR.tools.isArray( ret.features ) ) {
+				ret.features = [];
 			}
 
-			ret.widgetFeatures.push( name );
+			ret.features.push( name );
 
 			return ret;
 		}

--- a/plugins/imagebase/plugin.js
+++ b/plugins/imagebase/plugin.js
@@ -205,6 +205,13 @@
 
 			requiredContent: 'figure; img[!src]',
 
+			/**
+			 * The array containing names of features added to this widget's definition
+			 *
+			 * @property {String[]} widgetFeatures
+			 */
+			widgetFeatures: [],
+
 			editables: {
 				caption: {
 					selector: 'figcaption',
@@ -310,6 +317,8 @@
 
 				delete featureDefinition.setUp;
 			}
+
+			featureDefinition.widgetFeatures = [ name ];
 
 			return CKEDITOR.tools.object.merge( definition, featureDefinition );
 		}

--- a/plugins/imagebase/plugin.js
+++ b/plugins/imagebase/plugin.js
@@ -83,6 +83,10 @@
 					dialog.setupContent( widget.data.link || {} );
 					displayTextField.hide();
 
+					// This listener overwrites the default action after pressing "OK" button in link dialog.
+					// It gets the user input and set appropriate data in the widget.
+					// `evt.stop` and higher priority are necessary to prevent adding unwanted link to
+					// widget's caption.
 					okListener = dialog.once( 'ok', function( evt ) {
 						if ( !isLinkable( widget ) ) {
 							return;

--- a/plugins/imagebase/plugin.js
+++ b/plugins/imagebase/plugin.js
@@ -11,7 +11,7 @@
 	}
 
 	function isLinkable( widget ) {
-		return widget && typeof widget.parts.link !== 'undefined';
+		return widget && widget.widgetFeatures && CKEDITOR.tools.array.indexOf( widget.widgetFeatures, 'link' ) !== -1;
 	}
 
 	function addLinkAttributes( editor, linkElement, linkData ) {

--- a/plugins/imagebase/plugin.js
+++ b/plugins/imagebase/plugin.js
@@ -11,7 +11,14 @@
 	}
 
 	function wrapInLink( img, linkData ) {
-		var link = img.getDocument().createElement( 'a', {
+		// Covers cases when widget with link inside is upcasted.
+		var link = img.getAscendant( 'a' );
+
+		if ( link ) {
+			return link;
+		}
+
+		link = img.getDocument().createElement( 'a', {
 			attributes: {
 				href: linkData.url.url
 			}

--- a/plugins/imagebase/plugin.js
+++ b/plugins/imagebase/plugin.js
@@ -271,6 +271,20 @@
 			editor.addFeature( widget );
 		},
 
+		/**
+		 * Adds new feature to the newly created image widget by invoking initial setup once for the editor
+		 * and extending widget's definition to include all fields needed by this feature.
+		 *
+		 *		var widgetDefinition = {};
+		 *		widgetDefinition = CKEDITOR.plugins.imagebase.addFeature( editor, 'link', widgetDefinition );
+		 *		CKEDITOR.plugins.imagebase.addImageWidget( editor, 'myWidget', widgetDefinition );
+		 *
+		 * @param {CKEDITOR.editor} editor Editor that will get the widget registered.
+		 * @param {String} name Feature name.
+		 * @param {CKEDITOR.plugins.imagebase.imageWidgetDefinition} definition Widget's definition.
+		 * @returns {CKEDITOR.plugins.imagebase.imageWidgetDefinition} Widget's definition extended
+		 * with fields needed by feature.
+		 */
 		addFeature: function( editor, name, definition ) {
 			var featureDefinition = featuresDefinitions[ name ];
 

--- a/plugins/imagebase/plugin.js
+++ b/plugins/imagebase/plugin.js
@@ -291,7 +291,8 @@
 		 * with fields needed by feature.
 		 */
 		addFeature: function( editor, name, definition ) {
-			var featureDefinition = CKEDITOR.tools.clone( this.featuresDefinitions[ name ] );
+			var featureDefinition = CKEDITOR.tools.clone( this.featuresDefinitions[ name ] ),
+				ret;
 
 			function mergeMethods( oldOne, newOne ) {
 				if ( !oldOne && !newOne ) {
@@ -313,9 +314,15 @@
 				delete featureDefinition.setUp;
 			}
 
-			featureDefinition.widgetFeatures = [ name ];
+			ret = CKEDITOR.tools.object.merge( definition, featureDefinition );
 
-			return CKEDITOR.tools.object.merge( definition, featureDefinition );
+			if ( !CKEDITOR.tools.isArray( ret.widgetFeatures ) ) {
+				ret.widgetFeatures = [];
+			}
+
+			ret.widgetFeatures.push( name );
+
+			return ret;
 		}
 	};
 }() );

--- a/plugins/imagebase/plugin.js
+++ b/plugins/imagebase/plugin.js
@@ -152,9 +152,7 @@
 					this.parts.link.remove( true );
 					this.parts.link = null;
 				} else {
-					var linkElement = createLink( editor, img, link );
-
-					this.parts.link = linkElement;
+					this.parts.link = createLink( editor, img, link );
 				}
 			}
 		}

--- a/plugins/imagebase/plugin.js
+++ b/plugins/imagebase/plugin.js
@@ -134,7 +134,8 @@
 			},
 
 			data: function( evt ) {
-				var link = evt.data.link,
+				var editor = this.editor,
+					link = evt.data.link,
 					img = this.element.findOne( 'img' );
 
 				// Widget is inited with link, so let's set appropriate data.
@@ -152,7 +153,19 @@
 
 					this.parts.link = null;
 				} else {
-					this.parts.link = wrapInLink( img, link );
+					var linkElement = wrapInLink( img, link ),
+						// Set and remove all attributes associated with this state.
+						attributes = CKEDITOR.plugins.link.getLinkAttributes( editor, link );
+
+					if ( !CKEDITOR.tools.isEmpty( attributes.set ) ) {
+						linkElement.setAttributes( attributes.set );
+					}
+
+					if ( attributes.removed.length ) {
+						linkElement.removeAttributes( attributes.removed );
+					}
+
+					this.parts.link = linkElement;
 				}
 			}
 		}

--- a/plugins/imagebase/plugin.js
+++ b/plugins/imagebase/plugin.js
@@ -28,7 +28,6 @@
 	}
 
 	function createLink( editor, img, linkData ) {
-		// Covers cases when widget with link inside is upcasted.
 		var link = img.getAscendant( 'a' ) || editor.document.createElement( 'a' );
 
 		addLinkAttributes( editor, link, linkData );

--- a/plugins/imagebase/plugin.js
+++ b/plugins/imagebase/plugin.js
@@ -272,7 +272,7 @@
 		},
 
 		/**
-		 * Adds new feature to the newly created image widget by invoking initial setup once for the editor
+		 * Adds new feature to the passed widget's definition by invoking initial setup once for the editor
 		 * and extending widget's definition to include all fields needed by this feature.
 		 *
 		 *		var widgetDefinition = {};

--- a/plugins/imagebase/plugin.js
+++ b/plugins/imagebase/plugin.js
@@ -303,7 +303,7 @@
 			featureDefinition.data = mergeMethods( definition.data, featureDefinition.data );
 
 			if ( featureDefinition.setUp ) {
-				featureDefinition.setUp( editor );
+				featureDefinition.setUp( editor, definition );
 
 				delete featureDefinition.setUp;
 			}

--- a/plugins/imagebase/plugin.js
+++ b/plugins/imagebase/plugin.js
@@ -57,6 +57,7 @@
 
 			setUp: function( editor ) {
 				if ( !editor.plugins.link ) {
+					// All of listeners registered later on make only when link plugin is loaded.
 					return;
 				}
 
@@ -200,7 +201,7 @@
 			requiredContent: 'figure; img[!src]',
 
 			/**
-			 * The array containing names of features added to this widget's definition
+			 * The array containing names of features added to this widget's definition.
 			 *
 			 * @property {String[]} widgetFeatures
 			 */

--- a/plugins/imagebase/plugin.js
+++ b/plugins/imagebase/plugin.js
@@ -259,6 +259,12 @@
 	 */
 	CKEDITOR.plugins.imagebase = {
 		/**
+		 * Object containing all available features definitions.
+		 * @property {Object}
+		 */
+		featuresDefinitions: featuresDefinitions,
+
+		/**
 		 * Registers a new widget based on passed definition.
 		 *
 		 * @param {CKEDITOR.editor} editor Editor that will get the widget registered.
@@ -286,7 +292,7 @@
 		 * with fields needed by feature.
 		 */
 		addFeature: function( editor, name, definition ) {
-			var featureDefinition = CKEDITOR.tools.clone( featuresDefinitions[ name ] );
+			var featureDefinition = CKEDITOR.tools.clone( this.featuresDefinitions[ name ] );
 
 			function mergeMethods( oldOne, newOne ) {
 				if ( !oldOne && !newOne ) {

--- a/tests/plugins/easyimage/widget.js
+++ b/tests/plugins/easyimage/widget.js
@@ -1,4 +1,4 @@
-/* bender-tags: editor,widget */
+﻿/* bender-tags: editor,widget */
 /* bender-ckeditor-plugins: floatingspace,easyimage,toolbar */
 /* bender-include: ../widget/_helpers/tools.js */
 /* global widgetTestsTools */
@@ -23,6 +23,12 @@
 		classicAllFigures: {
 			config: {
 				easyimage_class: null
+			}
+		},
+
+		linkEditor: {
+			config: {
+				extraPlugins: 'link'
 			}
 		}
 	};
@@ -77,6 +83,13 @@
 				bot: bot,
 
 				assertCreated: function( widget ) {
+					if ( editor.name === 'linkEditor' ) {
+						assert.isNull( widget.parts.link, 'Widget does have link part if the editor has link plugin' );
+					} else {
+						assert.isUndefined( widget.parts.link,
+							'Widget does not have link part if the editor does not have link plugin' );
+					}
+
 					if ( editor.name !== 'classicAllFigures' ) {
 						assert.isTrue( widget.hasClass( 'easyimage' ), 'Widget wrapper has main class' );
 					}

--- a/tests/plugins/imagebase/features/api.js
+++ b/tests/plugins/imagebase/features/api.js
@@ -93,6 +93,7 @@
 
 			// Cleanup.
 			delete plugin.featuresDefinitions.foo;
+			delete plugin.featuresDefinitions.bar;
 
 			arrayAssert.itemsAreSame( [ 'bar', 'foo' ], outputDefinition.features );
 		}

--- a/tests/plugins/imagebase/features/api.js
+++ b/tests/plugins/imagebase/features/api.js
@@ -29,6 +29,39 @@
 				'Widget definition has correct value for widgetFeatures property' );
 		},
 
+		'test baseWidget functions remain called': function() {
+			var plugin = CKEDITOR.plugins.imagebase,
+				editor = this.editor,
+				inputDefinition = {
+					init: sinon.stub(),
+					data: sinon.stub()
+				},
+				dummyFeature = {
+					init: sinon.stub(),
+					data: sinon.stub()
+				},
+				outputDefinition;
+
+			plugin.featuresDefinitions.dummy = dummyFeature;
+
+			outputDefinition = plugin.addFeature( editor, 'dummy', inputDefinition );
+
+			delete plugin.featuresDefinitions.dummy;
+
+			outputDefinition.init( 1 );
+			outputDefinition.data( 2 );
+
+			assert.areSame( 1, inputDefinition.init.callCount, 'inputDefinition.init call count' );
+			assert.areSame( 1, inputDefinition.data.callCount, 'inputDefinition.data call count' );
+			assert.areSame( 1, dummyFeature.init.callCount, 'dummyFeature.init call count' );
+			assert.areSame( 1, dummyFeature.data.callCount, 'dummyFeature.data call count' );
+
+			sinon.assert.alwaysCalledWithExactly( inputDefinition.init, 1 );
+			sinon.assert.alwaysCalledWithExactly( inputDefinition.data, 2 );
+			sinon.assert.alwaysCalledWithExactly( dummyFeature.init, 1 );
+			sinon.assert.alwaysCalledWithExactly( dummyFeature.data, 2 );
+		},
+
 		'test feature.setUp parameters': function() {
 			var plugin = CKEDITOR.plugins.imagebase,
 				editor = this.editor,

--- a/tests/plugins/imagebase/features/api.js
+++ b/tests/plugins/imagebase/features/api.js
@@ -29,6 +29,8 @@
 				'Link feature definition is not modified' );
 			assert.areNotSame( widgetDefinition, extendedDefinition, 'addFeature returns new definition' );
 			assert.areSame( 1, callCount, 'setUp was called only once' );
+			arrayAssert.itemsAreSame( [ 'link' ], extendedDefinition.widgetFeatures,
+				'Widget definition has correct value for widgetFeatures property' );
 
 			linkDefinition.setUp = originalSetUp;
 		}

--- a/tests/plugins/imagebase/features/api.js
+++ b/tests/plugins/imagebase/features/api.js
@@ -51,6 +51,23 @@
 				'setUp is called with appropriate parameters' );
 
 			delete plugin.featuresDefinitions.foo;
+		},
+
+		'test widgetDefinition.widgetFeatures stacking': function() {
+			var plugin = CKEDITOR.plugins.imagebase,
+				inputDefinition = {
+					widgetFeatures: [ 'bar' ]
+				};
+
+			plugin.featuresDefinitions.foo = {};
+			plugin.featuresDefinitions.bar = {};
+
+			var outputDefinition = plugin.addFeature( this.editor, 'foo', inputDefinition );
+
+			// Cleanup.
+			delete plugin.featuresDefinitions.foo;
+
+			arrayAssert.itemsAreSame( [ 'bar', 'foo' ], outputDefinition.widgetFeatures );
 		}
 	} );
 } )();

--- a/tests/plugins/imagebase/features/api.js
+++ b/tests/plugins/imagebase/features/api.js
@@ -8,34 +8,28 @@
 	bender.editor = true;
 
 	bender.test( {
-		'testing adding new feature': function() {
+		'test adding new feature': function() {
 			var plugin = CKEDITOR.plugins.imagebase,
 				editor = this.editor,
 				widgetDefinition = {},
 				linkDefinition = plugin.featuresDefinitions.link,
-				originalSetUp = linkDefinition.setUp,
-				callCount = 0,
-				originalLinkDefinition,
+				originalLinkDefinition = CKEDITOR.tools.clone( linkDefinition ),
+				setUp = sinon.stub( linkDefinition, 'setUp' ),
 				extendedDefinition;
 
-			linkDefinition.setUp = function() {
-				callCount++;
-			};
-			originalLinkDefinition = CKEDITOR.tools.clone( linkDefinition );
-
 			extendedDefinition = plugin.addFeature( editor, 'link', widgetDefinition );
+
+			setUp.restore();
 
 			objectAssert.areDeepEqual( originalLinkDefinition, plugin.featuresDefinitions.link,
 				'Link feature definition is not modified' );
 			assert.areNotSame( widgetDefinition, extendedDefinition, 'addFeature returns new definition' );
-			assert.areSame( 1, callCount, 'setUp was called only once' );
+			assert.areSame( 1, setUp.callCount, 'setUp call count' );
 			arrayAssert.itemsAreSame( [ 'link' ], extendedDefinition.widgetFeatures,
 				'Widget definition has correct value for widgetFeatures property' );
-
-			linkDefinition.setUp = originalSetUp;
 		},
 
-		'testing feature.setUp parameters': function() {
+		'test feature.setUp parameters': function() {
 			var plugin = CKEDITOR.plugins.imagebase,
 				editor = this.editor,
 				widgetDefinition = {},
@@ -47,10 +41,10 @@
 
 			plugin.addFeature( editor, 'foo', widgetDefinition );
 
+			delete plugin.featuresDefinitions.foo;
+
 			assert.isTrue( spy.calledWithExactly( editor, widgetDefinition ),
 				'setUp is called with appropriate parameters' );
-
-			delete plugin.featuresDefinitions.foo;
 		},
 
 		'test widgetDefinition.widgetFeatures stacking': function() {

--- a/tests/plugins/imagebase/features/api.js
+++ b/tests/plugins/imagebase/features/api.js
@@ -25,8 +25,8 @@
 				'Link feature definition is not modified' );
 			assert.areNotSame( widgetDefinition, extendedDefinition, 'addFeature returns new definition' );
 			assert.areSame( 1, setUp.callCount, 'setUp call count' );
-			arrayAssert.itemsAreSame( [ 'link' ], extendedDefinition.widgetFeatures,
-				'Widget definition has correct value for widgetFeatures property' );
+			arrayAssert.itemsAreSame( [ 'link' ], extendedDefinition.features,
+				'Widget definition has correct value for features property' );
 		},
 
 		'test baseWidget functions remain called': function() {
@@ -80,10 +80,10 @@
 				'setUp is called with appropriate parameters' );
 		},
 
-		'test widgetDefinition.widgetFeatures stacking': function() {
+		'test widgetDefinition.features stacking': function() {
 			var plugin = CKEDITOR.plugins.imagebase,
 				inputDefinition = {
-					widgetFeatures: [ 'bar' ]
+					features: [ 'bar' ]
 				};
 
 			plugin.featuresDefinitions.foo = {};
@@ -94,7 +94,7 @@
 			// Cleanup.
 			delete plugin.featuresDefinitions.foo;
 
-			arrayAssert.itemsAreSame( [ 'bar', 'foo' ], outputDefinition.widgetFeatures );
+			arrayAssert.itemsAreSame( [ 'bar', 'foo' ], outputDefinition.features );
 		}
 	} );
 } )();

--- a/tests/plugins/imagebase/features/api.js
+++ b/tests/plugins/imagebase/features/api.js
@@ -1,0 +1,36 @@
+/* bender-tags: editor,imagebase */
+/* bender-ckeditor-plugins: imagebase,link */
+
+
+( function() {
+	'use strict';
+
+	bender.editor = true;
+
+	bender.test( {
+		'testing adding new feature': function() {
+			var plugin = CKEDITOR.plugins.imagebase,
+				editor = this.editor,
+				widgetDefinition = {},
+				linkDefinition = plugin.featuresDefinitions.link,
+				originalSetUp = linkDefinition.setUp,
+				callCount = 0,
+				originalLinkDefinition,
+				extendedDefinition;
+
+			linkDefinition.setUp = function() {
+				callCount++;
+			};
+			originalLinkDefinition = CKEDITOR.tools.clone( linkDefinition );
+
+			extendedDefinition = plugin.addFeature( editor, 'link', widgetDefinition );
+
+			objectAssert.areDeepEqual( originalLinkDefinition, plugin.featuresDefinitions.link,
+				'Link feature definition is not modified' );
+			assert.areNotSame( widgetDefinition, extendedDefinition, 'addFeature returns new definition' );
+			assert.areSame( 1, callCount, 'setUp was called only once' );
+
+			linkDefinition.setUp = originalSetUp;
+		}
+	} );
+} )();

--- a/tests/plugins/imagebase/features/api.js
+++ b/tests/plugins/imagebase/features/api.js
@@ -33,6 +33,24 @@
 				'Widget definition has correct value for widgetFeatures property' );
 
 			linkDefinition.setUp = originalSetUp;
+		},
+
+		'testing feature.setUp parameters': function() {
+			var plugin = CKEDITOR.plugins.imagebase,
+				editor = this.editor,
+				widgetDefinition = {},
+				spy = sinon.spy();
+
+			plugin.featuresDefinitions.foo = {
+				setUp: spy
+			};
+
+			plugin.addFeature( editor, 'foo', widgetDefinition );
+
+			assert.isTrue( spy.calledWithExactly( editor, widgetDefinition ),
+				'setUp is called with appropriate parameters' );
+
+			delete plugin.featuresDefinitions.foo;
 		}
 	} );
 } )();

--- a/tests/plugins/imagebase/features/link.html
+++ b/tests/plugins/imagebase/features/link.html
@@ -1,0 +1,7 @@
+<div id="upcastTest">
+	<figure>
+		<a href="http://foo">
+			<img src="http://foo">
+		</a>
+	</figure>
+</div>

--- a/tests/plugins/imagebase/features/link.html
+++ b/tests/plugins/imagebase/features/link.html
@@ -1,7 +1,7 @@
 <div id="upcastTest">
 	<figure>
 		<a href="http://foo">
-			<img src="http://foo">
+			<img src="%BASE_PATH%_assets/logo.png">
 		</a>
 	</figure>
 </div>
@@ -9,7 +9,7 @@
 <div id="upcastTestHttps">
 	<figure>
 		<a href="https://img">
-			<img src="http://foo">
+			<img src="%BASE_PATH%_assets/logo.png">
 		</a>
 	</figure>
 </div>

--- a/tests/plugins/imagebase/features/link.html
+++ b/tests/plugins/imagebase/features/link.html
@@ -5,3 +5,11 @@
 		</a>
 	</figure>
 </div>
+
+<div id="upcastTestHttps">
+	<figure>
+		<a href="https://img">
+			<img src="http://foo">
+		</a>
+	</figure>
+</div>

--- a/tests/plugins/imagebase/features/link.js
+++ b/tests/plugins/imagebase/features/link.js
@@ -1,0 +1,343 @@
+/* bender-tags: editor,widget */
+/* bender-ckeditor-plugins: imagebase,link,toolbar */
+/* bender-include: ../../widget/_helpers/tools.js */
+/* global widgetTestsTools */
+
+( function() {
+	'use strict';
+
+	bender.editors = {
+		classic: {},
+
+		divarea: {
+			config: {
+				extraPlugins: 'divarea'
+			}
+		},
+
+		inline: {
+			creator: 'inline'
+		}
+	};
+
+	function addTestWidget( editor ) {
+		if ( editor.widgets.registered.testWidget ) {
+			return;
+		}
+
+		var plugin = CKEDITOR.plugins.imagebase;
+
+		plugin.addImageWidget( editor, 'testWidget', plugin.addFeature( editor, 'link', {} ) );
+	}
+
+	function assertAttributes( editor, linkElement, linkData ) {
+		var attributes = CKEDITOR.plugins.link.getLinkAttributes( editor, linkData ),
+			attribute;
+
+		for ( attribute in attributes.set ) {
+			assert.areSame( attributes.set[ attribute ], linkElement.getAttribute( attribute ),
+				'Link has proper value for ' + attribute + ' attribute' );
+		}
+
+		CKEDITOR.tools.array.forEach( attributes.removed, function( attribute ) {
+			assert.isFalse( linkElement.hasAttribute( attribute ), 'Link does not have ' + attribute + ' attribute' );
+		} );
+	}
+
+	function assertLinkWidget( options ) {
+		var editor = options.editor,
+			linkCmd = editor.getCommand( 'link' ),
+			unlinkCmd = editor.getCommand( 'unlink' ),
+			widget;
+
+		if ( options.widget ) {
+			widget = options.widget;
+		} else {
+			widget = widgetTestsTools.getWidgetByDOMOffset( editor, 0 );
+		}
+
+		widget.focus();
+
+		assert.areSame( 1, widget.element.find( 'a' ).count(), 'There is only one link element inside widget' );
+		assert.areSame( CKEDITOR.TRISTATE_OFF, linkCmd.state, 'Link command state' );
+		assert.areSame( CKEDITOR.TRISTATE_OFF, unlinkCmd.state, 'Unlink command state' );
+		assert.isObject( widget.parts.link, 'Widget has link part' );
+		objectAssert.areDeepEqual( options.data, widget.data.link, 'Widget has correct link data' );
+		assertAttributes( editor, widget.parts.link, options.data );
+	}
+
+	function assertUnlinkWidget( options ) {
+		var editor = options.editor,
+			linkCmd = editor.getCommand( 'link' ),
+			unlinkCmd = editor.getCommand( 'unlink' ),
+			widget;
+
+		if ( options.widget ) {
+			widget = options.widget;
+		} else {
+			widget = widgetTestsTools.getWidgetByDOMOffset( editor, 0 );
+		}
+
+		widget.focus();
+
+		assert.areSame( 0, widget.element.find( 'a' ).count(), 'There is no link element inside widget' );
+		assert.areSame( CKEDITOR.TRISTATE_OFF, linkCmd.state, 'Link command state' );
+		assert.areSame( CKEDITOR.TRISTATE_DISABLED, unlinkCmd.state, 'Unlink command state' );
+		assert.isNull( widget.parts.link, 'Widget does not have link part' );
+		assert.isNull( widget.data.link, 'Widget does not have link data' );
+	}
+
+	function testLinkCommand( options ) {
+		var bot = options.bot,
+			editor = bot.editor,
+			linkCmd = editor.getCommand( 'link' ),
+			unlinkCmd = editor.getCommand( 'unlink' ),
+			linkCmdState = typeof options.linkCmdState === 'number' ? options.linkCmdState : CKEDITOR.TRISTATE_OFF,
+			unlinkCmdState = typeof options.unlinkCmdState === 'number' ? options.unlinkCmdState :
+				CKEDITOR.TRISTATE_DISABLED;
+
+		bot.setData( options.html, function() {
+			var widget = widgetTestsTools.getWidgetByDOMOffset( editor, 0 );
+
+			editor.once( 'dialogShow', function( evt ) {
+				resume( function() {
+					var dialog = evt.data;
+
+					options.dialogCallback( dialog, widget );
+				} );
+			} );
+
+			widget.focus();
+
+			assert.areSame( linkCmdState, linkCmd.state, 'Link command state' );
+			assert.areSame( unlinkCmdState, unlinkCmd.state, 'Unlink command state' );
+
+			editor.execCommand( 'link' );
+			wait();
+		} );
+	}
+
+	function testUnlinkCommand( options ) {
+		var bot = options.bot,
+			editor = bot.editor,
+			linkCmd = editor.getCommand( 'link' ),
+			unlinkCmd = editor.getCommand( 'unlink' ),
+			linkCmdState = typeof options.linkCmdState === 'number' ? options.linkCmdState : CKEDITOR.TRISTATE_OFF,
+			unlinkCmdState = typeof options.unlinkCmdState === 'number' ? options.unlinkCmdState :
+				CKEDITOR.TRISTATE_OFF;
+
+		bot.setData( options.html, function() {
+			var widget = widgetTestsTools.getWidgetByDOMOffset( editor, 0 );
+
+			editor.once( 'afterCommandExec', function( evt ) {
+				resume( function() {
+					options.callback( evt, widget );
+				} );
+			} );
+
+			widget.focus();
+
+			assert.areSame( linkCmdState, linkCmd.state, 'Link command state' );
+			assert.areSame( unlinkCmdState, unlinkCmd.state, 'Unlink command state' );
+
+			editor.execCommand( 'unlink' );
+			wait();
+		} );
+	}
+
+	var tests = {
+		'test adding image widget with link feature': function( editor ) {
+			var expectedParts = {
+				caption: 'figcaption',
+				image: 'img',
+				link: 'a'
+			};
+
+			addTestWidget( editor );
+
+			objectAssert.ownsKeys( [ 'testWidget' ], editor.widgets.registered );
+			objectAssert.areDeepEqual( expectedParts, editor.widgets.registered.testWidget.parts );
+
+		},
+
+		'test upcasting image widget with link': function( editor, bot ) {
+			addTestWidget( editor );
+
+			widgetTestsTools.assertWidget( {
+				count: 1,
+				widgetOffset: 0,
+				nameCreated: 'testWidget',
+				html: CKEDITOR.document.getById( 'upcastTest' ).getHtml(),
+				bot: bot,
+				assertCreated: function( widget ) {
+					assertLinkWidget( {
+						widget: widget,
+						editor: editor,
+						url: 'foo',
+						data: {
+							type: 'url',
+							url: {
+								protocol: 'http://',
+								url: 'foo'
+							}
+						}
+					} );
+				}
+			} );
+		},
+
+		'test add link to existing image widget': function( editor, bot ) {
+			addTestWidget( editor );
+
+			testLinkCommand( {
+				bot: bot,
+				html: '<figure><img src="http://foo"></figure>',
+				url: 'x',
+				dialogCallback: function( dialog, widget ) {
+					var data = {};
+
+					dialog.setValueOf( 'info', 'url', 'x' );
+					dialog.getButton( 'ok' ).click();
+
+					dialog.commitContent( data );
+
+					assertLinkWidget( {
+						widget: widget,
+						editor: editor,
+						data: data
+					} );
+				}
+			} );
+		},
+
+		'test edit link in existing image widget': function( editor, bot ) {
+			addTestWidget( editor );
+
+			testLinkCommand( {
+				bot: bot,
+				html: '<figure><a href="http://foo"><img src="http://foo"></a></figure>',
+				initialUrl: 'foo',
+				unlinkCmdState: CKEDITOR.TRISTATE_OFF,
+				dialogCallback: function( dialog, widget ) {
+					var data = {};
+
+					assert.areSame( 'foo', dialog.getValueOf( 'info', 'url' ),
+						'Dialog contains correct URL' );
+
+					dialog.setValueOf( 'info', 'url', 'x' );
+					dialog.getButton( 'ok' ).click();
+
+					dialog.commitContent( data );
+
+					assertLinkWidget( {
+						widget: widget,
+						editor: editor,
+						data: data
+					} );
+				}
+			} );
+		},
+
+		'test add link with attribute to existing image widget': function( editor, bot ) {
+			addTestWidget( editor );
+
+			testLinkCommand( {
+				bot: bot,
+				html: '<figure><img src="http://foo"></figure>',
+				url: 'x',
+				dialogCallback: function( dialog, widget ) {
+					var data = {};
+
+					dialog.setValueOf( 'info', 'url', 'x' );
+					dialog.setValueOf( 'target', 'linkTargetType', '_blank' );
+					dialog.getButton( 'ok' ).click();
+
+					dialog.commitContent( data );
+
+					assertLinkWidget( {
+						widget: widget,
+						editor: editor,
+						data: data
+					} );
+				}
+			} );
+		},
+
+		'test edit link attribute in existing image widget': function( editor, bot ) {
+			addTestWidget( editor );
+
+			testLinkCommand( {
+				bot: bot,
+				html: '<figure><a href="http://foo" target="_blank"><img src="http://foo"></a></figure>',
+				initialUrl: 'foo',
+				unlinkCmdState: CKEDITOR.TRISTATE_OFF,
+				dialogCallback: function( dialog, widget ) {
+					var data = {};
+
+					assert.areSame( 'foo', dialog.getValueOf( 'info', 'url' ),
+						'Dialog contains correct URL' );
+
+					dialog.setValueOf( 'info', 'url', 'x' );
+					dialog.setValueOf( 'target', 'linkTargetType', 'popup' );
+					dialog.getButton( 'ok' ).click();
+
+					dialog.commitContent( data );
+
+					assertLinkWidget( {
+						widget: widget,
+						editor: editor,
+						data: data
+					} );
+				}
+			} );
+		},
+
+		'test remove link attribute in existing image widget': function( editor, bot ) {
+			addTestWidget( editor );
+
+			testLinkCommand( {
+				bot: bot,
+				html: '<figure><a href="http://foo" target="_blank"><img src="http://foo"></a></figure>',
+				initialUrl: 'foo',
+				unlinkCmdState: CKEDITOR.TRISTATE_OFF,
+				dialogCallback: function( dialog, widget ) {
+					var data = {};
+
+					assert.areSame( 'foo', dialog.getValueOf( 'info', 'url' ),
+						'Dialog contains correct URL' );
+
+					dialog.setValueOf( 'info', 'url', 'x' );
+					dialog.setValueOf( 'target', 'linkTargetType', 'notSet' );
+					dialog.getButton( 'ok' ).click();
+
+					dialog.commitContent( data );
+
+					assertLinkWidget( {
+						widget: widget,
+						editor: editor,
+						data: data
+					} );
+				}
+			} );
+		},
+
+		'test unlink image widget': function( editor, bot ) {
+			addTestWidget( editor );
+
+			testUnlinkCommand( {
+				bot: bot,
+				html: '<figure><a href="http://foo"><img src="http://foo"></a></figure>',
+
+				callback: function( evt, widget ) {
+					assertUnlinkWidget( {
+						widget: widget,
+						editor: editor
+					} );
+				}
+			} );
+		}
+	};
+
+	tests = bender.tools.createTestsForEditors( CKEDITOR.tools.objectKeys( bender.editors ), tests );
+	bender.test( tests );
+} )();

--- a/tests/plugins/imagebase/features/link.js
+++ b/tests/plugins/imagebase/features/link.js
@@ -243,7 +243,6 @@
 			testLinkCommand( {
 				bot: bot,
 				html: '<figure><a href="http://foo"><img src="%BASE_PATH%_assets/logo.png"></a></figure>',
-				initialUrl: 'foo',
 				unlinkCmdState: CKEDITOR.TRISTATE_OFF,
 				dialogCallback: function( dialog, widget ) {
 					var data = {};
@@ -296,7 +295,6 @@
 			testLinkCommand( {
 				bot: bot,
 				html: '<figure><a href="http://foo" target="_blank"><img src="%BASE_PATH%_assets/logo.png"></a></figure>',
-				initialUrl: 'foo',
 				unlinkCmdState: CKEDITOR.TRISTATE_OFF,
 				dialogCallback: function( dialog, widget ) {
 					var data = {};
@@ -325,7 +323,6 @@
 			testLinkCommand( {
 				bot: bot,
 				html: '<figure><a href="http://foo" target="_blank"><img src="%BASE_PATH%_assets/logo.png"></a></figure>',
-				initialUrl: 'foo',
 				unlinkCmdState: CKEDITOR.TRISTATE_OFF,
 				dialogCallback: function( dialog, widget ) {
 					var data = {};

--- a/tests/plugins/imagebase/features/link.js
+++ b/tests/plugins/imagebase/features/link.js
@@ -173,6 +173,32 @@
 			} );
 		},
 
+		'test upcasting image widget with https link': function( editor, bot ) {
+			addTestWidget( editor );
+
+			widgetTestsTools.assertWidget( {
+				count: 1,
+				widgetOffset: 0,
+				nameCreated: 'testWidget',
+				html: CKEDITOR.document.getById( 'upcastTestHttps' ).getHtml(),
+				bot: bot,
+				assertCreated: function( widget ) {
+					assertLinkWidget( {
+						widget: widget,
+						editor: editor,
+						url: 'foo',
+						data: {
+							type: 'url',
+							url: {
+								protocol: 'https://',
+								url: 'img'
+							}
+						}
+					} );
+				}
+			} );
+		},
+
 		'test add link to existing image widget': function( editor, bot ) {
 			addTestWidget( editor );
 

--- a/tests/plugins/imagebase/features/link.js
+++ b/tests/plugins/imagebase/features/link.js
@@ -44,45 +44,32 @@
 		} );
 	}
 
-	function assertLinkWidget( options ) {
+	function assertLinkWidgetStatus( options, linkCount, linkCmdState, unlinkCmdState ) {
 		var editor = options.editor,
 			linkCmd = editor.getCommand( 'link' ),
 			unlinkCmd = editor.getCommand( 'unlink' ),
-			widget;
-
-		if ( options.widget ) {
-			widget = options.widget;
-		} else {
-			widget = widgetTestsTools.getWidgetByDOMOffset( editor, 0 );
-		}
+			widget = options.widget || widgetTestsTools.getWidgetByDOMOffset( editor, 0 );
 
 		widget.focus();
 
-		assert.areSame( 1, widget.element.find( 'a' ).count(), 'There is only one link element inside widget' );
-		assert.areSame( CKEDITOR.TRISTATE_OFF, linkCmd.state, 'Link command state' );
-		assert.areSame( CKEDITOR.TRISTATE_OFF, unlinkCmd.state, 'Unlink command state' );
+		assert.areSame( linkCount, widget.element.find( 'a' ).count(), 'There is only one link element inside widget' );
+		assert.areSame( linkCmdState, linkCmd.state, 'Link command state' );
+		assert.areSame( unlinkCmdState, unlinkCmd.state, 'Unlink command state' );
+
+		return widget;
+	}
+
+	function assertLinkWidget( options ) {
+		var widget = assertLinkWidgetStatus( options, 1, CKEDITOR.TRISTATE_OFF, CKEDITOR.TRISTATE_OFF );
+
 		assert.isObject( widget.parts.link, 'Widget has link part' );
 		objectAssert.areDeepEqual( options.data, widget.data.link, 'Widget has correct link data' );
-		assertAttributes( editor, widget.parts.link, options.data );
+		assertAttributes( options.editor, widget.parts.link, options.data );
 	}
 
 	function assertUnlinkWidget( options ) {
-		var editor = options.editor,
-			linkCmd = editor.getCommand( 'link' ),
-			unlinkCmd = editor.getCommand( 'unlink' ),
-			widget;
+		var widget = assertLinkWidgetStatus( options, 0, CKEDITOR.TRISTATE_OFF, CKEDITOR.TRISTATE_DISABLED );
 
-		if ( options.widget ) {
-			widget = options.widget;
-		} else {
-			widget = widgetTestsTools.getWidgetByDOMOffset( editor, 0 );
-		}
-
-		widget.focus();
-
-		assert.areSame( 0, widget.element.find( 'a' ).count(), 'There is no link element inside widget' );
-		assert.areSame( CKEDITOR.TRISTATE_OFF, linkCmd.state, 'Link command state' );
-		assert.areSame( CKEDITOR.TRISTATE_DISABLED, unlinkCmd.state, 'Unlink command state' );
 		assert.isNull( widget.parts.link, 'Widget does not have link part' );
 		assert.isNull( widget.data.link, 'Widget does not have link data' );
 	}

--- a/tests/plugins/imagebase/features/link.js
+++ b/tests/plugins/imagebase/features/link.js
@@ -44,7 +44,7 @@
 		} );
 	}
 
-	function assertLinkWidgetStatus( options, linkCount, linkCmdState, unlinkCmdState ) {
+	function assertLinkWidgetStatus( options ) {
 		var editor = options.editor,
 			linkCmd = editor.getCommand( 'link' ),
 			unlinkCmd = editor.getCommand( 'unlink' ),
@@ -52,15 +52,22 @@
 
 		widget.focus();
 
-		assert.areSame( linkCount, widget.element.find( 'a' ).count(), 'There is only one link element inside widget' );
-		assert.areSame( linkCmdState, linkCmd.state, 'Link command state' );
-		assert.areSame( unlinkCmdState, unlinkCmd.state, 'Unlink command state' );
+		assert.areSame( options.linkCount, widget.element.find( 'a' ).count(), 'There is only one link element inside widget' );
+		assert.areSame( options.linkCmdState, linkCmd.state, 'Link command state' );
+		assert.areSame( options.unlinkCmdState, unlinkCmd.state, 'Unlink command state' );
 
 		return widget;
 	}
 
 	function assertLinkWidget( options ) {
-		var widget = assertLinkWidgetStatus( options, 1, CKEDITOR.TRISTATE_OFF, CKEDITOR.TRISTATE_OFF );
+		var widget;
+
+		CKEDITOR.tools.extend( options, {
+			linkCount: 1,
+			linkCmdState: CKEDITOR.TRISTATE_OFF,
+			unlinkCmdState: CKEDITOR.TRISTATE_OFF
+		} );
+		widget = assertLinkWidgetStatus( options );
 
 		assert.isObject( widget.parts.link, 'Widget has link part' );
 		objectAssert.areDeepEqual( options.data, widget.data.link, 'Widget has correct link data' );
@@ -68,7 +75,14 @@
 	}
 
 	function assertUnlinkWidget( options ) {
-		var widget = assertLinkWidgetStatus( options, 0, CKEDITOR.TRISTATE_OFF, CKEDITOR.TRISTATE_DISABLED );
+		var widget;
+
+		CKEDITOR.tools.extend( options, {
+			linkCount: 0,
+			linkCmdState: CKEDITOR.TRISTATE_OFF,
+			unlinkCmdState: CKEDITOR.TRISTATE_DISABLED
+		} );
+		widget = assertLinkWidgetStatus( options );
 
 		assert.isNull( widget.parts.link, 'Widget does not have link part' );
 		assert.isNull( widget.data.link, 'Widget does not have link data' );

--- a/tests/plugins/imagebase/features/link.js
+++ b/tests/plugins/imagebase/features/link.js
@@ -204,7 +204,7 @@
 
 			testLinkCommand( {
 				bot: bot,
-				html: '<figure><img src="http://foo"></figure>',
+				html: '<figure><img src="%BASE_PATH%_assets/logo.png"></figure>',
 				url: 'x',
 				dialogCallback: function( dialog, widget ) {
 					var data = {};
@@ -228,7 +228,7 @@
 
 			testLinkCommand( {
 				bot: bot,
-				html: '<figure><a href="http://foo"><img src="http://foo"></a></figure>',
+				html: '<figure><a href="http://foo"><img src="%BASE_PATH%_assets/logo.png"></a></figure>',
 				initialUrl: 'foo',
 				unlinkCmdState: CKEDITOR.TRISTATE_OFF,
 				dialogCallback: function( dialog, widget ) {
@@ -256,7 +256,7 @@
 
 			testLinkCommand( {
 				bot: bot,
-				html: '<figure><img src="http://foo"></figure>',
+				html: '<figure><img src="%BASE_PATH%_assets/logo.png"></figure>',
 				url: 'x',
 				dialogCallback: function( dialog, widget ) {
 					var data = {};
@@ -281,7 +281,7 @@
 
 			testLinkCommand( {
 				bot: bot,
-				html: '<figure><a href="http://foo" target="_blank"><img src="http://foo"></a></figure>',
+				html: '<figure><a href="http://foo" target="_blank"><img src="%BASE_PATH%_assets/logo.png"></a></figure>',
 				initialUrl: 'foo',
 				unlinkCmdState: CKEDITOR.TRISTATE_OFF,
 				dialogCallback: function( dialog, widget ) {
@@ -310,7 +310,7 @@
 
 			testLinkCommand( {
 				bot: bot,
-				html: '<figure><a href="http://foo" target="_blank"><img src="http://foo"></a></figure>',
+				html: '<figure><a href="http://foo" target="_blank"><img src="%BASE_PATH%_assets/logo.png"></a></figure>',
 				initialUrl: 'foo',
 				unlinkCmdState: CKEDITOR.TRISTATE_OFF,
 				dialogCallback: function( dialog, widget ) {
@@ -339,7 +339,7 @@
 
 			testLinkCommand( {
 				bot: bot,
-				html: '<p>test</p><figure><img src="http://foo"></figure>',
+				html: '<p>test</p><figure><img src="%BASE_PATH%_assets/logo.png"></figure>',
 				dialogCallback: function( dialog ) {
 					var paragraph = editor.editable().findOne( 'p' ).getChild( 0 ),
 						range = editor.createRange();
@@ -369,7 +369,7 @@
 
 			testUnlinkCommand( {
 				bot: bot,
-				html: '<figure><a href="http://foo"><img src="http://foo"></a></figure>',
+				html: '<figure><a href="http://foo"><img src="%BASE_PATH%_assets/logo.png"></a></figure>',
 
 				callback: function( evt, widget ) {
 					assertUnlinkWidget( {

--- a/tests/plugins/imagebase/features/link.js
+++ b/tests/plugins/imagebase/features/link.js
@@ -321,6 +321,36 @@
 			} );
 		},
 
+		'test dialog ok listener is deleted when closing the dialog': function( editor, bot ) {
+			addTestWidget( editor );
+
+			testLinkCommand( {
+				bot: bot,
+				html: '<p>test</p><figure><img src="http://foo"></figure>',
+				dialogCallback: function( dialog ) {
+					var paragraph = editor.editable().findOne( 'p' ).getChild( 0 ),
+						range = editor.createRange();
+
+					editor.once( 'dialogShow', function() {
+						resume( function() {
+							dialog.setValueOf( 'info', 'url', 'x' );
+							dialog.getButton( 'ok' ).click();
+
+							assert.areSame( 1, editor.editable().find( 'p > a' ).count(), 'Link is correctly added' );
+						} );
+					} );
+
+					dialog.getButton( 'cancel' ).click();
+
+					range.setStart( paragraph, 1 );
+					range.setEnd( paragraph, 3 );
+					range.select();
+					editor.execCommand( 'link' );
+					wait();
+				}
+			} );
+		},
+
 		'test unlink image widget': function( editor, bot ) {
 			addTestWidget( editor );
 

--- a/tests/plugins/imagebase/features/manual/link.html
+++ b/tests/plugins/imagebase/features/manual/link.html
@@ -16,7 +16,6 @@
 
 <script>
 	CKEDITOR.replace( 'classic', {
-		extraAllowedContent: 'figure(*)',
 		on: {
 			pluginsLoaded: function( evt ) {
 				var editor = evt.editor,
@@ -24,6 +23,7 @@
 
 				plugin.addImageWidget( editor, 'testWidget', plugin.addFeature( editor, 'link', {} ) );
 			}
-		}
+		},
+		height: 500
 	} );
 </script>

--- a/tests/plugins/imagebase/features/manual/link.html
+++ b/tests/plugins/imagebase/features/manual/link.html
@@ -1,0 +1,29 @@
+
+<div id="classic">
+	<p>Widget with no link:</p>
+	<figure>
+		<img src="../../../image2/_assets/foo.png" alt="foo">
+		<figcaption>Test image</figcaption>
+	</figure>
+	<p>Widget with predefined link:</p>
+	<figure>
+		<a href="https://cksource.com">
+			<img src="../../../image2/_assets/foo.png" alt="foo">
+		</a>
+		<figcaption>Test image</figcaption>
+	</figure>
+</div>
+
+<script>
+	CKEDITOR.replace( 'classic', {
+		extraAllowedContent: 'figure(*)',
+		on: {
+			pluginsLoaded: function( evt ) {
+				var editor = evt.editor,
+					plugin = CKEDITOR.plugins.imagebase;
+
+				plugin.addImageWidget( editor, 'testWidget', plugin.addFeature( editor, 'link', {} ) );
+			}
+		}
+	} );
+</script>

--- a/tests/plugins/imagebase/features/manual/link.md
+++ b/tests/plugins/imagebase/features/manual/link.md
@@ -1,0 +1,11 @@
+@bender-tags: 4.8.0, feature, 932
+@bender-ui: collapsed
+@bender-ckeditor-plugins: sourcearea, wysiwygarea, floatingspace, toolbar, imagebase, link, htmlwriter, elementspath
+
+Check if integration with link is working:
+
+* Widget with link inside is properly upcasted.
+* Widget could be linked.
+* Widget could be unlinked.
+* Link in the widget is editable.
+* All attributes defined in link dialog are bound to the link.

--- a/tests/plugins/imagebase/imagebase.html
+++ b/tests/plugins/imagebase/imagebase.html
@@ -2,10 +2,10 @@
 	<figure>Foo</figure>
 
 	<div>
-		<img src="foo">
+		<img src="%BASE_PATH%_assets/logo.png">
 	</div>
 
 	<figure>
-		<img src="foo">
+		<img src="%BASE_PATH%_assets/logo.png">
 	</figure>
 </div>


### PR DESCRIPTION
## What is the purpose of this pull request?

New feature

## Does your PR contain necessary tests?

All patches which change the editor code must include tests. You can always read more
on [PR testing](https://docs.ckeditor.com/ckeditor4/docs/#!/guide/dev_contributing_code-section-tests),
[how to set the testing environment](https://docs.ckeditor.com/ckeditor4/docs/#!/guide/dev_tests) and
[how to create tests](https://docs.ckeditor.com/ckeditor4/docs/#!/guide/dev_tests-section-creating-your-own-test)
in the official CKEditor documentation.

### This PR contains

- [x] Unit tests
- [x] Manual tests

## What changes did you make?

I've created new API for adding new features to new image widgets. Currently it's used only to add link feature to `easyimage` plugin.

The API is based on one new method in `CKEDITOR.plugins.imagebase`:

```javascript
addFeature( editor: CKEDITOR.editor, featureName: String, widgetDefinition: WidgetDefinition );
```

Every feature extends widget definition with all needed fields and callbacks. Additionally callbacks are merged together (e.g. multiple features with `init` callback will result in widget definition with `init` callback that will fire all features' init callbacks). There is also `setUp` callback, that is fire immediately and is fired once. It's suitable to e.g. add new listeners to the editor.

Link feature hooks itself to `unlink` command, however it hijacks it and stop propagation. Such solution is inspired by `image2`, however it prevents `afterCommandExec` from firing. Probably it'd be good to fire `afterCommandExec` manually.
