### PR TITLE
Fix failing tests due to lack of 'document.location.origin'

### DIFF
--- a/tests/plugins/balloonpanel/_helpers/tools.js
+++ b/tests/plugins/balloonpanel/_helpers/tools.js
@@ -49,5 +49,13 @@ var balloonTestsTools = {
 		balloon.attach( elem );
 		// For some reason cke_reset_all overrides balloon styling in tests.
 		balloon.parts.panel.removeClass( 'cke_reset_all' );
+	},
+
+	getDocumentOrigin: function() {
+		// The `document.location.origin` is not available on IE8-10.
+		if ( !document.location.origin ) {
+			return document.location.protocol + '//' + document.location.hostname + ( document.location.port ? ':' + document.location.port : '' );
+		}
+		return document.location.origin;
 	}
 };

--- a/tests/plugins/balloonpanel/_helpers/tools.js
+++ b/tests/plugins/balloonpanel/_helpers/tools.js
@@ -52,7 +52,7 @@ var balloonTestsTools = {
 	},
 
 	getDocumentOrigin: function() {
-		// The `document.location.origin` is not available on IE8-10.
+		// The `document.location.origin` is not available on IE8-10 (#1276).
 		if ( !document.location.origin ) {
 			return document.location.protocol + '//' + document.location.hostname + ( document.location.port ? ':' + document.location.port : '' );
 		}

--- a/tests/plugins/balloonpanel/cssloading.js
+++ b/tests/plugins/balloonpanel/cssloading.js
@@ -1,5 +1,7 @@
 /* bender-tags: balloonpanel, bug, 4.8.0, 1221 */
 /* bender-ckeditor-plugins: balloonpanel */
+/* bender-include: _helpers/tools.js */
+/* global balloonTestsTools */
 
 ( function() {
 	'use strict';
@@ -21,7 +23,9 @@
 
 		'test loading css with path': function() {
 			assert.areSame( 'kama,/apps/ckeditor/skins/kama/', CKEDITOR.skinName, 'config skinName should be with path' );
-			sinon.assert.calledWith( spy, document.location.origin + '/apps/ckeditor/plugins/balloonpanel/skins/kama/balloonpanel.css' );
+			sinon.assert.calledWith( spy, balloonTestsTools.getDocumentOrigin() + '/apps/ckeditor/plugins/balloonpanel/skins/kama/balloonpanel.css' );
 		}
 	} );
+
+
 } )();

--- a/tests/plugins/balloontoolbar/cssloading.js
+++ b/tests/plugins/balloontoolbar/cssloading.js
@@ -1,5 +1,7 @@
 /* bender-tags: balloontoolbar */
 /* bender-ckeditor-plugins: balloontoolbar */
+/* bender-include: ../balloonpanel/_helpers/tools.js */
+/* global balloonTestsTools */
 
 ( function() {
 	'use strict';
@@ -22,7 +24,7 @@
 
 		'test loading CSS with path': function() {
 			assert.areSame( 'kama,/apps/ckeditor/skins/kama/', CKEDITOR.skinName, 'Config skinName should be with path' );
-			sinon.assert.calledWith( spy, document.location.origin + '/apps/ckeditor/plugins/balloontoolbar/skins/kama/balloontoolbar.css' );
+			sinon.assert.calledWith( spy, balloonTestsTools.getDocumentOrigin() + '/apps/ckeditor/plugins/balloontoolbar/skins/kama/balloontoolbar.css' );
 		}
 	} );
 } )();


### PR DESCRIPTION
## What is the purpose of this pull request?

Failing test fix

## Does your PR contain necessary tests?

All patches which change the editor code must include tests. You can always read more
on [PR testing](https://docs.ckeditor.com/ckeditor4/docs/#!/guide/dev_contributing_code-section-tests),
[how to set the testing environment](https://docs.ckeditor.com/ckeditor4/docs/#!/guide/dev_tests) and
[how to create tests](https://docs.ckeditor.com/ckeditor4/docs/#!/guide/dev_tests-section-creating-your-own-test)
in the official CKEditor documentation.

### This PR contains

- [ ] Unit tests
- [ ] Manual tests

## What changes did you make?

Closes #1276.
