### PR TITLE
Ignore two unstable tests for balloontoolbar

### DIFF
--- a/tests/plugins/balloontoolbar/positioning.js
+++ b/tests/plugins/balloontoolbar/positioning.js
@@ -53,6 +53,10 @@
 		},
 
 		'test divaera - out of view - bottom center': function( editor ) {
+			// Due to a high unstability of this test, that fails on mobile devices, small screens
+			// and when devtools are open, it's disabled for 4.8.0 release (#1296)
+			assert.ignore();
+
 			if ( editor.name == 'divarea' ) {
 				// divarea tests are failing, it's an upstream issue from balloonpanel (#1064).
 				assert.ignore();
@@ -80,6 +84,10 @@
 		},
 
 		'test divaera - out of view - hcenter top': function( editor ) {
+			// Due to a high unstability of this test, that fails on mobile devices, small screens
+			// and when devtools are open, it's disabled for 4.8.0 release (#1296)
+			assert.ignore();
+
 			if ( editor.name == 'divarea' ) {
 				// divarea tests are failing, it's an upstream issue from balloonpanel (#1064).
 				assert.ignore();

--- a/tests/plugins/balloontoolbar/positioning.js
+++ b/tests/plugins/balloontoolbar/positioning.js
@@ -53,8 +53,8 @@
 		},
 
 		'test divaera - out of view - bottom center': function( editor ) {
-			// Due to a high unstability of this test, that fails on mobile devices, small screens
-			// and when devtools are open, it's disabled for 4.8.0 release (#1295)
+			// Due to a high instability of this test, that fails on mobile devices, small screens
+			// and when devtools are open, it's disabled for 4.8.0 release (#1295).
 			assert.ignore();
 
 			if ( editor.name == 'divarea' ) {
@@ -84,8 +84,8 @@
 		},
 
 		'test divaera - out of view - hcenter top': function( editor ) {
-			// Due to a high unstability of this test, that fails on mobile devices, small screens
-			// and when devtools are open, it's disabled for 4.8.0 release (#1295)
+			// Due to a high instability of this test, that fails on mobile devices, small screens
+			// and when devtools are open, it's disabled for 4.8.0 release (#1295).
 			assert.ignore();
 
 			if ( editor.name == 'divarea' ) {

--- a/tests/plugins/balloontoolbar/positioning.js
+++ b/tests/plugins/balloontoolbar/positioning.js
@@ -54,7 +54,7 @@
 
 		'test divaera - out of view - bottom center': function( editor ) {
 			// Due to a high unstability of this test, that fails on mobile devices, small screens
-			// and when devtools are open, it's disabled for 4.8.0 release (#1296)
+			// and when devtools are open, it's disabled for 4.8.0 release (#1295)
 			assert.ignore();
 
 			if ( editor.name == 'divarea' ) {
@@ -85,7 +85,7 @@
 
 		'test divaera - out of view - hcenter top': function( editor ) {
 			// Due to a high unstability of this test, that fails on mobile devices, small screens
-			// and when devtools are open, it's disabled for 4.8.0 release (#1296)
+			// and when devtools are open, it's disabled for 4.8.0 release (#1295)
 			assert.ignore();
 
 			if ( editor.name == 'divarea' ) {


### PR DESCRIPTION
## What is the purpose of this pull request?

Fix for failing tests

## Does your PR contain necessary tests?

All patches which change the editor code must include tests. You can always read more
on [PR testing](https://docs.ckeditor.com/ckeditor4/docs/#!/guide/dev_contributing_code-section-tests),
[how to set the testing environment](https://docs.ckeditor.com/ckeditor4/docs/#!/guide/dev_tests) and
[how to create tests](https://docs.ckeditor.com/ckeditor4/docs/#!/guide/dev_tests-section-creating-your-own-test)
in the official CKEditor documentation.

### This PR contains

- [ ] Unit tests
- [ ] Manual tests

## What changes did you make?

Added ignore for two failing tests, see https://github.com/ckeditor/ckeditor-dev/issues/1295#issuecomment-348498506 for details.
