### PR TITLE
Disable drag function in inline toolbar elements

### DIFF
--- a/plugins/inlinetoolbar/plugin.js
+++ b/plugins/inlinetoolbar/plugin.js
@@ -693,6 +693,14 @@
 				}
 
 				this.parts.content.setHtml( output.join( '' ) );
+				this.parts.content.unselectable();
+				var element,
+					elements = this.parts.content.getElementsByTag( '*' );
+
+				for ( var i = 0, count = elements.count() ; i < count ; i++ ) {
+					element = elements.getItem( i );
+					element.setAttribute( 'draggable', 'false' );
+				}
 			};
 
 			/**

--- a/plugins/inlinetoolbar/plugin.js
+++ b/plugins/inlinetoolbar/plugin.js
@@ -694,13 +694,9 @@
 
 				this.parts.content.setHtml( output.join( '' ) );
 				this.parts.content.unselectable();
-				var element,
-					elements = this.parts.content.getElementsByTag( '*' );
-
-				for ( var i = 0, count = elements.count() ; i < count ; i++ ) {
-					element = elements.getItem( i );
+				CKEDITOR.tools.array.forEach( this.parts.content.find( 'a' ).toArray(), function( element ) {
 					element.setAttribute( 'draggable', 'false' );
-				}
+				} );
 			};
 
 			/**

--- a/tests/plugins/inlinetoolbar/manual/drag.html
+++ b/tests/plugins/inlinetoolbar/manual/drag.html
@@ -1,0 +1,67 @@
+<style>
+		body {
+			/* (#1048) */
+			margin-left: 0px;
+			padding-left: 400px;
+		}
+	</style>
+	<textarea id="editor1" cols="10" rows="10">
+		<p>Apollo 11</p>
+		<p>Apollo 11</p>
+		<p>Apollo 11</p>
+		<img src="%BASE_PATH%_assets/lena.jpg">
+		<p>Apollo 11</p>
+		<p>Apollo 11</p>
+		<p>Apollo 11</p>
+	</textarea>
+	
+	<div id="editor2" contenteditable="true">
+		<p>Apollo 11</p>
+		<p>Apollo 11</p>
+		<p>Apollo 11</p>
+		<img src="%BASE_PATH%_assets/lena.jpg">
+		<p>Apollo 11</p>
+		<p>Apollo 11</p>
+		<p>Apollo 11</p>
+	</div>
+	
+	<div id="editor3" contenteditable="true">
+		<p>Apollo 11</p>
+		<p>Apollo 11</p>
+		<p>Apollo 11</p>
+		<img src="%BASE_PATH%_assets/lena.jpg">
+		<p>Apollo 11</p>
+		<p>Apollo 11</p>
+		<p>Apollo 11</p>
+	</div>
+	
+	<script>
+		CKEDITOR.disableAutoInline = true;
+		function instanceReadyListener( evt ) {
+			var image = this.editable().findOne( 'img' ),
+				panel = new CKEDITOR.ui.inlineToolbar( this );
+	
+			image.on( 'click', function() {
+				panel.addItems( {
+					link: new CKEDITOR.ui.button( {
+						command: 'link'
+					} ),
+					unlink: new CKEDITOR.ui.button( {
+						command: 'unlink'
+					} )
+				} );
+				panel.attach( this );
+			} );
+		}
+		var config = {
+			height: 300,
+			width: 600,
+			on: {
+				instanceReady: instanceReadyListener
+			}
+		};
+		CKEDITOR.replace( 'editor1', config );
+		CKEDITOR.inline( 'editor2', config );
+		CKEDITOR.replace( 'editor3', CKEDITOR.tools.extend( { extraPlugins: 'divarea' }, config ) );
+	
+	</script>

--- a/tests/plugins/inlinetoolbar/manual/drag.md
+++ b/tests/plugins/inlinetoolbar/manual/drag.md
@@ -1,0 +1,14 @@
+@bender-ui: collapsed
+@bender-tags: 4.8.0, bug, inlinetoolbar
+@bender-ckeditor-plugins: wysiwygarea,toolbar,basicstyles,floatingspace,inlinetoolbar,link,image
+
+1. Click (some browsers need double click) on image in the editor to open inline toolbar.
+2. Try to drag buttons from inline toolbar into editor.
+
+## Expected
+
+Buttons are not draggable.
+
+## Unexpected
+
+You are able to drag buttons to editor.

--- a/tests/plugins/inlinetoolbar/manual/drag.md
+++ b/tests/plugins/inlinetoolbar/manual/drag.md
@@ -1,5 +1,5 @@
 @bender-ui: collapsed
-@bender-tags: 4.8.0, bug, inlinetoolbar
+@bender-tags: 4.8.0, bug, inlinetoolbar, tp3200
 @bender-ckeditor-plugins: wysiwygarea,toolbar,basicstyles,floatingspace,inlinetoolbar,link,image
 
 1. Click (some browsers need double click) on image in the editor to open inline toolbar.


### PR DESCRIPTION
## What is the purpose of this pull request?

Bug fix

## Does your PR contain necessary tests?


### This PR contains

- [ ] Unit tests
- [X] Manual tests

## What changes did you make?

Added HTML `draggable="false"` flag to all elements inside inline toolbar.
