### PR TITLE
Fixed failing Balloon Toolbar test on IE8

### DIFF
--- a/tests/plugins/balloontoolbar/view.js
+++ b/tests/plugins/balloontoolbar/view.js
@@ -29,7 +29,7 @@
 			view.renderItems( items );
 
 			var expectedOutput = CKEDITOR.env.ie ? '<span class="cke_toolgroup" unselectable="on">aabb</span>' : '<span class="cke_toolgroup">aabb</span>';
-			assert.areSame( expectedOutput, view.parts.content.getHtml() );
+			assert.beautified.html( expectedOutput, view.parts.content.getHtml() );
 		},
 
 		'test balloonToolbarView.render empty list': function() {


### PR DESCRIPTION
## What is the purpose of this pull request?

Bug fix

### This PR contains

- [x] Unit tests
- [ ] Manual tests

## What changes did you make?

Reason was very simple, IE8 returns HTML tags uppercased. It's preferred to use `assert.beautified.html` for HTML comparing.

Closes #1200.