### PR TITLE
Balloon toolbar should be repositioned on window resize

### DIFF
--- a/plugins/balloontoolbar/plugin.js
+++ b/plugins/balloontoolbar/plugin.js
@@ -535,10 +535,7 @@
 				}, this, null, 9999 ),
 				this.editor.on( 'blur', function() {
 					this.hide();
-				}, this, null, 9999 ),
-				CKEDITOR.document.getWindow().on( 'resize', function() {
-					this.check();
-				}, this )
+				}, this, null, 9999 )
 			);
 		}
 	};
@@ -614,6 +611,12 @@
 						focusElement: false
 					} );
 				}, this ) );
+				this._listeners.push( CKEDITOR.document.getWindow().on( 'resize', function() {
+					this.attach( this._pointedElement, {
+						focusElement: false
+					} );
+				}, this ) );
+
 				CKEDITOR.ui.balloonPanel.prototype.show.call( this );
 			};
 

--- a/plugins/balloontoolbar/plugin.js
+++ b/plugins/balloontoolbar/plugin.js
@@ -535,7 +535,10 @@
 				}, this, null, 9999 ),
 				this.editor.on( 'blur', function() {
 					this.hide();
-				}, this, null, 9999 )
+				}, this, null, 9999 ),
+				CKEDITOR.document.getWindow().on( 'resize', function() {
+					this.check();
+				}, this )
 			);
 		}
 	};

--- a/tests/plugins/balloontoolbar/manual/windowresize.html
+++ b/tests/plugins/balloontoolbar/manual/windowresize.html
@@ -1,0 +1,92 @@
+<style>
+	body {
+		/* (#1048) */
+		margin-left: 0px;
+		padding-left: 400px;
+	}
+
+</style>
+
+<h2>Classic</h2>
+<textarea id="editor1" cols="10" rows="10">
+	<p>
+		Sample paragraph with <em>emphasize</em>, <strong>strong</strong>, <u>underline</u> and <s>strikethrough</s>.
+		Sample paragraph with <em>emphasize</em>, <strong>strong</strong>, <u>underline</u> and <s>strikethrough</s>.
+	</p>
+	<ol>
+		<li>List item with a plain text only.</li>
+		<li>
+			<p>List item with <em>emphasize</em>, <strong>strong</strong>, <u>underline</u> and <s>strikethrough</s>.</p>
+		</li>
+		<li>List item with a plain text only.</li>
+	</ol>
+	<p>Last paragraph with an <a href="#">example link</a>.</p>
+</textarea>
+
+<h2>Inline</h2>
+<div id="editor2" contenteditable="true">
+	<p>
+		Sample paragraph with <em>emphasize</em>, <strong>strong</strong>, <u>underline</u> and <s>strikethrough</s>. Sample paragraph with <em>emphasize</em>, <strong>strong</strong>, <u>underline</u> and <s>strikethrough</s>.
+	</p>
+	<ol>
+		<li>List item with a plain text only.</li>
+		<li>
+			<p>List item with <em>emphasize</em>, <strong>strong</strong>, <u>underline</u> and <s>strikethrough</s>.</p>
+		</li>
+		<li>List item with a plain text only.</li>
+	</ol>
+	<p>Last paragraph with an <a href="#">example link</a>.</p>
+</div>
+
+<h2>Divarea</h2>
+<textarea id="editor3" cols="10" rows="10">
+	<p>
+		Sample paragraph with <em>emphasize</em>, <strong>strong</strong>, <u>underline</u> and <s>strikethrough</s>.
+		Sample paragraph with <em>emphasize</em>, <strong>strong</strong>, <u>underline</u> and <s>strikethrough</s>.
+	</p>
+	<ol>
+		<li>List item with a plain text only.</li>
+		<li>
+			<p>List item with <em>emphasize</em>, <strong>strong</strong>, <u>underline</u> and <s>strikethrough</s>.</p>
+		</li>
+		<li>List item with a plain text only.</li>
+	</ol>
+	<p>Last paragraph with an <a href="#">example link</a>.</p>
+</textarea>
+
+<script>
+	if ( CKEDITOR.env.ie && CKEDITOR.env.version === 8 ) {
+		bender.ignore();
+	}
+
+	CKEDITOR.disableAutoInline = true;
+
+	var config = {
+		height: 300,
+		on: {
+			instanceReady: function( evt ) {
+				// Register the toolbar for inline elements.
+				evt.editor.balloonToolbars.create( {
+					buttons: 'Bold,Underline',
+					cssSelector: 'strong, em'
+				} );
+
+				evt.editor.balloonToolbars.create( {
+					buttons: 'Link,Unlink',
+					cssSelector: 'a[href], img'
+				} );
+
+				evt.editor.balloonToolbars.create( {
+					buttons: 'BulletedList,NumberedList',
+					cssSelector: 'li'
+				} );
+			}
+		}
+	};
+
+	CKEDITOR.replace( 'editor1', config );
+	CKEDITOR.inline( 'editor2', config );
+
+	config.extraPlugins = 'divarea';
+	CKEDITOR.replace( 'editor3', config );
+</script>

--- a/tests/plugins/balloontoolbar/manual/windowresize.md
+++ b/tests/plugins/balloontoolbar/manual/windowresize.md
@@ -1,0 +1,16 @@
+@bender-ui: collapsed
+@bender-tags: 4.8.0, feature, balloontoolbar, 933
+@bender-ckeditor-plugins: wysiwygarea, toolbar, undo, basicstyles, floatingspace, balloontoolbar, sourcearea, list, link, elementspath, image
+
+## Window Resize
+
+### Test Scenario
+
+_Perform for each editor instance._
+
+1. Click inside an element (`strong`, `em`, `a`, `li`) so balloon toolbar appears.
+2. Resize the whole window.
+
+#### Expected
+
+If element moves on the window resize, balloon toolbar should move with the element so it is always properly attached to it.

--- a/tests/plugins/balloontoolbar/manual/windowresize.md
+++ b/tests/plugins/balloontoolbar/manual/windowresize.md
@@ -8,7 +8,7 @@
 
 _Perform for each editor instance._
 
-1. Click inside an element (`strong`, `em`, `a`, `li`) so balloon toolbar appears.
+1. Click inside an element (`strong`, `em`, `a` or `li`) so balloon toolbar appears.
 1. Resize the whole window.
 
 #### Expected
@@ -23,4 +23,4 @@ If element moves on the window resize, balloon toolbar should move with the elem
 
 #### Expected
 
-Window is resized, no new toolbars are shown.
+Window is resized, no toolbars are shown.

--- a/tests/plugins/balloontoolbar/manual/windowresize.md
+++ b/tests/plugins/balloontoolbar/manual/windowresize.md
@@ -4,13 +4,23 @@
 
 ## Window Resize
 
-### Test Scenario
+### Scenario 1
 
 _Perform for each editor instance._
 
 1. Click inside an element (`strong`, `em`, `a`, `li`) so balloon toolbar appears.
-2. Resize the whole window.
+1. Resize the whole window.
 
 #### Expected
 
 If element moves on the window resize, balloon toolbar should move with the element so it is always properly attached to it.
+
+### Scenario 2
+
+1. Put a selection in any `strong` within the each editor.
+1. Blur last editor by clicking outside.
+1. Resize the whole window.
+
+#### Expected
+
+Window is resized, no new toolbars are shown.

--- a/tests/plugins/balloontoolbar/manual/windowresize.md
+++ b/tests/plugins/balloontoolbar/manual/windowresize.md
@@ -15,6 +15,8 @@ _Perform for each editor instance._
 
 If element moves on the window resize, balloon toolbar should move with the element so it is always properly attached to it.
 
+Note: Edge the toolbar will be hidden during the resize as editor fires `blur` events ([#1265](https://github.com/ckeditor/ckeditor-dev/issues/1265)).
+
 ### Scenario 2
 
 1. Put a selection in any `strong` within the each editor.

--- a/tests/plugins/balloontoolbar/view.js
+++ b/tests/plugins/balloontoolbar/view.js
@@ -76,7 +76,7 @@
 
 				view.show();
 				assert.isTrue( view.rect.visible, 'Toolbar should be shown after show method' );
-				assert.areEqual( 2, view._listeners.length, 'Listeners should be attached after show method' );
+				assert.areEqual( 3, view._listeners.length, 'Listeners should be attached after show method' );
 
 				view.hide();
 				assert.isFalse( view.rect.visible, 'Toolbar should not be shown after hide method' );


### PR DESCRIPTION
## What is the purpose of this pull request?

Bug fix

## Does your PR contain necessary tests?

All patches which change the editor code must include tests. You can always read more
on [PR testing](https://docs.ckeditor.com/ckeditor4/docs/#!/guide/dev_contributing_code-section-tests),
[how to set the testing environment](https://docs.ckeditor.com/ckeditor4/docs/#!/guide/dev_tests) and
[how to create tests](https://docs.ckeditor.com/ckeditor4/docs/#!/guide/dev_tests-section-creating-your-own-test)
in the official CKEditor documentation.

### This PR contains

- [ ] Unit tests
- [x] Manual tests

## What changes did you make?

Balloon toolbar is now repositioned on window resize.
