### PR TITLE
forcePasteAsPlainText adjusted to work with Paste from Word

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -8,6 +8,7 @@ Fixed Issues:
 * [#1048](https://github.com/ckeditor/ckeditor-dev/issues/1048): Fixed: [Balloon Panel](https://ckeditor.com/cke4/addon/balloonpanel) is not properly positioned when margin added to its non-static parent.
 * [#889](https://github.com/ckeditor/ckeditor-dev/issues/889): Fixed: Unclear error message for width and height fields in [Image](https://ckeditor.com/cke4/addon/image) and [Enhanced Image](https://ckeditor.com/cke4/addon/image2) plugins.
 * [#859](https://github.com/ckeditor/ckeditor-dev/issues/859): Fixed: Can't edit link after double click on text in link.
+* [#1013](https://github.com/ckeditor/ckeditor-dev/issues/1013): Fixed: [Paste from Word](https://ckeditor.com/cke4/addon/pastefromword) does not work correctly with [`config.forcePasteAsPlainText`](https://docs.ckeditor.com/ckeditor4/docs/#!/api/CKEDITOR.config-cfg-forcePasteAsPlainText) property.
 
 ## CKEditor 4.8
 

--- a/plugins/clipboard/plugin.js
+++ b/plugins/clipboard/plugin.js
@@ -733,8 +733,8 @@
 						} );
 					}
 
-					// Force type for the next paste.
-					if ( forcedType ) {
+					// Force type for the next paste. Do not force if `config.forcePasteAsPlainText` set to true (#1013).
+					if ( forcedType && editor.config.forcePasteAsPlainText !== true ) {
 						editor._.nextPasteType = forcedType;
 					} else {
 						delete editor._.nextPasteType;

--- a/plugins/clipboard/plugin.js
+++ b/plugins/clipboard/plugin.js
@@ -733,8 +733,8 @@
 						} );
 					}
 
-					// Force type for the next paste. Do not force if `config.forcePasteAsPlainText` set to true (#1013).
-					if ( forcedType && editor.config.forcePasteAsPlainText !== true ) {
+					// Force type for the next paste. Do not force if `config.forcePasteAsPlainText` set to true or 'ignore-word' (#1013).
+					if ( forcedType && editor.config.forcePasteAsPlainText !== true && editor.config.forcePasteAsPlainText !== 'ignore-word' ) {
 						editor._.nextPasteType = forcedType;
 					} else {
 						delete editor._.nextPasteType;

--- a/plugins/clipboard/plugin.js
+++ b/plugins/clipboard/plugin.js
@@ -733,8 +733,8 @@
 						} );
 					}
 
-					// Force type for the next paste. Do not force if `config.forcePasteAsPlainText` set to true or 'ignore-word' (#1013).
-					if ( forcedType && editor.config.forcePasteAsPlainText !== true && editor.config.forcePasteAsPlainText !== 'ignore-word' ) {
+					// Force type for the next paste. Do not force if `config.forcePasteAsPlainText` set to true or 'allow-word' (#1013).
+					if ( forcedType && editor.config.forcePasteAsPlainText !== true && editor.config.forcePasteAsPlainText !== 'allow-word' ) {
 						editor._.nextPasteType = forcedType;
 					} else {
 						delete editor._.nextPasteType;

--- a/plugins/pastefromword/plugin.js
+++ b/plugins/pastefromword/plugin.js
@@ -105,7 +105,7 @@
 							// If `config.forcePasteAsPlainText` set to true, force plain text even on Word content (#1013).
 							data.type = 'text';
 						} else if ( CKEDITOR.env.ie && editor.config.forcePasteAsPlainText === 'ignore-word' ) {
-							// In IE when pasting from Word, evt.dat.type is 'auto' (not 'html') so it gets converted
+							// In IE when pasting from Word, evt.data.type is 'auto' (not 'html') so it gets converted
 							// by 'pastetext' plugin to 'text'. We need to restore 'html' type (#1013).
 							data.type = 'html';
 						}

--- a/plugins/pastefromword/plugin.js
+++ b/plugins/pastefromword/plugin.js
@@ -101,9 +101,13 @@
 						editor.fire( 'afterPasteFromWord', pfwEvtData );
 
 						data.dataValue = pfwEvtData.dataValue;
-						// If `config.forcePasteAsPlainText` set to true, force plain text even on Word content (#1013).
 						if ( editor.config.forcePasteAsPlainText === true ) {
+							// If `config.forcePasteAsPlainText` set to true, force plain text even on Word content (#1013).
 							data.type = 'text';
+						} else if ( CKEDITOR.env.ie && editor.config.forcePasteAsPlainText === 'ignore-word' ) {
+							// In IE when pasting from Word, evt.dat.type is 'auto' (not 'html') so it gets converted
+							// by 'pastetext' plugin to 'text'. We need to restore 'html' type (#1013).
+							data.type = 'html';
 						}
 					}
 

--- a/plugins/pastefromword/plugin.js
+++ b/plugins/pastefromword/plugin.js
@@ -101,7 +101,7 @@
 						editor.fire( 'afterPasteFromWord', pfwEvtData );
 
 						data.dataValue = pfwEvtData.dataValue;
-						// If `config.forcePasteAsPlainText` set to true, force plain text even on Word content.
+						// If `config.forcePasteAsPlainText` set to true, force plain text even on Word content (#1013).
 						if ( editor.config.forcePasteAsPlainText === true ) {
 							data.type = 'text';
 						}

--- a/plugins/pastefromword/plugin.js
+++ b/plugins/pastefromword/plugin.js
@@ -104,7 +104,7 @@
 						if ( editor.config.forcePasteAsPlainText === true ) {
 							// If `config.forcePasteAsPlainText` set to true, force plain text even on Word content (#1013).
 							data.type = 'text';
-						} else if ( CKEDITOR.env.ie && editor.config.forcePasteAsPlainText === 'ignore-word' ) {
+						} else if ( CKEDITOR.env.ie && editor.config.forcePasteAsPlainText === 'allow-word' ) {
 							// In IE when pasting from Word, evt.data.type is 'auto' (not 'html') so it gets converted
 							// by 'pastetext' plugin to 'text'. We need to restore 'html' type (#1013).
 							data.type = 'html';

--- a/plugins/pastefromword/plugin.js
+++ b/plugins/pastefromword/plugin.js
@@ -95,11 +95,16 @@
 					if ( isLazyLoad ) {
 						editor.fire( 'paste', data );
 					} else if ( !editor.config.pasteFromWordPromptCleanup || ( forceFromWord || confirm( editor.lang.pastefromword.confirmCleanup ) ) ) {
+
 						pfwEvtData.dataValue = CKEDITOR.cleanWord( pfwEvtData.dataValue, editor );
 
 						editor.fire( 'afterPasteFromWord', pfwEvtData );
 
 						data.dataValue = pfwEvtData.dataValue;
+						// If `config.forcePasteAsPlainText` set to true, force plain text even on Word content.
+						if ( editor.config.forcePasteAsPlainText === true ) {
+							data.type = 'text';
+						}
 					}
 
 					// Reset forceFromWord.

--- a/plugins/pastetext/plugin.js
+++ b/plugins/pastetext/plugin.js
@@ -90,10 +90,13 @@
  * editor, loosing any formatting information possibly available in the source
  * text.
  *
- * **Note:** paste from word (dialog) is not affected by this configuration.
- *
  *		config.forcePasteAsPlainText = true;
  *
- * @cfg {Boolean} [forcePasteAsPlainText=false]
+ * This setting accepts also third value - `ignore-word`. In such case content pasted from Word
+ * will keep its formatting while any other content will be pasted as plain text.
+ *
+ * 		config.forcePasteAsPlainText = 'ignore-word';
+ *
+ * @cfg {Boolean|String} [forcePasteAsPlainText=false]
  * @member CKEDITOR.config
  */

--- a/plugins/pastetext/plugin.js
+++ b/plugins/pastetext/plugin.js
@@ -98,6 +98,6 @@
  *
  * 		config.forcePasteAsPlainText = 'allow-word';
  *
- * @cfg {Boolean|String} [forcePasteAsPlainText=false]
+ * @cfg {Boolean/String} [forcePasteAsPlainText=false]
  * @member CKEDITOR.config
  */

--- a/plugins/pastetext/plugin.js
+++ b/plugins/pastetext/plugin.js
@@ -93,10 +93,10 @@
  *
  *		config.forcePasteAsPlainText = true;
  *
- * This setting accepts also third value - `ignore-word`. In such case content pasted from Word
+ * This setting accepts also third value - `allow-word`. In such case content pasted from Word
  * will keep its formatting while any other content will be pasted as plain text.
  *
- * 		config.forcePasteAsPlainText = 'ignore-word';
+ * 		config.forcePasteAsPlainText = 'allow-word';
  *
  * @cfg {Boolean|String} [forcePasteAsPlainText=false]
  * @member CKEDITOR.config

--- a/plugins/pastetext/plugin.js
+++ b/plugins/pastetext/plugin.js
@@ -72,8 +72,9 @@
 				editor.on( 'beforePaste', function( evt ) {
 					// Do NOT overwrite if HTML format is explicitly requested.
 					// This allows pastefromword dominates over pastetext.
-					if ( evt.data.type != 'html' )
+					if ( evt.data.type != 'html' ) {
 						evt.data.type = 'text';
+					}
 				} );
 			}
 

--- a/tests/plugins/clipboard/forcepasteasplaintext.js
+++ b/tests/plugins/clipboard/forcepasteasplaintext.js
@@ -1,0 +1,184 @@
+/* bender-tags: editor,clipboard */
+/* bender-ckeditor-plugins: basicstyles,clipboard,pastetext,pastefromword */
+/* bender-include: ../clipboard/_helpers/pasting.js */
+/* global createFixtures */
+
+( function() {
+	'use strict';
+
+	bender.editors = {
+		force_default: {
+			config: {
+				language: 'en'
+			}
+		},
+
+		force_true: {
+			config: {
+				language: 'en',
+				forcePasteAsPlainText: true
+			}
+		},
+
+		force_ignoreword: {
+			config: {
+				language: 'en',
+				forcePasteAsPlainText: 'ignore-word'
+			}
+		}
+	};
+
+	var fixtures = createFixtures( {
+
+			pasteText: {
+				data: 'Plain text',
+				plain: 'Plain text'
+			},
+
+			pasteHTML: {
+				data: '<strong>HTML <em>content</em></strong>',
+				plain: 'HTML content'
+			},
+
+			pasteWord: {
+				data: '<strong class="MsoNormal">Word <em>content</em></strong>',
+				plain: 'Word content'
+			}
+		} ),
+		tests = {
+
+			'test paste with plain text': function( editor, bot ) {
+				var tc = bot.testCase;
+				tc.editor = editor;
+
+				bender.tools.selection.setWithHtml( editor, '' );
+				bender.tools.emulatePaste( editor, fixtures.get( 'pasteText' ).data );
+
+				assertAfterPasteContent( tc, getExpected( editor.name, 'pasteText' ) );
+				tc.wait();
+			},
+
+			'test paste with HTML content': function( editor, bot ) {
+				var tc = bot.testCase;
+				tc.editor = editor;
+
+				bender.tools.selection.setWithHtml( editor, '' );
+				bender.tools.emulatePaste( editor, fixtures.get( 'pasteHTML' ).data );
+
+				assertAfterPasteContent( tc, getExpected( editor.name, 'pasteHTML' ) );
+				tc.wait();
+			},
+
+			'test paste with Word content': function( editor, bot ) {
+				var tc = bot.testCase;
+				tc.editor = editor;
+
+				bender.tools.selection.setWithHtml( editor, '' );
+				bender.tools.emulatePaste( editor, fixtures.get( 'pasteWord' ).data );
+
+				assertAfterPasteContent( tc, getExpected( editor.name, 'pasteWord' ) );
+				tc.wait();
+			},
+
+			'test paste with plain text after pastetext click': function( editor, bot ) {
+				var tc = bot.testCase;
+				tc.editor = editor;
+
+				bender.tools.selection.setWithHtml( editor, '' );
+				editor.execCommand( 'paste', { type: 'text', dataValue: '', notification: false } );
+				bender.tools.emulatePaste( editor, fixtures.get( 'pasteText' ).data );
+
+				assertAfterPasteContent( tc, getExpected( editor.name, 'pasteText', true ) );
+				tc.wait();
+			},
+
+			'test paste with HTML content after pastetext click': function( editor, bot ) {
+				var tc = bot.testCase;
+				tc.editor = editor;
+
+				bender.tools.selection.setWithHtml( editor, '' );
+				editor.execCommand( 'paste', { type: 'text', dataValue: '', notification: false } );
+				bender.tools.emulatePaste( editor, fixtures.get( 'pasteHTML' ).data );
+
+				assertAfterPasteContent( tc, getExpected( editor.name, 'pasteHTML', true ) );
+				tc.wait();
+			},
+
+			'test paste with Word content after pastetext click': function( editor, bot ) {
+				var tc = bot.testCase;
+				tc.editor = editor;
+
+				// There is some inconsistency that pasting Word content after using
+				// `pastetext` button, still pastes rich content. Related to #1328 issue.
+				var forcePlain = editor.name !== 'force_ignoreword';
+
+				bender.tools.selection.setWithHtml( editor, '' );
+				editor.execCommand( 'paste', { type: 'text', dataValue: '', notification: false } );
+				bender.tools.emulatePaste( editor, fixtures.get( 'pasteWord' ).data );
+
+				assertAfterPasteContent( tc, getExpected( editor.name, 'pasteWord', forcePlain ) );
+				tc.wait();
+			},
+
+			'test paste with plain text after pastefromword click': function( editor, bot ) {
+				var tc = bot.testCase;
+				tc.editor = editor;
+
+				bender.tools.selection.setWithHtml( editor, '' );
+				editor.execCommand( 'paste', { type: 'html', dataValue: '', notification: false } );
+				bender.tools.emulatePaste( editor, fixtures.get( 'pasteText' ).data );
+
+				assertAfterPasteContent( tc, getExpected( editor.name, 'pasteText' ) );
+				tc.wait();
+			},
+
+			'test paste with HTML content after pastefromword click': function( editor, bot ) {
+				var tc = bot.testCase;
+				tc.editor = editor;
+
+				bender.tools.selection.setWithHtml( editor, '' );
+				editor.execCommand( 'paste', { type: 'html', dataValue: '', notification: false } );
+				bender.tools.emulatePaste( editor, fixtures.get( 'pasteHTML' ).data );
+
+				assertAfterPasteContent( tc, getExpected( editor.name, 'pasteHTML' ) );
+				tc.wait();
+			},
+
+			'test paste with Word content after pastefromword click': function( editor, bot ) {
+				var tc = bot.testCase;
+				tc.editor = editor;
+
+				bender.tools.selection.setWithHtml( editor, '' );
+				editor.execCommand( 'paste', { type: 'html', dataValue: '', notification: false } );
+				bender.tools.emulatePaste( editor, fixtures.get( 'pasteWord' ).data );
+
+				assertAfterPasteContent( tc, getExpected( editor.name, 'pasteWord' ) );
+				tc.wait();
+			}
+		};
+
+	bender.test(
+		bender.tools.createTestsForEditors( CKEDITOR.tools.objectKeys( bender.editors ), tests )
+	);
+
+	function assertAfterPasteContent( tc, expected ) {
+		tc.editor.on( 'afterPaste', function( evt ) {
+			evt.removeListener();
+			tc.resume( function() {
+				assert.isInnerHtmlMatching( expected, tc.editor.getData() );
+			} );
+		} );
+	}
+
+	function getExpected( editorName, fixtureName, forcePlain ) {
+		var expected = 'plain';
+
+		// Default editor (with forcePasteAsPlainText=false) always pastes rich content.
+		// Editor with forcePasteAsPlainText='ignore-word' only pastes rich context if it is copied from Word.
+		if ( !forcePlain && ( editorName === 'force_default' || ( editorName === 'force_ignoreword' && fixtureName === 'pasteWord' ) ) ) {
+			expected = 'data';
+		}
+
+		return '<p>' + fixtures.get( fixtureName )[ expected ].replace( /\s+class="MsoNormal"/g, '' ) + '</p>';
+	}
+} )();

--- a/tests/plugins/clipboard/forcepasteasplaintext.js
+++ b/tests/plugins/clipboard/forcepasteasplaintext.js
@@ -23,7 +23,7 @@
 		force_ignoreword: {
 			config: {
 				language: 'en',
-				forcePasteAsPlainText: 'ignore-word'
+				forcePasteAsPlainText: 'allow-word'
 			}
 		}
 	};
@@ -174,7 +174,7 @@
 		var expected = 'plain';
 
 		// Default editor (with forcePasteAsPlainText=false) always pastes rich content.
-		// Editor with forcePasteAsPlainText='ignore-word' only pastes rich context if it is copied from Word.
+		// Editor with forcePasteAsPlainText='allow-word' only pastes rich context if it is copied from Word.
 		if ( !forcePlain && ( editorName === 'force_default' || ( editorName === 'force_ignoreword' && fixtureName === 'pasteWord' ) ) ) {
 			expected = 'data';
 		}

--- a/tests/plugins/clipboard/manual/forcepasteasplaintext.html
+++ b/tests/plugins/clipboard/manual/forcepasteasplaintext.html
@@ -11,7 +11,7 @@
 	</div>
 </div>
 <div>
-	<pre>forcePasteAsPlainText=ignore-word</pre>
+	<pre>forcePasteAsPlainText=allow-word</pre>
 	<div>
 		<textarea cols="80" id="classic3"rows="10"></textarea>
 	</div>
@@ -26,6 +26,6 @@
 	} );
 
 	CKEDITOR.replace( 'classic3', {
-		forcePasteAsPlainText: 'ignore-word'
+		forcePasteAsPlainText: 'allow-word'
 	} );
 </script>

--- a/tests/plugins/clipboard/manual/forcepasteasplaintext.html
+++ b/tests/plugins/clipboard/manual/forcepasteasplaintext.html
@@ -1,0 +1,31 @@
+<div>
+	<pre>forcePasteAsPlainText=false</pre>
+	<div>
+		<textarea cols="80" id="classic1"rows="10"></textarea>
+	</div>
+</div>
+<div>
+	<pre>forcePasteAsPlainText=true</pre>
+	<div>
+		<textarea cols="80" id="classic2"rows="10"></textarea>
+	</div>
+</div>
+<div>
+	<pre>forcePasteAsPlainText=ignore-word</pre>
+	<div>
+		<textarea cols="80" id="classic3"rows="10"></textarea>
+	</div>
+</div>
+<script>
+	CKEDITOR.replace( 'classic1', {
+		forcePasteAsPlainText: false
+	} );
+
+	CKEDITOR.replace( 'classic2', {
+		forcePasteAsPlainText: true
+	} );
+
+	CKEDITOR.replace( 'classic3', {
+		forcePasteAsPlainText: 'ignore-word'
+	} );
+</script>

--- a/tests/plugins/clipboard/manual/forcepasteasplaintext.md
+++ b/tests/plugins/clipboard/manual/forcepasteasplaintext.md
@@ -1,0 +1,21 @@
+@bender-ui: collapsed
+@bender-tags: 4.8.1, bug
+@bender-ckeditor-plugins: wysiwygarea,toolbar,undo,basicstyles,image2,font,stylescombo,format,blockquote,list,table,elementspath,justify,clipboard,link,pastefromword,pastetext
+
+## Scenario:
+
+Perform below scenario with both HTML and Word copied content.
+
+1. Copy some rich content.
+1. Paste to each editor using all 3 paste buttons.
+
+**Expected:**
+* `forcePasteAsPlainText=false` only after _Paste as plain text_ content is pasted as plain text.
+* `forcePasteAsPlainText=true` content is always pasted as plain text.
+* `forcePasteAsPlainText=ignore-word` only Word content after using _Paste from Word_ is pasted as rich text.
+
+**Important:**
+After pressing _Paste as plain text_ and then pasting content from Word via `Ctrl + V` it is still pasted
+as rich content [#1328](https://github.com/ckeditor/ckeditor-dev/issues/1328).
+
+

--- a/tests/plugins/clipboard/manual/forcepasteasplaintext.md
+++ b/tests/plugins/clipboard/manual/forcepasteasplaintext.md
@@ -12,7 +12,7 @@ Perform below scenario with both HTML and Word copied content.
 **Expected:**
 * `forcePasteAsPlainText=false` only after _Paste as plain text_ content is pasted as plain text.
 * `forcePasteAsPlainText=true` content is always pasted as plain text.
-* `forcePasteAsPlainText=ignore-word` only Word content after using _Paste from Word_ is pasted as rich text.
+* `forcePasteAsPlainText=allow-word` only Word content after using _Paste from Word_ is pasted as rich text.
 
 **Important:**
 After pressing _Paste as plain text_ and then pasting content from Word via `Ctrl + V` it is still pasted

--- a/tests/plugins/clipboard/manual/forcepasteasplaintext.md
+++ b/tests/plugins/clipboard/manual/forcepasteasplaintext.md
@@ -18,4 +18,9 @@ Perform below scenario with both HTML and Word copied content.
 After pressing _Paste as plain text_ and then pasting content from Word via `Ctrl + V` it is still pasted
 as rich content [#1328](https://github.com/ckeditor/ckeditor-dev/issues/1328).
 
+**HTML helper:**
+<div>
+	<p>Foo <strong>Bar <em>Baz</em></strong></p>
+</div>
+
 


### PR DESCRIPTION
## What is the purpose of this pull request?

Bug fix

## Does your PR contain necessary tests?

All patches which change the editor code must include tests. You can always read more
on [PR testing](https://docs.ckeditor.com/ckeditor4/docs/#!/guide/dev_contributing_code-section-tests),
[how to set the testing environment](https://docs.ckeditor.com/ckeditor4/docs/#!/guide/dev_tests) and
[how to create tests](https://docs.ckeditor.com/ckeditor4/docs/#!/guide/dev_tests-section-creating-your-own-test)
in the official CKEditor documentation.

### This PR contains

- [x] Unit tests
- [x] Manual tests

## What changes did you make?

Closes #1013.

There is one related issue #1328 which describes/covers some inconsistent paste behaviours.
