### PR TITLE
Prevent of loading widgets if querrySelectorAll is undefiend

### DIFF
--- a/plugins/widget/plugin.js
+++ b/plugins/widget/plugin.js
@@ -18,6 +18,10 @@
 		// jscs:enable maximumLineLength
 		requires: 'lineutils,clipboard,widgetselection',
 		onLoad: function() {
+			// Widgets require querySelectorAll for proper work (#1319).
+			if ( CKEDITOR.document.$.querySelectorAll === undefined ) {
+				return;
+			}
 			CKEDITOR.addCss(
 				'.cke_widget_wrapper{' +
 					'position:relative;' +
@@ -85,6 +89,10 @@
 		},
 
 		beforeInit: function( editor ) {
+			// Widgets require querySelectorAll for proper work (#1319).
+			if ( CKEDITOR.document.$.querySelectorAll === undefined ) {
+				return;
+			}
 			/**
 			 * An instance of widget repository. It contains all
 			 * {@link CKEDITOR.plugins.widget.repository#registered registered widget definitions} and
@@ -105,6 +113,10 @@
 		},
 
 		afterInit: function( editor ) {
+			// Widgets require querySelectorAll for proper work (#1319).
+			if ( CKEDITOR.document.$.querySelectorAll === undefined ) {
+				return;
+			}
 			addWidgetButtons( editor );
 			setupContextMenu( editor );
 		}


### PR DESCRIPTION
## What is the purpose of this pull request?

Bug fix

### This PR contains

- [ ] Unit tests
- [ ] Manual tests

## What changes did you make?

- prevent of running widget if `querrySelectorAll` is unavaialble

close #1319 