### PR TITLE
Balloon toolbar now register its items in focusmanager

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -5,6 +5,7 @@
 
 Fixed Issues:
 
+* [#1232](https://github.com/ckeditor/ckeditor-dev/issues/1232): Fixed: [Balloon Toolbar](https://ckeditor.com/cke4/addon/balloontoolbar) buttons should be registered as focusable elements.
 * [#1342](https://github.com/ckeditor/ckeditor-dev/issues/1342): Fixed: [Balloon Toolbar](https://ckeditor.com/cke4/addon/balloontoolbar) should be re-positioned after a [change](https://docs.ckeditor.com/ckeditor4/docs/#!/api/CKEDITOR.editor-event-change) event.
 * [#1048](https://github.com/ckeditor/ckeditor-dev/issues/1048): Fixed: [Balloon Panel](https://ckeditor.com/cke4/addon/balloonpanel) is not properly positioned when margin added to its non-static parent.
 * [#889](https://github.com/ckeditor/ckeditor-dev/issues/889): Fixed: Unclear error message for width and height fields in [Image](https://ckeditor.com/cke4/addon/image) and [Enhanced Image](https://ckeditor.com/cke4/addon/image2) plugins.

--- a/plugins/balloontoolbar/plugin.js
+++ b/plugins/balloontoolbar/plugin.js
@@ -663,7 +663,7 @@
 			};
 
 			CKEDITOR.ui.balloonToolbarView.prototype.destroy = function() {
-				this.deregisterFocusableItems();
+				this._deregisterItemFocusables();
 				CKEDITOR.ui.balloonPanel.prototype.destroy.call( this );
 				this._detachListeners();
 			};
@@ -680,7 +680,7 @@
 					groupStarted = false;
 
 				// When we rerender toolbar we want to clear focusable in case of removing some items.
-				this.deregisterFocusableItems();
+				this._deregisterItemFocusables();
 
 				CKEDITOR.tools.array.forEach( keys, function( itemKey ) {
 
@@ -728,19 +728,17 @@
 			};
 
 			/**
-			 * Method deregister all focusable items from balloontoolbar.
+			 * Method deregisters {@link #focusables} registered by UI items, like buttons.
 			 *
 			 * @private
 			 * @since 4.8.1
 			 * @member CKEDITOR.ui.balloonToolbarView
 			 */
-			CKEDITOR.ui.balloonToolbarView.prototype.deregisterFocusableItems = function() {
+			CKEDITOR.ui.balloonToolbarView.prototype._deregisterItemFocusables = function() {
 				var focusables = this.focusables;
 				for ( var id in focusables ) {
-					if ( focusables.hasOwnProperty( id ) ) {
-						if ( focusables[ id ].getId() && focusables[ id ].getName() === 'a' ) {
-							this.deregisterFocusable( focusables[ id ] );
-						}
+					if ( this.parts.content.contains( focusables[ id ] ) ) {
+						this.deregisterFocusable( focusables[ id ] );
 					}
 				}
 			};

--- a/plugins/balloontoolbar/plugin.js
+++ b/plugins/balloontoolbar/plugin.js
@@ -34,12 +34,6 @@
 		 * @private
 		 */
 		this._listeners = [];
-
-		/**
-		 * Reference to {@link CKEDITOR.dom.element} belong to rendered items inside {@link CKEDITOR.ui.balloonToolbar}.
-		 * Array is necessary to clear out those items from {@link CKEDITOR.focusManager}.
-		 */
-		this._focusablesItems = [];
 	};
 
 	/**
@@ -667,7 +661,7 @@
 			};
 
 			CKEDITOR.ui.balloonToolbarView.prototype.destroy = function() {
-				deregisterAllFocusableItems.call( this, this._focusablesItems );
+				this.deregisterFocusableItems();
 				CKEDITOR.ui.balloonPanel.prototype.destroy.call( this );
 				this._detachListeners();
 			};
@@ -684,7 +678,7 @@
 					groupStarted = false;
 
 				// When we rerender toolbar we want to clear focusable in case of removing some items.
-				deregisterAllFocusableItems.call( this, this._focusablesItems );
+				this.deregisterFocusableItems();
 
 				CKEDITOR.tools.array.forEach( keys, function( itemKey ) {
 
@@ -711,7 +705,6 @@
 				CKEDITOR.tools.array.forEach( this.parts.content.find( 'a' ).toArray(), function( element ) {
 					element.setAttribute( 'draggable', 'false' );
 					this.registerFocusable( element );
-					this._focusablesItems.push( element );
 				}, this );
 			};
 
@@ -732,15 +725,23 @@
 				CKEDITOR.ui.balloonPanel.prototype.attach.call( this, element, options );
 			};
 
-			// We don't want to expose this method as it should be called only in very specific moments:
-			// 1. Rendering view to clear out toolbar from possible deleted items.
-			// 2. Destroying view.
-			function deregisterAllFocusableItems( elements ) {
-				var element;
-				while ( element = elements.pop() ) {
-					CKEDITOR.ui.balloonPanel.prototype.deregisterFocusable.call( this, element );
+			/**
+			 * Method deregister all focusable items from balloontoolbar.
+			 *
+			 * @private
+			 * @since 4.8.1
+			 * @member CKEDITOR.ui.balloonToolbarView
+			 */
+			CKEDITOR.ui.balloonToolbarView.prototype.deregisterFocusableItems = function() {
+				var focusables = this.focusables;
+				for ( var id in focusables ) {
+					if ( focusables.hasOwnProperty( id ) ) {
+						if ( focusables[ id ].getId() && focusables[ id ].getName() === 'a' ) {
+							this.deregisterFocusable( focusables[ id ] );
+						}
+					}
 				}
-			}
+			};
 		}
 	} );
 

--- a/plugins/balloontoolbar/plugin.js
+++ b/plugins/balloontoolbar/plugin.js
@@ -593,6 +593,8 @@
 				CKEDITOR.ui.balloonPanel.prototype.build.call( this );
 				this.parts.panel.addClass( 'cke_balloontoolbar' );
 				this.parts.title.remove();
+				// Following workaround is needed until #1370 is resolved.
+				this.deregisterFocusable( this.parts.close );
 				this.parts.close.remove();
 			};
 

--- a/plugins/balloontoolbar/plugin.js
+++ b/plugins/balloontoolbar/plugin.js
@@ -34,6 +34,12 @@
 		 * @private
 		 */
 		this._listeners = [];
+
+		/**
+		 * Reference to {@link CKEDITOR.dom.element} belong to rendered items inside {@link CKEDITOR.ui.balloonToolbar}.
+		 * Array is necessary to clear out those items from {@link CKEDITOR.focusManager}.
+		 */
+		this._focusablesItems = [];
 	};
 
 	/**
@@ -163,6 +169,8 @@
 	CKEDITOR.ui.balloonToolbar.prototype.deleteItem = function( name ) {
 		if ( this._items[ name ] ) {
 			delete this._items[ name ];
+			// Redraw balloon toolbar when item is removed.
+			this._view.renderItems( this._items );
 		}
 	};
 
@@ -659,6 +667,7 @@
 			};
 
 			CKEDITOR.ui.balloonToolbarView.prototype.destroy = function() {
+				deregisterAllFocusableItems.call( this, this._focusablesItems );
 				CKEDITOR.ui.balloonPanel.prototype.destroy.call( this );
 				this._detachListeners();
 			};
@@ -674,6 +683,9 @@
 					keys = CKEDITOR.tools.objectKeys( items ),
 					groupStarted = false;
 
+				// When we rerender toolbar we want to clear focusable in case of removing some items.
+				deregisterAllFocusableItems.call( this, this._focusablesItems );
+
 				CKEDITOR.tools.array.forEach( keys, function( itemKey ) {
 
 					// If next element to render is richCombo and we have already opened group we have to close it.
@@ -685,7 +697,6 @@
 						groupStarted = true;
 						output.push( '<span class="cke_toolgroup">' );
 					}
-
 					// Now we can render element.
 					items[ itemKey ].render( this.editor, output );
 				}, this );
@@ -699,7 +710,9 @@
 				this.parts.content.unselectable();
 				CKEDITOR.tools.array.forEach( this.parts.content.find( 'a' ).toArray(), function( element ) {
 					element.setAttribute( 'draggable', 'false' );
-				} );
+					this.registerFocusable( element );
+					this._focusablesItems.push( element );
+				}, this );
 			};
 
 			/**
@@ -718,6 +731,16 @@
 
 				CKEDITOR.ui.balloonPanel.prototype.attach.call( this, element, options );
 			};
+
+			// We don't want to expose this method as it should be called only in very specific moments:
+			// 1. Rendering view to clear out toolbar from possible deleted items.
+			// 2. Destroying view.
+			function deregisterAllFocusableItems( elements ) {
+				var element;
+				while ( element = elements.pop() ) {
+					CKEDITOR.ui.balloonPanel.prototype.deregisterFocusable.call( this, element );
+				}
+			}
 		}
 	} );
 

--- a/tests/plugins/balloontoolbar/context/focusablebuttons.js
+++ b/tests/plugins/balloontoolbar/context/focusablebuttons.js
@@ -1,0 +1,87 @@
+/* bender-tags: balloontoolbar */
+/* bender-ckeditor-plugins: balloontoolbar, basicstyles, button, toolbar */
+
+( function() {
+	'use strict';
+
+	bender.editor = {
+		startupData: '<p>Hello <strong>world</strong>.</p>',
+		config: {
+			extraAllowedContent: 'strong em'
+		}
+	};
+
+	bender.test( {
+		'test check if balloon toolbar elements are registered as focusable': function() {
+			var editor = this.editor,
+				toolbar = new CKEDITOR.ui.balloonToolbar( editor ),
+				before,
+				afterAdding,
+				afterDeleting;
+
+			toolbar.addItem( 'Bold', new CKEDITOR.ui.button( {
+				label: 'Bold',
+				command: 'bold'
+			} ) );
+
+			before = CKEDITOR.tools.objectKeys( toolbar._view.focusables );
+
+			toolbar.attach( editor.editable().findOne( 'strong' ) );
+			afterAdding = CKEDITOR.tools.objectKeys( toolbar._view.focusables );
+
+			toolbar.deleteItem( 'Bold' );
+			afterDeleting = CKEDITOR.tools.objectKeys( toolbar._view.focusables );
+
+			assert.isFalse( CKEDITOR.tools.arrayCompare( before, afterAdding ), 'After adding new button, there should appear new focusables.' );
+			assert.isFalse( CKEDITOR.tools.arrayCompare( afterAdding, afterDeleting ), 'After removing button, there should be removed focusables.' );
+			assert.isTrue( CKEDITOR.tools.arrayCompare( before, afterDeleting ), 'After adding and then removing button, focusables should be the same.' );
+			toolbar.destroy();
+		},
+
+		'test focusing toolbar doesn\'t blur editor': function() {
+			var editor = this.editor,
+				context = editor.balloonToolbars.create( {
+					buttons: 'Bold,Italic',
+					cssSelector: 'strong'
+				} ),
+				blurSpy = sinon.spy();
+
+			editor.focus();
+			editor.on( 'blur', blurSpy, null, null, 10000 );
+
+			context.show( editor.editable().findOne( 'strong' ) );
+			context.toolbar._view._focusablesItems[ 0 ].once( 'focus', function() {
+				// Blur is delayed a little bit, that's why, it's necessary to wait more than this delay to check result.
+				// https://github.com/ckeditor/ckeditor-dev/blob/230f715926634e4056a87a572c94707c4190921c/core/focusmanager.js#L72
+				setTimeout( function() {
+					resume( function() {
+						assert.isFalse( blurSpy.called, 'Editor should remain focused, when balloontoolbar is focused.' );
+						context.destroy();
+					} );
+				}, 210 );
+			} );
+
+			setTimeout( function() {
+				context.toolbar._view._focusablesItems[ 0 ].focus();
+			}, 0 );
+			wait();
+		},
+
+		'test destroying toolbar will unregister focusables': function() {
+			var editor = this.editor,
+				context = editor.balloonToolbars.create( {
+					buttons: 'Bold,Italic',
+					cssSelector: 'strong'
+				} );
+
+			editor.focus();
+			context.show( editor.editable().findOne( 'strong' ) );
+
+			arrayAssert.isNotEmpty( context.toolbar._view._focusablesItems );
+
+			context.destroy();
+			arrayAssert.isEmpty( context.toolbar._view._focusablesItems );
+		}
+	} );
+
+} )();

--- a/tests/plugins/balloontoolbar/context/focusablebuttons.js
+++ b/tests/plugins/balloontoolbar/context/focusablebuttons.js
@@ -11,27 +11,36 @@
 		}
 	};
 
+	// Looks for a key of an element in a given dictionary.
+	// @param {Object.<string, CKEDITOR.dom.element>} dict
+	// @param {CKEDITOR.dom.element} needle
+	// @returns {string/undefined}
+	function indexOfElement( dict, needle ) {
+		return CKEDITOR.tools.array.filter( CKEDITOR.tools.objectKeys( dict ), function( key ) {
+			return needle.equals( dict[ key ] );
+		} )[ 0 ];
+	}
+
 	bender.test( {
 		'test if balloon toolbar elements are registered as focusable': function() {
 			var editor = this.editor,
 				toolbar = new CKEDITOR.ui.balloonToolbar( editor ),
-				oldFocusables;
+				focusables,
+				boldButton;
 
 			toolbar.addItem( 'Bold', new CKEDITOR.ui.button( {
 				label: 'Bold',
 				command: 'bold'
 			} ) );
 
-			oldFocusables = CKEDITOR.tools.objectKeys( toolbar._view.focusables );
 			toolbar.attach( editor.editable().findOne( 'strong' ) );
-			assert.isFalse( CKEDITOR.tools.arrayCompare( oldFocusables, CKEDITOR.tools.objectKeys( toolbar._view.focusables ) ),
-				'With new button, its element should appear in focusables' );
+			boldButton = toolbar._view.parts.panel.findOne( '.cke_button__bold' );
+			focusables = toolbar._view.focusables;
 
+			assert.isNotUndefined( -1, indexOfElement( focusables, boldButton ), 'Button is contained in focusable list' );
 
-			oldFocusables = CKEDITOR.tools.objectKeys( toolbar._view.focusables );
 			toolbar.deleteItem( 'Bold' );
-			assert.isFalse( CKEDITOR.tools.arrayCompare( oldFocusables, CKEDITOR.tools.objectKeys( toolbar._view.focusables ) ),
-				'With removing button, its element should be removed from focusables' );
+			assert.isUndefined( indexOfElement( focusables, boldButton ), 'Button was removed from focusable list' );
 
 			toolbar.destroy();
 		},
@@ -74,24 +83,23 @@
 					buttons: 'Bold,Italic',
 					cssSelector: 'strong'
 				} ),
-				focusables,
-				buttonList = [];
+				buttonList = [],
+				focusables;
 
 			editor.focus();
 			context.show( editor.editable().findOne( 'strong' ) );
 			context.destroy();
 
 			focusables = context.toolbar._view.focusables;
+
 			// Create list of buttons element in balloontoolbar.
 			for ( var id in focusables ) {
-				if ( focusables.hasOwnProperty( id ) ) {
-					if ( focusables[ id ].getId() ) {
-						buttonList.push( id );
-					}
+				if ( focusables[ id ].getName() == 'a' ) {
+					buttonList.push( focusables[ id ] );
 				}
 			}
 
-			arrayAssert.isEmpty( buttonList, 'Balloontoolbar should be empty' );
+			arrayAssert.isEmpty( buttonList, 'Focusable list should be empty' );
 		}
 	} );
 

--- a/tests/plugins/balloontoolbar/context/manual/focusablebuttons.html
+++ b/tests/plugins/balloontoolbar/context/manual/focusablebuttons.html
@@ -1,0 +1,42 @@
+<style>
+	body {
+		position: static;
+	}
+</style>
+
+<h2>Classic editor</h2>
+<textarea id="classic">
+	<p>Hello world <em>emphasize</em>, <strong>strong</strong>.</p>
+</textarea>
+
+<h2>Divarea editor</h2>
+<div id="divarea" contenteditable="true">
+	<p>Hello world <em>emphasize</em>, <strong>strong</strong>.</p>
+</div>
+
+<h2>Inline editor</h2>
+<div id="inline" contenteditable="true" style="width:500px;">
+	<p>Hello world <em>emphasize</em>, <strong>strong</strong>.</p>
+</div>
+
+<script>
+	if ( CKEDITOR.env.ie && CKEDITOR.env.version < 9 ) {
+		bender.ignore();
+	}
+
+	CKEDITOR.on( 'instanceReady', function( evt ) {
+		evt.editor.balloonToolbars.create( {
+			buttons: 'Bold,Italic',
+			cssSelector: 'strong, em'
+		} );
+	} );
+
+	CKEDITOR.replace( 'classic', {
+		width: 500
+	} );
+	CKEDITOR.replace( 'divarea', {
+		extraPlugins: 'divarea',
+		width: 500
+	} );
+	CKEDITOR.inline( 'inline' );
+</script>

--- a/tests/plugins/balloontoolbar/context/manual/focusablebuttons.md
+++ b/tests/plugins/balloontoolbar/context/manual/focusablebuttons.md
@@ -5,8 +5,8 @@
 ----
 
 1. Click into `emphasize` or `strong` element.
-2. When ballon toolbar show click into unselected button and keep mosedown for a few seconds.
+2. When balloon toolbar show click into unselected button and keep mousedown for a few seconds.
 
-**Expected:** Ballon toolbar will remain on screen.
+**Expected:** balloon toolbar remains on the screen.
 
 **Unexpected:** Balloon toolbar disappears.

--- a/tests/plugins/balloontoolbar/context/manual/focusablebuttons.md
+++ b/tests/plugins/balloontoolbar/context/manual/focusablebuttons.md
@@ -9,4 +9,4 @@
 
 **Expected:** balloon toolbar remains on the screen.
 
-**Unexpected:** Balloon toolbar disappears.
+**Unexpected:** balloon toolbar disappears.

--- a/tests/plugins/balloontoolbar/context/manual/focusablebuttons.md
+++ b/tests/plugins/balloontoolbar/context/manual/focusablebuttons.md
@@ -1,0 +1,12 @@
+@bender-ui: collapsed
+@bender-tags: 4.8.1, bug, balloontoolbar
+@bender-ckeditor-plugins: wysiwygarea,toolbar,basicstyles,floatingspace,balloontoolbar,link,image
+
+----
+
+1. Click into `emphasize` or `strong` element.
+2. When ballon toolbar show click into unselected button and keep mosedown for a few seconds.
+
+**Expected:** Ballon toolbar will remain on screen.
+
+**Unexpected:** Balloon toolbar disappears.

--- a/tests/plugins/balloontoolbar/context/manual/focusablebuttons.md
+++ b/tests/plugins/balloontoolbar/context/manual/focusablebuttons.md
@@ -1,5 +1,5 @@
 @bender-ui: collapsed
-@bender-tags: 4.8.1, bug, balloontoolbar
+@bender-tags: 4.8.1, bug, 1232, balloontoolbar
 @bender-ckeditor-plugins: wysiwygarea,toolbar,basicstyles,floatingspace,balloontoolbar,link,image
 
 ----


### PR DESCRIPTION
## What is the purpose of this pull request?

Bug fix

## Does your PR contain necessary tests?

yes

### This PR contains

- [x] Unit tests
- [x] Manual tests

## What changes did you make?

- Currently when balloon toolbar will be created then all added items will be registered in focus manager
- There is added additional array which store reference to elements which was registered is focus manager.

close #1232 