### PR TITLE
Upload progress bar for Easy Image

### DIFF
--- a/plugins/easyimage/plugin.js
+++ b/plugins/easyimage/plugin.js
@@ -11,6 +11,8 @@
 	// jscs:disable maximumLineLength
 	// Black rectangle which is shown before image is loaded.
 	var loadingImage = 'data:image/gif;base64,R0lGODlhDgAOAIAAAAAAAP///yH5BAAAAAAALAAAAAAOAA4AAAIMhI+py+0Po5y02qsKADs=';
+	// Throttling of progress update in ms.
+	var UPLOAD_PROGRESS_THROTTLING = 100;
 	// jscs:enable maximumLineLength
 
 	function addCommands( editor ) {
@@ -196,7 +198,7 @@
 					// Add a progress bar.
 					this.definition._createProgressBar( this );
 
-					progressListeners.push( loader.on( 'update', function() {
+					var updateListener = CKEDITOR.tools.eventsBuffer( UPLOAD_PROGRESS_THROTTLING, function() {
 						var progressBar = this.parts.progressBar.findOne( '.cke_bar' ),
 							percentage;
 
@@ -204,7 +206,9 @@
 							percentage = ( loader.uploaded / loader.uploadTotal ) * 100;
 							progressBar.setStyle( 'width', percentage + '%' );
 						}
-					}, this ) );
+					}, this );
+
+					progressListeners.push( loader.on( 'update', updateListener.input ) );
 
 					progressListeners.push( loader.once( 'abort', removeProgressListeners ) );
 					progressListeners.push( loader.once( 'error', removeProgressListeners ) );
@@ -369,7 +373,7 @@
 			CKEDITOR.dialog.add( 'easyimageAlt', this.path + 'dialogs/easyimagealt.js' );
 
 			CKEDITOR.addCss( '.cke_loader { height: 15px; display: block; background: yellow; position: absolute; left: 0px; right: 0px; }\n' +
-				'.cke_loader .cke_bar { display:block; height: 13px; background: red; width: 0; }' );
+				'.cke_loader .cke_bar { display:block; height: 13px; background: red; width: 0; transition: width ' + UPLOAD_PROGRESS_THROTTLING / 1000 + 's; }' );
 		},
 
 		init: function( editor ) {

--- a/plugins/easyimage/plugin.js
+++ b/plugins/easyimage/plugin.js
@@ -226,6 +226,8 @@
 			// Easy image uses only upload method, as is manually handled in onUploading function.
 			loadMethod: 'upload',
 
+			skipNotifications: true,
+
 			loaderType: CKEDITOR.plugins.cloudservices.cloudServicesLoader,
 
 			fileToElement: function() {
@@ -372,8 +374,8 @@
 		onLoad: function() {
 			CKEDITOR.dialog.add( 'easyimageAlt', this.path + 'dialogs/easyimagealt.js' );
 
-			CKEDITOR.addCss( '.cke_loader { height: 15px; display: block; background: yellow; position: absolute; left: 0px; right: 0px; }\n' +
-				'.cke_loader .cke_bar { display:block; height: 13px; background: red; width: 0; transition: width ' + UPLOAD_PROGRESS_THROTTLING / 1000 + 's; }' );
+			CKEDITOR.addCss( '.cke_loader { display: block; position: absolute; left: 0px; right: 0px; }\n' +
+				'.cke_loader .cke_bar { display:block; height: 10px; background: #6a9ed1; width: 0; transition: width ' + UPLOAD_PROGRESS_THROTTLING / 1000 + 's; }' );
 		},
 
 		init: function( editor ) {

--- a/plugins/easyimage/plugin.js
+++ b/plugins/easyimage/plugin.js
@@ -245,8 +245,6 @@
 					loader.upload( widgetDef.uploadUrl, widgetDef.additionalRequestParameters );
 
 					fileTools.markElement( img, 'uploadeasyimage', loader.id );
-
-					fileTools.bindNotifications( editor, loader );
 				}
 			}
 

--- a/plugins/easyimage/plugin.js
+++ b/plugins/easyimage/plugin.js
@@ -374,8 +374,20 @@
 		onLoad: function() {
 			CKEDITOR.dialog.add( 'easyimageAlt', this.path + 'dialogs/easyimagealt.js' );
 
-			CKEDITOR.addCss( '.cke_loader { display: block; position: absolute; left: 0px; right: 0px; }\n' +
-				'.cke_loader .cke_bar { display:block; height: 10px; background: #6a9ed1; width: 0; transition: width ' + UPLOAD_PROGRESS_THROTTLING / 1000 + 's; }' );
+			CKEDITOR.addCss(
+				'.cke_loader {' +
+					'display: block;' +
+					'position: absolute;' +
+					'left: 0px;' +
+					'right: 0px;' +
+				'}' +
+				'.cke_loader .cke_bar {' +
+					'display:block;' +
+					'height: 10px;' +
+					'background: #6a9ed1;' +
+					'width: 0;' +
+					'transition: width ' + UPLOAD_PROGRESS_THROTTLING / 1000 + 's;' +
+				'}' );
 		},
 
 		init: function( editor ) {

--- a/plugins/easyimage/plugin.js
+++ b/plugins/easyimage/plugin.js
@@ -259,14 +259,10 @@
 			 * @param {CKEDITOR.plugins.widget} widget
 			 */
 			_createProgressBar: function( widget ) {
-				var ret = new  CKEDITOR.dom.element( 'span' );
-				ret.addClass( 'cke_loader' );
-
-				ret.setHtml( '<span class="cke_bar" styles="transition: width ' + UPLOAD_PROGRESS_THROTTLING / 1000 + 's"></span>' );
-
-				widget.wrapper.append( ret, true );
-
-				widget.parts.progressBar = ret;
+				widget.parts.progressBar = CKEDITOR.dom.element.createFromHtml( '<div class="cke_loader">' +
+						'<div class="cke_bar" styles="transition: width ' + UPLOAD_PROGRESS_THROTTLING / 1000 + 's"></div>' +
+					'</div>' );
+				widget.wrapper.append( widget.parts.progressBar, true );
 			},
 
 			// @todo: this function should be moved to uploadwidget core definition.

--- a/plugins/easyimage/plugin.js
+++ b/plugins/easyimage/plugin.js
@@ -6,14 +6,11 @@
 ( function() {
 	'use strict';
 
-	var stylesLoaded = false;
-
-	// jscs:disable maximumLineLength
-	// Black rectangle which is shown before image is loaded.
-	var loadingImage = 'data:image/gif;base64,R0lGODlhDgAOAIAAAAAAAP///yH5BAAAAAAALAAAAAAOAA4AAAIMhI+py+0Po5y02qsKADs=';
-	// Throttling of progress update in ms.
-	var UPLOAD_PROGRESS_THROTTLING = 100;
-	// jscs:enable maximumLineLength
+	var stylesLoaded = false,
+		// Black rectangle which is shown before image is loaded.
+		loadingImage = 'data:image/gif;base64,R0lGODlhDgAOAIAAAAAAAP///yH5BAAAAAAALAAAAAAOAA4AAAIMhI+py+0Po5y02qsKADs=',
+		// Throttling of progress update in ms.
+		UPLOAD_PROGRESS_THROTTLING = 100;
 
 	function addCommands( editor ) {
 		function isSideImage( widget ) {
@@ -254,7 +251,7 @@
 			},
 
 			/*
-			 * Creates a progress bar in a given widget.h
+			 * Creates a progress bar in a given widget.
 			 *
 			 * Also puts it in it's {@link CKEDITOR.plugins.widget#parts} structure as `progressBar`
 			 *
@@ -265,7 +262,7 @@
 				var ret = new  CKEDITOR.dom.element( 'span' );
 				ret.addClass( 'cke_loader' );
 
-				ret.setHtml( '<span class="cke_bar"></span>' );
+				ret.setHtml( '<span class="cke_bar" styles="transition: width ' + UPLOAD_PROGRESS_THROTTLING / 1000 + 's"></span>' );
 
 				widget.wrapper.append( ret, true );
 
@@ -373,21 +370,6 @@
 
 		onLoad: function() {
 			CKEDITOR.dialog.add( 'easyimageAlt', this.path + 'dialogs/easyimagealt.js' );
-
-			CKEDITOR.addCss(
-				'.cke_loader {' +
-					'display: block;' +
-					'position: absolute;' +
-					'left: 0px;' +
-					'right: 0px;' +
-				'}' +
-				'.cke_loader .cke_bar {' +
-					'display:block;' +
-					'height: 10px;' +
-					'background: #6a9ed1;' +
-					'width: 0;' +
-					'transition: width ' + UPLOAD_PROGRESS_THROTTLING / 1000 + 's;' +
-				'}' );
 		},
 
 		init: function( editor ) {

--- a/plugins/easyimage/plugin.js
+++ b/plugins/easyimage/plugin.js
@@ -253,7 +253,7 @@
 					upload.responseData.response[ 'default' ] + '" srcset="' + srcset + '" sizes="100vw"><figcaption></figcaption></figure>' );
 			},
 
-			/**
+			/*
 			 * Creates a progress bar in a given widget.h
 			 *
 			 * Also puts it in it's {@link CKEDITOR.plugins.widget#parts} structure as `progressBar`

--- a/plugins/easyimage/plugin.js
+++ b/plugins/easyimage/plugin.js
@@ -272,11 +272,6 @@
 			widget.wrapper.append( widget.parts.progressBar, true );
 		};
 
-		// @todo: this function should be moved to uploadwidget core definition.
-		definition._getLoader = function( widget ) {
-			return widget.editor.uploadRepository.loaders[ widget.wrapper.findOne( '[data-cke-upload-id]' ).data( 'cke-upload-id' ) ];
-		};
-
 		editor.on( 'widgetDefinition', function( evt ) {
 			var definition = evt.data,
 				baseInit;
@@ -286,7 +281,7 @@
 				baseInit =  definition.init;
 
 				definition.init = function() {
-					var loader = this.definition._getLoader( this ),
+					var loader = this._getLoader( this ),
 						progressListeners = [];
 
 					function removeProgressListeners() {

--- a/plugins/easyimage/styles/easyimage.css
+++ b/plugins/easyimage/styles/easyimage.css
@@ -42,3 +42,19 @@ For licensing, see LICENSE.md or http://ckeditor.com/license
 	border: 1px solid #48a3f5;
 	outline: none;
 }
+
+/* Loaders */
+
+.cke_loader {
+	display: block;
+	position: absolute;
+	left: 0px;
+	right: 0px;
+}
+
+.cke_loader .cke_bar {
+	display: block;
+	height: 10px;
+	background: #6a9ed1;
+	width: 0;
+}

--- a/plugins/easyimage/styles/easyimage.css
+++ b/plugins/easyimage/styles/easyimage.css
@@ -46,14 +46,12 @@ For licensing, see LICENSE.md or http://ckeditor.com/license
 /* Loaders */
 
 .cke_loader {
-	display: block;
 	position: absolute;
 	left: 0px;
 	right: 0px;
 }
 
 .cke_loader .cke_bar {
-	display: block;
 	height: 10px;
 	background: #6a9ed1;
 	width: 0;

--- a/plugins/easyimage/styles/easyimage.css
+++ b/plugins/easyimage/styles/easyimage.css
@@ -11,7 +11,7 @@ For licensing, see LICENSE.md or http://ckeditor.com/license
 	clear: both;
 }
 
-.easyimage img {
+.easyimage img, .cke_widget_uploadeasyimage img {
 	display: block;
 	height: auto;
 	margin: 0 auto;

--- a/plugins/uploadwidget/plugin.js
+++ b/plugins/uploadwidget/plugin.js
@@ -337,7 +337,15 @@
 				} else {
 					editor.getSelection().selectBookmarks( bookmarks );
 				}
+			},
 
+			/**
+			 * @private
+			 * @returns {CKEDITOR.fileTools.fileLoader/null} Loader associated with this widget instance or `null` if not found.
+			 */
+			_getLoader: function() {
+				var marker = this.wrapper.findOne( '[data-cke-upload-id]' );
+				return marker ? this.editor.uploadRepository.loaders[ marker.data( 'cke-upload-id' ) ] : null;
 			}
 
 			/**

--- a/tests/plugins/easyimage/manual/progressbar.html
+++ b/tests/plugins/easyimage/manual/progressbar.html
@@ -1,0 +1,52 @@
+
+<h2>Classic editor</h2>
+
+<div id="classic">
+	<h1>Sample editor</h1>
+
+	<p>Go on, put some content here.</p>
+</div>
+
+<h2>Divarea editor</h2>
+
+<div id="divarea">
+	<h1>Sample editor</h1>
+
+	<p>Go on, put some content here.</p>
+</div>
+
+<h2>Inline editor</h2>
+
+<div id="inline" contenteditable="true">
+	<h1>Sample editor</h1>
+
+	<p>Go on, put some content here.</p>
+</div>
+
+<script>
+	if ( CKEDITOR.env.ie && CKEDITOR.env.version < 11 ) {
+		bender.ignore();
+	}
+
+	var IMG_URL = '%BASE_PATH%_assets/logo.png',
+		commonConfig = {
+			cloudServices_url: 'https://files.cke-cs.com/upload/'
+		};
+
+	window.XMLHttpRequest.responseData = {
+		100: IMG_URL,
+		200: IMG_URL,
+		default: IMG_URL,
+		// Unset properties set by the generic XHR mock implementation.
+		fileName: undefined,
+		uploaded: undefined,
+		url: undefined,
+		error: undefined
+	};
+
+	CKEDITOR.replace( 'classic', commonConfig );
+	CKEDITOR.replace( 'divarea', CKEDITOR.tools.extend( {
+		extraPlugins: 'divarea'
+	}, commonConfig ) );
+	CKEDITOR.inline( 'inline', commonConfig );
+</script>

--- a/tests/plugins/easyimage/manual/progressbar.md
+++ b/tests/plugins/easyimage/manual/progressbar.md
@@ -1,0 +1,19 @@
+@bender-tags: 4.8.0, feature, 932
+@bender-ui: collapsed
+@bender-ckeditor-plugins: sourcearea, wysiwygarea, floatingspace, toolbar, easyimage
+@bender-include: ../../uploadwidget/manual/_helpers/xhr.js
+
+## Upload Progress
+
+Remarks:
+
+* In the end your image will be replaced with old CKEditor 4 logo.
+* Upload progress is intentionally slowed down.
+
+### Steps
+
+1. Drop an image into the editor.
+
+### Expected
+
+* Upload progress is shown.

--- a/tests/plugins/easyimage/uploadwidget.js
+++ b/tests/plugins/easyimage/uploadwidget.js
@@ -141,7 +141,7 @@
 				pasteFiles( editor, [], '<p>x<img src="' + bender.tools.pngBase64 + '">x</p>' );
 
 				assertUploadingWidgets( editor, DATA_IMG );
-				assert.areSame( '<p>xx</p>', editor.getData(), 'getData on loading.' );
+				assert.areSame( '<p>x</p><p>x</p>', editor.getData(), 'getData on loading.' );
 
 				var loader = editor.uploadRepository.loaders[ 0 ];
 
@@ -149,7 +149,7 @@
 				loader.changeStatus( 'uploading' );
 
 				assertUploadingWidgets( editor, BLOB_IMG );
-				assert.areSame( '<p>xx</p>', editor.getData(), 'getData on uploading.' );
+				assert.areSame( '<p>x</p><p>x</p>', editor.getData(), 'getData on uploading.' );
 
 				var image = editor.editable().find( 'img[data-widget="uploadeasyimage"]' ).getItem( 0 );
 

--- a/tests/plugins/easyimage/uploadwidget.js
+++ b/tests/plugins/easyimage/uploadwidget.js
@@ -392,14 +392,12 @@
 			wait();
 		},
 
-		'test bindNotifications when paste image': function( editor ) {
+		'test custom loader': function( editor ) {
 			CKEDITOR.fileTools.bindNotifications = sinon.spy();
 
 			resumeAfter( editor, 'paste', function() {
 				var spy = CKEDITOR.fileTools.bindNotifications;
-				assert.areSame( 1, spy.callCount );
-				assert.isTrue( spy.calledWith( editor ) );
-				assert.areSame( bender.tools.pngBase64, spy.firstCall.args[ 1 ].data );
+				assert.areSame( 0, spy.callCount );
 			} );
 
 			editor.fire( 'paste', {

--- a/tests/plugins/uploadwidget/manual/_helpers/xhr.js
+++ b/tests/plugins/uploadwidget/manual/_helpers/xhr.js
@@ -11,7 +11,7 @@ window.FormData = function() {
 	var total, uploadedFilename;
 	return {
 		append: function( name, file, filename ) {
-			if ( name == 'upload' ) {
+			if ( CKEDITOR.tools.array.indexOf( [ 'upload', 'file' ], name ) !== -1 ) {
 				total = file.size;
 				uploadedFilename = filename;
 			}
@@ -31,6 +31,8 @@ window.XMLHttpRequest = function() {
 
 	return {
 		open: function() {},
+
+		setRequestHeader: function() {},
 
 		upload: {},
 

--- a/tests/plugins/uploadwidget/uploadwidget.js
+++ b/tests/plugins/uploadwidget/uploadwidget.js
@@ -162,6 +162,21 @@
 			assert.sameData( '<p data-cke-upload-id="1" data-widget="widgetName"></p>', element.getOuterHtml() );
 		},
 
+		'test _getLoader': function() {
+			var bot = this.editorBot,
+				editor = bot.editor,
+				uploads = editor.uploadRepository,
+				loader = uploads.create( bender.tools.getTestPngFile() );
+
+			addTestUploadWidget( editor, 'testGetLoader' );
+
+			bot.setData( '<p>x<span data-cke-upload-id="' + loader.id + '" data-widget="testGetLoader">uploading...</span>x</p>', function() {
+				var widget = editor.widgets.getByElement( editor.editable().findOne( 'span[data-widget="testGetLoader"]' ) );
+
+				assert.areSame( loader, widget._getLoader(), '_getLoader return value' );
+			} );
+		},
+
 		'test replaceWith 1 element': function() {
 			var bot = this.editorBot,
 				editor = bot.editor,


### PR DESCRIPTION
## What is the purpose of this pull request?

New feature

### This PR contains

- [x] Unit tests
- [x] Manual tests

## What changes did you make?

This pull requests adds a fancy progress bar to Easy Image widget:

![Progress  bar in upload widget](https://i.imgur.com/GkGXOW7.png)

Note that it also registers `uploadWidgetDefinition.skipNotification` which was added in #1145, but it's not in the base of current Easy Image feature branch, thus standard notification will remain in _most cases_.