### PR TITLE
Fix for race condition while uploading multiple files with uploadimage plugin

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -31,6 +31,7 @@ Fixed Issues:
 * [#1057](https://github.com/ckeditor/ckeditor-dev/issues/1057): Fixed: The [Notification](https://ckeditor.com/addon/notification) plugin overwrites Web Notifications API due to leakage to the global scope.
 * [#1068](https://github.com/ckeditor/ckeditor-dev/issues/1068): Fixed: Upload widget paste listener ignores changes to the [`uploadWidgetDefinition`](https://docs.ckeditor.com/ckeditor4/docs/#!/api/CKEDITOR.fileTools.uploadWidgetDefinition).
 * [#921](https://github.com/ckeditor/ckeditor-dev/issues/921): Fixed: [Edge] CKEditor erroneously perceives internal copy and paste as type "external".
+* [#1213](https://github.com/ckeditor/ckeditor-dev/issues/1213): Fixed: Multiple images uploaded using [Upload Image](https://ckeditor.com/cke4/addon/uploadimage) plugin are randomly duplicated or mangled.
 
 API Changes:
 

--- a/plugins/uploadimage/plugin.js
+++ b/plugins/uploadimage/plugin.js
@@ -6,12 +6,12 @@
 'use strict';
 
 ( function() {
-	var counter = 0,
+	var uniqueNameCounter = 0,
 		// Black rectangle which is shown before image is loaded.
 		loadingImage = 'data:image/gif;base64,R0lGODlhDgAOAIAAAAAAAP///yH5BAAAAAAALAAAAAAOAA4AAAIMhI+py+0Po5y02qsKADs=';
 
 	// Returns number as a string. If a number has 1 digit only it returns it prefixed with an extra 0.
-	function padDate( input ) {
+	function padNumber( input ) {
 		if ( input <= 9 ) {
 			input = '0' + input;
 		}
@@ -24,9 +24,9 @@
 		var date = new Date(),
 			dateParts = [ date.getFullYear(), date.getMonth() + 1, date.getDate(), date.getHours(), date.getMinutes(), date.getSeconds() ];
 
-		counter += 1;
+		uniqueNameCounter += 1;
 
-		return 'image-' + CKEDITOR.tools.array.map( dateParts, padDate ).join( '' ) + '-' + counter + '.' + type;
+		return 'image-' + CKEDITOR.tools.array.map( dateParts, padNumber ).join( '' ) + '-' + uniqueNameCounter + '.' + type;
 	}
 
 	CKEDITOR.plugins.add( 'uploadimage', {

--- a/tests/plugins/uploadimage/uploadimage.js
+++ b/tests/plugins/uploadimage/uploadimage.js
@@ -68,6 +68,8 @@
 
 				this.responseData = {};
 			};
+
+			// sinon.spy( CKEDITOR.fileTools.fileLoader.prototype, 'upload' );
 		},
 
 		setUp: function() {
@@ -547,6 +549,30 @@
 			editor.once( 'afterPaste', function() {
 				resume( function() {
 					assert.isTrue( createspy.notCalled );
+				} );
+			} );
+
+			wait();
+		},
+
+		'test uploads generate unique names (#1213)': function() {
+			var editor = this.editors.inline,
+				createSpy = sinon.spy( editor.uploadRepository, 'create' );
+
+			editor.fire( 'paste', {
+				dataValue: '<img src="data:image/gif;base64,aw==" alt="gif" />' +
+					'<img src="data:image/gif;base64,aw==" alt="gif" />' +
+					'<img src="data:image/png;base64,aw==" alt="png" />'
+			} );
+
+			editor.once( 'afterPaste', function() {
+				resume( function() {
+					assert.areSame( 3, createSpy.callCount, 'create call count' );
+
+					assert.isMatching( /image-\d+-\d+\.gif/, createSpy.args[ 0 ][ 1 ], 'file name passed to first call' );
+					assert.isMatching( /image-\d+-\d+\.gif/, createSpy.args[ 1 ][ 1 ], 'file name passed to second call' );
+					assert.areNotSame( createSpy.args[ 0 ][ 1 ], createSpy.args[ 1 ][ 1 ], 'first and second call names are different' );
+					assert.isMatching( /image-\d+-\d+\.png/, createSpy.args[ 2 ][ 1 ], 'png type is recognized' );
 				} );
 			} );
 

--- a/tests/plugins/uploadimage/uploadimage.js
+++ b/tests/plugins/uploadimage/uploadimage.js
@@ -538,7 +538,7 @@
 
 		'test prevent upload fake elements (https://dev.ckeditor.com/ticket/13003)': function() {
 			var editor = this.editors.inline,
-				createspy = sinon.spy( editor.uploadRepository, 'create' );
+				createSpy = sinon.spy( editor.uploadRepository, 'create' );
 
 			editor.fire( 'paste', {
 				dataValue: '<img src="data:image/gif;base64,aw==" alt="nothing" data-cke-realelement="some" />'
@@ -546,8 +546,8 @@
 
 			editor.once( 'afterPaste', function() {
 				resume( function() {
-					createspy.restore();
-					assert.isTrue( createspy.notCalled );
+					createSpy.restore();
+					assert.isTrue( createSpy.notCalled );
 				} );
 			} );
 

--- a/tests/plugins/uploadimage/uploadimage.js
+++ b/tests/plugins/uploadimage/uploadimage.js
@@ -68,8 +68,6 @@
 
 				this.responseData = {};
 			};
-
-			// sinon.spy( CKEDITOR.fileTools.fileLoader.prototype, 'upload' );
 		},
 
 		setUp: function() {
@@ -548,6 +546,7 @@
 
 			editor.once( 'afterPaste', function() {
 				resume( function() {
+					createspy.restore();
 					assert.isTrue( createspy.notCalled );
 				} );
 			} );
@@ -567,6 +566,7 @@
 
 			editor.once( 'afterPaste', function() {
 				resume( function() {
+					createSpy.restore();
 					assert.areSame( 3, createSpy.callCount, 'create call count' );
 
 					assert.isMatching( /image-\d+-\d+\.gif/, createSpy.args[ 0 ][ 1 ], 'file name passed to first call' );


### PR DESCRIPTION
## What is the purpose of this pull request?

Bug fix

### This PR contains

- [x] Unit tests
- [ ] Manual tests

## What changes did you make?

This issue is more of a workaround, as the problem is actually on a CKFinder side, but we can't quickly fix it there, so we'll patch client side first.

Now, the problem was that CKFinder had a problem handling multiple files with the same name loaded at once, so we'll generate unique file name for each one. It's a bit dirty, and optimistic, but should do the trick for now.

### Manaul Tests

To be honest I had no good idea how to make a good manual test here. To make it reliable I have set a CKFinder 3 instance on my dev workstation, and added configuration to `config.js`:

By adding:

```
	config.uploadUrl = '/ckfinder/core/connector/php/connector.php?command=QuickUpload&type=Files&responseType=json';
```

And adding `'uploadimage'` to the plugin list.

Closes #1213.