### PR TITLE
Ignore balloonpanel/cssloading test on built version

### DIFF
--- a/tests/plugins/balloonpanel/cssloading.js
+++ b/tests/plugins/balloonpanel/cssloading.js
@@ -10,6 +10,14 @@
 	var spy = sinon.spy( CKEDITOR.dom.document.prototype, 'appendStyleSheet' );
 
 	bender.test( {
+		_should: {
+			ignore: {
+				// As we don't have straight way to recognise editor's built version,
+				// such trick must be used.
+				'test loading css with path': CKEDITOR.revision !== '%REV%'
+			}
+		},
+
 		'test loading css with path': function() {
 			assert.areSame( 'kama,/apps/ckeditor/skins/kama/', CKEDITOR.skinName, 'config skinName should be with path' );
 			sinon.assert.calledWith( spy, document.location.origin + '/apps/ckeditor/plugins/balloonpanel/skins/kama/balloonpanel.css' );

--- a/tests/plugins/balloonpanel/cssloading.js
+++ b/tests/plugins/balloonpanel/cssloading.js
@@ -12,8 +12,9 @@
 	bender.test( {
 		_should: {
 			ignore: {
-				// As we don't have straight way to recognise editor's built version,
-				// such trick must be used.
+				// Our release version is built with moono-lisa skin inlined, thus we can't
+				// test it against other skin. We don't have straight way to recognise editor's
+				// built version, such trick must be used (#1251).
 				'test loading css with path': CKEDITOR.revision !== '%REV%'
 			}
 		},


### PR DESCRIPTION
## What is the purpose of this pull request?

Failing test fix.

## Does your PR contain necessary tests?

This PR fixes failing test, so no additional tests are needed

## What changes did you make?

Ignores failing `balloonpanel/cssloading` test only for built version of CKEditor.

Closes #1251.
