### PR TITLE
Corrections to PR fixing asynchronous clipboard return value

### DIFF
--- a/plugins/clipboard/plugin.js
+++ b/plugins/clipboard/plugin.js
@@ -2616,14 +2616,6 @@
 	 */
 	CKEDITOR.plugins.clipboard.fallbackDataTransfer = function( dataTransfer ) {
 		/**
-		 * Cache object. Shared with {@link CKEDITOR.plugins.clipboard.dataTransfer} instance.
-		 *
-		 * @private
-		 * @property {Object} _cache
-		 */
-		this._cache = dataTransfer._.data;
-
-		/**
 		 * DataTransfer object which internal cache and
 		 * {@link CKEDITOR.plugins.clipboard.dataTransfer#$ data transfer} objects will be modified if needed.
 		 *
@@ -2814,8 +2806,10 @@
 		 * @returns {String|null}
 		 */
 		_getData: function( type, skipCache ) {
-			if ( !skipCache && this._cache[ type ] ) {
-				return this._cache[ type ];
+			var cache = this._dataTransfer._.data;
+
+			if ( !skipCache && cache[ type ] ) {
+				return cache[ type ];
 			} else {
 				try {
 					return this._dataTransfer.$.getData( type );
@@ -2833,7 +2827,7 @@
 		 * @returns {String}
 		 */
 		_getFallbackTypeContent: function() {
-			var fallbackTypeContent = this._cache[ this._customDataFallbackType ];
+			var fallbackTypeContent = this._dataTransfer._.data[ this._customDataFallbackType ];
 
 			if ( !fallbackTypeContent ) {
 				fallbackTypeContent = this._extractDataComment( this._getData( this._customDataFallbackType, true ) ).content;
@@ -2850,11 +2844,12 @@
 		 */
 		_getFallbackTypeData: function() {
 			var fallbackTypes = CKEDITOR.plugins.clipboard.fallbackDataTransfer._customTypes,
-				fallbackTypeData = this._extractDataComment( this._getData( this._customDataFallbackType, true ) ).data || {};
+				fallbackTypeData = this._extractDataComment( this._getData( this._customDataFallbackType, true ) ).data || {},
+				cache = this._dataTransfer._.data;
 
 			CKEDITOR.tools.array.forEach( fallbackTypes, function( type ) {
-				if ( this._cache[ type ] !== undefined ) {
-					fallbackTypeData[ type ] = this._cache[ type ];
+				if ( cache[ type ] !== undefined ) {
+					fallbackTypeData[ type ] = cache[ type ];
 
 				} else if ( fallbackTypeData[ type ] !== undefined ) {
 					fallbackTypeData[ type ] = fallbackTypeData[ type ];

--- a/plugins/clipboard/plugin.js
+++ b/plugins/clipboard/plugin.js
@@ -2360,11 +2360,7 @@
 			}
 
 			if ( this._.fallbackDataTransfer.isRequired() ) {
-				var data = this._.fallbackDataTransfer.setData( type, value );
-				// If fallback used, the native data is different so we overwrite `nativeHtmlCache` here.
-				if ( type == 'text/html' ) {
-					this._.nativeHtmlCache = data;
-				}
+				this._.fallbackDataTransfer.setData( type, value );
 			} else {
 				try {
 					this.$.setData( type, value );
@@ -2761,8 +2757,9 @@
 			//
 			// This way, accessing cache will always return proper value for a given type without a need for further processing.
 			// Cache is already set in CKEDITOR.plugins.clipboard.dataTransfer#setData so it is skipped here.
+			var isFallbackDataType = type === this._customDataFallbackType;
 
-			if ( type === this._customDataFallbackType ) {
+			if ( isFallbackDataType ) {
 				value = this._applyDataComment( value, this._getFallbackTypeData() );
 			}
 
@@ -2771,6 +2768,11 @@
 
 			try {
 				nativeDataTransfer.setData( type, data );
+
+				if ( isFallbackDataType ) {
+					// If fallback type used, the native data is different so we overwrite `nativeHtmlCache` here.
+					this._dataTransfer._.nativeHtmlCache = data;
+				}
 			} catch ( e ) {
 				if ( this._isUnsupportedMimeTypeError( e ) ) {
 					var fallbackDataTransfer = CKEDITOR.plugins.clipboard.fallbackDataTransfer;
@@ -2787,6 +2789,8 @@
 					try {
 						data = this._applyDataComment( fallbackTypeContent, fallbackTypeData );
 						nativeDataTransfer.setData( this._customDataFallbackType, data );
+						// Again, fallback type was changed, so we need to refresh the cache.
+						this._dataTransfer._.nativeHtmlCache = data;
 					} catch ( e ) {
 						data = '';
 						// Some dev logger should be added here.

--- a/plugins/clipboard/plugin.js
+++ b/plugins/clipboard/plugin.js
@@ -2160,7 +2160,7 @@
 			data: {},
 			files: [],
 
-			// Stores full html so it can be accessed asynchronously with `getData( 'text/html', true )`.
+			// Stores full HTML so it can be accessed asynchronously with `getData( 'text/html', true )`.
 			nativeHtmlCache: '',
 
 			normalizeType: function( type ) {
@@ -2573,18 +2573,18 @@
 		},
 
 		/**
-		 * Removes meta tags and returns only the contents of the <body> element if found for the given html.
+		 * This function removes this meta information and returns only the contents of the `<body>` element if found.
+		 *
+		 * Various environments use miscellaneous meta tags in HTML clipboard, e.g.
+		 *
+		 * * `<meta http-equiv="content-type" content="text/html; charset=utf-8">` at the begging of the HTML data.
+		 * * Surrounding HTML with `<!--StartFragment-->` and `<!--EndFragment-->` nested within `<html><body>` elements.
 		 *
 		 * @private
 		 * @param {String} html
 		 * @returns {String}
 		 */
 		_stripHtml: function( html ) {
-			// Some browsers add <meta http-equiv="content-type" content="text/html; charset=utf-8"> at the begging of the HTML data
-			// or surround it with <html><head>...</head><body>(some content)<!--StartFragment--> and <!--EndFragment-->(some content)</body></html>
-			// This code removes meta tags and returns only the contents of the <body> element if found. Note that
-			// some significant content may be placed outside Start/EndFragment comments so it's kept.
-			//
 			// See https://dev.ckeditor.com/ticket/13583 for more details.
 			// Additionally https://dev.ckeditor.com/ticket/16847 adds a flag allowing to get the whole, original content.
 			var result = html.replace( this._.metaRegExp, '' ),

--- a/plugins/clipboard/plugin.js
+++ b/plugins/clipboard/plugin.js
@@ -2365,7 +2365,6 @@
 				if ( type == 'text/html' ) {
 					this._.nativeHtmlCache = data;
 				}
-
 			} else {
 				try {
 					this.$.setData( type, value );
@@ -2625,12 +2624,13 @@
 		this._cache = dataTransfer._.data;
 
 		/**
-		 * A native dataTransfer object.
+		 * DataTransfer object which internal cache and
+		 * {@link CKEDITOR.plugins.clipboard.dataTransfer#$ data transfer} objects will be modified if needed.
 		 *
 		 * @private
-		 * @property {Object} _nativeDataTransfer
+		 * @property {CKEDITOR.plugins.clipboard.dataTransfer} _dataTransfer
 		 */
-		this._nativeDataTransfer = dataTransfer.$;
+		this._dataTransfer = dataTransfer;
 
 		/**
 		 * A MIME type used for storing custom MIME types.
@@ -2677,12 +2677,13 @@
 		 * @returns {Boolean}
 		 */
 		isRequired: function() {
-			var fallbackDataTransfer = CKEDITOR.plugins.clipboard.fallbackDataTransfer;
+			var fallbackDataTransfer = CKEDITOR.plugins.clipboard.fallbackDataTransfer,
+				nativeDataTransfer = this._dataTransfer.$;
 
 			if ( fallbackDataTransfer._isCustomMimeTypeSupported === null ) {
 				// If there is no `dataTransfer` we cannot detect if fallback is needed.
 				// Method returns `false` so regular flow will be applied.
-				if ( !this._nativeDataTransfer ) {
+				if ( !nativeDataTransfer ) {
 					return false;
 				} else {
 					var testValue = 'cke test value',
@@ -2691,9 +2692,9 @@
 					fallbackDataTransfer._isCustomMimeTypeSupported = false;
 
 					try {
-						this._nativeDataTransfer.setData( testType, testValue );
-						fallbackDataTransfer._isCustomMimeTypeSupported = this._nativeDataTransfer.getData( testType ) === testValue;
-						this._nativeDataTransfer.clearData( testType );
+						nativeDataTransfer.setData( testType, testValue );
+						fallbackDataTransfer._isCustomMimeTypeSupported = nativeDataTransfer.getData( testType ) === testValue;
+						nativeDataTransfer.clearData( testType );
 					} catch ( e ) {}
 				}
 			}
@@ -2773,9 +2774,11 @@
 				value = this._applyDataComment( value, this._getFallbackTypeData() );
 			}
 
-			var data = value;
+			var data = value,
+				nativeDataTransfer = this._dataTransfer.$;
+
 			try {
-				this._nativeDataTransfer.setData( type, data );
+				nativeDataTransfer.setData( type, data );
 			} catch ( e ) {
 				if ( this._isUnsupportedMimeTypeError( e ) ) {
 					var fallbackDataTransfer = CKEDITOR.plugins.clipboard.fallbackDataTransfer;
@@ -2791,7 +2794,7 @@
 
 					try {
 						data = this._applyDataComment( fallbackTypeContent, fallbackTypeData );
-						this._nativeDataTransfer.setData( this._customDataFallbackType, data );
+						nativeDataTransfer.setData( this._customDataFallbackType, data );
 					} catch ( e ) {
 						data = '';
 						// Some dev logger should be added here.
@@ -2815,7 +2818,7 @@
 				return this._cache[ type ];
 			} else {
 				try {
-					return this._nativeDataTransfer.getData( type );
+					return this._dataTransfer.$.getData( type );
 				} catch ( e ) {
 					return null;
 				}

--- a/tests/plugins/clipboard/fallbackdatatransfer.js
+++ b/tests/plugins/clipboard/fallbackdatatransfer.js
@@ -549,6 +549,30 @@ bender.test( {
 		assert.areSame( html, dataTransfer.getData( 'text/html', true ), 'text/html value' );
 	},
 
+	'test getData with getNative with custom type other sequence': function() {
+		// This test has a different setData sequence than the "test getData with getNative with custom type" test.
+		var nativeData = bender.tools.mockNativeDataTransfer(),
+			eventMock = { data: { $: { clipboardData: nativeData } }, name: 'copy' },
+			dataTransfer = CKEDITOR.plugins.clipboard.initPasteDataTransfer( eventMock ),
+			html = '<s>html</s>';
+
+		dataTransfer.setData( 'cke/custom', 'cke-custom data' );
+		dataTransfer.setData( 'text/html', html );
+		dataTransfer.setData( 'custom/tag', '<p>custom html tag</p>' );
+
+		assert.areSame( 'cke-custom data', dataTransfer.getData( 'cke/custom', true ), 'cke/custom value' );
+		assert.areSame( '<p>custom html tag</p>', dataTransfer.getData( 'custom/tag', true ), 'custom/tag value' );
+
+		if ( isEdge16 ) {
+			html = getHtmlWithCustomData( html, {
+				'cke/id': dataTransfer.id,
+				'cke/custom': 'cke-custom data',
+				'custom/tag': '<p>custom html tag</p>'
+			} );
+		}
+		assert.areSame( html, dataTransfer.getData( 'text/html', true ), 'text/html value' );
+	},
+
 	assertDataTransferType: function( dataTransfer, type, value, customValue ) {
 		if ( isEdge16 && customValue ) {
 			value = getHtmlWithCustomData( value, customValue );

--- a/tests/plugins/clipboard/fallbackdatatransfer.js
+++ b/tests/plugins/clipboard/fallbackdatatransfer.js
@@ -455,9 +455,10 @@ bender.test( {
 
 	'test getFallbackTypeContent prioritize cache': function() {
 		var nativeData = bender.tools.mockNativeDataTransfer(),
-			dataTransferFallback = new CKEDITOR.plugins.clipboard.dataTransfer( nativeData )._.fallbackDataTransfer;
+			dataTransfer = new CKEDITOR.plugins.clipboard.dataTransfer( nativeData ),
+			dataTransferFallback = dataTransfer._.fallbackDataTransfer;
 
-		dataTransferFallback._cache[ dataTransferFallback._customDataFallbackType ] = 'cache value';
+		dataTransfer._.data[ dataTransferFallback._customDataFallbackType ] = 'cache value';
 		nativeData.setData( dataTransferFallback._customDataFallbackType, 'native value' );
 
 		assert.areEqual( 'cache value', dataTransferFallback._getFallbackTypeContent() );
@@ -481,9 +482,10 @@ bender.test( {
 
 	'test getFallbackTypeData prioritize cache': function() {
 		var nativeData = bender.tools.mockNativeDataTransfer(),
-			dataTransferFallback = new CKEDITOR.plugins.clipboard.dataTransfer( nativeData )._.fallbackDataTransfer;
+			dataTransfer = new CKEDITOR.plugins.clipboard.dataTransfer( nativeData ),
+			dataTransferFallback = dataTransfer._.fallbackDataTransfer;
 
-		dataTransferFallback._cache[ 'cke/id' ] = 'cache value';
+		dataTransfer._.data[ 'cke/id' ] = 'cache value';
 		CKEDITOR.plugins.clipboard.fallbackDataTransfer._customTypes.push( 'cke/id' );
 		nativeData.setData( dataTransferFallback._customDataFallbackType,
 			dataTransferFallback._applyDataComment( 'html', { 'cke/id': 'native value' } ) );

--- a/tests/plugins/clipboard/fallbackdatatransfer.js
+++ b/tests/plugins/clipboard/fallbackdatatransfer.js
@@ -260,18 +260,18 @@ bender.test( {
 			setValue;
 
 		setValue = dataTransferFallback.setData( 'cke/custom', 'custom data' );
-		assert.areSame( dataTransferFallback.getData( 'cke/custom' ), 'custom data' );
-		assert.areSame( setValue, isEdge16 ? getHtmlWithCustomData( '', { 'cke/custom': 'custom data' } ) : 'custom data' );
+		assert.areSame( dataTransferFallback.getData( 'cke/custom' ), 'custom data', 'cke/custom 1' );
+		assert.areSame( setValue, isEdge16 ? getHtmlWithCustomData( '', { 'cke/custom': 'custom data' } ) : 'custom data', 'return val 1' );
 
 		setValue = dataTransferFallback.setData( 'text/html', '<h1>Header1</h1>' );
-		assert.areSame( dataTransferFallback.getData( 'text/html' ), '<h1>Header1</h1>' );
-		assert.areSame( dataTransferFallback.getData( 'cke/custom' ), 'custom data' );
-		assert.areSame( setValue, getHtmlWithCustomData( '<h1>Header1</h1>', isEdge16 ? { 'cke/custom': 'custom data' } : null ) );
+		assert.areSame( dataTransferFallback.getData( 'text/html' ), '<h1>Header1</h1>', 'text/html 2' );
+		assert.areSame( dataTransferFallback.getData( 'cke/custom' ), 'custom data', 'cke/custom 2' );
+		assert.areSame( setValue, getHtmlWithCustomData( '<h1>Header1</h1>', isEdge16 ? { 'cke/custom': 'custom data' } : null ), 'return val 2' );
 
 		setValue = dataTransferFallback.setData( 'text/html', '<h2>Header2</h2>' );
-		assert.areSame( dataTransferFallback.getData( 'text/html' ), '<h2>Header2</h2>' );
-		assert.areSame( dataTransferFallback.getData( 'cke/custom' ), 'custom data' );
-		assert.areSame( setValue, getHtmlWithCustomData( '<h2>Header2</h2>', isEdge16 ? { 'cke/custom': 'custom data' } : null ) );
+		assert.areSame( dataTransferFallback.getData( 'text/html' ), '<h2>Header2</h2>', 'text/html 3' );
+		assert.areSame( dataTransferFallback.getData( 'cke/custom' ), 'custom data', 'cke/custom 3' );
+		assert.areSame( setValue, getHtmlWithCustomData( '<h2>Header2</h2>', isEdge16 ? { 'cke/custom': 'custom data' } : null ), 'return val 3' );
 	},
 
 	'test getting "text/html" and "cke/test" from cache': function() {
@@ -534,8 +534,8 @@ bender.test( {
 		dataTransfer.setData( 'custom/tag', '<p>custom html tag</p>' );
 		dataTransfer.setData( 'text/html', html );
 
-		assert.areSame( 'cke-custom data', dataTransfer.getData( 'cke/custom', true ) );
-		assert.areSame( '<p>custom html tag</p>', dataTransfer.getData( 'custom/tag', true ) );
+		assert.areSame( 'cke-custom data', dataTransfer.getData( 'cke/custom', true ), 'cke/custom value' );
+		assert.areSame( '<p>custom html tag</p>', dataTransfer.getData( 'custom/tag', true ), 'custom/tag value' );
 
 		if ( isEdge16 ) {
 			html = getHtmlWithCustomData( html, {
@@ -544,8 +544,7 @@ bender.test( {
 				'custom/tag': '<p>custom html tag</p>'
 			} );
 		}
-		assert.areSame( html, dataTransfer.getData( 'text/html', true ) );
-
+		assert.areSame( html, dataTransfer.getData( 'text/html', true ), 'text/html value' );
 	},
 
 	assertDataTransferType: function( dataTransfer, type, value, customValue ) {

--- a/tests/plugins/clipboard/fallbackdatatransfer.js
+++ b/tests/plugins/clipboard/fallbackdatatransfer.js
@@ -552,7 +552,7 @@ bender.test( {
 			value = getHtmlWithCustomData( value, customValue );
 		}
 
-		var nativeDataTransfer = dataTransfer.$ || dataTransfer._nativeDataTransfer;
+		var nativeDataTransfer = dataTransfer.$ || dataTransfer._dataTransfer.$;
 		assert.areSame( value, nativeDataTransfer.getData( type ) );
 	},
 


### PR DESCRIPTION
## What is the purpose of this pull request?

Other, PR corrections

### This PR contains

- [x] Unit tests
- [ ] Manual tests

## What changes did you make?

Corrections to #1233 PR.

Some docs adjustments, most notably `_stripHtml`. I felt like it's initial docs were not precise enough (I felt like it might remove just meta tags, which is not only the case). Actually I made a good use of inline comments within the function. :)

It also introduced `_dataTransfer` property to fallbackDataTransfer.

With my PR I have caught another small edge case that would fail.

See "test getData with getNative with custom type other sequence" in `tests/plugins/clipboard/fallbackdatatransfer.js`.