### PR TITLE
Inline Toolbar Context should not throw exception if provided with an invalid button name

### DIFF
--- a/plugins/inlinetoolbar/plugin.js
+++ b/plugins/inlinetoolbar/plugin.js
@@ -217,7 +217,11 @@
 			if ( buttons ) {
 				buttons = buttons.split( ',' );
 				CKEDITOR.tools.array.forEach( buttons, function( name ) {
-					this.toolbar.addItem( name, this.editor.ui.create( name ) );
+					var newUiItem = this.editor.ui.create( name );
+
+					if ( newUiItem ) {
+						this.toolbar.addItem( name, newUiItem );
+					}
 				}, this );
 			}
 		}

--- a/tests/plugins/inlinetoolbar/context/integration.js
+++ b/tests/plugins/inlinetoolbar/context/integration.js
@@ -73,6 +73,19 @@
 			wait();
 		},
 
+		'test invalid buttons wont break creation': function() {
+			var context = this.editor.plugins.inlinetoolbar.create( {
+				buttons: 'foo!,Bold,Boldzzz,|',
+				refresh: sinon.stub().returns( true )
+			} );
+
+			this.editorBot.setHtmlWithSelection( '<p><strong>foo^bar</strong></p>' );
+
+			this._assertToolbarVisible( true, context );
+
+			arrayAssert.itemsAreSame( [ 'Bold' ], Object.keys( context.toolbar._items ) );
+		},
+
 		'test switching source mode hides the toolbar': function() {
 			var initialMode = this.editor.mode;
 


### PR DESCRIPTION
## What is the purpose of this pull request?

Bug fix

## Does your PR contain necessary tests?

All patches which change the editor code must include tests. You can always read more
on [PR testing](http://docs.ckeditor.com/#!/guide/dev_contributing_code-section-tests),
[how to set the testing environment](http://docs.ckeditor.com/#!/guide/dev_tests) and
[how to create tests](http://docs.ckeditor.com/#!/guide/dev_tests-section-creating-your-own-test)
in the official CKEditor documentation.

### This PR contains

- [x] Unit tests
- [ ] Manual tests

Skipped manual tests, as it's more of an API change, which is well covered by the unit tests.

## What changes did you make?

Simply check if the button was created before adding it.