### PR TITLE
Corrected outdated property references in the clipboard plugin docs

### DIFF
--- a/plugins/clipboard/plugin.js
+++ b/plugins/clipboard/plugin.js
@@ -2825,7 +2825,7 @@
 
 		/**
 		 * Returns content stored in {@link #\_customDataFallbackType}. Content is always first retrieved
-		 * from {@link #_cache} and then from native `dataTransfer` object.
+		 * from {@link #_dataTransfer} cache and then from native `dataTransfer` object.
 		 *
 		 * @private
 		 * @returns {String}
@@ -2841,7 +2841,7 @@
 
 		/**
 		 * Returns custom data stored in {@link #\_customDataFallbackType}. Custom data is always first retrieved
-		 * from {@link #_cache} and then from native `dataTransfer` object.
+		 * from {@link #_dataTransfer} cache and then from native `dataTransfer` object.
 		 *
 		 * @private
 		 * @returns {Object}


### PR DESCRIPTION
## What is the purpose of this pull request?

Typo fix

## What changes did you make?

While removing `_cache` property, we missed two references in API docs.

Without this change following warnings were logged during building docs:

```
Warning: /mnt/c/Development/htdocs/ckSource/ckeditor-dev/plugins/clipboard/plugin.js:2826: {@link #_cache} links to non-existing member
Warning: /mnt/c/Development/htdocs/ckSource/ckeditor-dev/plugins/clipboard/plugin.js:2842: {@link #_cache} links to non-existing member
```

This PR fixes this issue.