### PR TITLE
Balloon Toolbar should prefer bottom position

### DIFF
--- a/plugins/balloontoolbar/plugin.js
+++ b/plugins/balloontoolbar/plugin.js
@@ -634,14 +634,12 @@
 			};
 
 			CKEDITOR.ui.balloonToolbarView.prototype._getAlignments = function( elementRect, panelWidth, panelHeight ) {
-				var filter = [ 'top hcenter', 'bottom hcenter' ],
-					alignments = CKEDITOR.ui.balloonPanel.prototype._getAlignments.call( this, elementRect, panelWidth, panelHeight );
-				for ( var a in alignments ) {
-					if ( CKEDITOR.tools.indexOf( filter, a ) === -1 ) {
-						delete alignments[ a ];
-					}
-				}
-				return alignments;
+				var alignments = CKEDITOR.ui.balloonPanel.prototype._getAlignments.call( this, elementRect, panelWidth, panelHeight );
+
+				return {
+					'bottom hcenter': alignments[ 'bottom hcenter' ],
+					'top hcenter': alignments[ 'top hcenter' ]
+				};
 			};
 
 			/**

--- a/tests/plugins/balloontoolbar/positioning.js
+++ b/tests/plugins/balloontoolbar/positioning.js
@@ -115,6 +115,16 @@
 			assert.isTrue( balloonToolbar.parts.panel.hasClass( 'cke_balloon' ), 'Class cke_balloon class was not removed' );
 			balloonToolbar.destroy();
 			balloonToolbar = null;
+		},
+
+		'test panel prefers bottom positioning': function( editor ) {
+			var balloonToolbar = new CKEDITOR.ui.balloonToolbarView( editor, {
+					width: 100,
+					height: 200
+				} ),
+				res = balloonToolbar._getAlignments( editor.editable().getFirst().getClientRect(), 10, 10 );
+
+			arrayAssert.itemsAreEqual( [ 'bottom hcenter', 'top hcenter' ], CKEDITOR.tools.objectKeys( res ) );
 		}
 	};
 


### PR DESCRIPTION
## What is the purpose of this pull request?

New feature

### This PR contains

- [x] Unit tests
- [ ] Manual tests (there's already tons of manuals, that will show this feature :))

## What changes did you make?

The toolbar should prefer bottom position. Reason for that is that on mobile, native context menu (e.g. in case of a ranged selection) is displayed on top (mobile chrome, ios safari, chrome on Windows).

Having our toolbar on the bottom of selection will allow user to use native and our toolbar as well.