### PR TITLE
Corrected Balloon Toolbar CSS loading unit test for a built version of CKEditor

### DIFF
--- a/tests/plugins/balloontoolbar/cssloading.js
+++ b/tests/plugins/balloontoolbar/cssloading.js
@@ -11,6 +11,15 @@
 	var spy = sinon.spy( CKEDITOR.dom.document.prototype, 'appendStyleSheet' );
 
 	bender.test( {
+		_should: {
+			ignore: {
+				// Our release version is built with moono-lisa skin inlined, thus we can't
+				// test it against other skin. We don't have straight way to recognise editor's
+				// built version, such trick must be used (#1251).
+				'test loading css with path': CKEDITOR.revision !== '%REV%'
+			}
+		},
+
 		'test loading CSS with path': function() {
 			assert.areSame( 'kama,/apps/ckeditor/skins/kama/', CKEDITOR.skinName, 'Config skinName should be with path' );
 			sinon.assert.calledWith( spy, document.location.origin + '/apps/ckeditor/plugins/balloontoolbar/skins/kama/balloontoolbar.css' );

--- a/tests/plugins/balloontoolbar/cssloading.js
+++ b/tests/plugins/balloontoolbar/cssloading.js
@@ -16,7 +16,7 @@
 				// Our release version is built with moono-lisa skin inlined, thus we can't
 				// test it against other skin. We don't have straight way to recognise editor's
 				// built version, such trick must be used (#1251).
-				'test loading css with path': CKEDITOR.revision !== '%REV%'
+				'test loading CSS with path': CKEDITOR.revision !== '%REV%'
 			}
 		},
 


### PR DESCRIPTION
## What is the purpose of this pull request?

Bug fix

### This PR contains

- [x] Unit tests
- [ ] Manual tests

## What changes did you make?

Without this fix the test will try to load moono-lisa skin.

Similar to #1251.