### PR TITLE
Enable Upload Iamge plugin and prevent logging error in case of missing configuration

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -3,6 +3,10 @@
 
 ## CKEditor 4.8
 
+**Important Notes:**
+
+* [#1249](https://github.com/ckeditor/ckeditor-dev/issues/1249): Enabled the [Upload Image](https://ckeditor.com/cke4/addon/uploadimage) plugin by default in standard and full presets. Also it will no longer log an error in case of missing [`config.imageUploadUrl`](https://docs.ckeditor.com/ckeditor4/docs/#!/api/CKEDITOR.config-cfg-imageUploadUrl) property.
+
 New Features:
 
 * [#662](https://github.com/ckeditor/ckeditor-dev/issues/662): Introduced image inlining for the [Paste from Word](https://ckeditor.com/cke4/addon/pastefromword) plugin.

--- a/config.js
+++ b/config.js
@@ -67,6 +67,7 @@ CKEDITOR.editorConfig = function( config ) {
 		'templates,' +
 		'toolbar,' +
 		'undo,' +
+		'uploadimage,' +
 		'wysiwygarea';
 	// %REMOVE_END%
 };

--- a/dev/builder/build-config.js
+++ b/dev/builder/build-config.js
@@ -91,6 +91,7 @@ var CKBUILDER_CONFIG = {
 		templates: 1,
 		toolbar: 1,
 		undo: 1,
+		uploadimage: 1,
 		wysiwygarea: 1
 	}
 };

--- a/plugins/uploadimage/plugin.js
+++ b/plugins/uploadimage/plugin.js
@@ -50,7 +50,6 @@
 				uploadUrl = fileTools.getUploadUrl( editor.config, 'image' );
 
 			if ( !uploadUrl ) {
-				CKEDITOR.error( 'uploadimage-config' );
 				return;
 			}
 

--- a/tests/plugins/uploadimage/manual/configerror.md
+++ b/tests/plugins/uploadimage/manual/configerror.md
@@ -1,5 +1,5 @@
 @bender-ui: collapsed
-@bender-tags: 4.5.1, bug, trac13486, filetools
+@bender-tags: 4.5.1, bug, trac13486, 4.8.0, 1249, filetools
 @bender-ckeditor-plugins: uploadimage, wysiwygarea, toolbar, basicstyles
 
 Run this test with the console opened.
@@ -7,4 +7,4 @@ Run this test with the console opened.
 Expected:
 
 * Editor should be fully functional except the `uploadimage` plugin.
-* No errors on IE8-9, an error logged in the console that `upload URL` was not set on other browsers.
+* No errors in the console on any browser.

--- a/tests/plugins/uploadimage/uploadimage.js
+++ b/tests/plugins/uploadimage/uploadimage.js
@@ -577,6 +577,20 @@
 			} );
 
 			wait();
+		},
+
+		'test no error if missing configuration': function() {
+			var spy = sinon.spy( CKEDITOR, 'error' );
+
+			bender.editorBot.create( {
+				name: 'configerror_test',
+				extraPlugins: 'uploadimage'
+			}, function( bot ) {
+				spy.restore();
+
+				assert.areSame( 0, spy.callCount, 'CKEDITOR.error call count' );
+				assert.isFalse( !!bot.editor.widgets.registered.uploadimage, 'uploadimage widget' );
+			} );
 		}
 	} );
 } )();


### PR DESCRIPTION
## What is the purpose of this pull request?

Task

## Does your PR contain necessary tests?

All patches which change the editor code must include tests. You can always read more
on [PR testing](https://docs.ckeditor.com/ckeditor4/docs/#!/guide/dev_contributing_code-section-tests),
[how to set the testing environment](https://docs.ckeditor.com/ckeditor4/docs/#!/guide/dev_tests) and
[how to create tests](https://docs.ckeditor.com/ckeditor4/docs/#!/guide/dev_tests-section-creating-your-own-test)
in the official CKEditor documentation.

### This PR contains

- [x] Unit tests
- [x] Manual tests

## What changes did you make?

After this change `uploadimage` plugin does not throw error anymore, it silently returns.

Closes #1249.
