### PR TITLE
Ignore manual tests related to balloon toolbar on old IE browsers.

### DIFF
--- a/tests/plugins/balloontoolbar/_helpers/default.js
+++ b/tests/plugins/balloontoolbar/_helpers/default.js
@@ -1,4 +1,4 @@
-/* exported stubAppendStyleSheet, convertRgbaToRgb */
+/* exported stubAppendStyleSheet, convertRgbaToRgb, ignoreUnsupportedEnvironment */
 
 'use strict';
 
@@ -15,4 +15,17 @@ function stubAppendStyleSheet() {
 function convertRgbaToRgb( input ) {
 	var re = /^rgba\(\s*\d+\s*,\s*\d+\s*,\s*\d+\s*,\s*\d+\s*\)$/gi;
 	return re.test( input ) ? input.replace( /,\s*?\d+?\s*?\)$/, ')' ).replace( 'rgba(', 'rgb(' ) : input;
+}
+
+function ignoreUnsupportedEnvironment( testSuite, check ) {
+	var isSupported = CKEDITOR.env.ie && CKEDITOR.env.version > 8;
+
+	testSuite._should = testSuite._should || {};
+	testSuite._should.ignore = testSuite._should.ignore || {};
+
+	for ( var key in testSuite ) {
+		if ( ( typeof check !== 'undefined' && !check ) || !isSupported ) {
+			testSuite._should.ignore[ key ] = true;
+		}
+	}
 }

--- a/tests/plugins/balloontoolbar/_helpers/default.js
+++ b/tests/plugins/balloontoolbar/_helpers/default.js
@@ -18,7 +18,7 @@ function convertRgbaToRgb( input ) {
 }
 
 function ignoreUnsupportedEnvironment( testSuite, check ) {
-	var isSupported = CKEDITOR.env.ie && CKEDITOR.env.version > 8;
+	var isSupported = !CKEDITOR.env.ie || CKEDITOR.env.version > 8;
 
 	testSuite._should = testSuite._should || {};
 	testSuite._should.ignore = testSuite._should.ignore || {};

--- a/tests/plugins/balloontoolbar/buttons.js
+++ b/tests/plugins/balloontoolbar/buttons.js
@@ -1,12 +1,14 @@
 /* bender-tags: balloontoolbar */
 /* bender-ckeditor-plugins: balloontoolbar,button,richcombo */
+/* bender-include: _helpers/default.js */
+/* global ignoreUnsupportedEnvironment */
 
 ( function() {
 	'use strict';
 
 	bender.editor = {};
 
-	bender.test( {
+	var tests = {
 		'test adding buttion': function() {
 			var panel = new CKEDITOR.ui.balloonToolbar( this.editor );
 			panel.addItems( {
@@ -110,5 +112,8 @@
 			panel._view.renderItems( panel._items );
 			assert.areEqual( 2, panel._view.parts.content.find( '.cke_toolgroup' ).count(), 'There should be two toolgroups' );
 		}
-	} );
+	};
+
+	ignoreUnsupportedEnvironment( tests );
+	bender.test( tests );
 } )();

--- a/tests/plugins/balloontoolbar/context.js
+++ b/tests/plugins/balloontoolbar/context.js
@@ -9,12 +9,6 @@
 	bender.editor = {};
 
 	var tests = {
-		setUp: function() {
-			if ( CKEDITOR.env.ie && CKEDITOR.env.version === 8 ) {
-				assert.ignore();
-			}
-		},
-
 		tearDown: function() {
 			this.editor.balloonToolbars._clear();
 		},

--- a/tests/plugins/balloontoolbar/context.js
+++ b/tests/plugins/balloontoolbar/context.js
@@ -1,12 +1,14 @@
 /* bender-tags: balloontoolbar, context */
 /* bender-ckeditor-plugins: balloontoolbar */
+/* bender-include: _helpers/default.js */
+/* global ignoreUnsupportedEnvironment */
 
 ( function() {
 	'use strict';
 
 	bender.editor = {};
 
-	bender.test( {
+	var tests = {
 		setUp: function() {
 			if ( CKEDITOR.env.ie && CKEDITOR.env.version === 8 ) {
 				assert.ignore();
@@ -32,5 +34,8 @@
 			assert.isInstanceOf( ContextTypeStub, ret, 'Ret type' );
 			sinon.assert.calledWithExactly( ContextTypeStub, this.editor, {} );
 		}
-	} );
+	};
+
+	ignoreUnsupportedEnvironment( tests );
+	bender.test( tests );
 } )();

--- a/tests/plugins/balloontoolbar/cssdefault.js
+++ b/tests/plugins/balloontoolbar/cssdefault.js
@@ -1,7 +1,7 @@
 /* bender-tags: balloontoolbar */
 /* bender-ckeditor-plugins: toolbar,balloontoolbar,basicstyles */
 /* bender-include: ./_helpers/default.js */
-/* global stubAppendStyleSheet */
+/* global ignoreUnsupportedEnvironment, stubAppendStyleSheet */
 
 ( function() {
 	'use strict';
@@ -58,5 +58,6 @@
 	};
 
 	tests = bender.tools.createTestsForEditors( CKEDITOR.tools.objectKeys( bender.editors ), tests );
+	ignoreUnsupportedEnvironment( tests );
 	bender.test( tests );
 } )();

--- a/tests/plugins/balloontoolbar/cssloading.js
+++ b/tests/plugins/balloontoolbar/cssloading.js
@@ -18,7 +18,8 @@
 				// Our release version is built with moono-lisa skin inlined, thus we can't
 				// test it against other skin. We don't have straight way to recognise editor's
 				// built version, such trick must be used (#1251).
-				'test loading CSS with path': CKEDITOR.revision !== '%REV%'
+				'test loading CSS with path': CKEDITOR.revision !== '%REV%' ||
+					( CKEDITOR.env.ie && CKEDITOR.env.version < 9 )
 			}
 		},
 

--- a/tests/plugins/balloontoolbar/cssskin.js
+++ b/tests/plugins/balloontoolbar/cssskin.js
@@ -1,7 +1,7 @@
 /* bender-tags: balloontoolbar */
 /* bender-ckeditor-plugins: toolbar,balloontoolbar,basicstyles */
 /* bender-include: ./_helpers/default.js */
-/* global convertRgbaToRgb */
+/* global ignoreUnsupportedEnvironment, convertRgbaToRgb */
 
 ( function() {
 	'use strict';
@@ -59,5 +59,6 @@
 	};
 
 	tests = bender.tools.createTestsForEditors( CKEDITOR.tools.objectKeys( bender.editors ), tests );
+	ignoreUnsupportedEnvironment( tests );
 	bender.test( tests );
 } )();

--- a/tests/plugins/balloontoolbar/loading.js
+++ b/tests/plugins/balloontoolbar/loading.js
@@ -1,12 +1,14 @@
 /* bender-tags: balloontoolbar */
 /* bender-ckeditor-plugins: balloontoolbar */
+/* bender-include: _helpers/default.js */
+/* global ignoreUnsupportedEnvironment */
 
 ( function() {
 	'use strict';
 
 	bender.editor = {};
 
-	bender.test( {
+	var tests = {
 		'test prototype overwriting': function() {
 			CKEDITOR.ui.balloonToolbarView.prototype.isItOk = true;
 			bender.editorBot.create( { name: 'editor1' }, function() {
@@ -14,5 +16,8 @@
 			} );
 		}
 
-	} );
+	};
+
+	ignoreUnsupportedEnvironment( tests );
+	bender.test( tests );
 } )();

--- a/tests/plugins/balloontoolbar/manual/balloontoolbar.html
+++ b/tests/plugins/balloontoolbar/manual/balloontoolbar.html
@@ -17,6 +17,11 @@
 	<p>Armstrong spent about&nbsp;<s>three and a half</s>&nbsp;two and a half hours <strong>outside the spacecraft</strong>, Aldrin slightly less; and together they collected 47.5 pounds (21.5&nbsp;kg) of lunar material for return to Earth. A third member of the mission,&nbsp;Michael Collins, piloted the&nbsp;command&nbsp;<strong>spacecraft alone in lunar</strong> orbit until Armstrong and Aldrin <strong>returned to it for the trip</strong> back to Earth.</p>
 </div>
 <script>
+	// Currently balloon toolbar is not integrated with old IE browsers.
+	if ( CKEDITOR.env.ie && CKEDITOR.env.version < 9 ) {
+		bender.ignore();
+	}
+
 	CKEDITOR.disableAutoInline = true;
 
 	function instanceReadyListener( evt ) {

--- a/tests/plugins/balloontoolbar/manual/drag.html
+++ b/tests/plugins/balloontoolbar/manual/drag.html
@@ -36,6 +36,11 @@
 </div>
 
 <script>
+	// Currently balloon toolbar is not integrated with old IE browsers.
+	if ( CKEDITOR.env.ie && CKEDITOR.env.version < 9 ) {
+		bender.ignore();
+	}
+
 	CKEDITOR.disableAutoInline = true;
 	function instanceReadyListener( evt ) {
 		var image = this.editable().findOne( 'img' ),

--- a/tests/plugins/balloontoolbar/manual/fallbackstyles.html
+++ b/tests/plugins/balloontoolbar/manual/fallbackstyles.html
@@ -37,7 +37,7 @@
 </div>
 
 <script>
-	if ( CKEDITOR.env.ie && CKEDITOR.env.version < 11 ) {
+	if ( CKEDITOR.env.ie && CKEDITOR.env.version < 9 ) {
 		bender.ignore();
 	}
 	function instanceReadyListener( evt ) {

--- a/tests/plugins/balloontoolbar/manual/focus.html
+++ b/tests/plugins/balloontoolbar/manual/focus.html
@@ -39,6 +39,11 @@
 </div>
 
 <script>
+	// Currently balloon toolbar is not integrated with old IE browsers.
+	if ( CKEDITOR.env.ie && CKEDITOR.env.version < 9 ) {
+		bender.ignore();
+	}
+
 	CKEDITOR.disableAutoInline = true;
 	function instanceReadyListener( evt ) {
 		var image = this.editable().findOne( 'img' ),

--- a/tests/plugins/balloontoolbar/manual/kama.html
+++ b/tests/plugins/balloontoolbar/manual/kama.html
@@ -37,7 +37,7 @@
 
 <script>
 	// Currently balloon toolbar is not integrated with old IE browsers.
-	if ( CKEDITOR.env.ie && CKEDITOR.env.version < 11 ) {
+	if ( CKEDITOR.env.ie && CKEDITOR.env.version < 9 ) {
 		bender.ignore();
 	}
 	CKEDITOR.disableAutoInline = true;

--- a/tests/plugins/balloontoolbar/manual/kama.html
+++ b/tests/plugins/balloontoolbar/manual/kama.html
@@ -36,6 +36,10 @@
 </div>
 
 <script>
+	// Currently balloon toolbar is not integrated with old IE browsers.
+	if ( CKEDITOR.env.ie && CKEDITOR.env.version < 11 ) {
+		bender.ignore();
+	}
 	CKEDITOR.disableAutoInline = true;
 
 	function instanceReadyListener( evt ) {

--- a/tests/plugins/balloontoolbar/manual/moono-lisa.html
+++ b/tests/plugins/balloontoolbar/manual/moono-lisa.html
@@ -37,7 +37,7 @@
 
 <script>
 	// Currently balloon toolbar is not integrated with old IE browsers.
-	if ( CKEDITOR.env.ie && CKEDITOR.env.version < 11 ) {
+	if ( CKEDITOR.env.ie && CKEDITOR.env.version < 9 ) {
 		bender.ignore();
 	}
 	CKEDITOR.disableAutoInline = true;

--- a/tests/plugins/balloontoolbar/manual/moono-lisa.html
+++ b/tests/plugins/balloontoolbar/manual/moono-lisa.html
@@ -36,6 +36,10 @@
 </div>
 
 <script>
+	// Currently balloon toolbar is not integrated with old IE browsers.
+	if ( CKEDITOR.env.ie && CKEDITOR.env.version < 11 ) {
+		bender.ignore();
+	}
 	CKEDITOR.disableAutoInline = true;
 
 	function instanceReadyListener( evt ) {

--- a/tests/plugins/balloontoolbar/manual/moono.html
+++ b/tests/plugins/balloontoolbar/manual/moono.html
@@ -37,7 +37,7 @@
 
 <script>
 	// Currently balloon toolbar is not integrated with old IE browsers.
-	if ( CKEDITOR.env.ie && CKEDITOR.env.version < 11 ) {
+	if ( CKEDITOR.env.ie && CKEDITOR.env.version < 9 ) {
 		bender.ignore();
 	}
 	CKEDITOR.disableAutoInline = true;

--- a/tests/plugins/balloontoolbar/manual/moono.html
+++ b/tests/plugins/balloontoolbar/manual/moono.html
@@ -36,6 +36,10 @@
 </div>
 
 <script>
+	// Currently balloon toolbar is not integrated with old IE browsers.
+	if ( CKEDITOR.env.ie && CKEDITOR.env.version < 11 ) {
+		bender.ignore();
+	}
 	CKEDITOR.disableAutoInline = true;
 
 	function instanceReadyListener( evt ) {

--- a/tests/plugins/balloontoolbar/manual/skinpath.html
+++ b/tests/plugins/balloontoolbar/manual/skinpath.html
@@ -11,6 +11,11 @@
 </textarea>
 
 <script>
+	// Currently balloon toolbar is not integrated with old IE browsers.
+	if ( CKEDITOR.env.ie && CKEDITOR.env.version < 9 ) {
+		bender.ignore();
+	}
+
 	CKEDITOR.disableAutoInline = true;
 
 	function instanceReadyListener( evt ) {

--- a/tests/plugins/balloontoolbar/positioning.js
+++ b/tests/plugins/balloontoolbar/positioning.js
@@ -1,5 +1,7 @@
 /* bender-tags: balloontoolbar */
 /* bender-ckeditor-plugins: toolbar,link,balloontoolbar */
+/* bender-include: _helpers/default.js */
+/* global ignoreUnsupportedEnvironment */
 
 ( function() {
 	'use strict';
@@ -129,5 +131,6 @@
 	};
 
 	tests = bender.tools.createTestsForEditors( CKEDITOR.tools.objectKeys( bender.editors ), tests );
+	ignoreUnsupportedEnvironment( tests );
 	bender.test( tests );
 } )();

--- a/tests/plugins/balloontoolbar/view.js
+++ b/tests/plugins/balloontoolbar/view.js
@@ -1,5 +1,7 @@
 /* bender-tags: balloontoolbar */
 /* bender-ckeditor-plugins: balloontoolbar */
+/* bender-include: _helpers/default.js */
+/* global ignoreUnsupportedEnvironment */
 
 ( function() {
 	'use strict';
@@ -10,7 +12,7 @@
 		}
 	};
 
-	bender.test( {
+	var tests = {
 		'test balloonToolbarView.render': function() {
 			var view = new CKEDITOR.ui.balloonToolbarView( this.editor ),
 				items = {
@@ -85,5 +87,8 @@
 				view.destroy();
 			} );
 		}
-	} );
+	};
+
+	ignoreUnsupportedEnvironment( tests );
+	bender.test( tests );
 } )();


### PR DESCRIPTION
## What is the purpose of this pull request?

Other, please explain:
Test update

## Does your PR contain necessary tests?

All patches which change the editor code must include tests. You can always read more
on [PR testing](https://docs.ckeditor.com/ckeditor4/docs/#!/guide/dev_contributing_code-section-tests),
[how to set the testing environment](https://docs.ckeditor.com/ckeditor4/docs/#!/guide/dev_tests) and
[how to create tests](https://docs.ckeditor.com/ckeditor4/docs/#!/guide/dev_tests-section-creating-your-own-test)
in the official CKEditor documentation.

### This PR contains

- [ ] Unit tests
- [ ] Manual tests

## What changes did you make?

- add ignore option in manual test for balloon toolbar
