### PR TITLE
Inline toolbar context feature

### DIFF
--- a/plugins/inlinetoolbar/plugin.js
+++ b/plugins/inlinetoolbar/plugin.js
@@ -276,7 +276,7 @@
 		 * Checks if given `element` matches `options.cssSelector` selector.
 		 *
 		 * @private
-		 * @param {CKEDITOR.dom.element} `elem` Element to be tested.
+		 * @param {CKEDITOR.dom.element} elem Element to be tested.
 		 * @returns {Boolean/CKEDITOR.dom.element} `true` if a given element matches the selector.
 		 * It may also return {@link CKEDITOR.dom.element} instance, that the toolbar should point to.
 		 */

--- a/plugins/inlinetoolbar/plugin.js
+++ b/plugins/inlinetoolbar/plugin.js
@@ -398,11 +398,17 @@
 		 * Check each registered context against `selection` to find the best match. By default only one
 		 * toolbar per manager will be shown.
 		 *
-		 * @param {CKEDITOR.dom.selection/null} [selection=null] Selection to be used for probing toolbar.
+		 * @param {CKEDITOR.dom.selection/null} [selection=null] Selection to be used for probing toolbar. If none provided, a
+		 * _shrunk_ selection of current editor will be used.
 		 */
 		check: function( selection ) {
 			if ( !selection ) {
 				selection = this.editor.getSelection();
+
+				// Shrink the selection so that we're ensured innermost elements are available.
+				CKEDITOR.tools.array.forEach( selection.getRanges(), function( range ) {
+					range.shrink( CKEDITOR.SHRINK_ELEMENT, true );
+				} );
 			}
 
 			if ( !selection ) {

--- a/plugins/inlinetoolbar/plugin.js
+++ b/plugins/inlinetoolbar/plugin.js
@@ -251,10 +251,13 @@
 		 */
 		_matchElements: function( path ) {
 			var elems = path.elements,
+				filter = new CKEDITOR.filter( this.options.elements ),
 				matching;
 
-			matching = CKEDITOR.tools.array.filter( elems, function() {
-				return false;
+			matching = CKEDITOR.tools.array.filter( elems, function( elem ) {
+				var styleDef = CKEDITOR.plugins.inlinetoolbar._convertElementToStyleDef( elem );
+
+				return filter.check( new CKEDITOR.style( styleDef ), true, true );
 			} );
 
 			return matching.length > 0;

--- a/plugins/inlinetoolbar/plugin.js
+++ b/plugins/inlinetoolbar/plugin.js
@@ -300,7 +300,11 @@
 			if ( buttons ) {
 				buttons = buttons.split( ',' );
 				CKEDITOR.tools.array.forEach( buttons, function( name ) {
-					this.toolbar.addItem( name, this.editor.ui.create( name ) );
+					var newUiItem = this.editor.ui.create( name );
+
+					if ( newUiItem ) {
+						this.toolbar.addItem( name, newUiItem );
+					}
 				}, this );
 			}
 		}

--- a/plugins/inlinetoolbar/plugin.js
+++ b/plugins/inlinetoolbar/plugin.js
@@ -286,7 +286,7 @@
 				return;
 			}
 
-			return !!elem.$.matches( this.options.cssSelector );
+			return !!elem.$.matches( this.options.cssSelector ) ? elem : false;
 		},
 
 		/**
@@ -385,7 +385,7 @@
 			var forEach = CKEDITOR.tools.array.forEach,
 				mainRange = selection.getRanges()[ 0 ],
 				path = mainRange && mainRange.startPath(),
-				highlightElement = ( path && path.lastElement ) || this.editor.editable(),
+				highlightElement,
 				contextMatched;
 
 			// This function encapsulates matching algorithm.
@@ -399,6 +399,9 @@
 						if ( !!result ) {
 							if ( result instanceof CKEDITOR.dom.element ) {
 								highlightElement = result;
+							} else {
+								// Reset what could have been previously set highlight element, as it's no longer relevant.
+								highlightElement = null;
 							}
 
 							contextMatched = curContext;
@@ -435,6 +438,10 @@
 			this.hide();
 
 			if ( contextMatched ) {
+				if ( !highlightElement ) {
+					highlightElement = ( path && path.lastElement ) || this.editor.editable();
+				}
+
 				contextMatched.show( highlightElement );
 			}
 		},

--- a/plugins/inlinetoolbar/plugin.js
+++ b/plugins/inlinetoolbar/plugin.js
@@ -274,7 +274,8 @@
 		 * Checks if any of `options.widgets` widgets is currently focused.
 		 *
 		 * @private
-		 * @returns {Boolean}
+		 * @returns {Boolean/CKEDITOR.dom.element} `true` if currently selected widget matches any tracked by this
+		 * context. It could also return {@link CKEDITOR.dom.element} instance, that the toolbar should point to.
 		 */
 		_hasWidgetFocused: function() {
 			if ( !this.options.widgets ) {
@@ -288,7 +289,11 @@
 				widgetNames = widgetNames.split( ',' );
 			}
 
-			return CKEDITOR.tools.array.indexOf( widgetNames, curWidgetName ) !== -1;
+			if ( CKEDITOR.tools.array.indexOf( widgetNames, curWidgetName ) !== -1 ) {
+				return this.editor.widgets.focused.element;
+			} else {
+				return false;
+			}
 		},
 
 		/**
@@ -420,8 +425,17 @@
 			// Match widgets.
 			if ( !contextMatched ) {
 				forEach( this._contexts, function( curContext ) {
-					if ( !contextMatched && !!curContext._hasWidgetFocused() ) {
-						contextMatched = curContext;
+					if ( !contextMatched ) {
+						var result = curContext._hasWidgetFocused();
+
+						if ( !!result ) {
+							// This method might return an element.
+							if ( result instanceof CKEDITOR.dom.element ) {
+								highlightElement = result;
+							}
+
+							contextMatched = curContext;
+						}
 					}
 				} );
 			}

--- a/plugins/inlinetoolbar/plugin.js
+++ b/plugins/inlinetoolbar/plugin.js
@@ -187,6 +187,14 @@
 		this._loadButtons();
 
 		this._attachListeners();
+
+		/**
+		 * A filter based on `options.elements` property. It's created only once at context construction time and cached.
+		 *
+		 * @private
+		 * @property {CKEDITOR.filter}
+		 */
+		this._filter = this.options.elements ? new CKEDITOR.filter( this.options.elements ) : null;
 	}
 
 	Context.prototype = {
@@ -251,7 +259,7 @@
 		 */
 		_matchElements: function( path ) {
 			var elems = path.elements,
-				filter = new CKEDITOR.filter( this.options.elements ),
+				filter = this._filter,
 				matching;
 
 			matching = CKEDITOR.tools.array.filter( elems, function( elem ) {

--- a/plugins/inlinetoolbar/plugin.js
+++ b/plugins/inlinetoolbar/plugin.js
@@ -221,35 +221,6 @@
 		},
 
 		/**
-		 * Function to be called in order to check whether inline toolbar visibility should change.
-		 *
-		 * @param {CKEDITOR.dom.elementPath} path
-		 */
-		refresh: function( path ) {
-			path = path || this.editor.elementPath();
-
-			var visibility = false,
-				// Element where the toolbar will be attached to.
-				// @todo: this will have to be adjusted to point matched element.
-				highlightElement = ( path && path.lastElement ) || this.editor.editable();
-
-			if ( this.options.refresh ) {
-				visibility = this._matchRefresh( path, this.editor.getSelection() );
-			} else if ( this.options.widgets ) {
-				visibility = this._hasWidgetFocused();
-			} else if ( this.options.elements ) {
-				visibility = this._matchElements( path );
-			}
-
-			if ( visibility ) {
-				this.toolbar.attach( highlightElement );
-				this.toolbar.show();
-			} else {
-				this.toolbar.hide();
-			}
-		},
-
-		/**
 		 * @param {CKEDITOR.dom.element} [pointedElement] Element that should be pointed by the inline toolbar.
 		 */
 		show: function( pointedElement ) {
@@ -294,22 +265,6 @@
 			} else {
 				return false;
 			}
-		},
-
-		/**
-		 * Tests ACF query given in `options.elements` against current path. If any element matches, returns true.
-		 *
-		 * @private
-		 * @param {CKEDITOR.dom.elementPath} path
-		 * @returns {Boolean}
-		 */
-		_matchElements: function( path ) {
-			var elems = path.elements,
-				matching;
-
-			matching = CKEDITOR.tools.array.filter( elems, this._matchElement, this );
-
-			return matching.length > 0;
 		},
 
 		_matchElement: function( elem ) {
@@ -447,7 +402,7 @@
 			}
 
 			// Match element selectors.
-			if ( !contextMatched ) {
+			if ( !contextMatched && path ) {
 				for ( var i = 0; i < path.elements.length; i++ ) {
 					var curElement = path.elements[ i ];
 					if ( !curElement.isReadOnly() ) {

--- a/plugins/inlinetoolbar/plugin.js
+++ b/plugins/inlinetoolbar/plugin.js
@@ -234,6 +234,7 @@
 		/**
 		 * Performs matching against `options.refresh`.
 		 *
+		 * @private
 		 * @param {CKEDITOR.dom.elementPath} path Element path to be checked.
 		 * @param {CKEDITOR.dom.selection} selection Selection object to be passed to the `refresh` function.
 		 * @returns {Boolean/CKEDITOR.dom.element} Returns the result of a `options.refresh`. It is expected to be
@@ -462,6 +463,8 @@
 
 		/**
 		 * Destroys any context in {@link #_contexts} and empties the managed contexts list.
+		 *
+		 * @private
 		 */
 		_clear: function() {
 			CKEDITOR.tools.array.forEach( this._contexts, function( curContext ) {

--- a/plugins/inlinetoolbar/plugin.js
+++ b/plugins/inlinetoolbar/plugin.js
@@ -254,6 +254,10 @@
 				this.refresh();
 			}, this );
 
+			this.editor.on( 'mode', function() {
+				this.toolbar.hide();
+			}, this, null, 9999 );
+
 			this.editor.on( 'blur', function() {
 				this.toolbar.hide();
 			}, this, null, 9999 );

--- a/plugins/inlinetoolbar/plugin.js
+++ b/plugins/inlinetoolbar/plugin.js
@@ -743,27 +743,6 @@
 			LOW: 999,
 			MEDIUM: 500,
 			HIGH: 10
-		},
-
-		/**
-		 * Converts a given element into a style definition that could be used to create an instance of {@link CKEDITOR.style}.
-		 *
-		 * @param {CKEDITOR.dom.element} element The element to be converted.
-		 * @returns {Object} The style definition created from the element.
-		 * @private
-		 */
-		_convertElementToStyleDef: function( element ) {
-			// @todo: this function is taken out from Copy Formatting plugin. It should be extracted to a common place.
-			// Note that this function already has some modifications compared to the original.
-			var attributes = element.getAttributes(),
-				styles = CKEDITOR.tools.parseCssText( element.getAttribute( 'style' ), true, true );
-
-			return {
-				element: element.getName(),
-				type: CKEDITOR.dtd.$block[ element.getName() ] ? CKEDITOR.STYLE_BLOCK : CKEDITOR.STYLE_INLINE,
-				attributes: attributes,
-				styles: styles
-			};
 		}
 	};
 

--- a/plugins/inlinetoolbar/plugin.js
+++ b/plugins/inlinetoolbar/plugin.js
@@ -266,12 +266,12 @@
 		 * Checks if any of `options.widgets` widgets is currently focused.
 		 *
 		 * @private
-		 * @returns {Boolean/CKEDITOR.dom.element} Returns {@link CKEDITOR.dom.element} instance that toolbar should
+		 * @returns {CKEDITOR.dom.element/null} Returns {@link CKEDITOR.dom.element} instance that toolbar should
 		 * point to, if any matched widget is focused. `false` otherwise, meaning no tracked widget was matched.
 		 */
 		_matchWidget: function() {
 			if ( !this.options.widgets ) {
-				return;
+				return null;
 			}
 
 			var widgetNames = this.options.widgets,
@@ -284,7 +284,7 @@
 			if ( CKEDITOR.tools.array.indexOf( widgetNames, curWidgetName ) !== -1 ) {
 				return this.editor.widgets.focused.element;
 			} else {
-				return false;
+				return null;
 			}
 		},
 
@@ -293,16 +293,16 @@
 		 *
 		 * @private
 		 * @param {CKEDITOR.dom.element} elem Element to be tested.
-		 * @returns {Boolean/CKEDITOR.dom.element} `true` if a given element matches the selector.
-		 * It may also return {@link CKEDITOR.dom.element} instance, that the toolbar should point to.
+		 * @returns {CKEDITOR.dom.element/null} {@link CKEDITOR.dom.element} instance if an element was matched,
+		 * `null` otherwise.
 		 */
 		_matchElement: function( elem ) {
 			if ( !this.options.cssSelector ) {
-				return;
+				return null;
 			}
 
 			// Note that IE8 doesn't have matching function at all.
-			return matchingFunctionName && !!elem.$[ matchingFunctionName ]( this.options.cssSelector ) ? elem : false;
+			return matchingFunctionName && !!elem.$[ matchingFunctionName ]( this.options.cssSelector ) ? elem : null;
 		},
 
 		/**

--- a/plugins/inlinetoolbar/plugin.js
+++ b/plugins/inlinetoolbar/plugin.js
@@ -297,12 +297,9 @@
 		 * `null` otherwise.
 		 */
 		_matchElement: function( elem ) {
-			if ( !this.options.cssSelector ) {
-				return null;
-			}
-
 			// Note that IE8 doesn't have matching function at all.
-			return matchingFunctionName && !!elem.$[ matchingFunctionName ]( this.options.cssSelector ) ? elem : null;
+			return this.options.cssSelector && matchingFunctionName && !!elem.$[ matchingFunctionName ]( this.options.cssSelector ) ?
+				elem : null;
 		},
 
 		/**

--- a/plugins/inlinetoolbar/plugin.js
+++ b/plugins/inlinetoolbar/plugin.js
@@ -266,8 +266,8 @@
 		 * Checks if any of `options.widgets` widgets is currently focused.
 		 *
 		 * @private
-		 * @returns {Boolean/CKEDITOR.dom.element} `true` if currently selected widget matches any tracked by this
-		 * context. It may also return {@link CKEDITOR.dom.element} instance, that the toolbar should point to.
+		 * @returns {Boolean/CKEDITOR.dom.element} Returns {@link CKEDITOR.dom.element} instance that toolbar should
+		 * point to, if any matched widget is focused. `false` otherwise, meaning no tracked widget was matched.
 		 */
 		_matchWidget: function() {
 			if ( !this.options.widgets ) {

--- a/plugins/inlinetoolbar/plugin.js
+++ b/plugins/inlinetoolbar/plugin.js
@@ -747,7 +747,7 @@
 	};
 
 	function getElementMatchFunctionName() {
-		// Temp solution, we'll extract it to CKEDITOR.dom.element.
+		// Temporary here, until #1205 is not resolved.
 		return CKEDITOR.tools.array.filter( [ 'matches', 'msMatchesSelector', 'webkitMatchesSelector', 'mozMatchesSelector', 'oMatchesSelector' ], function( fnName ) {
 			// Note that only IE8 doesn't know HTMLElement,  nor it has msMatchesSelector so we can return false.
 			return window.HTMLElement ? fnName in HTMLElement.prototype : false;

--- a/plugins/inlinetoolbar/plugin.js
+++ b/plugins/inlinetoolbar/plugin.js
@@ -37,6 +37,10 @@
 	/**
 	 * Class representing instance of inline toolbar.
 	 *
+	 * The easiest way to create an inline toolbar is by using {@link CKEDITOR.editor.inlineToolbar#create} function.
+	 *
+	 * However it's possible to maintain it by manually, like below:
+	 *
 	 *		// Following example will show an inline toolbar on any selection change. The toolbar is anchored to the
 	 *		// last element in selection, assuming that editor variable is an instance of CKEDITOR.editor.
 	 *		editor.on( 'instanceReady', function() {
@@ -169,7 +173,11 @@
 	};
 
 	/**
-	 * Class representing inline toolbar context in the editor.
+	 * Class representing a single inline toolbar context in the editor.
+	 *
+	 * It can be configured with a various of conditions for showing up the toolbar using `options` parameter.
+	 *
+	 * Multiple contexts are handled by the {@link CKEDITOR.plugins.inlinetoolbar.contextManager Context Manager}.
 	 *
 	 * @class CKEDITOR.plugins.inlinetoolbar.context
 	 * @constructor Creates an inline toolbar context instance.
@@ -314,14 +322,17 @@
 	/**
 	 * Class for managers that take care of handling multiple contexts.
 	 *
-	 * Making sure that only one is active at a time and implementing the logic, used to determine
-	 * best fitting context for a given selection.
+	 * Manager also make sure that only one is active (per manager) at a time and implement the logic used to determine
+	 * the best fitting context for a given selection.
 	 *
-	 * Context manager also implements logic for matching the best context. Priorities are as follows:
+	 * Context manager also implements logic for matching the best context. Default priorities are as follows:
 	 *
 	 * 1. Callback - `options.refresh`
 	 * 1. Widgets matching - `options.widgets`
 	 * 1. CSS matching - `options.cssSelector`
+	 *
+	 * It's worth noting that priorities could be further customized by explicitly providing {@link CKEDITOR.plugins.inlinetoolbar.contextDefinition#priority},
+	 * so that it's possible to match a widget over a refresh callback.
 	 *
 	 * @class CKEDITOR.plugins.inlinetoolbar.contextManager
 	 * @constructor
@@ -530,22 +541,26 @@
 			 */
 			editor.inlineToolbar = {
 				/**
+				 * Inline toolbar instance for a given editor instance.
+				 *
+				 * Makes sure that there's only one instance active at a time.
+				 *
 				 * @private
 				 * @property {CKEDITOR.plugins.inlinetoolbar.contextManager} manager
 				 */
 				_manager: new CKEDITOR.plugins.inlinetoolbar.contextManager( editor ),
 
 				/**
-				 * The simplest way to create an Inline Toolbar. The conditions to display the toolbar are configurable using `options` object.
+				 * The simplest way to create an Inline Toolbar.
 				 *
-				 * Following example will add a toolbar containing link/unlink buttons for any anchor or image:
+				 * Following example will add a toolbar containing link and unlink buttons for any anchor or image:
 				 *
 				 *		editor.inlinetoolbar.create( {
 				 *			buttons: 'Link,Unlink',
 				 *			cssSelector: 'a[href], img'
 				 *		} );
 				 *
-				 * @param {CKEDITOR.plugins.inlinetoolbar.contextDefinition} options Config object for the Inline Toolbar.
+				 * @param {CKEDITOR.plugins.inlinetoolbar.contextDefinition} options Config object that determines the conditions used to display the toolbar.
 				 * @returns {CKEDITOR.plugins.inlinetoolbar.context} A context object created for this inline toolbar configuration.
 				 */
 				create: function( options ) {
@@ -747,7 +762,7 @@
 	/**
 	 * This is an abstract class that describes the definition of a {@link CKEDITOR.plugins.inlinetoolbar.context Inline Toolbar Context}.
 	 *
-	 * **Note that context options have a different priority**, see more details in {@link CKEDITOR.plugins.inlinetoolbar.contextManager}.
+	 * **Note that context matching options have a different priority by default**, see more details in {@link CKEDITOR.plugins.inlinetoolbar.contextManager}.
 	 *
 	 * @class CKEDITOR.plugins.inlinetoolbar.contextDefinition
 	 * @abstract
@@ -789,6 +804,20 @@
 	/**
 	 * A number based on {@link CKEDITOR.plugins.inlinetoolbar#PRIORITY}.
 	 *
-	 * @property {Number} [priority]
+	 *		var defA = {
+	 *			buttons: 'Bold',
+	 *			refresh: function() { return true; }
+	 *		};
+	 *
+	 *		// Even though previous definition uses refresh function, it will not take priority
+	 *		// over this definition, as it explicitly states high priority.
+	 *		var defB = {
+	 *			buttons: 'NumberedList,BulletedList',
+	 *			cssSelector: 'li',
+	 *			priority: CKEDITOR.plugins.inlinetoolbar.PRIORITY.HIGH
+	 *		};
+	 *
+	 *
+	 * @property {Number} [priority=CKEDITOR.plugins.inlinetoolbar.PRIORITY.MEDIUM]
 	 */
 }() );

--- a/plugins/inlinetoolbar/plugin.js
+++ b/plugins/inlinetoolbar/plugin.js
@@ -258,7 +258,7 @@
 			var ret = null;
 
 			if ( this.options.refresh ) {
-				ret = this.options.refresh( this.editor, path, selection );
+				ret = this.options.refresh( this.editor, path, selection ) || null;
 
 				if ( ret && ret instanceof CKEDITOR.dom.element === false ) {
 					ret = ( path && path.lastElement ) || this.editor.editable();

--- a/plugins/inlinetoolbar/plugin.js
+++ b/plugins/inlinetoolbar/plugin.js
@@ -253,6 +253,10 @@
 			this.editor.on( 'selectionChange', function() {
 				this.refresh();
 			}, this );
+
+			this.editor.on( 'blur', function() {
+				this.toolbar.hide();
+			}, this, null, 9999 );
 		},
 
 		/**
@@ -392,6 +396,19 @@
 			CKEDITOR.ui.inlineToolbarView.prototype.hide = function() {
 				this._detachListeners();
 				CKEDITOR.ui.balloonPanel.prototype.hide.call( this );
+			};
+
+			/**
+			 * @inheritdoc CKEDITOR.ui.balloonPanel#blur
+			 * @param {Boolean} [focusEditor=false] Whether the editor should be focused after blurring.
+			 */
+			CKEDITOR.ui.inlineToolbarView.prototype.blur = function( focusEditor ) {
+				if ( !!focusEditor ) {
+					// This is actually different behavior from standard balloonpanel, where it always puts the focus back to editor.
+					// We don't want to do it here, as e.g. we hide the toolbar as user leaves the editor (tabs out). Forcing focus
+					// back to the editor would trap end user inside of the editor, and show the toolbar... again.
+					this.editor.focus();
+				}
 			};
 
 			CKEDITOR.ui.inlineToolbarView.prototype._getAlignments = function( elementRect, panelWidth, panelHeight ) {

--- a/plugins/inlinetoolbar/plugin.js
+++ b/plugins/inlinetoolbar/plugin.js
@@ -458,10 +458,6 @@
 			this.hide();
 
 			if ( contextMatched ) {
-				if ( !highlightElement ) {
-					highlightElement = ( path && path.lastElement ) || this.editor.editable();
-				}
-
 				contextMatched.show( highlightElement );
 			}
 		},

--- a/plugins/inlinetoolbar/plugin.js
+++ b/plugins/inlinetoolbar/plugin.js
@@ -422,14 +422,8 @@
 					if ( !contextMatched || contextMatched.options.priority > curContext.options.priority ) {
 						var result = matchingFunction( curContext, matchingArg1 );
 
-						if ( !!result ) {
-							if ( result instanceof CKEDITOR.dom.element ) {
-								highlightElement = result;
-							} else {
-								// Reset what could have been previously set highlight element, as it's no longer relevant.
-								highlightElement = null;
-							}
-
+						if ( result instanceof CKEDITOR.dom.element ) {
+							highlightElement = result;
 							contextMatched = curContext;
 						}
 					}

--- a/plugins/inlinetoolbar/plugin.js
+++ b/plugins/inlinetoolbar/plugin.js
@@ -41,7 +41,7 @@
 	 *
 	 * The easiest way to create an inline toolbar is by using {@link CKEDITOR.editor.inlineToolbar#create} function.
 	 *
-	 * However it's possible to maintain it by manually, like below:
+	 * However it's possible to maintain it manually, like below:
 	 *
 	 *		// Following example will show an inline toolbar on any selection change. The toolbar is anchored to the
 	 *		// last element in selection, assuming that editor variable is an instance of CKEDITOR.editor.
@@ -218,7 +218,7 @@
 
 	Context.prototype = {
 		/**
-		 * Destroy inline toolbar context
+		 * Destroys the toolbar maintained by this context.
 		 */
 		destroy: function() {
 			if ( this.toolbar ) {
@@ -227,6 +227,8 @@
 		},
 
 		/**
+		 * Shows the toolbar controlled by this context.
+		 *
 		 * @param {CKEDITOR.dom.element} [pointedElement] Element that should be pointed by the inline toolbar.
 		 */
 		show: function( pointedElement ) {
@@ -237,6 +239,9 @@
 			this.toolbar.show();
 		},
 
+		/**
+		 * Hides the toolbar controlled by this context.
+		 */
 		hide: function() {
 			this.toolbar.hide();
 		},
@@ -325,8 +330,8 @@
 	/**
 	 * Class for managers that take care of handling multiple contexts.
 	 *
-	 * Manager also make sure that only one is active (per manager) at a time and implement the logic used to determine
-	 * the best fitting context for a given selection.
+	 * Manager also make sure that only one toolbar is active (per manager) at a time and implement the logic used to
+	 * determine the best fitting context for a given selection.
 	 *
 	 * Context manager also implements logic for matching the best context. Default priorities are as follows:
 	 *

--- a/plugins/inlinetoolbar/plugin.js
+++ b/plugins/inlinetoolbar/plugin.js
@@ -188,7 +188,7 @@
 		/**
 		 * Options passed to the constructor.
 		 *
-		 * @property {Object}
+		 * @property {CKEDITOR.plugins.inlinetoolbar.contextDefinition}
 		 */
 		this.options = options;
 
@@ -532,33 +532,7 @@
 				 *			cssSelector: 'a[href], img'
 				 *		} );
 				 *
-				 * @param {Object} options Config object for Inline Toolbar.
-				 * @param {String} [options.cssSelector] CSS selector. If any element in the path matches against it, the toolbar will be shown.
-				 * @param {String[]/String} [options.widgets] An array of widget names that should trigger this toolbar. Alternatively can be passed as a comma-separated string.
-				 * @param {Function} [options.refresh] A function that determines whether the toolbar should be visible for a given `elementPath`.
-				 *
-				 * It gets following parameters:
-				 *
-				 * * `editor` - {@link CKEDITOR.editor} an editor that controls this context.
-				 * * `elementPath` - {@link CKEDITOR.dom.elementPath} path for probed selection.
-				 * * `selection` - {@link CKEDITOR.dom.selection} selection object used for probing.
-				 *
-				 * Function is expected to return `Boolean` value. Returning `true` means that the inline toolbar should be shown.
-				 *
-				 * An example below will show the toolbar only for paths containing `<strong>` elements.
-				 *
-				 *		// Assuming that editor is an CKEDITOR.editor instance.
-				 *		editor.plugins.inlinetoolbar.create( {
-				 *			buttons: 'Bold,Underline',
-				 *			refresh: function( editor, path ) {
-				 *				return path.contains( 'strong' );
-				 *			}
-				 *		} );
-				 *
-				 * **Note that context options have a different priority**, see more details in
-				 * {@link CKEDITOR.plugins.inlinetoolbar.contextManager}.
-				 *
-				 * @param {Number} [options.priority] A number based on {@link CKEDITOR.plugins.inlinetoolbar#PRIORITY}.
+				 * @param {CKEDITOR.plugins.inlinetoolbar.contextDefinition} options Config object for the Inline Toolbar.
 				 * @returns {CKEDITOR.plugins.inlinetoolbar.context} A context object created for this inline toolbar configuration.
 				 */
 				create: function( options ) {
@@ -726,6 +700,7 @@
 		/**
 		 * Context priority enumeration. `HIGH` priority context are checked first.
 		 *
+		 * @readonly
 		 * @property
 		 */
 		PRIORITY: {
@@ -755,4 +730,52 @@
 			};
 		}
 	};
+
+	/**
+	 * This is an abstract class that describes the definition of a {@link CKEDITOR.plugins.inlinetoolbar.context Inline Toolbar Context}.
+	 *
+	 * **Note that context options have a different priority**, see more details in {@link CKEDITOR.plugins.inlinetoolbar.contextManager}.
+	 *
+	 * @class CKEDITOR.plugins.inlinetoolbar.contextDefinition
+	 * @abstract
+	 */
+
+	/**
+	 * A CSS selector. If any element in the path matches against it, the toolbar will be shown.
+	 *
+	 * @property {String/null} [cssSelector=null]
+	 */
+
+	/**
+	 * An array of widget names that should show related toolbar. Alternatively can be passed as a comma-separated string.
+	 *
+	 * @property {String[]/String/null} [widgets=null]
+	 */
+
+	/**
+	 * An **optional** function that determines whether the toolbar should be visible for a given `path`.
+	 *
+	 * An example below will show the toolbar only for paths containing `<strong>` elements.
+	 *
+	 *		// Assuming that editor is an CKEDITOR.editor instance.
+	 *		editor.plugins.inlinetoolbar.create( {
+	 *			buttons: 'Bold,Underline',
+	 *			refresh: function( editor, path ) {
+	 *				return path.contains( 'strong' );
+	 *			}
+	 *		} );
+	 *
+	 * @method refresh
+	 * @param {CKEDITOR.editor} editor An editor that controls this context.
+	 * @param {CKEDITOR.dom.elementPath} path Path for a currently probed selection.
+	 * @param {CKEDITOR.dom.selection} selection Selection object used for probing.
+	 * @returns {Boolean/CKEDITOR.dom.element} Function is expected to return `Boolean` value. Returning `true` means that the inline toolbar should be shown.
+	 * It may also return {@link CKEDITOR.dom.element} instance, that the toolbar should point to.
+	 */
+
+	/**
+	 * A number based on {@link CKEDITOR.plugins.inlinetoolbar#PRIORITY}.
+	 *
+	 * @property {Number} [priority]
+	 */
 }() );

--- a/plugins/inlinetoolbar/plugin.js
+++ b/plugins/inlinetoolbar/plugin.js
@@ -334,9 +334,7 @@
 	 * Class for managers that take care of handling multiple contexts.
 	 *
 	 * Manager also make sure that only one toolbar is active (per manager) at a time and implement the logic used to
-	 * determine the best fitting context for a given selection.
-	 *
-	 * Context manager also implements logic for matching the best context. Default priorities are as follows:
+	 * determine the best fitting context for a given selection. Default priorities are as follows:
 	 *
 	 * 1. Callback - `options.refresh`
 	 * 1. Widgets matching - `options.widgets`

--- a/plugins/inlinetoolbar/plugin.js
+++ b/plugins/inlinetoolbar/plugin.js
@@ -6,6 +6,8 @@
 ( function() {
 	'use strict';
 
+	var matchingFunctionName = getElementMatchFuncitonName();
+
 	/**
 	 * Class representing view of inline toolbar, used by {@link CKEDITOR.ui.inlineToolbar}.
 	 *
@@ -294,7 +296,8 @@
 				return;
 			}
 
-			return !!elem.$.matches( this.options.cssSelector ) ? elem : false;
+			// Note that IE8 doesn't have matching function at all.
+			return matchingFunctionName && !!elem.$[ matchingFunctionName ]( this.options.cssSelector ) ? elem : false;
 		},
 
 		/**
@@ -758,6 +761,14 @@
 			};
 		}
 	};
+
+	function getElementMatchFuncitonName() {
+		// Temp solution, we'll extract it to CKEDITOR.dom.element.
+		return CKEDITOR.tools.array.filter( [ 'matches', 'msMatchesSelector', 'webkitMatchesSelector', 'mozMatchesSelector', 'oMatchesSelector' ], function( fnName ) {
+			// Note that only IE8 doesn't know HTMLElement,  nor it has msMatchesSelector so we can return false.
+			return window.HTMLElement ? fnName in HTMLElement.prototype : false;
+		} )[ 0 ];
+	}
 
 	/**
 	 * This is an abstract class that describes the definition of a {@link CKEDITOR.plugins.inlinetoolbar.context Inline Toolbar Context}.

--- a/plugins/inlinetoolbar/plugin.js
+++ b/plugins/inlinetoolbar/plugin.js
@@ -175,7 +175,7 @@
 	 * @constructor Creates an inline toolbar context instance.
 	 * @since 4.8
 	 * @param {CKEDITOR.editor} editor The editor instance for which the toolbar is created.
-	 * @param {Object} options Options object passed in {@link CKEDITOR.editor.plugins.inlinetoolbar#create} method.
+	 * @param {Object} options Options object passed in the {@link CKEDITOR.editor.plugins.inlinetoolbar#create} method.
 	 */
 	function Context( editor, options ) {
 		this.editor = editor;
@@ -190,34 +190,6 @@
 	}
 
 	Context.prototype = {
-		/**
-		 * Set up and create inline toolbar.
-		 *
-		 * @param {Object} params Configuration object for inline toolbar context.
-		 * @param {String} params.buttons Names of the elements that should be available in inline toolbar.
-		 * @param {String} params.context ACF rules that describes focused elements that should have inline toolbar
-		 */
-		context: function( params ) {
-			if ( !params ) {
-				return;
-			}
-
-			if ( params.buttons ) {
-				params.buttons = params.buttons.split( ',' );
-				CKEDITOR.tools.array.forEach( params.buttons, function( name ) {
-					this.toolbar.addItem( name, this.editor.ui.create( name ) );
-				}, this );
-			}
-			if ( params.context ) {
-				params.context = params.context.split( ',' );
-				this.filters = [];
-				CKEDITOR.tools.array.forEach( params.context, function( rule ) {
-					this.filters.push( new CKEDITOR.filter( rule ) );
-				}, this );
-			}
-			return this.toolbar;
-		},
-
 		/**
 		 * Destroy inline toolbar context
 		 */
@@ -239,7 +211,7 @@
 			var visibility = false,
 				// Element where the toolbar will be attached to.
 				// @todo: this will have to be adjusted to point matched element.
-				highlightElement = path.lastElement || this.editor.editable();
+				highlightElement = ( path && path.lastElement ) || this.editor.editable();
 
 			if ( this.options.refresh ) {
 				visibility = this.options.refresh( this.editor, path );
@@ -352,7 +324,25 @@
 			editor.plugins.inlinetoolbar = {
 				/**
 				 * @param {Object} options Config object for Inline Toolbar.
-				 * @param {String[]} options.widgets An array of widget names that should trigger this toolbar.
+				 * @param {String[]} [options.widgets] An array of widget names that should trigger this toolbar.
+				 * @param {Function} [options.refresh] A function that determines whether the toolbar should be visible for a given `elementPath`.
+				 *
+				 * It gets following parameters:
+				 * * `editor` - {@link CKEDITOR.editor} an editor that controls this context.
+				 * * `elementPath` - {@link CKEDITOR.dom.elementPath} path for probed selection.
+				 *
+				 * Function is expected to return `Boolean` value. Returning `true` means that the inline toolbar should be shown.
+				 *
+				 * An example below will show the toolbar only for paths containing `<strong>` elements.
+				 *
+				 *	// Assuming that editor is an CKEDITOR.editor instance.
+				 *	editor.plugins.inlinetoolbar.create( {
+				 *		buttons: 'Bold,Underline',
+				 *		refresh: function( editor, path ) {
+				 *			return path.contains( 'strong' );
+				 *		}
+				 *	} );
+				 *
 				 * @returns {CKEDITOR.plugins.inlinetoolbar.context} A context object created for this inline toolbar configuration.
 				 */
 				create: function( options ) {

--- a/plugins/inlinetoolbar/plugin.js
+++ b/plugins/inlinetoolbar/plugin.js
@@ -171,7 +171,7 @@
 	/**
 	 * Class representing inline toolbar context in the editor.
 	 *
-	 * @class
+	 * @class CKEDITOR.plugins.inlinetoolbar.context
 	 * @constructor Creates an inline toolbar context instance.
 	 * @since 4.8
 	 * @param {CKEDITOR.editor} editor The editor instance for which the toolbar is created.
@@ -202,7 +202,6 @@
 		 * Destroy inline toolbar context
 		 */
 		destroy: function() {
-
 			if ( this.toolbar ) {
 				this.toolbar.destroy();
 			}
@@ -312,6 +311,86 @@
 					this.toolbar.addItem( name, this.editor.ui.create( name ) );
 				}, this );
 			}
+		}
+	};
+
+
+	/**
+	 * Class for managers that take care of handling multiple contexts.
+	 *
+	 * Making sure that only one is active at a time and implementing the logic, used to determine
+	 * best fitting context for a given selection.
+	 *
+	 * @class CKEDITOR.plugins.inlinetoolbar.contextManager
+	 * @constructor
+	 * @since 4.8
+	 * @param {CKEDITOR.editor} editor The editor instance which the toolbar is created for.
+	 */
+	function ContextManager( editor ) {
+		/**
+		 * Editor for which the manager was created for.
+		 *
+		 * @property {CKEDITOR.editor}
+		 */
+		this.editor = editor;
+
+		/**
+		 * List of contexts controlled by this manager.
+		 *
+		 * @private
+		 * @property {CKEDITOR.plugins.inlinetoolbar.context}
+		 */
+		this._contexts = [];
+
+		this._attachListeners();
+	}
+
+	ContextManager.prototype = {
+		/**
+		 * Adds a `context` to the tracked contexts list.
+		 *
+		 * @param {CKEDITOR.plugins.inlinetoolbar.context} context
+		 */
+		add: function( context ) {
+			this._contexts.push( context );
+		},
+
+		check: function( selection ) {
+			if ( !selection ) {
+				selection = this.editor.getSelection();
+			}
+		},
+
+		/**
+		 * Hides every visible context controlled by manager.
+		 */
+		hide: function() {
+		},
+
+		/**
+		 * Destroys every context controlled by the manager.
+		 */
+		destroy: function() {
+		},
+
+		_attachListeners: function() {
+			this.editor.on( 'destroy', function() {
+				this.destroy();
+			}, this );
+
+			this.editor.on( 'selectionChange', function() {
+				this.check();
+			}, this );
+
+			this.editor.on( 'mode', function() {
+				// this.toolbar.hide();
+				this.hide();
+			}, this, null, 9999 );
+
+			this.editor.on( 'blur', function() {
+				// this.toolbar.hide();
+				this.hide();
+			}, this, null, 9999 );
 		}
 	};
 
@@ -542,6 +621,7 @@
 	 */
 	CKEDITOR.plugins.inlinetoolbar = {
 		context: Context,
+		contextManager: ContextManager,
 
 		/**
 		 * Converts a given element into a style definition that could be used to create an instance of {@link CKEDITOR.style}.

--- a/plugins/inlinetoolbar/plugin.js
+++ b/plugins/inlinetoolbar/plugin.js
@@ -6,7 +6,7 @@
 ( function() {
 	'use strict';
 
-	var matchingFunctionName = getElementMatchFuncitonName();
+	var matchingFunctionName = getElementMatchFunctionName();
 
 	/**
 	 * Class representing view of inline toolbar, used by {@link CKEDITOR.ui.inlineToolbar}.
@@ -746,7 +746,7 @@
 		}
 	};
 
-	function getElementMatchFuncitonName() {
+	function getElementMatchFunctionName() {
 		// Temp solution, we'll extract it to CKEDITOR.dom.element.
 		return CKEDITOR.tools.array.filter( [ 'matches', 'msMatchesSelector', 'webkitMatchesSelector', 'mozMatchesSelector', 'oMatchesSelector' ], function( fnName ) {
 			// Note that only IE8 doesn't know HTMLElement,  nor it has msMatchesSelector so we can return false.

--- a/plugins/inlinetoolbar/plugin.js
+++ b/plugins/inlinetoolbar/plugin.js
@@ -235,6 +235,14 @@
 			this.toolbar.hide();
 		},
 
+		/**
+		 * Performs matching against `options.refresh`.
+		 *
+		 * @param {CKEDITOR.dom.elementPath} path Element path to be checked.
+		 * @param {CKEDITOR.dom.selection} selection Selection object to be passed to the `refresh` function.
+		 * @returns {Boolean/undefined} Returns the result of a `options.refresh` options or `undefined` if there's no refresh
+		 * function provided.
+		 */
 		_matchRefresh: function( path, selection ) {
 			if ( this.options.refresh ) {
 				return this.options.refresh( this.editor, path, selection );
@@ -248,7 +256,7 @@
 		 * @returns {Boolean/CKEDITOR.dom.element} `true` if currently selected widget matches any tracked by this
 		 * context. It could also return {@link CKEDITOR.dom.element} instance, that the toolbar should point to.
 		 */
-		_hasWidgetFocused: function() {
+		_matchWidget: function() {
 			if ( !this.options.widgets ) {
 				return;
 			}
@@ -387,7 +395,7 @@
 			if ( !contextMatched ) {
 				forEach( this._contexts, function( curContext ) {
 					if ( !contextMatched ) {
-						var result = curContext._hasWidgetFocused();
+						var result = curContext._matchWidget();
 
 						if ( !!result ) {
 							// This method might return an element.
@@ -493,37 +501,7 @@
 			CKEDITOR.document.appendStyleSheet( this.path + 'skins/' + CKEDITOR.skinName + '/inlinetoolbar.css' );
 		},
 
-		/**
-		 * Create new inline toolbar
-		 *
-		 * @since 4.8
-		 * @class CKEDITOR.plugins.inlinetoolbar.create
-		 * @constructor Creates a class instance.
-		 */
-		create: function( params, editor ) {
-			if ( !params ) {
-				return;
-			}
-
-			this.toolbar = new CKEDITOR.ui.inlineToolbar( editor );
-
-			if ( params.buttons ) {
-				params.buttons = params.buttons.split( ',' );
-				CKEDITOR.tools.array.forEach( params.buttons, function( name ) {
-					if ( editor.ui.items[ name ] ) {
-						this.toolbar.addItem( name, new CKEDITOR.ui.button( {
-							command: editor.ui.items[ name ].command,
-							label: editor.ui.items[ name ].label
-						} ) );
-					}
-				} );
-			}
-
-			return this;
-		},
-
 		init: function( editor ) {
-			// editor.inlineToolbar = new Context( editor );
 
 			/**
 			 * Set of instance-specific public APIs exposed by Inline Toolbar plugin.

--- a/plugins/inlinetoolbar/plugin.js
+++ b/plugins/inlinetoolbar/plugin.js
@@ -252,14 +252,20 @@
 		 * @private
 		 * @param {CKEDITOR.dom.elementPath} path Element path to be checked.
 		 * @param {CKEDITOR.dom.selection} selection Selection object to be passed to the `refresh` function.
-		 * @returns {Boolean/CKEDITOR.dom.element} Returns the result of a `options.refresh`. It is expected to be
-		 * `true` if current path matches the context.
-		 * It may also return {@link CKEDITOR.dom.element} instance, that the toolbar should point to.
+		 * @returns {CKEDITOR.dom.element/null} Returns a {@link CKEDITOR.dom.element} if matched by `options.refresh`, `null` otherwise.
 		 */
 		_matchRefresh: function( path, selection ) {
+			var ret = null;
+
 			if ( this.options.refresh ) {
-				return this.options.refresh( this.editor, path, selection );
+				ret = this.options.refresh( this.editor, path, selection );
+
+				if ( ret && ret instanceof CKEDITOR.dom.element === false ) {
+					ret = ( path && path.lastElement ) || this.editor.editable();
+				}
 			}
+
+			return ret;
 		},
 
 		/**

--- a/plugins/inlinetoolbar/plugin.js
+++ b/plugins/inlinetoolbar/plugin.js
@@ -781,6 +781,7 @@
 	 * An example below will show the toolbar only for paths containing `<strong>` elements.
 	 *
 	 *		// Assuming that editor is an CKEDITOR.editor instance.
+	 *		// Show the toolbar only if there's a strong in the path.
 	 *		editor.inlinetoolbar.create( {
 	 *			buttons: 'Bold,Underline',
 	 *			refresh: function( editor, path ) {
@@ -788,12 +789,22 @@
 	 *			}
 	 *		} );
 	 *
+	 *		// In this case toolbar will be always visible, pointing at the editable, despite the selection.
+	 *		editor.inlinetoolbar.create( {
+	 *			buttons: 'Bold,Underline',
+	 *			refresh: function( editor, path ) {
+	 *				return editor.editable();
+	 *			}
+	 *		} );
+	 *
 	 * @method refresh
 	 * @param {CKEDITOR.editor} editor An editor that controls this context.
 	 * @param {CKEDITOR.dom.elementPath} path Path for a currently probed selection.
 	 * @param {CKEDITOR.dom.selection} selection Selection object used for probing.
-	 * @returns {Boolean/CKEDITOR.dom.element} Function is expected to return `Boolean` value. Returning `true` means that the inline toolbar should be shown.
-	 * It may also return {@link CKEDITOR.dom.element} instance, that the toolbar should point to.
+	 * @returns {Boolean/CKEDITOR.dom.element} Returning `true` means that the inline toolbar should be shown, pointing
+	 * at the last element in the selection. `false` means no toolbar should be shown.
+	 * It may also return a {@link CKEDITOR.dom.element} instance, in that case toolbar will be shown and point at given
+	 * element.
 	 */
 
 	/**

--- a/plugins/inlinetoolbar/plugin.js
+++ b/plugins/inlinetoolbar/plugin.js
@@ -217,6 +217,8 @@
 				visibility = this.options.refresh( this.editor, path );
 			} else if ( this.options.widgets ) {
 				visibility = this._hasWidgetFocused();
+			} else if ( this.options.elements ) {
+				visibility = this._matchElements( path );
 			}
 
 			if ( visibility ) {
@@ -238,6 +240,24 @@
 				curWidgetName = this.editor.widgets && this.editor.widgets.focused && this.editor.widgets.focused.name;
 
 			return CKEDITOR.tools.array.indexOf( widgetNames, curWidgetName ) !== -1;
+		},
+
+		/**
+		 * Tests ACF query given in `options.elements` against current path. If any element matches, returns true.
+		 *
+		 * @private
+		 * @param {CKEDITOR.dom.elementPath} path
+		 * @returns {Boolean}
+		 */
+		_matchElements: function( path ) {
+			var elems = path.elements,
+				matching;
+
+			matching = CKEDITOR.tools.array.filter( elems, function() {
+				return false;
+			} );
+
+			return matching.length > 0;
 		},
 
 		/**
@@ -332,6 +352,7 @@
 			editor.plugins.inlinetoolbar = {
 				/**
 				 * @param {Object} options Config object for Inline Toolbar.
+				 * @param {String} [options.elements] ACF selector. If any elements in the path matches against it, the toolbar will be shown.
 				 * @param {String[]} [options.widgets] An array of widget names that should trigger this toolbar.
 				 * @param {Function} [options.refresh] A function that determines whether the toolbar should be visible for a given `elementPath`.
 				 *
@@ -510,21 +531,19 @@
 		/**
 		 * Converts a given element into a style definition that could be used to create an instance of {@link CKEDITOR.style}.
 		 *
-		 * Note that all definitions have a `type` property set to {@link CKEDITOR#STYLE_INLINE}.
-		 *
 		 * @param {CKEDITOR.dom.element} element The element to be converted.
 		 * @returns {Object} The style definition created from the element.
 		 * @private
 		 */
 		_convertElementToStyleDef: function( element ) {
 			// @todo: this function is taken out from Copy Formatting plugin. It should be extracted to a common place.
-			var tools = CKEDITOR.tools,
-				attributes = element.getAttributes( CKEDITOR.plugins.copyformatting.excludedAttributes ),
-				styles = tools.parseCssText( element.getAttribute( 'style' ), true, true );
+			// Note that this function already has some modifications compared to the original.
+			var attributes = element.getAttributes(),
+				styles = CKEDITOR.tools.parseCssText( element.getAttribute( 'style' ), true, true );
 
 			return {
 				element: element.getName(),
-				type: CKEDITOR.STYLE_INLINE,
+				type: CKEDITOR.dtd.$block[ element.getName() ] ? CKEDITOR.STYLE_BLOCK : CKEDITOR.STYLE_INLINE,
 				attributes: attributes,
 				styles: styles
 			};

--- a/plugins/inlinetoolbar/plugin.js
+++ b/plugins/inlinetoolbar/plugin.js
@@ -526,7 +526,7 @@
 				 *
 				 *		editor.plugins.inlinetoolbar.create( {
 				 *			buttons: 'Link,Unlink',
-				 *			elements: 'a[href];img[*]'
+				 *			cssSelector: 'a[href], img'
 				 *		} );
 				 *
 				 * @param {Object} options Config object for Inline Toolbar.

--- a/plugins/inlinetoolbar/plugin.js
+++ b/plugins/inlinetoolbar/plugin.js
@@ -276,22 +276,22 @@
 		 * point to, if any matched widget is focused. `false` otherwise, meaning no tracked widget was matched.
 		 */
 		_matchWidget: function() {
-			if ( !this.options.widgets ) {
-				return null;
-			}
-
 			var widgetNames = this.options.widgets,
-				curWidgetName = this.editor.widgets && this.editor.widgets.focused && this.editor.widgets.focused.name;
+				ret = null;
 
-			if ( typeof widgetNames === 'string' ) {
-				widgetNames = widgetNames.split( ',' );
+			if ( widgetNames ) {
+				var curWidgetName = this.editor.widgets && this.editor.widgets.focused && this.editor.widgets.focused.name;
+
+				if ( typeof widgetNames === 'string' ) {
+					widgetNames = widgetNames.split( ',' );
+				}
+
+				if ( CKEDITOR.tools.array.indexOf( widgetNames, curWidgetName ) !== -1 ) {
+					ret = this.editor.widgets.focused.element;
+				}
 			}
 
-			if ( CKEDITOR.tools.array.indexOf( widgetNames, curWidgetName ) !== -1 ) {
-				return this.editor.widgets.focused.element;
-			} else {
-				return null;
-			}
+			return ret;
 		},
 
 		/**
@@ -548,7 +548,7 @@
 			 * The main purpose is to {@link #create create} new toolbar contexts.
 			 *
 			 * @class CKEDITOR.editor.inlineToolbar
-	 		 * @singleton
+			 * @singleton
 			 */
 			editor.inlineToolbar = {
 				/**

--- a/plugins/inlinetoolbar/plugin.js
+++ b/plugins/inlinetoolbar/plugin.js
@@ -241,7 +241,7 @@
 		},
 
 		/**
-		 * Registers all the needed listeners, like {@link CKEDITOR.editor#selectionChange} listener.
+		 * Registers all the needed listeners, like {@link CKEDITOR.editor#event-selectionChange} listener.
 		 *
 		 * @private
 		 */
@@ -498,8 +498,6 @@
 		}
 	} );
 
-
-
 	/**
 	 * Static API exposed by the [Inline Toolbar](https://ckeditor.com/cke4/addon/inlinetoolbar) plugin.
 	 *
@@ -507,6 +505,29 @@
 	 * @singleton
 	 */
 	CKEDITOR.plugins.inlinetoolbar = {
-		context: Context
+		context: Context,
+
+		/**
+		 * Converts a given element into a style definition that could be used to create an instance of {@link CKEDITOR.style}.
+		 *
+		 * Note that all definitions have a `type` property set to {@link CKEDITOR#STYLE_INLINE}.
+		 *
+		 * @param {CKEDITOR.dom.element} element The element to be converted.
+		 * @returns {Object} The style definition created from the element.
+		 * @private
+		 */
+		_convertElementToStyleDef: function( element ) {
+			// @todo: this function is taken out from Copy Formatting plugin. It should be extracted to a common place.
+			var tools = CKEDITOR.tools,
+				attributes = element.getAttributes( CKEDITOR.plugins.copyformatting.excludedAttributes ),
+				styles = tools.parseCssText( element.getAttribute( 'style' ), true, true );
+
+			return {
+				element: element.getName(),
+				type: CKEDITOR.STYLE_INLINE,
+				attributes: attributes,
+				styles: styles
+			};
+		}
 	};
 }() );

--- a/plugins/inlinetoolbar/plugin.js
+++ b/plugins/inlinetoolbar/plugin.js
@@ -175,7 +175,7 @@
 	 * @constructor Creates an inline toolbar context instance.
 	 * @since 4.8
 	 * @param {CKEDITOR.editor} editor The editor instance for which the toolbar is created.
-	 * @param {Object} options Options object passed in the {@link CKEDITOR.editor.plugins.inlinetoolbar#create} method.
+	 * @param {CKEDITOR.plugins.inlinetoolbar.contextDefinition} options A set of options, defining context behavior.
 	 */
 	function Context( editor, options ) {
 		/**
@@ -521,12 +521,14 @@
 		init: function( editor ) {
 
 			/**
-			 * Set of instance-specific public APIs exposed by Inline Toolbar plugin.
+			 * Set of instance-specific public APIs exposed by the [Inline Toolbar](https://ckeditor.com/cke4/addon/inlinetoolbar) plugin.
 			 *
-			 * @class CKEDITOR.editor.plugins.inlinetoolbar
+			 * The main purpose is to {@link #create create} new toolbar contexts.
+			 *
+			 * @class CKEDITOR.editor.inlineToolbar
 	 		 * @singleton
 			 */
-			editor.plugins.inlinetoolbar = {
+			editor.inlineToolbar = {
 				/**
 				 * @private
 				 * @property {CKEDITOR.plugins.inlinetoolbar.contextManager} manager
@@ -538,7 +540,7 @@
 				 *
 				 * Following example will add a toolbar containing link/unlink buttons for any anchor or image:
 				 *
-				 *		editor.plugins.inlinetoolbar.create( {
+				 *		editor.inlinetoolbar.create( {
 				 *			buttons: 'Link,Unlink',
 				 *			cssSelector: 'a[href], img'
 				 *		} );
@@ -769,7 +771,7 @@
 	 * An example below will show the toolbar only for paths containing `<strong>` elements.
 	 *
 	 *		// Assuming that editor is an CKEDITOR.editor instance.
-	 *		editor.plugins.inlinetoolbar.create( {
+	 *		editor.inlinetoolbar.create( {
 	 *			buttons: 'Bold,Underline',
 	 *			refresh: function( editor, path ) {
 	 *				return path.contains( 'strong' );

--- a/plugins/inlinetoolbar/plugin.js
+++ b/plugins/inlinetoolbar/plugin.js
@@ -247,6 +247,10 @@
 			var widgetNames = this.options.widgets,
 				curWidgetName = this.editor.widgets && this.editor.widgets.focused && this.editor.widgets.focused.name;
 
+			if ( typeof widgetNames === 'string' ) {
+				widgetNames = widgetNames.split( ',' );
+			}
+
 			return CKEDITOR.tools.array.indexOf( widgetNames, curWidgetName ) !== -1;
 		},
 
@@ -364,7 +368,7 @@
 				/**
 				 * @param {Object} options Config object for Inline Toolbar.
 				 * @param {String} [options.elements] ACF selector. If any elements in the path matches against it, the toolbar will be shown.
-				 * @param {String[]} [options.widgets] An array of widget names that should trigger this toolbar.
+				 * @param {String[]/String} [options.widgets] An array of widget names that should trigger this toolbar. Alternatively can be passed as a comma-separated string.
 				 * @param {Function} [options.refresh] A function that determines whether the toolbar should be visible for a given `elementPath`.
 				 *
 				 * It gets following parameters:

--- a/plugins/inlinetoolbar/plugin.js
+++ b/plugins/inlinetoolbar/plugin.js
@@ -199,14 +199,6 @@
 		 */
 		this.toolbar = new CKEDITOR.ui.inlineToolbar( editor );
 
-		/**
-		 * A filter based on `options.elements` property. It's created only once at context construction time and cached.
-		 *
-		 * @private
-		 * @property {CKEDITOR.filter}
-		 */
-		this._filter = this.options.elements ? new CKEDITOR.filter( this.options.elements ) : null;
-
 		if ( this.options && typeof this.options.priority === 'undefined' ) {
 			this.options.priority = CKEDITOR.plugins.inlinetoolbar.PRIORITY.MEDIUM;
 		}
@@ -281,7 +273,7 @@
 		},
 
 		/**
-		 * Checks if given `element` matches `options.elements` selector.
+		 * Checks if given `element` matches `options.cssSelector` selector.
 		 *
 		 * @private
 		 * @param {CKEDITOR.dom.element} `elem` Element to be tested.
@@ -289,13 +281,11 @@
 		 * It may also return {@link CKEDITOR.dom.element} instance, that the toolbar should point to.
 		 */
 		_matchElement: function( elem ) {
-			if ( !this.options.elements ) {
+			if ( !this.options.cssSelector ) {
 				return;
 			}
 
-			var styleDef = CKEDITOR.plugins.inlinetoolbar._convertElementToStyleDef( elem );
-
-			return this._filter.check( new CKEDITOR.style( styleDef ), false, false );
+			return !!elem.$.matches( this.options.cssSelector );
 		},
 
 		/**
@@ -326,7 +316,7 @@
 	 *
 	 * 1. Callback - `options.refresh`
 	 * 1. Widgets matching - `options.widgets`
-	 * 1. ACF matching - `options.elements`
+	 * 1. CSS matching - `options.cssSelector`
 	 *
 	 * @class CKEDITOR.plugins.inlinetoolbar.contextManager
 	 * @constructor
@@ -540,7 +530,7 @@
 				 *		} );
 				 *
 				 * @param {Object} options Config object for Inline Toolbar.
-				 * @param {String} [options.elements] ACF selector. If any elements in the path matches against it, the toolbar will be shown.
+				 * @param {String} [options.cssSelector] CSS selector. If any element in the path matches against it, the toolbar will be shown.
 				 * @param {String[]/String} [options.widgets] An array of widget names that should trigger this toolbar. Alternatively can be passed as a comma-separated string.
 				 * @param {Function} [options.refresh] A function that determines whether the toolbar should be visible for a given `elementPath`.
 				 *

--- a/tests/plugins/inlinetoolbar/context.js
+++ b/tests/plugins/inlinetoolbar/context.js
@@ -1,5 +1,5 @@
 /* bender-tags: inlinetoolbar, context */
-/* bender-ckeditor-plugins: inlinetoolbar, basicstyles, format */
+/* bender-ckeditor-plugins: inlinetoolbar */
 
 ( function() {
 	'use strict';
@@ -9,55 +9,6 @@
 	bender.test( {
 		tearDown: function() {
 			this.editor.plugins.inlinetoolbar._manager._clear();
-		},
-
-		'test context.refresh picks up editor element path if none provided': function() {
-			var options = {
-					refresh: sinon.stub()
-				},
-				context,
-				elementsPathArgument;
-
-			this.editorBot.setHtmlWithSelection( '<p><strong>Fo^o</strong></p>' );
-
-			context = this.editor.plugins.inlinetoolbar.create( options );
-
-			context.refresh();
-
-			assert.areSame( 1, options.refresh.callCount, 'options.refresh call count' );
-
-			elementsPathArgument = options.refresh.args[ 0 ][ 1 ];
-
-			assert.isInstanceOf( CKEDITOR.dom.elementPath, elementsPathArgument, 'Elements path argument type' );
-			assert.areSame( 'body,p,strong', this._elementPathSerialize( elementsPathArgument ), 'Elements path used' );
-		},
-
-		'test context.refresh uses custom element path if explicitly provided': function() {
-			var options = {
-					refresh: sinon.stub()
-				},
-				context,
-				customElementPath,
-				elementsPathArgument,
-				selectionArgument;
-
-			this.editorBot.setHtmlWithSelection( '<p><strong>Fo^o</strong><em>bar</em></p>' );
-
-			context = this.editor.plugins.inlinetoolbar.create( options );
-
-			customElementPath = new CKEDITOR.dom.elementPath( this.editor.editable().findOne( 'em' ).getFirst(), this.editor.editable() );
-
-			context.refresh( customElementPath );
-
-			assert.areSame( 1, options.refresh.callCount, 'options.refresh call count' );
-
-			elementsPathArgument = options.refresh.args[ 0 ][ 1 ];
-			selectionArgument = options.refresh.args[ 0 ][ 2 ];
-
-			assert.isInstanceOf( CKEDITOR.dom.elementPath, elementsPathArgument, 'Elements path argument type' );
-			assert.areSame( 'body,p,em', this._elementPathSerialize( elementsPathArgument ), 'Elements path used' );
-
-			assert.isInstanceOf( CKEDITOR.dom.selection, selectionArgument, 'Selection argument type' );
 		},
 
 		'test exposes editor.plugins.inlinetoolbar.create': function() {
@@ -74,13 +25,6 @@
 
 			assert.isInstanceOf( ContextTypeStub, ret, 'Ret type' );
 			sinon.assert.calledWithExactly( ContextTypeStub, this.editor, {} );
-		},
-
-		// Returns a string with given `elementPath` member names, joined with comma, e.g. "body,ul,li,a,strong".
-		_elementPathSerialize: function( elementPath ) {
-			return CKEDITOR.tools.array.map( elementPath.elements, function( elem ) {
-				return elem.getName();
-			} ).reverse().join( ',' );
 		}
 	} );
 } )();

--- a/tests/plugins/inlinetoolbar/context.js
+++ b/tests/plugins/inlinetoolbar/context.js
@@ -8,10 +8,10 @@
 
 	bender.test( {
 		tearDown: function() {
-			this.editor.plugins.inlinetoolbar._manager._clear();
+			this.editor.inlineToolbar._manager._clear();
 		},
 
-		'test exposes editor.plugins.inlinetoolbar.create': function() {
+		'test exposes editor.inlineToolbar.create': function() {
 			var ContextTypeStub = sinon.stub( CKEDITOR.plugins.inlinetoolbar, 'context' ),
 				ret;
 
@@ -19,7 +19,7 @@
 			ContextTypeStub.prototype.hide = sinon.stub();
 			ContextTypeStub.prototype.destroy = sinon.stub();
 
-			ret = this.editor.plugins.inlinetoolbar.create( {} );
+			ret = this.editor.inlineToolbar.create( {} );
 
 			ContextTypeStub.restore();
 

--- a/tests/plugins/inlinetoolbar/context.js
+++ b/tests/plugins/inlinetoolbar/context.js
@@ -7,6 +7,12 @@
 	bender.editor = {};
 
 	bender.test( {
+		setUp: function() {
+			if ( CKEDITOR.env.ie && CKEDITOR.env.version === 8 ) {
+				assert.ignore();
+			}
+		},
+
 		tearDown: function() {
 			this.editor.inlineToolbar._manager._clear();
 		},

--- a/tests/plugins/inlinetoolbar/context.js
+++ b/tests/plugins/inlinetoolbar/context.js
@@ -1,5 +1,5 @@
 /* bender-tags: inlinetoolbar, context */
-/* bender-ckeditor-plugins: inlinetoolbar, button, richcombo, basicstyles, format */
+/* bender-ckeditor-plugins: inlinetoolbar, basicstyles, format */
 
 ( function() {
 	'use strict';
@@ -13,35 +13,10 @@
 			sinon.stub( CKEDITOR.plugins.inlinetoolbar.context.prototype, '_attachListeners' );
 		},
 
-		// 'test adding button': function() {
-		// 	var panel = this.editor.inlineToolbar.context( { buttons: 'Bold' } );
-		// 	assert.isInstanceOf( CKEDITOR.ui.button, panel.getItem( 'Bold' ), 'Registered button type.' );
-		// 	panel.destroy();
-		// },
-
 		// 'test adding rich combo': function() {
 		// 	var panel = this.editor.inlineToolbar.context( { buttons: 'Format' } );
 		// 	assert.isInstanceOf( CKEDITOR.ui.richCombo, panel.getItem( 'Format' ), 'Registered richCombo type.' );
 		// 	panel.destroy();
-		// },
-		/*'test context adding': function() {
-
-		},
-
-		'test focus change': function() {
-
-		},
-
-		'test widget adding': function() {
-
-		},
-		'Test widget focusing'*/
-
-		// 'test context destroy': function() {
-		// 	var stub = sinon.stub( this.editor.inlineToolbar, 'destroy' );
-		// 	bender.editor.destroy();
-		// 	assert.isTrue( stub.called, 'Event show should be fired when editor is destroyed.' );
-		// 	stub.restore();
 		// },
 
 		'test context.refresh picks up editor element path if none provided': function() {

--- a/tests/plugins/inlinetoolbar/context/_helpers/tools.js
+++ b/tests/plugins/inlinetoolbar/context/_helpers/tools.js
@@ -1,0 +1,14 @@
+( function() {
+	'use strict';
+
+	/* exported contextTools */
+
+	window.contextTools = {
+		/*
+		 * @param {Boolean} expected What's the expected visibility? If `true` toolbar must be visible.
+		 */
+		_assertToolbarVisible: function( expected, context, msg ) {
+			assert.areSame( expected, context.toolbar._view.parts.panel.isVisible(), msg || 'Toolbar visibility' );
+		}
+	};
+} )();

--- a/tests/plugins/inlinetoolbar/context/cssselector.js
+++ b/tests/plugins/inlinetoolbar/context/cssselector.js
@@ -12,6 +12,12 @@
 	};
 
 	bender.test( {
+		setUp: function() {
+			if ( CKEDITOR.env.ie && CKEDITOR.env.version === 8 ) {
+				assert.ignore();
+			}
+		},
+
 		tearDown: function() {
 			this.editor.inlineToolbar._manager._clear();
 		},

--- a/tests/plugins/inlinetoolbar/context/cssselector.js
+++ b/tests/plugins/inlinetoolbar/context/cssselector.js
@@ -13,7 +13,7 @@
 
 	bender.test( {
 		tearDown: function() {
-			this.editor.plugins.inlinetoolbar._manager._clear();
+			this.editor.inlineToolbar._manager._clear();
 		},
 
 		'test falsy matching': function() {
@@ -63,7 +63,7 @@
 		 * @returns {CKEDITOR.plugins.inlinetoolbar.context}
 		 */
 		_getContextStub: function( selector ) {
-			return this.editor.plugins.inlinetoolbar.create( {
+			return this.editor.inlineToolbar.create( {
 				cssSelector: selector
 			} );
 		},

--- a/tests/plugins/inlinetoolbar/context/cssselector.js
+++ b/tests/plugins/inlinetoolbar/context/cssselector.js
@@ -33,14 +33,14 @@
 		},
 
 		'test correct matching multiple': function() {
-			var context = this._getContextStub( 'em;strong;s' );
+			var context = this._getContextStub( 'em, strong, s' );
 
 			this.editorBot.setHtmlWithSelection( '<p><strong>foo^ bar</strong></p>' );
 
 			this._assertToolbarVisible( true, context );
 		},
 
-		'test ACF matching by attribute': function() {
+		'test matching by attribute': function() {
 			var context = this._getContextStub( 'strong[data-foo-bar]' );
 
 			this.editorBot.setHtmlWithSelection( '<p><strong data-foo-bar="1">foo^ bar</strong></p>' );
@@ -48,18 +48,10 @@
 			this._assertToolbarVisible( true, context );
 		},
 
-		'test ACF reject by attribute': function() {
-			var context = this._getContextStub( 'strong' );
+		'test reject by attribute': function() {
+			var context = this._getContextStub( 'strong:not([data-foo-bar])' );
 
 			this.editorBot.setHtmlWithSelection( '<p><strong data-foo-bar="1">foo^ bar</strong></p>' );
-
-			this._assertToolbarVisible( false, context );
-		},
-
-		'test ACF reject by style': function() {
-			var context = this._getContextStub( 'strong[data-foo-bar]' );
-
-			this.editorBot.setHtmlWithSelection( '<p><strong data-foo-bar="1" style="text-decoration: underline">foo^ bar</strong></p>' );
 
 			this._assertToolbarVisible( false, context );
 		},
@@ -72,7 +64,7 @@
 		 */
 		_getContextStub: function( selector ) {
 			return this.editor.plugins.inlinetoolbar.create( {
-				elements: selector
+				cssSelector: selector
 			} );
 		},
 

--- a/tests/plugins/inlinetoolbar/context/cssselector.js
+++ b/tests/plugins/inlinetoolbar/context/cssselector.js
@@ -75,8 +75,8 @@
 		},
 
 		/*
-			* @param {Boolean} expected What's the expected visibility? If `true` toolbar must be visible.
-			*/
+		 * @param {Boolean} expected What's the expected visibility? If `true` toolbar must be visible.
+		 */
 		_assertToolbarVisible: function( expected, context, msg ) {
 			assert.areSame( expected, context.toolbar._view.parts.panel.isVisible(), msg || 'Toolbar visibility' );
 		}

--- a/tests/plugins/inlinetoolbar/context/cssselector.js
+++ b/tests/plugins/inlinetoolbar/context/cssselector.js
@@ -32,6 +32,14 @@
 			contextTools._assertToolbarVisible( false, context );
 		},
 
+		'test falsy matching multiple': function() {
+			var context = this._getContextStub( 'video, audio, aside' );
+
+			this.editorBot.setHtmlWithSelection( '<p><strong>foo^ bar</strong></p>' );
+
+			contextTools._assertToolbarVisible( false, context );
+		},
+
 		'test correct matching': function() {
 			var context = this._getContextStub( 'strong' );
 
@@ -56,10 +64,26 @@
 			contextTools._assertToolbarVisible( true, context );
 		},
 
+		'test matching by class': function() {
+			var context = this._getContextStub( 'em.item' );
+
+			this.editorBot.setHtmlWithSelection( '<p><em class="multi item class">foo^ bar</em></p>' );
+
+			contextTools._assertToolbarVisible( true, context );
+		},
+
 		'test reject by attribute': function() {
 			var context = this._getContextStub( 'strong:not([data-foo-bar])' );
 
 			this.editorBot.setHtmlWithSelection( '<p><strong data-foo-bar="1">foo^ bar</strong></p>' );
+
+			contextTools._assertToolbarVisible( false, context );
+		},
+
+		'test reject by class': function() {
+			var context = this._getContextStub( 'em:not(.multi)' );
+
+			this.editorBot.setHtmlWithSelection( '<p><em class="multi item class">foo^ bar</em></p>' );
 
 			contextTools._assertToolbarVisible( false, context );
 		},

--- a/tests/plugins/inlinetoolbar/context/cssselector.js
+++ b/tests/plugins/inlinetoolbar/context/cssselector.js
@@ -1,5 +1,7 @@
 /* bender-tags: inlinetoolbar,context */
 /* bender-ckeditor-plugins: inlinetoolbar */
+/* bender-include: _helpers/tools.js */
+/* global contextTools */
 
 ( function() {
 	'use strict';
@@ -27,7 +29,7 @@
 
 			this.editorBot.setHtmlWithSelection( '<p><strong>foo^ bar</strong></p>' );
 
-			this._assertToolbarVisible( false, context );
+			contextTools._assertToolbarVisible( false, context );
 		},
 
 		'test correct matching': function() {
@@ -35,7 +37,7 @@
 
 			this.editorBot.setHtmlWithSelection( '<p><strong>foo^ bar</strong></p>' );
 
-			this._assertToolbarVisible( true, context );
+			contextTools._assertToolbarVisible( true, context );
 		},
 
 		'test correct matching multiple': function() {
@@ -43,7 +45,7 @@
 
 			this.editorBot.setHtmlWithSelection( '<p><strong>foo^ bar</strong></p>' );
 
-			this._assertToolbarVisible( true, context );
+			contextTools._assertToolbarVisible( true, context );
 		},
 
 		'test matching by attribute': function() {
@@ -51,7 +53,7 @@
 
 			this.editorBot.setHtmlWithSelection( '<p><strong data-foo-bar="1">foo^ bar</strong></p>' );
 
-			this._assertToolbarVisible( true, context );
+			contextTools._assertToolbarVisible( true, context );
 		},
 
 		'test reject by attribute': function() {
@@ -59,26 +61,17 @@
 
 			this.editorBot.setHtmlWithSelection( '<p><strong data-foo-bar="1">foo^ bar</strong></p>' );
 
-			this._assertToolbarVisible( false, context );
+			contextTools._assertToolbarVisible( false, context );
 		},
 
 		/*
-		 * Returns a Context instance with toolbar show/hide methods stubbed.
-		 *
 		 * @param {String} selector A selector to be used as `options.elements`.
-		 * @returns {CKEDITOR.plugins.inlinetoolbar.context}
+		 * @returns {CKEDITOR.plugins.inlinetoolbar.context} Context instance with `selector` used as a CSS selector.
 		 */
 		_getContextStub: function( selector ) {
 			return this.editor.inlineToolbar.create( {
 				cssSelector: selector
 			} );
-		},
-
-		/*
-		 * @param {Boolean} expected What's the expected visibility? If `true` toolbar must be visible.
-		 */
-		_assertToolbarVisible: function( expected, context, msg ) {
-			assert.areSame( expected, context.toolbar._view.parts.panel.isVisible(), msg || 'Toolbar visibility' );
 		}
 	} );
 } )();

--- a/tests/plugins/inlinetoolbar/context/elements.js
+++ b/tests/plugins/inlinetoolbar/context/elements.js
@@ -5,7 +5,10 @@
 	'use strict';
 
 	bender.editor = {
-		config: {}
+		config: {
+			// We're using various weird markup combinations, thus disabling ACF filtering.
+			allowedContent: true
+		}
 	};
 
 	bender.test( {
@@ -46,6 +49,39 @@
 
 			assert.areSame( 0, context.toolbar.hide.callCount, 'Toolbar hide calls' );
 			assert.areSame( 1, context.toolbar.show.callCount, 'Toolbar show calls' );
+		},
+
+		'test ACF matching by attribute': function() {
+			this.editorBot.setHtmlWithSelection( '<p><strong data-foo-bar="1">foo^ bar</strong></p>' );
+
+			var context = this._getContextStub( 'strong[data-foo-bar]' );
+
+			context.refresh();
+
+			assert.areSame( 0, context.toolbar.hide.callCount, 'Toolbar hide calls' );
+			assert.areSame( 1, context.toolbar.show.callCount, 'Toolbar show calls' );
+		},
+
+		'test ACF reject by attribute': function() {
+			this.editorBot.setHtmlWithSelection( '<p><strong data-foo-bar="1">foo^ bar</strong></p>' );
+
+			var context = this._getContextStub( 'strong' );
+
+			context.refresh();
+
+			assert.areSame( 1, context.toolbar.hide.callCount, 'Toolbar hide calls' );
+			assert.areSame( 0, context.toolbar.show.callCount, 'Toolbar show calls' );
+		},
+
+		'test ACF reject by style': function() {
+			this.editorBot.setHtmlWithSelection( '<p><strong data-foo-bar="1" style="text-decoration: underline">foo^ bar</strong></p>' );
+
+			var context = this._getContextStub( 'strong[data-foo-bar]' );
+
+			context.refresh();
+
+			assert.areSame( 1, context.toolbar.hide.callCount, 'Toolbar hide calls' );
+			assert.areSame( 0, context.toolbar.show.callCount, 'Toolbar show calls' );
 		},
 
 		/*

--- a/tests/plugins/inlinetoolbar/context/elements.js
+++ b/tests/plugins/inlinetoolbar/context/elements.js
@@ -17,69 +17,51 @@
 		},
 
 		'test falsy matching': function() {
-			this.editorBot.setHtmlWithSelection( '<p><strong>foo^ bar</strong></p>' );
-
 			var context = this._getContextStub( 'video' );
 
-			context.refresh();
+			this.editorBot.setHtmlWithSelection( '<p><strong>foo^ bar</strong></p>' );
 
-			assert.areSame( 1, context.toolbar.hide.callCount, 'Toolbar hide calls' );
-			assert.areSame( 0, context.toolbar.show.callCount, 'Toolbar show calls' );
+			this._assertToolbarVisible( false, context );
 		},
 
 		'test correct matching': function() {
-			this.editorBot.setHtmlWithSelection( '<p><strong>foo^ bar</strong></p>' );
-
 			var context = this._getContextStub( 'strong' );
 
-			context.refresh();
+			this.editorBot.setHtmlWithSelection( '<p><strong>foo^ bar</strong></p>' );
 
-			assert.areSame( 0, context.toolbar.hide.callCount, 'Toolbar hide calls' );
-			assert.areSame( 1, context.toolbar.show.callCount, 'Toolbar show calls' );
+			this._assertToolbarVisible( true, context );
 		},
 
 		'test correct matching multiple': function() {
-			this.editorBot.setHtmlWithSelection( '<p><strong>foo^ bar</strong></p>' );
-
 			var context = this._getContextStub( 'em;strong;s' );
 
-			context.refresh();
+			this.editorBot.setHtmlWithSelection( '<p><strong>foo^ bar</strong></p>' );
 
-			assert.areSame( 0, context.toolbar.hide.callCount, 'Toolbar hide calls' );
-			assert.areSame( 1, context.toolbar.show.callCount, 'Toolbar show calls' );
+			this._assertToolbarVisible( true, context );
 		},
 
 		'test ACF matching by attribute': function() {
-			this.editorBot.setHtmlWithSelection( '<p><strong data-foo-bar="1">foo^ bar</strong></p>' );
-
 			var context = this._getContextStub( 'strong[data-foo-bar]' );
 
-			context.refresh();
+			this.editorBot.setHtmlWithSelection( '<p><strong data-foo-bar="1">foo^ bar</strong></p>' );
 
-			assert.areSame( 0, context.toolbar.hide.callCount, 'Toolbar hide calls' );
-			assert.areSame( 1, context.toolbar.show.callCount, 'Toolbar show calls' );
+			this._assertToolbarVisible( true, context );
 		},
 
 		'test ACF reject by attribute': function() {
-			this.editorBot.setHtmlWithSelection( '<p><strong data-foo-bar="1">foo^ bar</strong></p>' );
-
 			var context = this._getContextStub( 'strong' );
 
-			context.refresh();
+			this.editorBot.setHtmlWithSelection( '<p><strong data-foo-bar="1">foo^ bar</strong></p>' );
 
-			assert.areSame( 1, context.toolbar.hide.callCount, 'Toolbar hide calls' );
-			assert.areSame( 0, context.toolbar.show.callCount, 'Toolbar show calls' );
+			this._assertToolbarVisible( false, context );
 		},
 
 		'test ACF reject by style': function() {
-			this.editorBot.setHtmlWithSelection( '<p><strong data-foo-bar="1" style="text-decoration: underline">foo^ bar</strong></p>' );
-
 			var context = this._getContextStub( 'strong[data-foo-bar]' );
 
-			context.refresh();
+			this.editorBot.setHtmlWithSelection( '<p><strong data-foo-bar="1" style="text-decoration: underline">foo^ bar</strong></p>' );
 
-			assert.areSame( 1, context.toolbar.hide.callCount, 'Toolbar hide calls' );
-			assert.areSame( 0, context.toolbar.show.callCount, 'Toolbar show calls' );
+			this._assertToolbarVisible( false, context );
 		},
 
 		/*
@@ -89,14 +71,16 @@
 		 * @returns {CKEDITOR.plugins.inlinetoolbar.context}
 		 */
 		_getContextStub: function( selector ) {
-			var ret = this.editor.plugins.inlinetoolbar.create( {
+			return this.editor.plugins.inlinetoolbar.create( {
 				elements: selector
 			} );
+		},
 
-			sinon.stub( ret.toolbar, 'hide' );
-			sinon.stub( ret.toolbar, 'show' );
-
-			return ret;
+		/*
+			* @param {Boolean} expected What's the expected visibility? If `true` toolbar must be visible.
+			*/
+		_assertToolbarVisible: function( expected, context, msg ) {
+			assert.areSame( expected, context.toolbar._view.parts.panel.isVisible(), msg || 'Toolbar visibility' );
 		}
 	} );
 } )();

--- a/tests/plugins/inlinetoolbar/context/elements.js
+++ b/tests/plugins/inlinetoolbar/context/elements.js
@@ -1,0 +1,68 @@
+/* bender-tags: inlinetoolbar,context */
+/* bender-ckeditor-plugins: inlinetoolbar */
+
+( function() {
+	'use strict';
+
+	bender.editor = {
+		config: {}
+	};
+
+	bender.test( {
+		init: function() {
+			// Stub listener register method, as since it's called in a constructor and it adds
+			// selectionChange listener, it causes extra calls to toolbar hide/show methods.
+			sinon.stub( CKEDITOR.plugins.inlinetoolbar.context.prototype, '_attachListeners' );
+		},
+
+		'test falsy matching': function() {
+			this.editorBot.setHtmlWithSelection( '<p><strong>foo^ bar</strong></p>' );
+
+			var context = this._getContextStub( 'video' );
+
+			context.refresh();
+
+			assert.areSame( 1, context.toolbar.hide.callCount, 'Toolbar hide calls' );
+			assert.areSame( 0, context.toolbar.show.callCount, 'Toolbar show calls' );
+		},
+
+		'test correct matching': function() {
+			this.editorBot.setHtmlWithSelection( '<p><strong>foo^ bar</strong></p>' );
+
+			var context = this._getContextStub( 'strong' );
+
+			context.refresh();
+
+			assert.areSame( 0, context.toolbar.hide.callCount, 'Toolbar hide calls' );
+			assert.areSame( 1, context.toolbar.show.callCount, 'Toolbar show calls' );
+		},
+
+		'test correct matching multiple': function() {
+			this.editorBot.setHtmlWithSelection( '<p><strong>foo^ bar</strong></p>' );
+
+			var context = this._getContextStub( 'em;strong;s' );
+
+			context.refresh();
+
+			assert.areSame( 0, context.toolbar.hide.callCount, 'Toolbar hide calls' );
+			assert.areSame( 1, context.toolbar.show.callCount, 'Toolbar show calls' );
+		},
+
+		/*
+		 * Returns a Context instance with toolbar show/hide methods stubbed.
+		 *
+		 * @param {String} selector A selector to be used as `options.elements`.
+		 * @returns {CKEDITOR.plugins.inlinetoolbar.context}
+		 */
+		_getContextStub: function( selector ) {
+			var ret = this.editor.plugins.inlinetoolbar.create( {
+				elements: selector
+			} );
+
+			sinon.stub( ret.toolbar, 'hide' );
+			sinon.stub( ret.toolbar, 'show' );
+
+			return ret;
+		}
+	} );
+} )();

--- a/tests/plugins/inlinetoolbar/context/elements.js
+++ b/tests/plugins/inlinetoolbar/context/elements.js
@@ -12,10 +12,8 @@
 	};
 
 	bender.test( {
-		init: function() {
-			// Stub listener register method, as since it's called in a constructor and it adds
-			// selectionChange listener, it causes extra calls to toolbar hide/show methods.
-			sinon.stub( CKEDITOR.plugins.inlinetoolbar.context.prototype, '_attachListeners' );
+		tearDown: function() {
+			this.editor.plugins.inlinetoolbar._manager._clear();
 		},
 
 		'test falsy matching': function() {

--- a/tests/plugins/inlinetoolbar/context/integration.html
+++ b/tests/plugins/inlinetoolbar/context/integration.html
@@ -1,0 +1,1 @@
+<input id="focusHost" type="button" value="foo"/>

--- a/tests/plugins/inlinetoolbar/context/integration.js
+++ b/tests/plugins/inlinetoolbar/context/integration.js
@@ -12,11 +12,11 @@
 
 	bender.test( {
 		tearDown: function() {
-			this.editor.plugins.inlinetoolbar._manager._clear();
+			this.editor.inlineToolbar._manager._clear();
 		},
 
 		'test selectionChange with options.refresh': function() {
-			var context = this.editor.plugins.inlinetoolbar.create( {
+			var context = this.editor.inlineToolbar.create( {
 					buttons: 'Bold,Italic,Underline',
 					refresh: function( editor, path ) {
 						return path.contains( 'em' );
@@ -52,7 +52,7 @@
 
 		'test moving focus out of the editor hides the toolbar': function() {
 			// Note: this test is verified to fail with testing window blurred (e.g. when dev console window focused).
-			var context = this.editor.plugins.inlinetoolbar.create( {
+			var context = this.editor.inlineToolbar.create( {
 					buttons: 'Bold,Italic',
 					refresh: sinon.stub().returns( true )
 				} );
@@ -74,7 +74,7 @@
 		},
 
 		'test invalid buttons wont break creation': function() {
-			var context = this.editor.plugins.inlinetoolbar.create( {
+			var context = this.editor.inlineToolbar.create( {
 				buttons: 'foo!,Bold,Boldzzz,|',
 				refresh: sinon.stub().returns( true )
 			} );
@@ -89,7 +89,7 @@
 		'test switching source mode hides the toolbar': function() {
 			var initialMode = this.editor.mode;
 
-			var context = this.editor.plugins.inlinetoolbar.create( {
+			var context = this.editor.inlineToolbar.create( {
 				buttons: 'Bold,Italic',
 				refresh: sinon.stub().returns( true )
 			} );
@@ -134,19 +134,19 @@
 
 			this.editorBot.setHtmlWithSelection( '<p><em>foo<strong>b^ar</strong>baz</em</p>' );
 
-			this.editor.plugins.inlinetoolbar.create( {
+			this.editor.inlineToolbar.create( {
 				buttons: 'Bold,Italic',
 				refresh: sinon.stub().returns( this.editor.editable().findOne( 'p' ) ),
 				priority: CKEDITOR.plugins.inlinetoolbar.PRIORITY.LOW
 			} );
 
-			var cssContext = this.editor.plugins.inlinetoolbar.create( {
+			var cssContext = this.editor.inlineToolbar.create( {
 					buttons: 'Bold,Italic',
 					cssSelector: 'em'
 				} ),
 				showSpy = sinon.spy( cssContext, 'show' );
 
-			this.editor.plugins.inlinetoolbar._manager.check();
+			this.editor.inlineToolbar._manager.check();
 
 			this._assertToolbarVisible( true, cssContext );
 
@@ -159,10 +159,10 @@
 		'test correct highlighted with refresh after widget was matched': function() {
 			this.editorBot.setHtmlWithSelection( '<p><em>foo<strong>b^ar</strong>baz</em</p>' );
 
-			var widgetContext = this.editor.plugins.inlinetoolbar.create( {
+			var widgetContext = this.editor.inlineToolbar.create( {
 					buttons: 'Bold,Italic'
 				} ),
-				refreshContext = this.editor.plugins.inlinetoolbar.create( {
+				refreshContext = this.editor.inlineToolbar.create( {
 					buttons: 'Bold,Italic',
 					// Since we're returning true, it should highlight default element, which is path's last element - a strong.
 					refresh: sinon.stub().returns( true )
@@ -173,7 +173,7 @@
 			// the hassle of faking a widget.
 			sinon.stub( widgetContext, '_matchWidget' ).returns( this.editor.editable().findOne( 'em' ) );
 
-			this.editor.plugins.inlinetoolbar._manager.check();
+			this.editor.inlineToolbar._manager.check();
 
 			this._assertToolbarVisible( true, refreshContext );
 

--- a/tests/plugins/inlinetoolbar/context/integration.js
+++ b/tests/plugins/inlinetoolbar/context/integration.js
@@ -1,5 +1,5 @@
 /* bender-tags: inlinetoolbar, context */
-/* bender-ckeditor-plugins: inlinetoolbar, toolbar, basicstyles */
+/* bender-ckeditor-plugins: inlinetoolbar, toolbar, basicstyles, sourcearea */
 
 ( function() {
 	'use strict';
@@ -72,6 +72,35 @@
 
 			// Keep in mind that modern browsers will "debounce" the focus event, it will happen asynchronously.
 			CKEDITOR.document.getById( 'focusHost' ).focus();
+
+			wait();
+		},
+
+		'test switching source mode hides the toolbar': function() {
+			var initialMode = this.editor.mode;
+
+			this.curContext = this.editor.plugins.inlinetoolbar.create( {
+				buttons: 'Bold,Italic',
+				refresh: sinon.stub().returns( true )
+			} );
+
+			this.editorBot.setHtmlWithSelection( '<p><strong>foo^bar</strong></p>' );
+
+			this._assertToolbarVisible( true, this.curContext );
+
+			this.editor.setMode( 'source', function() {
+				resume( function() {
+					try {
+						this._assertToolbarVisible( false, this.curContext, 'Toolbar visibility after switching to source area' );
+					} catch ( e ) {
+						// Propagate the exception.
+						throw e;
+					} finally {
+						// In any case, set the mode back to initial editor mode.
+						this.editor.setMode( initialMode );
+					}
+				} );
+			} );
 
 			wait();
 		},

--- a/tests/plugins/inlinetoolbar/context/integration.js
+++ b/tests/plugins/inlinetoolbar/context/integration.js
@@ -12,10 +12,7 @@
 
 	bender.test( {
 		tearDown: function() {
-			if ( this.curContext ) {
-				this.curContext.destroy();
-				this.curContext = null;
-			}
+			this.editor.plugins.inlinetoolbar._manager._clear();
 		},
 
 		'test selectionChange with options.refresh': function() {
@@ -55,18 +52,18 @@
 
 		'test moving focus out of the editor hides the toolbar': function() {
 			// Note: this test is verified to fail with testing window blurred (e.g. when dev console window focused).
-			this.curContext = this.editor.plugins.inlinetoolbar.create( {
+			var context = this.editor.plugins.inlinetoolbar.create( {
 					buttons: 'Bold,Italic',
 					refresh: sinon.stub().returns( true )
 				} );
 
 			this.editorBot.setHtmlWithSelection( '<p><strong>foo^bar</strong></p>' );
 
-			this._assertToolbarVisible( true, this.curContext );
+			this._assertToolbarVisible( true, context );
 
 			this.editor.once( 'blur', function() {
 				resume( function() {
-					this._assertToolbarVisible( false, this.curContext, 'Toolbar visibility after blurring the editor' );
+					this._assertToolbarVisible( false, context, 'Toolbar visibility after blurring the editor' );
 				} );
 			}, this, null, 99999 );
 
@@ -79,19 +76,19 @@
 		'test switching source mode hides the toolbar': function() {
 			var initialMode = this.editor.mode;
 
-			this.curContext = this.editor.plugins.inlinetoolbar.create( {
+			var context = this.editor.plugins.inlinetoolbar.create( {
 				buttons: 'Bold,Italic',
 				refresh: sinon.stub().returns( true )
 			} );
 
 			this.editorBot.setHtmlWithSelection( '<p><strong>foo^bar</strong></p>' );
 
-			this._assertToolbarVisible( true, this.curContext );
+			this._assertToolbarVisible( true, context );
 
 			this.editor.setMode( 'source', function() {
 				resume( function() {
 					try {
-						this._assertToolbarVisible( false, this.curContext, 'Toolbar visibility after switching to source area' );
+						this._assertToolbarVisible( false, context, 'Toolbar visibility after switching to source area' );
 					} catch ( e ) {
 						// Propagate the exception.
 						throw e;

--- a/tests/plugins/inlinetoolbar/context/integration.js
+++ b/tests/plugins/inlinetoolbar/context/integration.js
@@ -137,7 +137,10 @@
 
 			this._assertToolbarVisible( true, cssContext );
 
-			sinon.assert.calledWithExactly( showSpy, this.editor.editable().findOne( 'em' ) );
+			// Note can't be checked simply against this.editor.editable().findOne( '...' ) as it will be two different objects.
+			sinon.assert.alwaysCalledWithMatch( showSpy, function( el ) {
+				return el.getName() === 'em';
+			} );
 		},
 
 		'test correct highlighted with refresh after widget was matched': function() {
@@ -161,7 +164,10 @@
 
 			this._assertToolbarVisible( true, refreshContext );
 
-			sinon.assert.calledWithExactly( showSpy, this.editor.editable().findOne( 'strong' ) );
+			// Note can't be checked simply against this.editor.editable().findOne( '...' ) as it will be two different objects.
+			sinon.assert.alwaysCalledWithMatch( showSpy, function( el ) {
+				return el.getName() === 'strong';
+			} );
 		},
 
 		/*

--- a/tests/plugins/inlinetoolbar/context/integration.js
+++ b/tests/plugins/inlinetoolbar/context/integration.js
@@ -73,6 +73,19 @@
 			wait();
 		},
 
+		'test invalid buttons wont break creation': function() {
+			var context = this.editor.plugins.inlinetoolbar.create( {
+				buttons: 'foo!,Bold,Boldzzz,|',
+				refresh: sinon.stub().returns( true )
+			} );
+
+			this.editorBot.setHtmlWithSelection( '<p><strong>foo^bar</strong></p>' );
+
+			this._assertToolbarVisible( true, context );
+
+			arrayAssert.itemsAreSame( [ 'Bold' ], Object.keys( context.toolbar._items ) );
+		},
+
 		'test switching source mode hides the toolbar': function() {
 			var initialMode = this.editor.mode;
 

--- a/tests/plugins/inlinetoolbar/context/integration.js
+++ b/tests/plugins/inlinetoolbar/context/integration.js
@@ -11,6 +11,12 @@
 	};
 
 	bender.test( {
+		setUp: function() {
+			if ( CKEDITOR.env.ie && CKEDITOR.env.version === 8 ) {
+				assert.ignore();
+			}
+		},
+
 		tearDown: function() {
 			this.editor.inlineToolbar._manager._clear();
 		},

--- a/tests/plugins/inlinetoolbar/context/integration.js
+++ b/tests/plugins/inlinetoolbar/context/integration.js
@@ -1,5 +1,7 @@
 /* bender-tags: inlinetoolbar, context */
 /* bender-ckeditor-plugins: inlinetoolbar, toolbar, basicstyles, sourcearea */
+/* bender-include: _helpers/tools.js */
+/* global contextTools */
 
 ( function() {
 	'use strict';
@@ -39,16 +41,16 @@
 
 			this.editor.getSelection().selectRanges( [ newRange ] );
 
-			this._assertToolbarVisible( false, context );
+			contextTools._assertToolbarVisible( false, context );
 
 			// Now, change the selection to a place that should show the toolbar.
 			// For example: "<em>b^ar</em>".
-			newRange.setStartAt( this.editor.editable().findOne( 'em' ).getFirst(), 1 );
+			newRange.setStart( this.editor.editable().findOne( 'em' ).getFirst(), 1 );
 			newRange.collapse( true );
 
 			this.editor.getSelection().selectRanges( [ newRange ] );
 
-			this._assertToolbarVisible( true, context );
+			contextTools._assertToolbarVisible( true, context );
 
 			context.destroy();
 		},
@@ -62,11 +64,11 @@
 
 			this.editorBot.setHtmlWithSelection( '<p><strong>foo^bar</strong></p>' );
 
-			this._assertToolbarVisible( true, context );
+			contextTools._assertToolbarVisible( true, context );
 
 			this.editor.once( 'blur', function() {
 				resume( function() {
-					this._assertToolbarVisible( false, context, 'Toolbar visibility after blurring the editor' );
+					contextTools._assertToolbarVisible( false, context, 'Toolbar visibility after blurring the editor' );
 				} );
 			}, this, null, 99999 );
 
@@ -84,7 +86,7 @@
 
 			this.editorBot.setHtmlWithSelection( '<p><strong>foo^bar</strong></p>' );
 
-			this._assertToolbarVisible( true, context );
+			contextTools._assertToolbarVisible( true, context );
 
 			arrayAssert.itemsAreSame( [ 'Bold' ], Object.keys( context.toolbar._items ) );
 		},
@@ -99,14 +101,14 @@
 
 			this.editorBot.setHtmlWithSelection( '<p><strong>foo^bar</strong></p>' );
 
-			this._assertToolbarVisible( true, context );
+			contextTools._assertToolbarVisible( true, context );
 
 			this.editor.setMode( 'source', function() {
 				resume( function() {
 					var storedException;
 
 					try {
-						this._assertToolbarVisible( false, context, 'Toolbar visibility after switching to source area' );
+						contextTools._assertToolbarVisible( false, context, 'Toolbar visibility after switching to source area' );
 					} catch ( e ) {
 						// Propagate the exception. We can't just rethrow here... as  it's YUI and wait in finally block will... also
 						// throw an exception, which will make our tests silently to pass :D
@@ -151,7 +153,7 @@
 
 			this.editor.inlineToolbar._manager.check();
 
-			this._assertToolbarVisible( true, cssContext );
+			contextTools._assertToolbarVisible( true, cssContext );
 
 			// Note can't be checked simply against this.editor.editable().findOne( '...' ) as it will be two different objects.
 			sinon.assert.alwaysCalledWithMatch( showSpy, function( el ) {
@@ -178,19 +180,12 @@
 
 			this.editor.inlineToolbar._manager.check();
 
-			this._assertToolbarVisible( true, refreshContext );
+			contextTools._assertToolbarVisible( true, refreshContext );
 
 			// Note can't be checked simply against this.editor.editable().findOne( '...' ) as it will be two different objects.
 			sinon.assert.alwaysCalledWithMatch( showSpy, function( el ) {
 				return el.getName() === 'strong';
 			} );
-		},
-
-		/*
-		 * @param {Boolean} expected What's the expected visibility? If `true` toolbar must be visible.
-		 */
-		_assertToolbarVisible: function( expected, context, msg ) {
-			assert.areSame( expected, context.toolbar._view.parts.panel.isVisible(), msg || 'Toolbar visibility' );
 		}
 	} );
 } )();

--- a/tests/plugins/inlinetoolbar/context/integration.js
+++ b/tests/plugins/inlinetoolbar/context/integration.js
@@ -28,12 +28,9 @@
 						return path.contains( 'em' );
 					}
 				} ),
-				newRange = this.editor.createRange(),
-				emElem;
+				newRange = this.editor.createRange();
 
 			this.editorBot.setHtmlWithSelection( '<p>Test^ <strong>Foo</strong><em>bar</em></p>' );
-
-			emElem = this.editor.editable().findOne( 'em' );
 
 			// First set the selection in a place where inline toolbar should not be shown.
 			// Set range at <strong>F^oo</strong>.
@@ -46,7 +43,7 @@
 
 			// Now, change the selection to a place that should show the toolbar.
 			// For example: "<em>b^ar</em>".
-			newRange.setStartAt( emElem.getFirst(), 1 );
+			newRange.setStartAt( this.editor.editable().findOne( 'em' ).getFirst(), 1 );
 			newRange.collapse( true );
 
 			this.editor.getSelection().selectRanges( [ newRange ] );
@@ -138,7 +135,7 @@
 			// However later on a cssSelector listener, will hint element B.
 			// Make sure B is pointed by the toolbar.
 
-			this.editorBot.setHtmlWithSelection( '<p><em>foo<strong>b^ar</strong>baz</em</p>' );
+			this.editorBot.setHtmlWithSelection( '<p><em>foo<strong>b^ar</strong>baz</em></p>' );
 
 			this.editor.inlineToolbar.create( {
 				buttons: 'Bold,Italic',

--- a/tests/plugins/inlinetoolbar/context/manager.js
+++ b/tests/plugins/inlinetoolbar/context/manager.js
@@ -8,7 +8,7 @@
 
 	bender.test( {
 		tearDown: function() {
-			this.editor.plugins.inlinetoolbar._manager._clear();
+			this.editor.inlineToolbar._manager._clear();
 		},
 
 		'test manager uses custom selection if provided': function() {
@@ -21,11 +21,11 @@
 			rng.setStart( this.editor.editable().findOne( 'em' ).getFirst(), 1 );
 			rng.collapse( true );
 
-			this.editor.plugins.inlinetoolbar.create( {
+			this.editor.inlineToolbar.create( {
 				refresh: refreshStub
 			} );
 
-			this.editor.plugins.inlinetoolbar._manager.check( selectionClone );
+			this.editor.inlineToolbar._manager.check( selectionClone );
 
 			assert.areSame( 1, refreshStub.callCount, 'Refresh call count' );
 			assert.areSame( 'body,p,em', this._elementPathSerialize( refreshStub.args[ 0 ][ 1 ] ), 'Path provided to the options.refresh' );
@@ -38,11 +38,11 @@
 
 			var refreshStub = sinon.stub().returns( false );
 
-			this.editor.plugins.inlinetoolbar.create( {
+			this.editor.inlineToolbar.create( {
 				refresh: refreshStub
 			} );
 
-			this.editor.plugins.inlinetoolbar._manager.check();
+			this.editor.inlineToolbar._manager.check();
 
 			assert.areSame( 1, refreshStub.callCount, 'Refresh call count' );
 			assert.areSame( 'body,p,strong', this._elementPathSerialize( refreshStub.args[ 0 ][ 1 ] ), 'Path provided to options.refresh' );

--- a/tests/plugins/inlinetoolbar/context/manager.js
+++ b/tests/plugins/inlinetoolbar/context/manager.js
@@ -11,8 +11,29 @@
 			this.editor.plugins.inlinetoolbar._manager._clear();
 		},
 
+		'test manager uses custom selection if provided': function() {
+			this.editorBot.setHtmlWithSelection( '<p>foo <strong>b^ar</strong> <em>baz</em></p>' );
+
+			var selectionClone = new CKEDITOR.dom.selection( this.editor.getSelection() ),
+				rng = selectionClone.getRanges()[ 0 ],
+				refreshStub = sinon.stub().returns( false );
+
+			rng.setStart( this.editor.editable().findOne( 'em' ).getFirst(), 1 );
+			rng.collapse( true );
+
+			this.editor.plugins.inlinetoolbar.create( {
+				refresh: refreshStub
+			} );
+
+			this.editor.plugins.inlinetoolbar._manager.check( selectionClone );
+
+			assert.areSame( 1, refreshStub.callCount, 'Refresh call count' );
+			assert.areSame( 'body,p,em', this._elementPathSerialize( refreshStub.args[ 0 ][ 1 ] ), 'Path provided to the options.refresh' );
+			assert.areSame( selectionClone, refreshStub.args[ 0 ][ 2 ], 'Selection provided to the options.refresh' );
+		},
+
 		'test manager uses shrinked selection': function() {
-			// Make selection outside of a strong. Still it should be used in elementspath.
+			// Make selection outside of a strong. Despite that, the strong should be used in elements path.
 			this.editorBot.setHtmlWithSelection( '<p>foo [<strong>bar</strong>] baz</p>' );
 
 			var refreshStub = sinon.stub().returns( false );

--- a/tests/plugins/inlinetoolbar/context/manager.js
+++ b/tests/plugins/inlinetoolbar/context/manager.js
@@ -1,0 +1,37 @@
+/* bender-tags: inlinetoolbar, context */
+/* bender-ckeditor-plugins: inlinetoolbar, basicstyles */
+
+( function() {
+	'use strict';
+
+	bender.editor = {};
+
+	bender.test( {
+		tearDown: function() {
+			this.editor.plugins.inlinetoolbar._manager._clear();
+		},
+
+		'test manager uses shrinked selection': function() {
+			// Make selection outside of a strong. Still it should be used in elementspath.
+			this.editorBot.setHtmlWithSelection( '<p>foo [<strong>bar</strong>] baz</p>' );
+
+			var refreshStub = sinon.stub().returns( false );
+
+			this.editor.plugins.inlinetoolbar.create( {
+				refresh: refreshStub
+			} );
+
+			this.editor.plugins.inlinetoolbar._manager.check();
+
+			assert.areSame( 1, refreshStub.callCount, 'Refresh call count' );
+			assert.areSame( 'body,p,strong', this._elementPathSerialize( refreshStub.args[ 0 ][ 1 ] ), 'Path provided to options.refresh' );
+		},
+
+		// Returns a string with given `elementPath` member names, joined with comma, e.g. "body,ul,li,a,strong".
+		_elementPathSerialize: function( elementPath ) {
+			return CKEDITOR.tools.array.map( elementPath.elements, function( elem ) {
+				return elem.getName();
+			} ).reverse().join( ',' );
+		}
+	} );
+} )();

--- a/tests/plugins/inlinetoolbar/context/manager.js
+++ b/tests/plugins/inlinetoolbar/context/manager.js
@@ -7,6 +7,12 @@
 	bender.editor = {};
 
 	bender.test( {
+		setUp: function() {
+			if ( CKEDITOR.env.ie && CKEDITOR.env.version === 8 ) {
+				assert.ignore();
+			}
+		},
+
 		tearDown: function() {
 			this.editor.inlineToolbar._manager._clear();
 		},

--- a/tests/plugins/inlinetoolbar/context/manual/complex.html
+++ b/tests/plugins/inlinetoolbar/context/manual/complex.html
@@ -40,23 +40,22 @@
 					// Register the toolbar for inline elements.
 					evt.editor.plugins.inlinetoolbar.create( {
 						buttons: 'Bold,Underline',
-						elements: 'strong;em'
+						cssSelector: 'strong, em'
 					} );
 
 					evt.editor.plugins.inlinetoolbar.create( {
 						buttons: 'Link,Unlink',
-						elements: 'a[href];img[*]'
+						cssSelector: 'a[href], img'
 					} );
 
 					evt.editor.plugins.inlinetoolbar.create( {
 						buttons: 'BulletedList,NumberedList',
-						elements: 'li[*]'
+						cssSelector: 'li'
 					} );
 				}
 			}
 		};
 
 	CKEDITOR.replace( 'editor1', config );
-
 	CKEDITOR.inline( 'editor2', config );
 </script>

--- a/tests/plugins/inlinetoolbar/context/manual/complex.html
+++ b/tests/plugins/inlinetoolbar/context/manual/complex.html
@@ -42,6 +42,16 @@
 						buttons: 'Bold,Underline',
 						elements: 'strong;em'
 					} );
+
+					evt.editor.plugins.inlinetoolbar.create( {
+						buttons: 'Link,Unlink',
+						elements: 'a[href];img[*]'
+					} );
+
+					evt.editor.plugins.inlinetoolbar.create( {
+						buttons: 'BulletedList,NumberedList',
+						elements: 'li[*]'
+					} );
 				}
 			}
 		};

--- a/tests/plugins/inlinetoolbar/context/manual/complex.html
+++ b/tests/plugins/inlinetoolbar/context/manual/complex.html
@@ -18,7 +18,7 @@
 	</ol>
 </textarea>
 
-<div id="editor2" contenteditable="true">
+<div id="editor2" contenteditable="true" style="width: 500px">
 	<p>Sample paragraph with <em>emphasize</em>, <strong>strong</strong>, <u>underline</u> and <s>strike thourgh</s>.</p>
 	<ol>
 		<li>List item with a plain text only.</li>

--- a/tests/plugins/inlinetoolbar/context/manual/complex.html
+++ b/tests/plugins/inlinetoolbar/context/manual/complex.html
@@ -30,6 +30,10 @@
 </div>
 
 <script>
+	if ( CKEDITOR.env.ie && CKEDITOR.env.version === 8 ) {
+		bender.ignore();
+	}
+
 	CKEDITOR.disableAutoInline = true;
 
 	var config = {

--- a/tests/plugins/inlinetoolbar/context/manual/complex.html
+++ b/tests/plugins/inlinetoolbar/context/manual/complex.html
@@ -38,17 +38,17 @@
 			on: {
 				instanceReady: function( evt ) {
 					// Register the toolbar for inline elements.
-					evt.editor.plugins.inlinetoolbar.create( {
+					evt.editor.inlineToolbar.create( {
 						buttons: 'Bold,Underline',
 						cssSelector: 'strong, em'
 					} );
 
-					evt.editor.plugins.inlinetoolbar.create( {
+					evt.editor.inlineToolbar.create( {
 						buttons: 'Link,Unlink',
 						cssSelector: 'a[href], img'
 					} );
 
-					evt.editor.plugins.inlinetoolbar.create( {
+					evt.editor.inlineToolbar.create( {
 						buttons: 'BulletedList,NumberedList',
 						cssSelector: 'li'
 					} );

--- a/tests/plugins/inlinetoolbar/context/manual/complex.html
+++ b/tests/plugins/inlinetoolbar/context/manual/complex.html
@@ -16,6 +16,7 @@
 		</li>
 		<li>List item with a plain text only.</li>
 	</ol>
+	<p>Last paragraph with an <a href="#">example link</a>.</p>
 </textarea>
 
 <div id="editor2" contenteditable="true" style="width: 500px">
@@ -27,6 +28,7 @@
 		</li>
 		<li>List item with a plain text only.</li>
 	</ol>
+	<p>Last paragraph with an <a href="#">example link</a>.</p>
 </div>
 
 <script>

--- a/tests/plugins/inlinetoolbar/context/manual/complex.html
+++ b/tests/plugins/inlinetoolbar/context/manual/complex.html
@@ -8,22 +8,22 @@
 </style>
 
 <textarea id="editor1" cols="10" rows="10">
-	<p>Sample paragraph with <em>emphasize</em>, <strong>strong</strong>, <u>underline</u> and <s>strike thourgh</s>.</p>
+	<p>Sample paragraph with <em>emphasize</em>, <strong>strong</strong>, <u>underline</u> and <s>strikethrough</s>.</p>
 	<ol>
 		<li>List item with a plain text only.</li>
 		<li>
-			<p>List item with <em>emphasize</em>, <strong>strong</strong>, <u>underline</u> and <s>strike thourgh</s>.</p>
+			<p>List item with <em>emphasize</em>, <strong>strong</strong>, <u>underline</u> and <s>strikethrough</s>.</p>
 		</li>
 		<li>List item with a plain text only.</li>
 	</ol>
 </textarea>
 
 <div id="editor2" contenteditable="true" style="width: 500px">
-	<p>Sample paragraph with <em>emphasize</em>, <strong>strong</strong>, <u>underline</u> and <s>strike thourgh</s>.</p>
+	<p>Sample paragraph with <em>emphasize</em>, <strong>strong</strong>, <u>underline</u> and <s>strikethrough</s>.</p>
 	<ol>
 		<li>List item with a plain text only.</li>
 		<li>
-			<p>List item with <em>emphasize</em>, <strong>strong</strong>, <u>underline</u> and <s>strike thourgh</s>.</p>
+			<p>List item with <em>emphasize</em>, <strong>strong</strong>, <u>underline</u> and <s>strikethrough</s>.</p>
 		</li>
 		<li>List item with a plain text only.</li>
 	</ol>

--- a/tests/plugins/inlinetoolbar/context/manual/complex.md
+++ b/tests/plugins/inlinetoolbar/context/manual/complex.md
@@ -1,0 +1,19 @@
+@bender-ui: collapsed
+@bender-tags: 4.8.0, feature, inlinetoolbar
+@bender-ckeditor-plugins: wysiwygarea, toolbar, undo, basicstyles, floatingspace, inlinetoolbar, sourcearea, list, link, elementspath, language,stylescombo, image
+
+## Complex Context Sample
+
+There are several inline toolbar listeners (from highest priority):
+
+1. `strong;em` selection should show `Bold,Underline` buttons.
+1. `a[href];img[*]` selection should show `Link,Unlink` buttons.
+1. `li[*]` selection should show `BulletedList,NumberedList` buttons.
+
+### Sample Test Case
+
+1. Click inside bold text in a list.
+
+#### Expected
+
+Toolbar with `Bold,Underline` is shown, as it has higher priority.

--- a/tests/plugins/inlinetoolbar/context/manual/complex.md
+++ b/tests/plugins/inlinetoolbar/context/manual/complex.md
@@ -1,19 +1,19 @@
 @bender-ui: collapsed
-@bender-tags: 4.8.0, feature, inlinetoolbar
-@bender-ckeditor-plugins: wysiwygarea, toolbar, undo, basicstyles, floatingspace, inlinetoolbar, sourcearea, list, link, elementspath, language,stylescombo, image
+@bender-tags: 4.8.0, feature, inlinetoolbar, 933
+@bender-ckeditor-plugins: wysiwygarea, toolbar, undo, basicstyles, floatingspace, inlinetoolbar, sourcearea, list, link, elementspath, image
 
 ## Complex Context Sample
 
 There are several inline toolbar listeners (from highest priority):
 
-1. `strong;em` selection should show `Bold,Underline` buttons.
-1. `a[href];img[*]` selection should show `Link,Unlink` buttons.
+1. `strong, em` selection should show `Bold,Underline` buttons.
+1. `a[href], img` selection should show `Link,Unlink` buttons.
 1. `li[*]` selection should show `BulletedList,NumberedList` buttons.
 
 ### Sample Test Case
 
-1. Click inside bold text in a list.
+1. Click inside of bold text in a list.
 
 #### Expected
 
-Toolbar with `Bold,Underline` is shown, as it has higher priority.
+Toolbar with `Bold,Underline` buttons is shown, as it has higher priority.

--- a/tests/plugins/inlinetoolbar/context/manual/context.html
+++ b/tests/plugins/inlinetoolbar/context/manual/context.html
@@ -40,13 +40,12 @@
 					// Register the toolbar for inline elements.
 					evt.editor.plugins.inlinetoolbar.create( {
 						buttons: 'Bold,Underline',
-						elements: 'strong;em'
+						cssSelector: 'strong, em'
 					} );
 				}
 			}
 		};
 
 	CKEDITOR.replace( 'editor1', config );
-
 	CKEDITOR.inline( 'editor2', config );
 </script>

--- a/tests/plugins/inlinetoolbar/context/manual/context.html
+++ b/tests/plugins/inlinetoolbar/context/manual/context.html
@@ -30,6 +30,10 @@
 </div>
 
 <script>
+	if ( CKEDITOR.env.ie && CKEDITOR.env.version === 8 ) {
+		bender.ignore();
+	}
+
 	CKEDITOR.disableAutoInline = true;
 
 	var config = {

--- a/tests/plugins/inlinetoolbar/context/manual/context.html
+++ b/tests/plugins/inlinetoolbar/context/manual/context.html
@@ -34,12 +34,14 @@
 
 	var listenersConfig = {
 		instanceReady: function( evt ) {
-			var editor = evt.editor;
-
-			window.context = editor.plugins.inlinetoolbar.create( {
+			// Register the toolbar for inline elements.
+			evt.editor.plugins.inlinetoolbar.create( {
 				buttons: 'Bold,Underline',
 				refresh: function( editor, path ) {
-					return path.contains( 'strong' ) || path.contains( 'em' );
+					return path.contains( {
+						strong: 1,
+						em: 1
+					} );
 				}
 			} );
 		}

--- a/tests/plugins/inlinetoolbar/context/manual/context.html
+++ b/tests/plugins/inlinetoolbar/context/manual/context.html
@@ -38,7 +38,7 @@
 			on: {
 				instanceReady: function( evt ) {
 					// Register the toolbar for inline elements.
-					evt.editor.plugins.inlinetoolbar.create( {
+					evt.editor.inlineToolbar.create( {
 						buttons: 'Bold,Underline',
 						cssSelector: 'strong, em'
 					} );

--- a/tests/plugins/inlinetoolbar/context/manual/context.html
+++ b/tests/plugins/inlinetoolbar/context/manual/context.html
@@ -8,22 +8,22 @@
 </style>
 
 <textarea id="editor1" cols="10" rows="10">
-	<p>Sample paragraph with <em>emphasize</em>, <strong>strong</strong>, <u>underline</u> and <s>strike thourgh</s>.</p>
+	<p>Sample paragraph with <em>emphasize</em>, <strong>strong</strong>, <u>underline</u> and <s>strikethrough</s>.</p>
 	<ol>
 		<li>List item with a plain text only.</li>
 		<li>
-			<p>List item with <em>emphasize</em>, <strong>strong</strong>, <u>underline</u> and <s>strike thourgh</s>.</p>
+			<p>List item with <em>emphasize</em>, <strong>strong</strong>, <u>underline</u> and <s>strikethrough</s>.</p>
 		</li>
 		<li>List item with a plain text only.</li>
 	</ol>
 </textarea>
 
 <div id="editor2" contenteditable="true">
-	<p>Sample paragraph with <em>emphasize</em>, <strong>strong</strong>, <u>underline</u> and <s>strike thourgh</s>.</p>
+	<p>Sample paragraph with <em>emphasize</em>, <strong>strong</strong>, <u>underline</u> and <s>strikethrough</s>.</p>
 	<ol>
 		<li>List item with a plain text only.</li>
 		<li>
-			<p>List item with <em>emphasize</em>, <strong>strong</strong>, <u>underline</u> and <s>strike thourgh</s>.</p>
+			<p>List item with <em>emphasize</em>, <strong>strong</strong>, <u>underline</u> and <s>strikethrough</s>.</p>
 		</li>
 		<li>List item with a plain text only.</li>
 	</ol>

--- a/tests/plugins/inlinetoolbar/context/manual/context.md
+++ b/tests/plugins/inlinetoolbar/context/manual/context.md
@@ -1,6 +1,6 @@
 @bender-ui: collapsed
 @bender-tags: 4.8.0, feature, inlinetoolbar
-@bender-ckeditor-plugins: wysiwygarea, toolbar, undo, basicstyles, floatingspace, inlinetoolbar, sourcearea, list, link, elementspath
+@bender-ckeditor-plugins: wysiwygarea, toolbar, undo, basicstyles, floatingspace, inlinetoolbar, sourcearea, list, link, elementspath, language, stylescombo
 
 ## Inline Toolbar Context
 

--- a/tests/plugins/inlinetoolbar/context/manual/context.md
+++ b/tests/plugins/inlinetoolbar/context/manual/context.md
@@ -1,10 +1,10 @@
 @bender-ui: collapsed
-@bender-tags: 4.8.0, feature, inlinetoolbar
-@bender-ckeditor-plugins: wysiwygarea, toolbar, undo, basicstyles, floatingspace, inlinetoolbar, sourcearea, list, link, elementspath, language, stylescombo
+@bender-tags: 4.8.0, feature, inlinetoolbar, 933
+@bender-ckeditor-plugins: wysiwygarea, toolbar, undo, basicstyles, floatingspace, inlinetoolbar, sourcearea, list, elementspath
 
 ## Inline Toolbar Context
 
-Inline toolbar should be shown only selections containing `strong` and `em` in its path.
+Inline toolbar should be shown only for selections containing `strong` and `em` in its path.
 
 Example test case:
 

--- a/tests/plugins/inlinetoolbar/context/manual/context.md
+++ b/tests/plugins/inlinetoolbar/context/manual/context.md
@@ -4,7 +4,7 @@
 
 ## Inline Toolbar Context
 
-Inline toolbar should be shown only selections containg `strong` and `em` in its path.
+Inline toolbar should be shown only selections containing `strong` and `em` in its path.
 
 Example test case:
 

--- a/tests/plugins/inlinetoolbar/context/manual/toolbar.html
+++ b/tests/plugins/inlinetoolbar/context/manual/toolbar.html
@@ -1,0 +1,78 @@
+<style>
+	body {
+		/* (#1048) */
+		margin-left: 0px;
+		padding-left: 400px;
+		padding-top: 40px;
+	}
+</style>
+
+<textarea id="editor1" cols="10" rows="10">
+	<p>Sample paragraph with <em>emphasize</em>, <strong>strong</strong>, <u>underline</u> and <s>strike thourgh</s>.</p>
+	<ol>
+		<li>List item with a plain text only.</li>
+		<li>
+			<p>List item with <em>emphasize</em>, <strong>strong</strong>, <u>underline</u> and <s>strike thourgh</s>.</p>
+		</li>
+		<li>List item with a plain text only.</li>
+	</ol>
+	<p>Paragraph after the list.</p>
+</textarea>
+
+<div id="editor2" contenteditable="true" style="width: 500px">
+	<p>Sample paragraph with <em>emphasize</em>, <strong>strong</strong>, <u>underline</u> and <s>strike thourgh</s>.</p>
+	<ol>
+		<li>List item with a plain text only.</li>
+		<li>
+			<p>List item with <em>emphasize</em>, <strong>strong</strong>, <u>underline</u> and <s>strike thourgh</s>.</p>
+		</li>
+		<li>List item with a plain text only.</li>
+	</ol>
+	<p>Paragraph after the list.</p>
+</div>
+
+<style>
+.cke_top { display: none; }
+</style>
+
+<script>
+	CKEDITOR.disableAutoInline = true;
+
+	var config = {
+			height: 300,
+			width: 500,
+			on: {
+				instanceReady: function( evt ) {
+					// Register the toolbar for inline elements.
+					evt.editor.inlineToolbar.create( {
+						buttons: 'Strike,Underline',
+						cssSelector: 'u, s'
+					} );
+
+
+					evt.editor.inlineToolbar.create( {
+						buttons: 'BulletedList,NumberedList',
+						cssSelector: 'li'
+					} );
+
+					var inlineToolbarContext = evt.editor.inlineToolbar.create( {
+						buttons: 'Source,Save,NewPage,Preview,Print,Templates,Cut,Copy,Paste,PasteText,PasteFromWord,Undo,Redo,Find,Replace,SelectAll,Scayt,Form,Checkbox,Radio,TextField,Textarea,Select,Button,ImageButton,HiddenField,Bold,Italic,Underline,Strike,Subscript,Superscript,CopyFormatting,RemoveFormat,NumberedList,BulletedList,Outdent,Indent,Blockquote,CreateDiv,JustifyLeft,JustifyCenter,JustifyRight,JustifyBlock,BidiLtr,BidiRtl,Language,Link,Unlink,Anchor,Image,Flash,Table,HorizontalRule,Smiley,SpecialChar,PageBreak,Iframe,Styles,Format,Font,FontSize,TextColor,BGColor,Maximize,ShowBlocks,About',
+						refresh: function( editor ) { return editor.editable(); },
+						priority: CKEDITOR.plugins.inlinetoolbar.PRIORITY.LOW
+					} );
+
+					// Only for that single toolbar, customize the alignment, so that it's always top hcenter.
+					inlineToolbarContext.toolbar._view._getAlignments = function( elementRect, panelWidth, panelHeight ) {
+						var ret = CKEDITOR.ui.inlineToolbarView.prototype._getAlignments.call( this, elementRect, panelWidth, panelHeight );
+
+						return {
+							'top hcenter': ret[ 'top hcenter' ]
+						}
+					};
+				}
+			}
+		};
+
+	CKEDITOR.replace( 'editor1', config );
+	CKEDITOR.inline( 'editor2', config );
+</script>

--- a/tests/plugins/inlinetoolbar/context/manual/toolbar.html
+++ b/tests/plugins/inlinetoolbar/context/manual/toolbar.html
@@ -36,6 +36,10 @@
 </style>
 
 <script>
+	if ( CKEDITOR.env.ie && CKEDITOR.env.version === 8 ) {
+		bender.ignore();
+	}
+
 	CKEDITOR.disableAutoInline = true;
 
 	var config = {

--- a/tests/plugins/inlinetoolbar/context/manual/toolbar.html
+++ b/tests/plugins/inlinetoolbar/context/manual/toolbar.html
@@ -8,11 +8,11 @@
 </style>
 
 <textarea id="editor1" cols="10" rows="10">
-	<p>Sample paragraph with <em>emphasize</em>, <strong>strong</strong>, <u>underline</u> and <s>strike thourgh</s>.</p>
+	<p>Sample paragraph with <em>emphasize</em>, <strong>strong</strong>, <u>underline</u> and <s>strikethrough</s>.</p>
 	<ol>
 		<li>List item with a plain text only.</li>
 		<li>
-			<p>List item with <em>emphasize</em>, <strong>strong</strong>, <u>underline</u> and <s>strike thourgh</s>.</p>
+			<p>List item with <em>emphasize</em>, <strong>strong</strong>, <u>underline</u> and <s>strikethrough</s>.</p>
 		</li>
 		<li>List item with a plain text only.</li>
 	</ol>
@@ -20,11 +20,11 @@
 </textarea>
 
 <div id="editor2" contenteditable="true" style="width: 500px">
-	<p>Sample paragraph with <em>emphasize</em>, <strong>strong</strong>, <u>underline</u> and <s>strike thourgh</s>.</p>
+	<p>Sample paragraph with <em>emphasize</em>, <strong>strong</strong>, <u>underline</u> and <s>strikethrough</s>.</p>
 	<ol>
 		<li>List item with a plain text only.</li>
 		<li>
-			<p>List item with <em>emphasize</em>, <strong>strong</strong>, <u>underline</u> and <s>strike thourgh</s>.</p>
+			<p>List item with <em>emphasize</em>, <strong>strong</strong>, <u>underline</u> and <s>strikethrough</s>.</p>
 		</li>
 		<li>List item with a plain text only.</li>
 	</ol>

--- a/tests/plugins/inlinetoolbar/context/manual/toolbar.md
+++ b/tests/plugins/inlinetoolbar/context/manual/toolbar.md
@@ -1,0 +1,23 @@
+@bender-ui: collapsed
+@bender-tags: 4.8.0, feature, inlinetoolbar, 933
+@bender-ckeditor-plugins: wysiwygarea, toolbar, undo, basicstyles, floatingspace, inlinetoolbar, sourcearea, list, link, elementspath, language, stylescombo, image
+
+## Editor Toolbar Imitation
+
+Selecting:
+* `u, s` - will show `Strike,Underline` buttons.
+*  `li` - will show `BulletedList,NumberedList` buttons.
+* _any other selection_ - shuold display a toolbar context displayed on the top of the editor.
+
+### Test Case
+
+Put a selection in `Para^graph after the list.`
+
+#### Expected
+
+A toolbar with many buttons is shown on top of the editor.
+
+#### Actual
+
+* Toolbar has only 2 buttons.
+* Toolbar is displayed over the focused paragraph.

--- a/tests/plugins/inlinetoolbar/context/manual/toolbar.md
+++ b/tests/plugins/inlinetoolbar/context/manual/toolbar.md
@@ -17,7 +17,7 @@ Put a selection in `Para^graph after the list.`
 
 A toolbar with many buttons is shown on top of the editor.
 
-#### Actual
+#### Unexpected
 
 * Toolbar has only 2 buttons.
 * Toolbar is displayed over the focused paragraph.

--- a/tests/plugins/inlinetoolbar/context/manual/widget.html
+++ b/tests/plugins/inlinetoolbar/context/manual/widget.html
@@ -1,0 +1,57 @@
+<style>
+	body {
+		/* (#1048) */
+		margin-left: 0px;
+		padding-left: 400px;
+	}
+
+</style>
+
+<textarea id="editor1" cols="10" rows="10">
+	<p>This is a sample [[image]] widdget:</p>
+
+	<figure class="image">
+		<img alt="Saturn V" src="%BASE_PATH%_assets/lena.jpg" width="120" />
+		<figcaption>This is an <strong>example</strong> [[caption]] description</figcaption>
+	</figure>
+
+	<pre><code>var foo = 'bar';</code></pre>
+</textarea>
+
+<div id="editor2" contenteditable="true">
+	<p>This is a sample [[image]] widdget:</p>
+
+	<figure class="image">
+		<img alt="Saturn V" src="%BASE_PATH%_assets/lena.jpg" width="120" />
+		<figcaption>This is an <strong>example</strong> [[caption]] description</figcaption>
+	</figure>
+
+	<pre><code>var foo = 'bar';</code></pre>
+</div>
+
+<script>
+	CKEDITOR.disableAutoInline = true;
+
+	var config = {
+			height: 320,
+			width: 500,
+			allowedContent: true,
+			on: {
+				instanceReady: function( evt ) {
+					// Register the toolbar for inline elements.
+					evt.editor.plugins.inlinetoolbar.create( {
+						buttons: 'Link,Unlink',
+						widgets: [ 'image', 'placeholder' ]
+					} );
+
+					evt.editor.plugins.inlinetoolbar.create( {
+						buttons: 'Bold,Underline',
+						elements: 'strong;u'
+					} );
+				}
+			}
+		};
+
+	CKEDITOR.replace( 'editor1', config );
+	CKEDITOR.inline( 'editor2', config );
+</script>

--- a/tests/plugins/inlinetoolbar/context/manual/widget.html
+++ b/tests/plugins/inlinetoolbar/context/manual/widget.html
@@ -46,7 +46,7 @@
 
 					evt.editor.plugins.inlinetoolbar.create( {
 						buttons: 'Bold,Underline',
-						elements: 'strong;u'
+						cssSelector: 'strong, u'
 					} );
 				}
 			}

--- a/tests/plugins/inlinetoolbar/context/manual/widget.html
+++ b/tests/plugins/inlinetoolbar/context/manual/widget.html
@@ -39,12 +39,12 @@
 			on: {
 				instanceReady: function( evt ) {
 					// Register the toolbar for inline elements.
-					evt.editor.plugins.inlinetoolbar.create( {
+					evt.editor.inlineToolbar.create( {
 						buttons: 'Link,Unlink',
 						widgets: [ 'image', 'placeholder' ]
 					} );
 
-					evt.editor.plugins.inlinetoolbar.create( {
+					evt.editor.inlineToolbar.create( {
 						buttons: 'Bold,Underline',
 						cssSelector: 'strong, u'
 					} );

--- a/tests/plugins/inlinetoolbar/context/manual/widget.html
+++ b/tests/plugins/inlinetoolbar/context/manual/widget.html
@@ -30,6 +30,10 @@
 </div>
 
 <script>
+	if ( CKEDITOR.env.ie && CKEDITOR.env.version === 8 ) {
+		bender.ignore();
+	}
+
 	CKEDITOR.disableAutoInline = true;
 
 	var config = {

--- a/tests/plugins/inlinetoolbar/context/manual/widget.md
+++ b/tests/plugins/inlinetoolbar/context/manual/widget.md
@@ -1,0 +1,39 @@
+@bender-ui: collapsed
+@bender-tags: 4.8.0, feature, inlinetoolbar
+@bender-ckeditor-plugins: wysiwygarea, basicstyles, floatingspace, inlinetoolbar, sourcearea, link, elementspath, image2, placeholder, codesnippet
+
+## Inline Toolbar with Widgets
+
+Linking toolbar should be shown for:
+
+* Placeholders,
+* Image widgets.
+
+Bold/underline toolbar should be shown for:
+
+* `<strong>` elements,
+* `<u>` elements.
+
+### TC1
+
+1. Focus image widget.
+
+#### Expected
+
+Linking toolbar is visible.
+
+### TC2
+
+1. Put selection in a "example" word in a editable, like `ex^ample`.
+
+#### Expected
+
+Bold/underline toolbar is visible.
+
+### TC3
+
+1. Focus code snippet widget.
+
+#### Expected
+
+No toolbar is visible.

--- a/tests/plugins/inlinetoolbar/context/manual/widget.md
+++ b/tests/plugins/inlinetoolbar/context/manual/widget.md
@@ -1,5 +1,5 @@
 @bender-ui: collapsed
-@bender-tags: 4.8.0, feature, inlinetoolbar
+@bender-tags: 4.8.0, feature, inlinetoolbar, 933
 @bender-ckeditor-plugins: wysiwygarea, basicstyles, floatingspace, inlinetoolbar, sourcearea, link, elementspath, image2, placeholder, codesnippet
 
 ## Inline Toolbar with Widgets

--- a/tests/plugins/inlinetoolbar/context/priorities.html
+++ b/tests/plugins/inlinetoolbar/context/priorities.html
@@ -1,0 +1,5 @@
+<div id="widgetWithEditable">
+	<div data-widget="bar" id="w1">
+		<h1>This is an <strong>editable</strong>.</h1>
+	</div>
+</div>

--- a/tests/plugins/inlinetoolbar/context/priorities.html
+++ b/tests/plugins/inlinetoolbar/context/priorities.html
@@ -1,5 +1,21 @@
 <div id="widgetWithEditable">
 	<div data-widget="bar" id="w1">
-		<h1>This is an <strong>editable</strong>.</h1>
+		<h1>This is an
+			<strong>editable</strong>.</h1>
+	</div>
+</div>
+
+<div id="nestedElements">
+	<div>
+		<h1>
+			foo
+			<strong>
+				bar
+				<em>
+					baz
+					<cite>b^om</cite>
+				</em>
+			</strong>
+		</h1>
 	</div>
 </div>

--- a/tests/plugins/inlinetoolbar/context/priorities.js
+++ b/tests/plugins/inlinetoolbar/context/priorities.js
@@ -37,7 +37,7 @@
 
 				this._assertToolbarVisible( true, contexts.refresh, 'contexts.refresh visibility' );
 				this._assertToolbarVisible( false, contexts.widgets, 'contexts.widgets visibility' );
-				this._assertToolbarVisible( false, contexts.elements, 'contexts.elements visibility' );
+				this._assertToolbarVisible( false, contexts.cssSelector, 'contexts.cssSelector visibility' );
 			} );
 		},
 
@@ -50,12 +50,12 @@
 
 				this._assertToolbarVisible( true, contexts.refresh, 'contexts.refresh visibility' );
 				this._assertToolbarVisible( false, contexts.widgets, 'contexts.widgets visibility' );
-				this._assertToolbarVisible( false, contexts.elements, 'contexts.elements visibility' );
+				this._assertToolbarVisible( false, contexts.cssSelector, 'contexts.cssSelector visibility' );
 			} );
 		},
 
 		// This case is yet to be decided.
-		// 'test options.widgets has the priority over options.elements': function() {
+		// 'test options.widgets has the priority over options.cssSelector': function() {
 		// 	this.editorBot.setData( CKEDITOR.document.getById( 'widgetWithEditable' ).getHtml(), function() {
 		// 		var rng = this.editor.createRange();
 		// 		rng.setStart( this.editor.editable().findOne( 'strong' ).getFirst(), 1 );
@@ -63,61 +63,61 @@
 
 		// 		this.editor.getSelection().selectRanges( [ rng ] );
 
-		// 		var contexts = this._createContexts( [ 'widgets', 'elements' ], true );
+		// 		var contexts = this._createContexts( [ 'widgets', 'cssSelector' ], true );
 
 		// 		assert.isUndefined( contexts.refresh, 'context refresh is undefined' );
 		// 		this._assertToolbarVisible( true, contexts.widgets, 'contexts.widgets visibility' );
-		// 		this._assertToolbarVisible( false, contexts.elements, 'contexts.elements visibility' );
+		// 		this._assertToolbarVisible( false, contexts.cssSelector, 'contexts.cssSelector visibility' );
 		// 	} );
 		// },
 
-		'test options.elements the top-most patch match wins': function() {
+		'test options.cssSelector the top-most patch match wins': function() {
 			// If we have path like: "foo > bar > baz" and there are contexts matching "bar" and "baz", only the context
 			// that matches for "baz" should be shown.
 			var additionalContextDefinitions = {
 				emContext: {
 					buttons: 'Bold,Italic',
-					elements: 'em'
+					cssSelector: 'em'
 				},
 				citeContext: {
 					buttons: 'Bold,Italic',
-					elements: 'cite'
+					cssSelector: 'cite'
 				}
 			};
 
 			this.editorBot.setHtmlWithSelection( CKEDITOR.document.getById( 'nestedElements' ).getHtml() );
 
-			var contexts = this._createContexts( [ 'elements', 'emContext', 'citeContext' ], true, additionalContextDefinitions );
+			var contexts = this._createContexts( [ 'cssSelector', 'emContext', 'citeContext' ], true, additionalContextDefinitions );
 
 			this._assertToolbarVisible( true, contexts.citeContext, 'contexts.citeContext visibility' );
 
-			this._assertToolbarVisible( false, contexts.elements, 'contexts.elements visibility' );
+			this._assertToolbarVisible( false, contexts.cssSelector, 'contexts.cssSelector visibility' );
 			this._assertToolbarVisible( false, contexts.emContext, 'contexts.emContext visibility' );
 		},
 
-		'test options.elements with a HGIH priority takes the precedence': function() {
+		'test options.cssSelector with a HGIH priority takes the precedence': function() {
 			var additionalContextDefinitions = {
-				elements: {
+				cssSelector: {
 					buttons: 'Bold,Italic',
-					elements: 'a;strong;u',
+					cssSelector: 'a, strong, u',
 					priority: CKEDITOR.plugins.inlinetoolbar.PRIORITY.HIGH
 				},
 				citeContext: {
 					buttons: 'Bold,Italic',
-					elements: 'cite'
+					cssSelector: 'cite'
 				}
 			};
 
 			this.editorBot.setHtmlWithSelection( CKEDITOR.document.getById( 'nestedElements' ).getHtml() );
 
-			var contexts = this._createContexts( [ 'elements', 'citeContext', 'refresh' ], true, additionalContextDefinitions );
+			var contexts = this._createContexts( [ 'cssSelector', 'citeContext', 'refresh' ], true, additionalContextDefinitions );
 
 			this._assertToolbarVisible( false, contexts.citeContext, 'contexts.citeContext visibility' );
-			this._assertToolbarVisible( true, contexts.elements, 'contexts.elements visibility' );
+			this._assertToolbarVisible( true, contexts.cssSelector, 'contexts.cssSelector visibility' );
 			this._assertToolbarVisible( false, contexts.refresh, 'contexts.refresh visibility' );
 		},
 
-		'test options.elements with a LOW priority are less favorable': function() {
+		'test options.cssSelector with a LOW priority are less favorable': function() {
 			var additionalContextDefinitions = {
 				refresh: {
 					buttons: 'Bold,Italic',
@@ -128,10 +128,10 @@
 
 			this.editorBot.setHtmlWithSelection( CKEDITOR.document.getById( 'nestedElements' ).getHtml() );
 
-			var contexts = this._createContexts( [ 'elements', 'refresh' ], true, additionalContextDefinitions );
+			var contexts = this._createContexts( [ 'cssSelector', 'refresh' ], true, additionalContextDefinitions );
 
 			this._assertToolbarVisible( false, contexts.refresh, 'contexts.refresh visibility' );
-			this._assertToolbarVisible( true, contexts.elements, 'contexts.elements visibility' );
+			this._assertToolbarVisible( true, contexts.cssSelector, 'contexts.cssSelector visibility' );
 		},
 
 		/*
@@ -144,14 +144,14 @@
 		/*
 		 * Creates three different context. Each with a different options selector.
 		 *
-		 * @param {String[]/null} [whitelist=null] Array of contexts to be returned, e.g. `[ 'refresh', 'elements' ]`.
+		 * @param {String[]/null} [whitelist=null] Array of contexts to be returned, e.g. `[ 'refresh', 'cssSelector' ]`.
 		 * If `null` white listing is ignored and all contexts are returned.
 		 * @param {Boolean} [autoRefresh=false] If `true` created contexts will be refreshed right after being created.
 		 * @param {Object} [additionalMappings] Additional context mappings, see the code for more details.
 		 * @return {Object} A dictionary of created contexts.
 		 * @return {CKEDITOR.plugins.inlinetoolbar.context} return.refresh A context with `options.refresh` that always returns `true`.
 		 * @return {CKEDITOR.plugins.inlinetoolbar.context} return.widgets A context with `options.widgets` alone set.
-		 * @return {CKEDITOR.plugins.inlinetoolbar.context} return.elements A context with `options.elements` alone set.
+		 * @return {CKEDITOR.plugins.inlinetoolbar.context} return.cssSelector A context with `options.cssSelector` alone set.
 		 */
 		_createContexts: function( whitelist, autoRefresh, additionalMappings ) {
 			var optionsMapping = {
@@ -163,9 +163,9 @@
 						buttons: 'Bold,Italic',
 						widgets: [ 'foo', 'bar' ]
 					},
-					elements: {
+					cssSelector: {
 						buttons: 'Bold,Italic',
-						elements: 'a;strong;u'
+						cssSelector: 'a, strong, u'
 					}
 				},
 				ret = {},

--- a/tests/plugins/inlinetoolbar/context/priorities.js
+++ b/tests/plugins/inlinetoolbar/context/priorities.js
@@ -14,7 +14,7 @@
 
 	bender.test( {
 		tearDown: function() {
-			this.editor.plugins.inlinetoolbar._manager._clear();
+			this.editor.inlineToolbar._manager._clear();
 		},
 
 		setUp: function() {
@@ -180,12 +180,12 @@
 
 			for ( i in optionsMapping ) {
 				if ( CKEDITOR.tools.array.indexOf( whitelist, i ) !== -1 ) {
-					ret[ i ] = this.editor.plugins.inlinetoolbar.create( optionsMapping[ i ] );
+					ret[ i ] = this.editor.inlineToolbar.create( optionsMapping[ i ] );
 				}
 			}
 
 			if ( autoRefresh ) {
-				this.editor.plugins.inlinetoolbar._manager.check();
+				this.editor.inlineToolbar._manager.check();
 			}
 
 			return ret;

--- a/tests/plugins/inlinetoolbar/context/priorities.js
+++ b/tests/plugins/inlinetoolbar/context/priorities.js
@@ -1,0 +1,134 @@
+/* bender-tags: inlinetoolbar, context */
+/* bender-ckeditor-plugins: inlinetoolbar, toolbar, basicstyles, sourcearea, widget */
+/* bender-include: ../../widget/_helpers/tools.js */
+/* global widgetTestsTools */
+
+( function() {
+	'use strict';
+
+	bender.editor = {
+		config: {
+			extraAllowedContent: 'div[*];strong;h1'
+		}
+	};
+
+	bender.test( {
+		tearDown: function() {
+			if ( this.contexts.length ) {
+				// Destroy each registered context.
+				CKEDITOR.tools.array.filter( this.contexts, function( curContext ) {
+					curContext.destroy();
+					return false;
+				} );
+			}
+		},
+
+		setUp: function() {
+			this.contexts = [];
+
+			this.editor.widgets.add( 'bar', {
+				editables: {
+					header: 'h1'
+				}
+			} );
+		},
+
+		'test options.refresh has the highest priority': function() {
+			this.editorBot.setData( CKEDITOR.document.getById( 'widgetWithEditable' ).getHtml(), function() {
+				var rng = this.editor.createRange();
+				rng.setStart( this.editor.editable().findOne( 'strong' ).getFirst(), 1 );
+				rng.collapse( true );
+
+				this.editor.getSelection().selectRanges( [ rng ] );
+
+				var contexts = this._createContexts( null, true );
+
+				this._assertToolbarVisible( true, contexts.refresh, 'contexts.refresh visibility' );
+				this._assertToolbarVisible( false, contexts.widgets, 'contexts.widgets visibility' );
+				this._assertToolbarVisible( false, contexts.elements, 'contexts.elements visibility' );
+			} );
+		},
+
+		'test options.refresh has the highest priority with widget selected': function() {
+			this.editorBot.setData( CKEDITOR.document.getById( 'widgetWithEditable' ).getHtml(), function() {
+				var widget = widgetTestsTools.getWidgetById( this.editor, 'w1' );
+				widget.focus();
+
+				var contexts = this._createContexts( null, true );
+
+				this._assertToolbarVisible( true, contexts.refresh, 'contexts.refresh visibility' );
+				this._assertToolbarVisible( false, contexts.widgets, 'contexts.widgets visibility' );
+				this._assertToolbarVisible( false, contexts.elements, 'contexts.elements visibility' );
+			} );
+		},
+
+		// This case is yet to be decided.
+		// 'test options.widgets has the priority over options.elements': function() {
+		// 	this.editorBot.setData( CKEDITOR.document.getById( 'widgetWithEditable' ).getHtml(), function() {
+		// 		var rng = this.editor.createRange();
+		// 		rng.setStart( this.editor.editable().findOne( 'strong' ).getFirst(), 1 );
+		// 		rng.collapse( true );
+
+		// 		this.editor.getSelection().selectRanges( [ rng ] );
+
+		// 		var contexts = this._createContexts( [ 'widgets', 'elements' ], true );
+
+		// 		assert.isUndefined( contexts.refresh, 'context refresh is undefined' );
+		// 		this._assertToolbarVisible( true, contexts.widgets, 'contexts.widgets visibility' );
+		// 		this._assertToolbarVisible( false, contexts.elements, 'contexts.elements visibility' );
+		// 	} );
+		// },
+
+		/*
+		 * @param {Boolean} expected What's the expected visibility? If `true` toolbar must be visible.
+		 */
+		_assertToolbarVisible: function( expected, context, msg ) {
+			assert.areSame( expected, context.toolbar._view.parts.panel.isVisible(), msg || 'Toolbar visibility' );
+		},
+
+		/*
+		 * Creates three different context. Each with a different options selector.
+		 *
+		 * @param {String[]/null} [whitelist=null] Array of contexts to be returned, e.g. `[ 'refresh', 'elements' ]`.
+		 * If `null` white listing is ignored and all contexts are returned.
+		 * @param {Boolean} [autoRefresh=false] If `true` created contexts will be refreshed right after being created.
+		 * @return {Object} A dictionary of created contexts.
+		 * @return {CKEDITOR.plugins.inlinetoolbar.context} return.refresh A context with `options.refresh` that always returns `true`.
+		 * @return {CKEDITOR.plugins.inlinetoolbar.context} return.widgets A context with `options.widgets` alone set.
+		 * @return {CKEDITOR.plugins.inlinetoolbar.context} return.elements A context with `options.elements` alone set.
+		 */
+		_createContexts: function( whitelist, autoRefresh ) {
+			var optionsMapping = {
+					refresh: {
+						buttons: 'Bold,Italic',
+						refresh: sinon.stub().returns( true )
+					},
+					widgets: {
+						buttons: 'Bold,Italic',
+						widgets: [ 'foo', 'bar' ]
+					},
+					elements: {
+						buttons: 'Bold,Italic',
+						elements: 'a,strong,u'
+					}
+				},
+				ret = {},
+				i;
+
+			whitelist = CKEDITOR.tools.isArray( whitelist ) ? whitelist : CKEDITOR.tools.objectKeys( optionsMapping );
+
+			for ( i in optionsMapping ) {
+				if ( CKEDITOR.tools.array.indexOf( whitelist, i ) !== -1 ) {
+					ret[ i ] = this.editor.plugins.inlinetoolbar.create( optionsMapping[ i ] );
+					this.contexts.push( ret[ i ] );
+
+					if ( autoRefresh ) {
+						ret[ i ].refresh();
+					}
+				}
+			}
+
+			return ret;
+		}
+	} );
+} )();

--- a/tests/plugins/inlinetoolbar/context/priorities.js
+++ b/tests/plugins/inlinetoolbar/context/priorities.js
@@ -95,6 +95,45 @@
 			this._assertToolbarVisible( false, contexts.emContext, 'contexts.emContext visibility' );
 		},
 
+		'test options.elements with a HGIH priority takes the precedence': function() {
+			var additionalContextDefinitions = {
+				elements: {
+					buttons: 'Bold,Italic',
+					elements: 'a;strong;u',
+					priority: CKEDITOR.plugins.inlinetoolbar.PRIORITY.HIGH
+				},
+				citeContext: {
+					buttons: 'Bold,Italic',
+					elements: 'cite'
+				}
+			};
+
+			this.editorBot.setHtmlWithSelection( CKEDITOR.document.getById( 'nestedElements' ).getHtml() );
+
+			var contexts = this._createContexts( [ 'elements', 'citeContext', 'refresh' ], true, additionalContextDefinitions );
+
+			this._assertToolbarVisible( false, contexts.citeContext, 'contexts.citeContext visibility' );
+			this._assertToolbarVisible( true, contexts.elements, 'contexts.elements visibility' );
+			this._assertToolbarVisible( false, contexts.refresh, 'contexts.refresh visibility' );
+		},
+
+		'test options.elements with a LOW priority are less favorable': function() {
+			var additionalContextDefinitions = {
+				refresh: {
+					buttons: 'Bold,Italic',
+					refresh: sinon.stub().returns( true ),
+					priority: CKEDITOR.plugins.inlinetoolbar.PRIORITY.LOW
+				}
+			};
+
+			this.editorBot.setHtmlWithSelection( CKEDITOR.document.getById( 'nestedElements' ).getHtml() );
+
+			var contexts = this._createContexts( [ 'elements', 'refresh' ], true, additionalContextDefinitions );
+
+			this._assertToolbarVisible( false, contexts.refresh, 'contexts.refresh visibility' );
+			this._assertToolbarVisible( true, contexts.elements, 'contexts.elements visibility' );
+		},
+
 		/*
 		 * @param {Boolean} expected What's the expected visibility? If `true` toolbar must be visible.
 		 */

--- a/tests/plugins/inlinetoolbar/context/priorities.js
+++ b/tests/plugins/inlinetoolbar/context/priorities.js
@@ -14,18 +14,10 @@
 
 	bender.test( {
 		tearDown: function() {
-			if ( this.contexts.length ) {
-				// Destroy each registered context.
-				CKEDITOR.tools.array.filter( this.contexts, function( curContext ) {
-					curContext.destroy();
-					return false;
-				} );
-			}
+			this.editor.plugins.inlinetoolbar._manager._clear();
 		},
 
 		setUp: function() {
-			this.contexts = [];
-
 			this.editor.widgets.add( 'bar', {
 				editables: {
 					header: 'h1'
@@ -150,12 +142,11 @@
 			for ( i in optionsMapping ) {
 				if ( CKEDITOR.tools.array.indexOf( whitelist, i ) !== -1 ) {
 					ret[ i ] = this.editor.plugins.inlinetoolbar.create( optionsMapping[ i ] );
-					this.contexts.push( ret[ i ] );
-
-					if ( autoRefresh ) {
-						ret[ i ].refresh();
-					}
 				}
+			}
+
+			if ( autoRefresh ) {
+				this.editor.plugins.inlinetoolbar._manager.check();
 			}
 
 			return ret;

--- a/tests/plugins/inlinetoolbar/context/priorities.js
+++ b/tests/plugins/inlinetoolbar/context/priorities.js
@@ -13,16 +13,20 @@
 	};
 
 	bender.test( {
-		tearDown: function() {
-			this.editor.inlineToolbar._manager._clear();
-		},
-
 		setUp: function() {
+			if ( CKEDITOR.env.ie && CKEDITOR.env.version === 8 ) {
+				assert.ignore();
+			}
+
 			this.editor.widgets.add( 'bar', {
 				editables: {
 					header: 'h1'
 				}
 			} );
+		},
+
+		tearDown: function() {
+			this.editor.inlineToolbar._manager._clear();
 		},
 
 		'test options.refresh has the highest priority': function() {

--- a/tests/plugins/inlinetoolbar/context/priorities.js
+++ b/tests/plugins/inlinetoolbar/context/priorities.js
@@ -1,7 +1,7 @@
 /* bender-tags: inlinetoolbar, context */
 /* bender-ckeditor-plugins: inlinetoolbar, toolbar, basicstyles, sourcearea, widget */
-/* bender-include: ../../widget/_helpers/tools.js */
-/* global widgetTestsTools */
+/* bender-include: ../../widget/_helpers/tools.js, _helpers/tools.js */
+/* global widgetTestsTools, contextTools */
 
 ( function() {
 	'use strict';
@@ -39,9 +39,9 @@
 
 				var contexts = this._createContexts( null, true );
 
-				this._assertToolbarVisible( true, contexts.refresh, 'contexts.refresh visibility' );
-				this._assertToolbarVisible( false, contexts.widgets, 'contexts.widgets visibility' );
-				this._assertToolbarVisible( false, contexts.cssSelector, 'contexts.cssSelector visibility' );
+				contextTools._assertToolbarVisible( true, contexts.refresh, 'contexts.refresh visibility' );
+				contextTools._assertToolbarVisible( false, contexts.widgets, 'contexts.widgets visibility' );
+				contextTools._assertToolbarVisible( false, contexts.cssSelector, 'contexts.cssSelector visibility' );
 			} );
 		},
 
@@ -52,9 +52,9 @@
 
 				var contexts = this._createContexts( null, true );
 
-				this._assertToolbarVisible( true, contexts.refresh, 'contexts.refresh visibility' );
-				this._assertToolbarVisible( false, contexts.widgets, 'contexts.widgets visibility' );
-				this._assertToolbarVisible( false, contexts.cssSelector, 'contexts.cssSelector visibility' );
+				contextTools._assertToolbarVisible( true, contexts.refresh, 'contexts.refresh visibility' );
+				contextTools._assertToolbarVisible( false, contexts.widgets, 'contexts.widgets visibility' );
+				contextTools._assertToolbarVisible( false, contexts.cssSelector, 'contexts.cssSelector visibility' );
 			} );
 		},
 
@@ -76,10 +76,10 @@
 
 			var contexts = this._createContexts( [ 'cssSelector', 'emContext', 'citeContext' ], true, additionalContextDefinitions );
 
-			this._assertToolbarVisible( true, contexts.citeContext, 'contexts.citeContext visibility' );
+			contextTools._assertToolbarVisible( true, contexts.citeContext, 'contexts.citeContext visibility' );
 
-			this._assertToolbarVisible( false, contexts.cssSelector, 'contexts.cssSelector visibility' );
-			this._assertToolbarVisible( false, contexts.emContext, 'contexts.emContext visibility' );
+			contextTools._assertToolbarVisible( false, contexts.cssSelector, 'contexts.cssSelector visibility' );
+			contextTools._assertToolbarVisible( false, contexts.emContext, 'contexts.emContext visibility' );
 		},
 
 		'test options.cssSelector with a HGIH priority takes the precedence': function() {
@@ -99,9 +99,9 @@
 
 			var contexts = this._createContexts( [ 'cssSelector', 'citeContext', 'refresh' ], true, additionalContextDefinitions );
 
-			this._assertToolbarVisible( false, contexts.citeContext, 'contexts.citeContext visibility' );
-			this._assertToolbarVisible( true, contexts.cssSelector, 'contexts.cssSelector visibility' );
-			this._assertToolbarVisible( false, contexts.refresh, 'contexts.refresh visibility' );
+			contextTools._assertToolbarVisible( false, contexts.citeContext, 'contexts.citeContext visibility' );
+			contextTools._assertToolbarVisible( true, contexts.cssSelector, 'contexts.cssSelector visibility' );
+			contextTools._assertToolbarVisible( false, contexts.refresh, 'contexts.refresh visibility' );
 		},
 
 		'test options.cssSelector with a LOW priority are less favorable': function() {
@@ -117,15 +117,8 @@
 
 			var contexts = this._createContexts( [ 'cssSelector', 'refresh' ], true, additionalContextDefinitions );
 
-			this._assertToolbarVisible( false, contexts.refresh, 'contexts.refresh visibility' );
-			this._assertToolbarVisible( true, contexts.cssSelector, 'contexts.cssSelector visibility' );
-		},
-
-		/*
-		 * @param {Boolean} expected What's the expected visibility? If `true` toolbar must be visible.
-		 */
-		_assertToolbarVisible: function( expected, context, msg ) {
-			assert.areSame( expected, context.toolbar._view.parts.panel.isVisible(), msg || 'Toolbar visibility' );
+			contextTools._assertToolbarVisible( false, contexts.refresh, 'contexts.refresh visibility' );
+			contextTools._assertToolbarVisible( true, contexts.cssSelector, 'contexts.cssSelector visibility' );
 		},
 
 		/*

--- a/tests/plugins/inlinetoolbar/context/priorities.js
+++ b/tests/plugins/inlinetoolbar/context/priorities.js
@@ -58,23 +58,6 @@
 			} );
 		},
 
-		// This case is yet to be decided.
-		// 'test options.widgets has the priority over options.cssSelector': function() {
-		// 	this.editorBot.setData( CKEDITOR.document.getById( 'widgetWithEditable' ).getHtml(), function() {
-		// 		var rng = this.editor.createRange();
-		// 		rng.setStart( this.editor.editable().findOne( 'strong' ).getFirst(), 1 );
-		// 		rng.collapse( true );
-
-		// 		this.editor.getSelection().selectRanges( [ rng ] );
-
-		// 		var contexts = this._createContexts( [ 'widgets', 'cssSelector' ], true );
-
-		// 		assert.isUndefined( contexts.refresh, 'context refresh is undefined' );
-		// 		this._assertToolbarVisible( true, contexts.widgets, 'contexts.widgets visibility' );
-		// 		this._assertToolbarVisible( false, contexts.cssSelector, 'contexts.cssSelector visibility' );
-		// 	} );
-		// },
-
 		'test options.cssSelector the top-most patch match wins': function() {
 			// If we have path like: "foo > bar > baz" and there are contexts matching "bar" and "baz", only the context
 			// that matches for "baz" should be shown.

--- a/tests/plugins/inlinetoolbar/context/refresh.js
+++ b/tests/plugins/inlinetoolbar/context/refresh.js
@@ -9,48 +9,53 @@
 	};
 
 	bender.test( {
+		tearDown: function() {
+			this.editor.plugins.inlinetoolbar._manager._clear();
+		},
+
 		'test refresh returning true': function() {
-			var context = this._getContextStub( sinon.stub().returns( true ) );
+			var context = this._getContextStub( sinon.stub().returns( true ), true );
 
-			context.refresh();
-
-			assert.areSame( 0, context.toolbar.hide.callCount, 'Toolbar hide calls' );
-			assert.areSame( 1, context.toolbar.show.callCount, 'Toolbar show calls' );
+			this._assertToolbarVisible( true, context );
 		},
 
 		'test refresh returning false': function() {
-			var context = this._getContextStub( sinon.stub().returns( false ) );
+			var context = this._getContextStub( sinon.stub().returns( false ), true );
 
-			context.refresh();
-
-			assert.areSame( 1, context.toolbar.hide.callCount, 'Toolbar hide calls' );
-			assert.areSame( 0, context.toolbar.show.callCount, 'Toolbar show calls' );
+			this._assertToolbarVisible( false, context );
 		},
 
 		'test refresh returning falsy value': function() {
-			var context = this._getContextStub( sinon.stub().returns( 0 ) );
+			var context = this._getContextStub( sinon.stub().returns( 0 ), true );
 
-			context.refresh();
-
-			assert.areSame( 1, context.toolbar.hide.callCount, 'Toolbar hide calls' );
-			assert.areSame( 0, context.toolbar.show.callCount, 'Toolbar show calls' );
+			this._assertToolbarVisible( false, context );
 		},
 
 		/*
 		 * Returns a Context instance with toolbar show/hide methods stubbed.
 		 *
 		 * @param {Function} refreshCallback Function to be used as `options.refresh`.
+		 * @param {Boolean} [autoRefresh=false] Whether function should automatically force context
+		 * manager, to recheck all the contexts.
 		 * @returns {CKEDITOR.plugins.inlinetoolbar.context}
 		 */
-		_getContextStub: function( refreshCallback ) {
+		_getContextStub: function( refreshCallback, autoRefresh ) {
 			var ret = this.editor.plugins.inlinetoolbar.create( {
 				refresh: refreshCallback
 			} );
 
-			sinon.stub( ret.toolbar, 'hide' );
-			sinon.stub( ret.toolbar, 'show' );
+			if ( autoRefresh ) {
+				this.editor.plugins.inlinetoolbar._manager.check();
+			}
 
 			return ret;
+		},
+
+		/*
+		 * @param {Boolean} expected What's the expected visibility? If `true` toolbar must be visible.
+		 */
+		_assertToolbarVisible: function( expected, context, msg ) {
+			assert.areSame( expected, context.toolbar._view.parts.panel.isVisible(), msg || 'Toolbar visibility' );
 		}
 	} );
 } )();

--- a/tests/plugins/inlinetoolbar/context/refresh.js
+++ b/tests/plugins/inlinetoolbar/context/refresh.js
@@ -9,6 +9,12 @@
 	};
 
 	bender.test( {
+		setUp: function() {
+			if ( CKEDITOR.env.ie && CKEDITOR.env.version === 8 ) {
+				assert.ignore();
+			}
+		},
+
 		tearDown: function() {
 			this.editor.inlineToolbar._manager._clear();
 		},

--- a/tests/plugins/inlinetoolbar/context/refresh.js
+++ b/tests/plugins/inlinetoolbar/context/refresh.js
@@ -10,7 +10,7 @@
 
 	bender.test( {
 		tearDown: function() {
-			this.editor.plugins.inlinetoolbar._manager._clear();
+			this.editor.inlineToolbar._manager._clear();
 		},
 
 		'test refresh returning true': function() {
@@ -40,12 +40,12 @@
 		 * @returns {CKEDITOR.plugins.inlinetoolbar.context}
 		 */
 		_getContextStub: function( refreshCallback, autoRefresh ) {
-			var ret = this.editor.plugins.inlinetoolbar.create( {
+			var ret = this.editor.inlineToolbar.create( {
 				refresh: refreshCallback
 			} );
 
 			if ( autoRefresh ) {
-				this.editor.plugins.inlinetoolbar._manager.check();
+				this.editor.inlineToolbar._manager.check();
 			}
 
 			return ret;

--- a/tests/plugins/inlinetoolbar/context/refresh.js
+++ b/tests/plugins/inlinetoolbar/context/refresh.js
@@ -5,9 +5,7 @@
 	'use strict';
 
 	bender.editor = {
-		config: {
-			extraAllowedContent: 'div[*]'
-		}
+		config: {}
 	};
 
 	bender.test( {

--- a/tests/plugins/inlinetoolbar/context/refresh.js
+++ b/tests/plugins/inlinetoolbar/context/refresh.js
@@ -7,7 +7,9 @@
 	'use strict';
 
 	bender.editor = {
-		config: {}
+		config: {
+			extraAllowedContent: true
+		}
 	};
 
 	bender.test( {
@@ -37,6 +39,22 @@
 			var context = this._getContextStub( sinon.stub().returns( 0 ), true );
 
 			contextTools._assertToolbarVisible( false, context );
+		},
+
+		'test refresh returning custom element': function() {
+			this.editorBot.setHtmlWithSelection( '<p>foo<strong>ba^r</strong>baz<em>em</em></p>' );
+
+			var emElem = this.editor.editable().findOne( 'em' ),
+				context = this._getContextStub( sinon.stub().returns( emElem ) ),
+				showSpy = sinon.spy( context, 'show' );
+
+			this.editor.inlineToolbar._manager.check();
+
+			contextTools._assertToolbarVisible( true, context );
+
+			sinon.assert.calledWithMatch( showSpy, function( actual ) {
+				return actual.equals( emElem );
+			} );
 		},
 
 		/*

--- a/tests/plugins/inlinetoolbar/context/refresh.js
+++ b/tests/plugins/inlinetoolbar/context/refresh.js
@@ -57,6 +57,16 @@
 			} );
 		},
 
+		'test _matchRefresh return type': function() {
+			var contextFalse = this._getContextStub( sinon.stub().returns( false ) ),
+				contextTrue = this._getContextStub( sinon.stub().returns( true ) ),
+				contextElem = this._getContextStub( sinon.stub().returns( new CKEDITOR.dom.element( 'p' ) ) );
+
+			assert.isNull( contextFalse._matchRefresh( null, null ) );
+			assert.isTrue( contextTrue._matchRefresh( null, null ) instanceof CKEDITOR.dom.element );
+			assert.isTrue( contextElem._matchRefresh( null, null ) instanceof CKEDITOR.dom.element );
+		},
+
 		/*
 		 * Returns a Context instance with toolbar show/hide methods stubbed.
 		 *

--- a/tests/plugins/inlinetoolbar/context/refresh.js
+++ b/tests/plugins/inlinetoolbar/context/refresh.js
@@ -1,5 +1,7 @@
 /* bender-tags: inlinetoolbar,context */
 /* bender-ckeditor-plugins: inlinetoolbar */
+/* bender-include: _helpers/tools.js */
+/* global contextTools */
 
 ( function() {
 	'use strict';
@@ -22,19 +24,19 @@
 		'test refresh returning true': function() {
 			var context = this._getContextStub( sinon.stub().returns( true ), true );
 
-			this._assertToolbarVisible( true, context );
+			contextTools._assertToolbarVisible( true, context );
 		},
 
 		'test refresh returning false': function() {
 			var context = this._getContextStub( sinon.stub().returns( false ), true );
 
-			this._assertToolbarVisible( false, context );
+			contextTools._assertToolbarVisible( false, context );
 		},
 
 		'test refresh returning falsy value': function() {
 			var context = this._getContextStub( sinon.stub().returns( 0 ), true );
 
-			this._assertToolbarVisible( false, context );
+			contextTools._assertToolbarVisible( false, context );
 		},
 
 		/*
@@ -55,13 +57,6 @@
 			}
 
 			return ret;
-		},
-
-		/*
-		 * @param {Boolean} expected What's the expected visibility? If `true` toolbar must be visible.
-		 */
-		_assertToolbarVisible: function( expected, context, msg ) {
-			assert.areSame( expected, context.toolbar._view.parts.panel.isVisible(), msg || 'Toolbar visibility' );
 		}
 	} );
 } )();

--- a/tests/plugins/inlinetoolbar/context/refresh.js
+++ b/tests/plugins/inlinetoolbar/context/refresh.js
@@ -63,8 +63,8 @@
 				contextElem = this._getContextStub( sinon.stub().returns( new CKEDITOR.dom.element( 'p' ) ) );
 
 			assert.isNull( contextFalse._matchRefresh( null, null ) );
-			assert.isTrue( contextTrue._matchRefresh( null, null ) instanceof CKEDITOR.dom.element );
-			assert.isTrue( contextElem._matchRefresh( null, null ) instanceof CKEDITOR.dom.element );
+			assert.isInstanceOf( CKEDITOR.dom.element, contextTrue._matchRefresh( null, null ), 'contextTrue return type' );
+			assert.isInstanceOf( CKEDITOR.dom.element, contextElem._matchRefresh( null, null ), 'contextTrue return type' );
 		},
 
 		/*

--- a/tests/plugins/inlinetoolbar/context/widget.html
+++ b/tests/plugins/inlinetoolbar/context/widget.html
@@ -1,0 +1,14 @@
+<div id="withCaption">
+	<div data-widget="widgetWithEditable" id="we1">
+		<div class="area">
+			foo
+			<strong>bar</strong> baz
+		</div>
+	</div>
+</div>
+
+<div id="simpleWidget">
+	<p>foo</p>
+	<div data-widget="bar" id="w1">foo</div>
+	</p>
+</div>

--- a/tests/plugins/inlinetoolbar/context/widget.js
+++ b/tests/plugins/inlinetoolbar/context/widget.js
@@ -14,7 +14,7 @@
 
 	bender.test( {
 		tearDown: function() {
-			this.editor.plugins.inlinetoolbar._manager._clear();
+			this.editor.inlineToolbar._manager._clear();
 		},
 
 		'test simple positive matching with one item': function() {
@@ -149,7 +149,7 @@
 		 * @returns {CKEDITOR.plugins.inlinetoolbar.context}
 		 */
 		_getContextStub: function( widgetNames ) {
-			return this.editor.plugins.inlinetoolbar.create( {
+			return this.editor.inlineToolbar.create( {
 				widgets: widgetNames
 			} );
 		},

--- a/tests/plugins/inlinetoolbar/context/widget.js
+++ b/tests/plugins/inlinetoolbar/context/widget.js
@@ -13,10 +13,8 @@
 	};
 
 	bender.test( {
-		init: function() {
-			// Stub listener register method, as since it's called in a constructor and it adds
-			// selectionChange listener, it causes extra calls to toolbar hide/show methods.
-			sinon.stub( CKEDITOR.plugins.inlinetoolbar.context.prototype, '_attachListeners' );
+		tearDown: function() {
+			this.editor.plugins.inlinetoolbar._manager._clear();
 		},
 
 		'test simple positive matching with one item': function() {

--- a/tests/plugins/inlinetoolbar/context/widget.js
+++ b/tests/plugins/inlinetoolbar/context/widget.js
@@ -133,6 +133,27 @@
 				} );
 		},
 
+		'test widget toolbar points to a proper element': function() {
+			// Toolbar matched to a widget, should point to a widget element.
+			var editor = this.editor,
+				context = this._getContextStub( [ 'pointing' ] );
+
+			editor.widgets.add( 'pointing' );
+
+			this.editorBot.setData(
+				'<p>foo</p><div data-widget="pointing" id="w1">foo</div></p>',
+				function() {
+					var widget = widgetTestsTools.getWidgetById( editor, 'w1' );
+
+					sinon.stub( context, 'show' );
+
+					widget.focus();
+
+					sinon.assert.calledWithExactly( context.show, widget.element );
+					assert.isTrue( true );
+				} );
+		},
+
 		/*
 		 * Returns a Context instance with toolbar show/hide methods stubbed.
 		 *

--- a/tests/plugins/inlinetoolbar/context/widget.js
+++ b/tests/plugins/inlinetoolbar/context/widget.js
@@ -79,6 +79,46 @@
 				} );
 		},
 
+		'test matching with options.widgets as a string': function() {
+			var editor = this.editor,
+				context = this._getContextStub( 'foo,bar,baz' );
+
+			editor.widgets.add( 'bar' );
+
+			this.editorBot.setData(
+				'<p>foo</p><div data-widget="bar" id="w1">foo</div></p>',
+				function() {
+					var widget = widgetTestsTools.getWidgetById( editor, 'w1' );
+
+					widget.focus();
+
+					context.refresh();
+
+					assert.areSame( 0, context.toolbar.hide.callCount, 'Toolbar hide calls' );
+					assert.areSame( 1, context.toolbar.show.callCount, 'Toolbar show calls' );
+				} );
+		},
+
+		'test negation with options.widgets as a string': function() {
+			var editor = this.editor,
+				context = this._getContextStub( 'foo,zbarz,baz' );
+
+			editor.widgets.add( 'bar' );
+
+			this.editorBot.setData(
+				'<p>foo</p><div data-widget="bar" id="w1">foo</div></p>',
+				function() {
+					var widget = widgetTestsTools.getWidgetById( editor, 'w1' );
+
+					widget.focus();
+
+					context.refresh();
+
+					assert.areSame( 1, context.toolbar.hide.callCount, 'Toolbar hide calls' );
+					assert.areSame( 0, context.toolbar.show.callCount, 'Toolbar show calls' );
+				} );
+		},
+
 		/*
 		 * Returns a Context instance with toolbar show/hide methods stubbed.
 		 *

--- a/tests/plugins/inlinetoolbar/context/widget.js
+++ b/tests/plugins/inlinetoolbar/context/widget.js
@@ -13,6 +13,12 @@
 	};
 
 	bender.test( {
+		setUp: function() {
+			if ( CKEDITOR.env.ie && CKEDITOR.env.version === 8 ) {
+				assert.ignore();
+			}
+		},
+
 		tearDown: function() {
 			this.editor.inlineToolbar._manager._clear();
 		},

--- a/tests/plugins/inlinetoolbar/context/widget.js
+++ b/tests/plugins/inlinetoolbar/context/widget.js
@@ -30,8 +30,6 @@
 
 					widget.focus();
 
-					context.refresh();
-
 					this._assertToolbarVisible( true, context );
 				} );
 		},
@@ -48,8 +46,6 @@
 					var widget = widgetTestsTools.getWidgetById( editor, 'w1' );
 
 					widget.focus();
-
-					context.refresh();
 
 					this._assertToolbarVisible( true, context );
 				} );
@@ -68,8 +64,6 @@
 
 					widget.focus();
 
-					context.refresh();
-
 					this._assertToolbarVisible( false, context );
 				} );
 		},
@@ -87,8 +81,6 @@
 
 					widget.focus();
 
-					context.refresh();
-
 					this._assertToolbarVisible( true, context );
 				} );
 		},
@@ -105,8 +97,6 @@
 					var widget = widgetTestsTools.getWidgetById( editor, 'w1' );
 
 					widget.focus();
-
-					context.refresh();
 
 					this._assertToolbarVisible( false, context );
 				} );
@@ -126,8 +116,6 @@
 				CKEDITOR.document.getById( 'withCaption' ).getHtml(),
 				function() {
 					this.editor.getSelection().selectElement( this.editor.editable().findOne( 'strong' ) );
-
-					context.refresh();
 
 					this._assertToolbarVisible( false, context );
 				} );

--- a/tests/plugins/inlinetoolbar/context/widget.js
+++ b/tests/plugins/inlinetoolbar/context/widget.js
@@ -34,8 +34,7 @@
 
 					context.refresh();
 
-					assert.areSame( 0, context.toolbar.hide.callCount, 'Toolbar hide calls' );
-					assert.areSame( 1, context.toolbar.show.callCount, 'Toolbar show calls' );
+					this._assertToolbarVisible( true, context );
 				} );
 		},
 
@@ -54,8 +53,7 @@
 
 					context.refresh();
 
-					assert.areSame( 0, context.toolbar.hide.callCount, 'Toolbar hide calls' );
-					assert.areSame( 1, context.toolbar.show.callCount, 'Toolbar show calls' );
+					this._assertToolbarVisible( true, context );
 				} );
 		},
 
@@ -74,8 +72,7 @@
 
 					context.refresh();
 
-					assert.areSame( 1, context.toolbar.hide.callCount, 'Toolbar hide calls' );
-					assert.areSame( 0, context.toolbar.show.callCount, 'Toolbar show calls' );
+					this._assertToolbarVisible( false, context );
 				} );
 		},
 
@@ -94,8 +91,7 @@
 
 					context.refresh();
 
-					assert.areSame( 0, context.toolbar.hide.callCount, 'Toolbar hide calls' );
-					assert.areSame( 1, context.toolbar.show.callCount, 'Toolbar show calls' );
+					this._assertToolbarVisible( true, context );
 				} );
 		},
 
@@ -114,8 +110,7 @@
 
 					context.refresh();
 
-					assert.areSame( 1, context.toolbar.hide.callCount, 'Toolbar hide calls' );
-					assert.areSame( 0, context.toolbar.show.callCount, 'Toolbar show calls' );
+					this._assertToolbarVisible( false, context );
 				} );
 		},
 
@@ -136,8 +131,7 @@
 
 					context.refresh();
 
-					assert.areSame( 1, context.toolbar.hide.callCount, 'Toolbar hide calls' );
-					assert.areSame( 0, context.toolbar.show.callCount, 'Toolbar show calls' );
+					this._assertToolbarVisible( false, context );
 				} );
 		},
 
@@ -148,14 +142,16 @@
 		 * @returns {CKEDITOR.plugins.inlinetoolbar.context}
 		 */
 		_getContextStub: function( widgetNames ) {
-			var ret = this.editor.plugins.inlinetoolbar.create( {
+			return this.editor.plugins.inlinetoolbar.create( {
 				widgets: widgetNames
 			} );
+		},
 
-			sinon.stub( ret.toolbar, 'hide' );
-			sinon.stub( ret.toolbar, 'show' );
-
-			return ret;
+		/*
+		 * @param {Boolean} expected What's the expected visibility? If `true` toolbar must be visible.
+		 */
+		_assertToolbarVisible: function( expected, context, msg ) {
+			assert.areSame( expected, context.toolbar._view.parts.panel.isVisible(), msg || 'Toolbar visibility' );
 		}
 	} );
 } )();

--- a/tests/plugins/inlinetoolbar/context/widget.js
+++ b/tests/plugins/inlinetoolbar/context/widget.js
@@ -8,7 +8,7 @@
 
 	bender.editor = {
 		config: {
-			extraAllowedContent: 'div[*]'
+			extraAllowedContent: 'div[*];strong'
 		}
 	};
 
@@ -46,7 +46,7 @@
 			editor.widgets.add( 'bar' );
 
 			this.editorBot.setData(
-				'<p>foo</p><div data-widget="bar" id="w1">foo</div></p>',
+				CKEDITOR.document.getById( 'simpleWidget' ).getHtml(),
 				function() {
 					var widget = widgetTestsTools.getWidgetById( editor, 'w1' );
 
@@ -86,7 +86,7 @@
 			editor.widgets.add( 'bar' );
 
 			this.editorBot.setData(
-				'<p>foo</p><div data-widget="bar" id="w1">foo</div></p>',
+				CKEDITOR.document.getById( 'simpleWidget' ).getHtml(),
 				function() {
 					var widget = widgetTestsTools.getWidgetById( editor, 'w1' );
 
@@ -106,11 +106,33 @@
 			editor.widgets.add( 'bar' );
 
 			this.editorBot.setData(
-				'<p>foo</p><div data-widget="bar" id="w1">foo</div></p>',
+				CKEDITOR.document.getById( 'simpleWidget' ).getHtml(),
 				function() {
 					var widget = widgetTestsTools.getWidgetById( editor, 'w1' );
 
 					widget.focus();
+
+					context.refresh();
+
+					assert.areSame( 1, context.toolbar.hide.callCount, 'Toolbar hide calls' );
+					assert.areSame( 0, context.toolbar.show.callCount, 'Toolbar show calls' );
+				} );
+		},
+
+		'test widget selector does not trigger in nested editable': function() {
+			var editor = this.editor,
+				context = this._getContextStub( 'widgetWithEditable' );
+
+			editor.widgets.add( 'widgetWithEditable', {
+				editables: {
+					area: 'div.area'
+				}
+			} );
+
+			this.editorBot.setData(
+				CKEDITOR.document.getById( 'withCaption' ).getHtml(),
+				function() {
+					this.editor.getSelection().selectElement( this.editor.editable().findOne( 'strong' ) );
 
 					context.refresh();
 

--- a/tests/plugins/inlinetoolbar/context/widget.js
+++ b/tests/plugins/inlinetoolbar/context/widget.js
@@ -1,7 +1,7 @@
 /* bender-tags: inlinetoolbar,context */
 /* bender-ckeditor-plugins: inlinetoolbar,button,widget */
-/* bender-include: ../../widget/_helpers/tools.js */
-/* global widgetTestsTools */
+/* bender-include: ../../widget/_helpers/tools.js, _helpers/tools.js */
+/* global widgetTestsTools, contextTools */
 
 ( function() {
 	'use strict';
@@ -36,7 +36,7 @@
 
 					widget.focus();
 
-					this._assertToolbarVisible( true, context );
+					contextTools._assertToolbarVisible( true, context );
 				} );
 		},
 
@@ -53,7 +53,7 @@
 
 					widget.focus();
 
-					this._assertToolbarVisible( true, context );
+					contextTools._assertToolbarVisible( true, context );
 				} );
 		},
 
@@ -70,7 +70,7 @@
 
 					widget.focus();
 
-					this._assertToolbarVisible( false, context );
+					contextTools._assertToolbarVisible( false, context );
 				} );
 		},
 
@@ -87,7 +87,7 @@
 
 					widget.focus();
 
-					this._assertToolbarVisible( true, context );
+					contextTools._assertToolbarVisible( true, context );
 				} );
 		},
 
@@ -104,7 +104,7 @@
 
 					widget.focus();
 
-					this._assertToolbarVisible( false, context );
+					contextTools._assertToolbarVisible( false, context );
 				} );
 		},
 
@@ -123,7 +123,7 @@
 				function() {
 					this.editor.getSelection().selectElement( this.editor.editable().findOne( 'strong' ) );
 
-					this._assertToolbarVisible( false, context );
+					contextTools._assertToolbarVisible( false, context );
 				} );
 		},
 
@@ -158,13 +158,6 @@
 			return this.editor.inlineToolbar.create( {
 				widgets: widgetNames
 			} );
-		},
-
-		/*
-		 * @param {Boolean} expected What's the expected visibility? If `true` toolbar must be visible.
-		 */
-		_assertToolbarVisible: function( expected, context, msg ) {
-			assert.areSame( expected, context.toolbar._view.parts.panel.isVisible(), msg || 'Toolbar visibility' );
 		}
 	} );
 } )();


### PR DESCRIPTION
## What is the purpose of this pull request?

New feature

### This PR contains

- [x] Unit tests
- [x] Manual tests

## What changes did you make?

Added context classes for inline toolbar. It makes stupid easy to maintain multiple inline toolbars in a single editor.

See [`CKEDITOR.editor.inlineToolbar` (local docs link)](http://docs.ckeditor.test/#!/api/CKEDITOR.editor.inlineToolbar) for more details.