### PR TITLE
Use XHR as possible uploading mechanism in filebrowser plugin

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -3,6 +3,10 @@
 
 ## CKEditor 4.8.1
 
+New Features:
+
+* [#933](https://github.com/ckeditor/ckeditor-dev/issues/933): [File Browser](https://ckeditor.com/cke4/addon/filetools) plugin can now upload files using XHR requests. This allows for setting custom HTTP headers using [`config.fileTools_requestHeaders`](http://docs.ckeditor.test/#!/api/CKEDITOR.config-cfg-fileTools_requestHeaders) configuration option.
+
 Fixed Issues:
 
 * [#1342](https://github.com/ckeditor/ckeditor-dev/issues/1342): Fixed: [Balloon Toolbar](https://ckeditor.com/cke4/addon/balloontoolbar) should be re-positioned after a [change](https://docs.ckeditor.com/ckeditor4/docs/#!/api/CKEDITOR.editor-event-change) event.

--- a/plugins/dialogui/plugin.js
+++ b/plugins/dialogui/plugin.js
@@ -749,7 +749,7 @@ CKEDITOR.plugins.add( 'dialogui', {
 					var responseType = onClick ? onClick.call( this, evt ) : false;
 
 					if ( responseType !== false ) {
-						if ( responseType === 'form' ) {
+						if ( responseType !== 'xhr' ) {
 							dialog.getContentElement( target[ 0 ], target[ 1 ] ).submit();
 						}
 						this.disable();

--- a/plugins/dialogui/plugin.js
+++ b/plugins/dialogui/plugin.js
@@ -745,10 +745,10 @@ CKEDITOR.plugins.add( 'dialogui', {
 					var target = elementDefinition[ 'for' ]; // [ pageId, elementId ]
 
 					// If exists onClick in elementDefinition, then it is called and checked response type.
-					// If it's posiblle, then XHR is used, what prevents of using submit.
-					var responseType = onClick && onClick.call( this, evt );
+					// If it's possible, then XHR is used, what prevents of using submit.
+					var responseType = onClick ? onClick.call( this, evt ) : false;
 
-					if ( !onClick || responseType !== false ) {
+					if ( responseType !== false ) {
 						if ( responseType === 'form' ) {
 							dialog.getContentElement( target[ 0 ], target[ 1 ] ).submit();
 						}

--- a/plugins/dialogui/plugin.js
+++ b/plugins/dialogui/plugin.js
@@ -743,6 +743,7 @@ CKEDITOR.plugins.add( 'dialogui', {
 				myDefinition.className = ( myDefinition.className ? myDefinition.className + ' ' : '' ) + 'cke_dialog_ui_button';
 				myDefinition.onClick = function( evt ) {
 					var target = elementDefinition[ 'for' ]; // [ pageId, elementId ]
+					// onClick.call() will create XHR request (if possible) and prevent of using submit method.
 					if ( !onClick || onClick.call( this, evt ) !== false ) {
 						dialog.getContentElement( target[ 0 ], target[ 1 ] ).submit();
 						this.disable();

--- a/plugins/dialogui/plugin.js
+++ b/plugins/dialogui/plugin.js
@@ -743,9 +743,15 @@ CKEDITOR.plugins.add( 'dialogui', {
 				myDefinition.className = ( myDefinition.className ? myDefinition.className + ' ' : '' ) + 'cke_dialog_ui_button';
 				myDefinition.onClick = function( evt ) {
 					var target = elementDefinition[ 'for' ]; // [ pageId, elementId ]
-					// onClick.call() will create XHR request (if possible) and prevent of using submit method.
-					if ( !onClick || onClick.call( this, evt ) !== false ) {
-						dialog.getContentElement( target[ 0 ], target[ 1 ] ).submit();
+
+					// If exists onClick in elementDefinition, then it is called and checked response type.
+					// If it's posiblle, then XHR is used, what prevents of using submit.
+					var responseType = onClick && onClick.call( this, evt );
+
+					if ( !onClick || responseType !== false ) {
+						if ( responseType === 'form' ) {
+							dialog.getContentElement( target[ 0 ], target[ 1 ] ).submit();
+						}
 						this.disable();
 					}
 				};

--- a/plugins/filebrowser/plugin.js
+++ b/plugins/filebrowser/plugin.js
@@ -313,7 +313,7 @@
 							if ( editor.config.filebrowser_forceFormSubmit || !CKEDITOR.fileTools.isFileUploadSupported ) {
 								// Append token preventing CSRF attacks.
 								appendToken( fileInput );
-								return 'form';
+								return true;
 
 							} else {
 								var loader = editor.uploadRepository.create( fileInput.$.files[ 0 ] );
@@ -323,7 +323,7 @@
 									setUrl.call( evt.sender.editor, response.url, response.message );
 								} );
 
-								loader.loadAndUpload( CKEDITOR.fileTools.getUploadUrl( editor.config, 'image' ) );
+								loader.loadAndUpload( url );
 
 								return 'xhr';
 							}

--- a/plugins/filebrowser/plugin.js
+++ b/plugins/filebrowser/plugin.js
@@ -311,7 +311,7 @@
 						if ( uploadFile.call( sender, evt ) ) {
 
 							// Backward compatibility for IE8 and IE9 (https://cksource.tpondemand.com/entity/3117).
-							if ( editor.config.filebrowser_forceSubmit || CKEDITOR.env.ie && CKEDITOR.env.version <= 9 ) {
+							if ( editor.config.filebrowser_forceFormSubmit || CKEDITOR.env.ie && CKEDITOR.env.version <= 9 ) {
 								// Append token preventing CSRF attacks.
 								appendToken( fileInput );
 								return 'form';
@@ -586,5 +586,14 @@
  *		config.filebrowserWindowHeight = '50%';
  *
  * @cfg {Number/String} [filebrowserWindowHeight='70%']
+ * @member CKEDITOR.config
+ */
+
+/**
+ * Force filebrowser plugin to use form submit action instead of XHR request when file is uploaded in dialogs.
+ *
+ * 		config.filebrowser_forceFormSubmit = true
+ *
+ * @cfg {Boolean} [filebrowser_forceFormSubmit=false]
  * @member CKEDITOR.config
  */

--- a/plugins/filebrowser/plugin.js
+++ b/plugins/filebrowser/plugin.js
@@ -297,42 +297,39 @@
 
 				if ( url ) {
 					var onClick = element.onClick;
+
+					// "element" here means the definition object, so we need to find the correct
+					// button to scope the event call
 					element.onClick = function( evt ) {
 						var sender = evt.sender;
 						var fileInput = sender.getDialog().getContentElement( this[ 'for' ][ 0 ], this[ 'for' ][ 1 ] ).getInputElement();
-						// Backward compatibility for IE8 and IE9 (https://cksource.tpondemand.com/entity/3117).
-						if ( editor.config.filebrowser_forceSubmit || !( CKEDITOR.plugins.clipboard && CKEDITOR.plugins.clipboard.isFileApiSupported ) ) {
-							// "element" here means the definition object, so we need to find the correct
-							// button to scope the event call
-							if ( onClick && onClick.call( sender, evt ) === false ) {
-								return false;
-							}
 
-							if ( uploadFile.call( sender, evt ) ) {
+						if ( onClick && onClick.call( sender, evt ) === false ) {
+							return false;
+						}
+
+						if ( uploadFile.call( sender, evt ) ) {
+
+							// Backward compatibility for IE8 and IE9 (https://cksource.tpondemand.com/entity/3117).
+							if ( editor.config.filebrowser_forceSubmit || !( CKEDITOR.plugins.clipboard && CKEDITOR.plugins.clipboard.isFileApiSupported ) ) {
 								// Append token preventing CSRF attacks.
 								appendToken( fileInput );
-								return true;
-							}
+								return 'form';
 
-							return false;
-						} else {
-							if ( uploadFile.call( sender, evt ) ) {
+							} else {
 								var loader = editor.uploadRepository.create( fileInput.$.files[ 0 ] );
-								// loader.loadAndUpload( sender.getDialog().getContentElement( this[ 'for' ][ 0 ], this[ 'for' ][ 1 ] ).action );
 
 								loader.on( 'uploaded', function( evt ) {
 									var response = evt.sender.responseData;
-
 									setUrl.call( evt.sender.editor, response.url, response.message );
-
 								} );
 
 								loader.loadAndUpload( CKEDITOR.fileTools.getUploadUrl( editor.config, 'image' ) );
-								// Return false to not trigger submit option in dialogui.
 
+								return 'xhr';
 							}
-							return false;
 						}
+						return false;
 					};
 
 					element.filebrowser.url = url;

--- a/plugins/filebrowser/plugin.js
+++ b/plugins/filebrowser/plugin.js
@@ -309,9 +309,8 @@
 						}
 
 						if ( uploadFile.call( sender, evt ) ) {
-
 							// Backward compatibility for IE8 and IE9 (https://cksource.tpondemand.com/entity/3117).
-							if ( editor.config.filebrowser_forceFormSubmit || CKEDITOR.env.ie && CKEDITOR.env.version <= 9 ) {
+							if ( editor.config.filebrowser_forceFormSubmit || !CKEDITOR.fileTools.isFileUploadSupported ) {
 								// Append token preventing CSRF attacks.
 								appendToken( fileInput );
 								return 'form';

--- a/plugins/filebrowser/plugin.js
+++ b/plugins/filebrowser/plugin.js
@@ -311,7 +311,7 @@
 						if ( uploadFile.call( sender, evt ) ) {
 
 							// Backward compatibility for IE8 and IE9 (https://cksource.tpondemand.com/entity/3117).
-							if ( editor.config.filebrowser_forceSubmit || !( CKEDITOR.plugins.clipboard && CKEDITOR.plugins.clipboard.isFileApiSupported ) ) {
+							if ( editor.config.filebrowser_forceSubmit || CKEDITOR.env.ie && CKEDITOR.env.version <= 9 ) {
 								// Append token preventing CSRF attacks.
 								appendToken( fileInput );
 								return 'form';

--- a/plugins/filebrowser/plugin.js
+++ b/plugins/filebrowser/plugin.js
@@ -324,6 +324,11 @@
 									setUrl.call( evt.sender.editor, response.url, response.message );
 								} );
 
+								// Return non-false value will disable fileButton in dialogui,
+								// below listeners takes care of such situation and re-enable "send" button.
+								loader.on( 'error', xhrUploadErrorHandler.bind( this ) );
+								loader.on( 'abort', xhrUploadErrorHandler.bind( this ) );
+
 								loader.loadAndUpload( url );
 
 								return 'xhr';
@@ -338,6 +343,12 @@
 				}
 			}
 		}
+	}
+
+	function xhrUploadErrorHandler( evt ) {
+		// `this` is a reference to ui.dialog.fileButton.
+		this.enable();
+		alert( evt.sender.message ); // jshint ignore:line
 	}
 
 	// Updates the target element with the url of uploaded/selected file.

--- a/plugins/filebrowser/plugin.js
+++ b/plugins/filebrowser/plugin.js
@@ -301,21 +301,20 @@
 					// "element" here means the definition object, so we need to find the correct
 					// button to scope the event call
 					element.onClick = function( evt ) {
-						var sender = evt.sender;
-						var fileInput = sender.getDialog().getContentElement( this[ 'for' ][ 0 ], this[ 'for' ][ 1 ] ).getInputElement();
+						var sender = evt.sender,
+							fileInput = sender.getDialog().getContentElement( this[ 'for' ][ 0 ], this[ 'for' ][ 1 ] ).getInputElement(),
+							isFileUploadApiSupported = CKEDITOR.fileTools && CKEDITOR.fileTools.isFileUploadSupported;
 
 						if ( onClick && onClick.call( sender, evt ) === false ) {
 							return false;
 						}
 
 						if ( uploadFile.call( sender, evt ) ) {
-							// Backward compatibility for IE8 and IE9 (https://cksource.tpondemand.com/entity/3117).
-							// With version 4.9.0 change: `!== 'xhr'` to `=== 'form'`.
-							if ( editor.config.filebrowserUploadMethod !== 'xhr' || !( CKEDITOR.fileTools && CKEDITOR.fileTools.isFileUploadSupported ) ) {
+							// Use one of two upload strategies, either form or XHR based (#643).
+							if ( editor.config.filebrowserUploadMethod !== 'xhr' || !isFileUploadApiSupported ) {
 								// Append token preventing CSRF attacks.
 								appendToken( fileInput );
 								return true;
-
 							} else {
 								var loader = editor.uploadRepository.create( fileInput.$.files[ 0 ] );
 
@@ -601,24 +600,25 @@
  */
 
 /**
- * Define preferred option to submit file upload with filebrowser plugin. If value is not specified,
- * `'form'` option is used. Additional XHR headers might be set up with {@link CKEDITOR.config#xmlHttpRequestHeaders}.
+ * Defines a preferred option for file uploading in the [File Browser](https://ckeditor.com/cke4/addon/filebrowser) plugin.
  *
  * Available values:
  *
- *	* `'xhr'` - XMLHttpRequest is used to upload file
- *	* `'form'` - Form submit is used to upload file
- *	* `undefiend` - when configuration option is not specified `'form'` configuration is used
+ *	* `'xhr'` - XMLHttpRequest is used to upload file. Using this option allows to set up with Additional XHR headers with
+ * {@link CKEDITOR.config#fileTools_requestHeaders} option.
+ *	* `'form'` - (default) File is uploaded by submitting a traditional `<form>` element.
+ *	* `null` - The default method is used.
  *
- * Note: please be aware that `'xhr'` requires {@link CKEDITOR.fileTools} for proper work. Missing this plugins
- * or using browsers which isn't supported {@link CKEDITOR.fileTools#isFileUploadSupported},
- * will force using `'form'` behaviour despite configuration option.
+ * Note: please be aware that `'xhr'` requires the [File Tools](https://ckeditor.com/cke4/addon/filetools) plugin to work
+ * properly. Without the plugin or using a browser that does not support
+ * {@link CKEDITOR.fileTools#isFileUploadSupported file uploading}, will fallback to the `'form'` method despite configuration
+ * option.
  *
- * 	// Modern browsers will use XMLHttpRequest to upload files.
- * 	// IE8 and IE9 will use form submit even tough config option is set to 'xhr'.
- * 	config.filebrowserUploadMethod = 'xhr';
+ *		// Modern browsers will use XMLHttpRequest to upload files.
+ *		// IE8 and IE9 will use form submit even though the config option is set to 'xhr'.
+ *		config.filebrowserUploadMethod = 'xhr';
  *
  * @since 4.8.1
- * @cfg {Boolean} [filebrowserUploadMethod=undefined]
+ * @cfg {String/null} [filebrowserUploadMethod=null]
  * @member CKEDITOR.config
  */

--- a/plugins/filebrowser/plugin.js
+++ b/plugins/filebrowser/plugin.js
@@ -310,7 +310,8 @@
 
 						if ( uploadFile.call( sender, evt ) ) {
 							// Backward compatibility for IE8 and IE9 (https://cksource.tpondemand.com/entity/3117).
-							if ( editor.config.filebrowser_forceFormSubmit || !CKEDITOR.fileTools.isFileUploadSupported ) {
+							// With version 4.9.0 change: `!== 'xhr'` to `=== 'form'`.
+							if ( editor.config.filebrowserUploadMethod !== 'xhr' || !( CKEDITOR.fileTools && CKEDITOR.fileTools.isFileUploadSupported ) ) {
 								// Append token preventing CSRF attacks.
 								appendToken( fileInput );
 								return true;
@@ -589,10 +590,24 @@
  */
 
 /**
- * Force filebrowser plugin to use form submit action instead of XHR request when file is uploaded in dialogs.
+ * Define preferred option to submit file upload with filebrowser plugin. If value is not specified,
+ * `'form'` option is used. Additional XHR headers might be set up with {@link CKEDITOR.config#xmlHttpRequestHeaders}.
  *
- * 		config.filebrowser_forceFormSubmit = true
+ * Available values:
  *
- * @cfg {Boolean} [filebrowser_forceFormSubmit=false]
+ *	* `'xhr'` - XMLHttpRequest is used to upload file
+ *	* `'form'` - Form submit is used to upload file
+ *	* `undefiend` - when configuration option is not specified `'form'` configuration is used
+ *
+ * Note: please be aware that `'xhr'` requires {@link CKEDITOR.fileTools} for proper work. Missing this plugins
+ * or using browsers which isn't supported {@link CKEDITOR.fileTools#isFileUploadSupported},
+ * will force using `'form'` behaviour despite configuration option.
+ *
+ * 	// Modern browsers will use XMLHttpRequest to upload files.
+ * 	// IE8 and IE9 will use form submit even tough config option is set to 'xhr'.
+ * 	config.filebrowserUploadMethod = 'xhr';
+ *
+ * @since 4.8.1
+ * @cfg {Boolean} [filebrowserUploadMethod=undefined]
  * @member CKEDITOR.config
  */

--- a/plugins/filetools/plugin.js
+++ b/plugins/filetools/plugin.js
@@ -49,6 +49,7 @@
 				var fileLoader = evt.data.fileLoader,
 					$formData = new FormData(),
 					requestData = evt.data.requestData,
+					configXHRHeaders = editor.config.xmlHttpRequestHeaders,
 					header;
 
 				for ( var name in requestData ) {
@@ -65,9 +66,9 @@
 				// Append token preventing CSRF attacks.
 				$formData.append( 'ckCsrfToken', CKEDITOR.tools.getCsrfToken() );
 
-				if ( editor.config.xmlHttpRequestHeaders ) {
-					for ( header in editor.config.xmlHttpRequestHeaders ) {
-						fileLoader.xhr.setRequestHeader( header, editor.config.xmlHttpRequestHeaders[ header ] );
+				if ( configXHRHeaders ) {
+					for ( header in configXHRHeaders ) {
+						fileLoader.xhr.setRequestHeader( header, configXHRHeaders[ header ] );
 					}
 				}
 
@@ -863,7 +864,24 @@
 		 */
 		isTypeSupported: function( file, supportedTypes ) {
 			return !!file.type.match( supportedTypes );
-		}
+		},
+
+		/**
+		 * Property inform if current browser poses native methods used by {@link CKEDITOR.fileTools} to upload files.
+		 *
+		 * @property {Boolean} isFileUploadSupported
+		 */
+		isFileUploadSupported: ( function() {
+			if ( typeof FileReader === 'function' &&
+				typeof ( new FileReader() ).readAsDataURL === 'function' &&
+				typeof FormData === 'function' &&
+				typeof ( new FormData() ).append === 'function' &&
+				typeof XMLHttpRequest === 'function' && typeof Blob === 'function' ) {
+
+				return true;
+			}
+			return false;
+		} )()
 	} );
 } )();
 

--- a/plugins/filetools/plugin.js
+++ b/plugins/filetools/plugin.js
@@ -48,7 +48,8 @@
 			editor.on( 'fileUploadRequest', function( evt ) {
 				var fileLoader = evt.data.fileLoader,
 					$formData = new FormData(),
-					requestData = evt.data.requestData;
+					requestData = evt.data.requestData,
+					header;
 
 				for ( var name in requestData ) {
 					var value = requestData[ name ];
@@ -63,6 +64,12 @@
 				}
 				// Append token preventing CSRF attacks.
 				$formData.append( 'ckCsrfToken', CKEDITOR.tools.getCsrfToken() );
+
+				if ( editor.config.xmlHttpRequestHeaders ) {
+					for ( header in editor.config.xmlHttpRequestHeaders ) {
+						fileLoader.xhr.setRequestHeader( header, editor.config.xmlHttpRequestHeaders[ header ] );
+					}
+				}
 
 				fileLoader.xhr.send( $formData );
 			}, null, null, 999 );

--- a/plugins/filetools/plugin.js
+++ b/plugins/filetools/plugin.js
@@ -49,7 +49,7 @@
 				var fileLoader = evt.data.fileLoader,
 					$formData = new FormData(),
 					requestData = evt.data.requestData,
-					configXHRHeaders = editor.config.xmlHttpRequestHeaders,
+					configXhrHeaders = editor.config.fileTools_requestHeaders,
 					header;
 
 				for ( var name in requestData ) {
@@ -66,9 +66,9 @@
 				// Append token preventing CSRF attacks.
 				$formData.append( 'ckCsrfToken', CKEDITOR.tools.getCsrfToken() );
 
-				if ( configXHRHeaders ) {
-					for ( header in configXHRHeaders ) {
-						fileLoader.xhr.setRequestHeader( header, configXHRHeaders[ header ] );
+				if ( configXhrHeaders ) {
+					for ( header in configXhrHeaders ) {
+						fileLoader.xhr.setRequestHeader( header, configXhrHeaders[ header ] );
 					}
 				}
 
@@ -867,21 +867,18 @@
 		},
 
 		/**
-		 * Property inform if current browser poses native methods used by {@link CKEDITOR.fileTools} to upload files.
+		 * Feature detection indicating whether current browser supports methods essential to send files over XHR request.
 		 *
+		 * @since 4.8.1
 		 * @property {Boolean} isFileUploadSupported
 		 */
 		isFileUploadSupported: ( function() {
-			if ( typeof FileReader === 'function' &&
+			return typeof FileReader === 'function' &&
 				typeof ( new FileReader() ).readAsDataURL === 'function' &&
 				typeof FormData === 'function' &&
 				typeof ( new FormData() ).append === 'function' &&
 				typeof XMLHttpRequest === 'function' &&
-				typeof Blob === 'function' ) {
-
-				return true;
-			}
-			return false;
+				typeof Blob === 'function';
 		} )()
 	} );
 } )();
@@ -913,14 +910,18 @@
  */
 
 /**
- * Additional headers of XMLHttpRequest used during file upload with plugins: {@link CKEDITOR.fileTools} and filebrowser.
+ * Allows to add extra headers for every request made using {@link CKEDITOR.fileTools} API.
  *
- * 	config.xmlHttpRequestHeaders = {
- * 		'Cache-Control': 'no-cache',
- * 		'X-CUSTOM': 'HEADER'
- * 	};
+ * Note that headers can still be customized per a single request, using the
+ * [`fileUploadRequest`](https://docs.ckeditor.com/ckeditor4/docs/#!/api/CKEDITOR.editor-event-fileUploadRequest)
+ * event.
+ *
+ *		config.fileTools_requestHeaders = {
+ *			'X-Requested-With': 'XMLHttpRequest',
+ *			'Custom-Header': 'header value'
+ *		};
  *
  * @since 4.8.1
- * @cfg {Object} [xmlHttpRequestHeaders=null]
+ * @cfg {Object} [fileTools_requestHeaders]
  * @member CKEDITOR.config
  */

--- a/plugins/filetools/plugin.js
+++ b/plugins/filetools/plugin.js
@@ -911,3 +911,16 @@
  * @cfg {String} [fileTools_defaultFileName='']
  * @member CKEDITOR.config
  */
+
+/**
+ * Additional headers of XMLHttpRequest used during file upload with plugins: {@link CKEDITOR.fileTools} and filebrowser.
+ *
+ * 	config.xmlHttpRequestHeaders = {
+ * 		'Cache-Control': 'no-cache',
+ * 		'X-CUSTOM': 'HEADER'
+ * 	};
+ *
+ * @since 4.8.1
+ * @cfg {Object} [xmlHttpRequestHeaders=null]
+ * @member CKEDITOR.config
+ */

--- a/plugins/filetools/plugin.js
+++ b/plugins/filetools/plugin.js
@@ -876,7 +876,8 @@
 				typeof ( new FileReader() ).readAsDataURL === 'function' &&
 				typeof FormData === 'function' &&
 				typeof ( new FormData() ).append === 'function' &&
-				typeof XMLHttpRequest === 'function' && typeof Blob === 'function' ) {
+				typeof XMLHttpRequest === 'function' &&
+				typeof Blob === 'function' ) {
 
 				return true;
 			}

--- a/tests/plugins/filebrowser/manual/uploadxhr.html
+++ b/tests/plugins/filebrowser/manual/uploadxhr.html
@@ -1,0 +1,50 @@
+<textarea id="classic">
+
+</textarea>
+
+<div id="output" style="background-color:lightgreen;"></div>
+
+<script>
+	var xhr, requests;
+
+	CKEDITOR.on( 'instanceLoaded', function() {
+		if ( !CKEDITOR.fileTools.isFileUploadSupported ) {
+			bender.ignore();
+		} else {
+			// Mock XHR
+			xhr = sinon.useFakeXMLHttpRequest();
+			requests = [];
+			xhr.onCreate = function( xhr ) {
+				requests.push( xhr );
+			};
+			window.onunload = function() {
+				xhr.restore();
+				server.restore();
+			}
+		}
+	} );
+
+	var classic = CKEDITOR.replace( 'classic', {
+		xmlHttpRequestHeaders: {
+			'hello': 'world',
+			'foo': 'bar'
+		},
+		filebrowserUploadUrl: 'fake-url'
+	} );
+
+	// Display XHR details when CKEDITOR process entire request.
+	classic.on( 'fileUploadRequest', function( evt ) {
+		var output = document.getElementById( 'output' );
+		var outputString = CKEDITOR.tools.array.reduce( requests, function( acc, item ) {
+			var line = '';
+			for ( header in item.requestHeaders ) {
+				if ( item.requestHeaders.hasOwnProperty( header ) ) {
+					line += '| <code>header: ' + header + ', value: ' + item.requestHeaders[ header ] + '</code> |';
+				}
+			}
+			acc += '<li>' + line + '</li>';
+			return acc;
+		}, '' );
+		output.innerHTML = '<ol>' + outputString + '</ol>';
+	}, null, null, 1000 )
+</script>

--- a/tests/plugins/filebrowser/manual/uploadxhr.html
+++ b/tests/plugins/filebrowser/manual/uploadxhr.html
@@ -18,7 +18,6 @@
 		};
 		window.onunload = function() {
 			xhr.restore();
-			server.restore();
 		}
 	}
 

--- a/tests/plugins/filebrowser/manual/uploadxhr.html
+++ b/tests/plugins/filebrowser/manual/uploadxhr.html
@@ -7,29 +7,28 @@
 <script>
 	var xhr, requests;
 
-	CKEDITOR.on( 'instanceLoaded', function() {
-		if ( !CKEDITOR.fileTools.isFileUploadSupported ) {
-			bender.ignore();
-		} else {
-			// Mock XHR
-			xhr = sinon.useFakeXMLHttpRequest();
-			requests = [];
-			xhr.onCreate = function( xhr ) {
-				requests.push( xhr );
-			};
-			window.onunload = function() {
-				xhr.restore();
-				server.restore();
-			}
+	if ( CKEDITOR.env.ie && CKEDITOR.env.version < 10 ) {
+		bender.ignore();
+	} else {
+		// Mock XHR
+		xhr = sinon.useFakeXMLHttpRequest();
+		requests = [];
+		xhr.onCreate = function( xhr ) {
+			requests.push( xhr );
+		};
+		window.onunload = function() {
+			xhr.restore();
+			server.restore();
 		}
-	} );
+	}
 
 	var classic = CKEDITOR.replace( 'classic', {
 		xmlHttpRequestHeaders: {
 			'hello': 'world',
 			'foo': 'bar'
 		},
-		filebrowserUploadUrl: 'fake-url'
+		filebrowserUploadUrl: 'fake-url',
+		filebrowserUploadMethod: 'xhr'
 	} );
 
 	// Display XHR details when CKEDITOR process entire request.
@@ -39,7 +38,7 @@
 			var line = '';
 			for ( header in item.requestHeaders ) {
 				if ( item.requestHeaders.hasOwnProperty( header ) ) {
-					line += '| <code>header: ' + header + ', value: ' + item.requestHeaders[ header ] + '</code> |';
+					line += ' | <code>header: ' + header + ', value: ' + item.requestHeaders[ header ] + '</code> |';
 				}
 			}
 			acc += '<li>' + line + '</li>';

--- a/tests/plugins/filebrowser/manual/uploadxhr.html
+++ b/tests/plugins/filebrowser/manual/uploadxhr.html
@@ -1,48 +1,42 @@
-<textarea id="classic">
+<textarea id="classic"></textarea>
 
-</textarea>
-
-<div id="output" style="background-color:lightgreen;"></div>
+<pre id="output" style="background-color:lightgreen;"></pre>
 
 <script>
-	var xhr, requests;
-
-	if ( CKEDITOR.env.ie && CKEDITOR.env.version < 10 ) {
-		bender.ignore();
-	} else {
-		// Mock XHR
-		xhr = sinon.useFakeXMLHttpRequest();
+	// Mock XHR
+	var xhr = sinon.useFakeXMLHttpRequest();
 		requests = [];
-		xhr.onCreate = function( xhr ) {
-			requests.push( xhr );
-		};
-		window.onunload = function() {
-			xhr.restore();
-		}
+
+	xhr.onCreate = function( xhr ) {
+		requests.push( xhr );
+	};
+	window.onunload = function() {
+		xhr.restore();
 	}
 
 	var classic = CKEDITOR.replace( 'classic', {
-		xmlHttpRequestHeaders: {
+		fileTools_requestHeaders: {
 			'hello': 'world',
 			'foo': 'bar'
 		},
 		filebrowserUploadUrl: 'fake-url',
-		filebrowserUploadMethod: 'xhr'
+		filebrowserUploadMethod: 'xhr',
+		on: {
+			instanceReady: function() {
+				if ( !CKEDITOR.fileTools.isFileUploadSupported ) {
+					bender.ignore();
+				}
+			}
+		}
 	} );
 
 	// Display XHR details when CKEDITOR process entire request.
 	classic.on( 'fileUploadRequest', function( evt ) {
-		var output = document.getElementById( 'output' );
-		var outputString = CKEDITOR.tools.array.reduce( requests, function( acc, item ) {
-			var line = '';
-			for ( header in item.requestHeaders ) {
-				if ( item.requestHeaders.hasOwnProperty( header ) ) {
-					line += ' | <code>header: ' + header + ', value: ' + item.requestHeaders[ header ] + '</code> |';
-				}
-			}
-			acc += '<li>' + line + '</li>';
-			return acc;
-		}, '' );
+		var output = document.getElementById( 'output' ),
+			outputString = CKEDITOR.tools.array.reduce( requests, function( acc, item ) {
+				return acc + '<li>' + JSON.stringify( item.requestHeaders, null, 4 ) + '</li>';
+			}, '' );
+
 		output.innerHTML = '<ol>' + outputString + '</ol>';
 	}, null, null, 1000 )
 </script>

--- a/tests/plugins/filebrowser/manual/uploadxhr.md
+++ b/tests/plugins/filebrowser/manual/uploadxhr.md
@@ -1,0 +1,18 @@
+@bender-tags: 4.8.1, feature, tp3117
+@bender-ui: collapsed
+@bender-ckeditor-plugins: wysiwygarea, toolbar, filebrowser, filetools, image, link, flash
+
+----
+1. Open image dialog
+2. Go to upload tab
+3. Select some image and send it to server
+4. Close dialog (There might appear warning that image url is not set up)
+
+Repeat those steps for Link and Flash plugin.
+
+_Note:_ When new upload request is made, it should be visible as separate line below.
+
+**Expected:** Below editor will appear green div with listed headers attempted to send. There are 2 headers in single line:
+`hello: world, foo: bar`.
+
+**Unexpected:** Headers are not listed below.

--- a/tests/plugins/filebrowser/manual/uploadxhr.md
+++ b/tests/plugins/filebrowser/manual/uploadxhr.md
@@ -1,4 +1,4 @@
-@bender-tags: 4.8.1, feature, tp3117
+@bender-tags: 4.8.1, feature, 643, tp3117
 @bender-ui: collapsed
 @bender-ckeditor-plugins: wysiwygarea, toolbar, filebrowser, filetools, image, link, flash
 
@@ -8,11 +8,17 @@
 3. Select some image and send it to server
 4. Close dialog (There might appear warning that image url is not set up)
 
-Repeat those steps for Link and Flash plugin.
+**Expected:** Below editor will appear green div with listed headers attempted to send. You should see following headers for each case:
 
-_Note:_ When new upload request is made, it should be visible as separate line below.
-
-**Expected:** Below editor will appear green div with listed headers attempted to send. There are 2 headers in single line:
-`hello: world, foo: bar`.
+```
+{
+    "hello": "world",
+    "foo": "bar"
+}
+```
 
 **Unexpected:** Headers are not listed below.
+
+Repeat those steps for Link and Flash plugin.
+
+_Note:_ When a new upload request is made, it should be visible as a separate line below.

--- a/tests/plugins/filebrowser/manual/uploadxhrwitherror.html
+++ b/tests/plugins/filebrowser/manual/uploadxhrwitherror.html
@@ -1,0 +1,18 @@
+<textarea id="classic">
+
+</textarea>
+
+<div id="output" style="background-color:lightgreen;"></div>
+
+<script>
+	var xhr, requests;
+
+	if ( CKEDITOR.env.ie && CKEDITOR.env.version < 10 ) {
+		bender.ignore();
+	}
+
+	var classic = CKEDITOR.replace( 'classic', {
+		filebrowserUploadUrl: 'fake-url',
+		filebrowserUploadMethod: 'xhr'
+	} );
+</script>

--- a/tests/plugins/filebrowser/manual/uploadxhrwitherror.html
+++ b/tests/plugins/filebrowser/manual/uploadxhrwitherror.html
@@ -1,18 +1,19 @@
 <textarea id="classic">
-
 </textarea>
 
 <div id="output" style="background-color:lightgreen;"></div>
 
 <script>
-	var xhr, requests;
-
-	if ( CKEDITOR.env.ie && CKEDITOR.env.version < 10 ) {
-		bender.ignore();
-	}
-
-	var classic = CKEDITOR.replace( 'classic', {
+	CKEDITOR.replace( 'classic', {
 		filebrowserUploadUrl: 'fake-url',
-		filebrowserUploadMethod: 'xhr'
+		filebrowserUploadMethod: 'xhr',
+		on: {
+			instanceReady: function() {
+				if ( !CKEDITOR.fileTools.isFileUploadSupported ) {
+					bender.ignore();
+				}
+			}
+		}
 	} );
+
 </script>

--- a/tests/plugins/filebrowser/manual/uploadxhrwitherror.md
+++ b/tests/plugins/filebrowser/manual/uploadxhrwitherror.md
@@ -1,16 +1,18 @@
-@bender-tags: 4.8.1, feature, tp3117
+@bender-tags: 4.8.1, feature, 643, tp3117
 @bender-ui: collapsed
 @bender-ckeditor-plugins: wysiwygarea, toolbar, filebrowser, filetools, image, link, flash
 
 ----
 1. Open image dialog
 2. Go to upload tab
-3. Select some image and send it to server
-4. **Alert** should be displayed
-5. Try to upload file again
+3. Select an image and send it to server
+
+	**Expected:** An alert with 404 message is displayed.
+
+5. Click "Send it to the Server" button again
+
+	**Expected:** An alert is shown again.
+
+	**Unexpected:** Second and further upload attempts won't trigger upload process, and alert is not shown.
 
 Repeat those steps for Link and Flash plugin.
-
-**Expected:** After first upload attempt, send button is enabled. Which means that every next click trigger new uploading process and generate new alert message.
-
-**Unexpected:** After first upload send button is disabled. Second and further upload attempts don't trigger upload process, and alert is not shown.

--- a/tests/plugins/filebrowser/manual/uploadxhrwitherror.md
+++ b/tests/plugins/filebrowser/manual/uploadxhrwitherror.md
@@ -1,0 +1,16 @@
+@bender-tags: 4.8.1, feature, tp3117
+@bender-ui: collapsed
+@bender-ckeditor-plugins: wysiwygarea, toolbar, filebrowser, filetools, image, link, flash
+
+----
+1. Open image dialog
+2. Go to upload tab
+3. Select some image and send it to server
+4. **Alert** should be displayed
+5. Try to upload file again
+
+Repeat those steps for Link and Flash plugin.
+
+**Expected:** After first upload attempt, send button is enabled. Which means that every next click trigger new uploading process and generate new alert message.
+
+**Unexpected:** After first upload send button is disabled. Second and further upload attempts don't trigger upload process, and alert is not shown.

--- a/tests/plugins/filebrowser/uploadbutton.js
+++ b/tests/plugins/filebrowser/uploadbutton.js
@@ -100,8 +100,8 @@
 
 			editor.addCommand( 'testDialog', new CKEDITOR.dialogCommand( 'testDialog' ) );
 			bot.dialog( 'testDialog', function( dialog ) {
-				var sendButton = dialog.getContentElement( 'Upload', 'uploadButton' );
-				var inputStub = mockInput( dialog );
+				var sendButton = dialog.getContentElement( 'Upload', 'uploadButton' ),
+					inputStub = mockInput( dialog );
 
 				// Execute just after XHR request is generated;
 				editor.on( 'fileUploadRequest', function() {
@@ -116,7 +116,6 @@
 				sendButton.click();
 				wait();
 			} );
-
 		},
 
 		'test for submit form': function() {
@@ -125,9 +124,10 @@
 
 			editor.addCommand( 'testDialog', new CKEDITOR.dialogCommand( 'testDialog' ) );
 			bot.dialog( 'testDialog', function( dialog ) {
-				var sendButton = dialog.getContentElement( 'Upload', 'uploadButton' );
-				var mockSubmit = sinon.spy();
-				var inputStub = mockInput( dialog, mockSubmit );
+				var sendButton = dialog.getContentElement( 'Upload', 'uploadButton' ),
+					mockSubmit = sinon.spy(),
+					inputStub = mockInput( dialog, mockSubmit );
+
 				sendButton.click();
 				assert.isTrue( mockSubmit.called, 'Submit method should be used.' );
 				inputStub.restore();

--- a/tests/plugins/filebrowser/uploadbutton.js
+++ b/tests/plugins/filebrowser/uploadbutton.js
@@ -1,0 +1,138 @@
+/* bender-tags: editor */
+/* bender-ckeditor-plugins: dialog,filebrowser,filetools,clipboard */
+
+( function() {
+	'use strict';
+
+	function mockInput( dialog, submit ) {
+		return sinon.stub( dialog, 'getContentElement', function() {
+			return {
+				getInputElement: function() {
+					return {
+						$: {
+							files: [
+								new File( [ '' ], 'sample.png' )
+							],
+							value: 'C:\\fakepath\\sample.gif',
+							form: ( new CKEDITOR.dom.element( 'form' ) ).$
+						}
+					};
+				},
+				getAction: function() {
+					return 'http://url-to-php-form';
+				},
+				submit: submit
+			};
+		} );
+	}
+
+	bender.editors = {
+		xhr: {
+			config: {
+				xmlHttpRequestHeaders: {
+					foo: 'bar',
+					hello: 'world'
+				},
+				filebrowserUploadUrl: 'foo'
+			}
+		},
+		submit: {
+			config: {
+				filebrowserUploadUrl: 'foo',
+				filebrowser_forceSubmit: true
+			}
+		}
+	};
+
+	CKEDITOR.on( 'instanceLoaded', function() {
+		CKEDITOR.dialog.add( 'testDialog', function() {
+			return {
+				title: 'Test Dialog',
+				contents: [
+					{
+						id: 'Upload',
+						hidden: true,
+						filebrowser: 'uploadButton',
+						label: 'Upload input',
+						elements: [ {
+							type: 'file',
+							id: 'upload',
+							label: 'Load file',
+							style: 'height:40px',
+							size: 38
+						},
+						{
+							type: 'fileButton',
+							id: 'uploadButton',
+							filebrowser: 'Upload:upload',
+							label: 'Send',
+							'for': [ 'Upload', 'upload' ]
+						} ]
+					}
+				]
+			};
+		} );
+	} );
+
+	bender.test( {
+		_should: {
+			ignore: {
+				'test for XHR request': CKEDITOR.env.ie && CKEDITOR.env.version < 9
+			}
+		},
+
+		setUp: function() {
+			this.xhr = sinon.useFakeXMLHttpRequest();
+			var requests = this.requests = [];
+
+			this.xhr.onCreate = function( xhr ) {
+				requests.push( xhr );
+			};
+		},
+
+		tearDown: function() {
+			this.xhr.restore();
+		},
+
+		'test for XHR request': function() {
+			var editor = this.editors.xhr,
+				bot = this.editorBots.xhr;
+
+			editor.addCommand( 'testDialog', new CKEDITOR.dialogCommand( 'testDialog' ) );
+			bot.dialog( 'testDialog', function( dialog ) {
+				var sendButton = dialog.getContentElement( 'Upload', 'uploadButton' );
+				var inputStub = mockInput( dialog );
+
+				// Execute just after XHR request is generated;
+				editor.on( 'fileUploadRequest', function() {
+					resume( function() {
+						arrayAssert.isNotEmpty( this.requests );
+						objectAssert.areEqual( { 'foo': 'bar', 'hello': 'world' }, this.requests[ 0 ].requestHeaders );
+						dialog.hide();
+						inputStub.restore();
+					} );
+				}, null, null, 1000 );
+
+				sendButton.click();
+				wait();
+			} );
+
+		},
+
+		'test for submit form': function() {
+			var editor = this.editors.submit,
+				bot = this.editorBots.submit;
+
+			editor.addCommand( 'testDialog', new CKEDITOR.dialogCommand( 'testDialog' ) );
+			bot.dialog( 'testDialog', function( dialog ) {
+				var sendButton = dialog.getContentElement( 'Upload', 'uploadButton' );
+				var mockSubmit = sinon.spy();
+				var inputStub = mockInput( dialog, mockSubmit );
+				sendButton.click();
+				assert.isTrue( mockSubmit.called, 'Submit method should be used.' );
+				inputStub.restore();
+				dialog.hide();
+			} );
+		}
+	} );
+} )();

--- a/tests/plugins/filebrowser/uploadbutton.js
+++ b/tests/plugins/filebrowser/uploadbutton.js
@@ -39,7 +39,7 @@
 		submit: {
 			config: {
 				filebrowserUploadUrl: 'foo',
-				filebrowser_forceSubmit: true
+				filebrowser_forceFormSubmit: true
 			}
 		}
 	};

--- a/tests/plugins/filebrowser/uploadbutton.js
+++ b/tests/plugins/filebrowser/uploadbutton.js
@@ -1,41 +1,47 @@
 /* bender-tags: editor */
 /* bender-ckeditor-plugins: dialog,filebrowser,filetools,clipboard */
+/* bender-include: ../filetools/_helpers/tools.js */
+/* global fileTools */
 
 ( function() {
 	'use strict';
 
 	function mockInput( dialog, submit ) {
-		return sinon.stub( dialog, 'getContentElement', function() {
-			return {
-				getInputElement: function() {
-					return {
-						$: {
-							files: [
-								new File( [ '' ], 'sample.png' )
-							],
-							value: 'C:\\fakepath\\sample.gif',
-							form: ( new CKEDITOR.dom.element( 'form' ) ).$
-						}
-					};
-				},
-				getAction: function() {
-					return 'http://url-to-php-form';
-				},
-				submit: submit
-			};
+		return sinon.stub( dialog, 'getContentElement' ).returns( {
+			getInputElement: function() {
+				var ret = {
+					$: {
+						value: 'C:\\fakepath\\sample.gif',
+						form: ( new CKEDITOR.dom.element( 'form' ) ).$
+					}
+				};
+
+				if ( CKEDITOR.fileTools.isFileUploadSupported ) {
+					// Only modern browsers will contain files property.
+					ret.$.files = [
+						new File( [ '' ], 'sample.png' )
+					];
+				}
+
+				return ret;
+			},
+			getAction: function() {
+				return 'http://url-to-php-form';
+			},
+			submit: submit
 		} );
 	}
 
 	bender.editors = {
 		xhr: {
 			config: {
-				xmlHttpRequestHeaders: {
+				fileTools_requestHeaders: {
 					foo: 'bar',
 					hello: 'world'
 				},
 				filebrowserUploadUrl: 'foo',
 				filebrowserUploadMethod: 'xhr',
-				lang: 'en'
+				language: 'en'
 			}
 		},
 		submit: {
@@ -77,13 +83,9 @@
 	} );
 
 	bender.test( {
-		_should: {
-			ignore: {
-				'test for XHR request': CKEDITOR.env.ie && CKEDITOR.env.version < 9
-			}
-		},
-
 		setUp: function() {
+			fileTools.mockFileType();
+
 			this.xhr = sinon.useFakeXMLHttpRequest();
 			var requests = this.requests = [];
 
@@ -96,7 +98,11 @@
 			this.xhr.restore();
 		},
 
-		'test for xhr request': function() {
+		'test for XHR request': function() {
+			if ( !CKEDITOR.fileTools.isFileUploadSupported ) {
+				assert.ignore();
+			}
+
 			var editor = this.editors.xhr,
 				bot = this.editorBots.xhr;
 
@@ -138,6 +144,10 @@
 		},
 
 		'test for xhr loader error': function() {
+			if ( !CKEDITOR.fileTools.isFileUploadSupported ) {
+				assert.ignore();
+			}
+
 			var editor = this.editors.xhr,
 				bot = this.editorBots.xhr;
 
@@ -174,6 +184,10 @@
 		},
 
 		'test for xhr loader abort': function() {
+			if ( !CKEDITOR.fileTools.isFileUploadSupported ) {
+				assert.ignore();
+			}
+
 			var editor = this.editors.xhr,
 				bot = this.editorBots.xhr;
 

--- a/tests/plugins/filetools/_helpers/tools.js
+++ b/tests/plugins/filetools/_helpers/tools.js
@@ -1,0 +1,21 @@
+'use strict';
+
+/* exported fileTools */
+
+var fileTools = {
+	// A mockup type that should replace File constructor.
+	fileMock: function( data, name ) {
+		var file = new Blob( data , {} );
+		file.name = name;
+
+		return file;
+	},
+
+	// Replaces window.File constructor with a callable constructor replacement, that
+	// returns file instances mock.
+	mockFileType: function() {
+		if ( typeof MSBlobBuilder === 'function' || !window.File ) {
+			window.File = fileTools.fileMock;
+		}
+	}
+};

--- a/tests/plugins/filetools/fileloader.js
+++ b/tests/plugins/filetools/fileloader.js
@@ -167,10 +167,7 @@
 						}, 0 );
 					},
 
-					setRequestHeader: function( key, value ) {
-						this.requestHeaders = this.requestHeaders || {};
-						this.requestHeaders[ key ] = value;
-					}
+					setRequestHeader: sinon.stub()
 				};
 
 			return xhr;
@@ -1234,7 +1231,12 @@
 			loader.loadAndUpload( 'http://example.com' );
 
 			resumeAfter( loader, 'uploaded', function( evt ) {
-				objectAssert.areEqual( { 'foo': 'bar', 'hello': 'world' }, evt.sender.xhr.requestHeaders, 'XHR headers are not equal.' );
+				var setRequestHeaderStub = evt.sender.xhr.setRequestHeader;
+
+				sinon.assert.calledWithExactly( setRequestHeaderStub, 'foo', 'bar' );
+				sinon.assert.calledWithExactly( setRequestHeaderStub, 'hello', 'world' );
+
+				assert.areSame( 2, setRequestHeaderStub.callCount, 'setRequestHeader call count' );
 			} );
 			wait();
 		}

--- a/tests/plugins/filetools/fileloader.js
+++ b/tests/plugins/filetools/fileloader.js
@@ -14,7 +14,12 @@
 		testFile, lastFormData,
 		listeners = [],
 		editorMock = {
-			config: {}
+			config: {
+				xmlHttpRequestHeaders: {
+					foo: 'bar',
+					hello: 'world'
+				}
+			}
 		},
 		editorMockDefaultFileName = {
 			config: {
@@ -160,6 +165,11 @@
 						setTimeout( function() {
 							xhr.onabort();
 						}, 0 );
+					},
+
+					setRequestHeader: function( key, value ) {
+						this.requestHeaders = this.requestHeaders || {};
+						this.requestHeaders[ key ] = value;
 					}
 				};
 
@@ -1215,6 +1225,18 @@
 			loader.status = 'abort';
 
 			assert.isTrue( loader.isFinished() );
+		},
+
+		'text custom XHR headers': function() {
+			var loader = new FileLoader( editorMock, pngBase64 );
+
+			createXMLHttpRequestMock( [ 'load' ] );
+			loader.loadAndUpload( 'http://example.com' );
+
+			resumeAfter( loader, 'uploaded', function( evt ) {
+				objectAssert.areEqual( { 'foo': 'bar', 'hello': 'world' }, evt.sender.xhr.requestHeaders, 'XHR headers are not equal.' );
+			} );
+			wait();
 		}
 	} );
 } )();

--- a/tests/plugins/filetools/fileloader.js
+++ b/tests/plugins/filetools/fileloader.js
@@ -1,9 +1,14 @@
 /* bender-tags: editor,clipboard,filetools */
 /* bender-ckeditor-plugins: filetools */
+/* bender-include: _helpers/tools.js */
+/* global fileTools */
 
 'use strict';
 
 ( function() {
+	// IE/Edge doesn't support File constructor, so there is a need to mimic it.
+	fileTools.mockFileType();
+
 	var File = window.File,
 		Blob = window.Blob,
 		FormData = window.FormData,
@@ -15,7 +20,7 @@
 		listeners = [],
 		editorMock = {
 			config: {
-				xmlHttpRequestHeaders: {
+				fileTools_requestHeaders: {
 					foo: 'bar',
 					hello: 'world'
 				}
@@ -26,15 +31,6 @@
 				fileTools_defaultFileName: 'default-file-name'
 			}
 		};
-
-	function createFileMock() {
-		window.File = File = function( data, name ) {
-			var file = new Blob( data , {} );
-			file.name = name;
-
-			return file;
-		};
-	}
 
 	function createFormDataMock() {
 		window.FormData = function() {
@@ -242,10 +238,6 @@
 			if ( !CKEDITOR.plugins.clipboard.isFileApiSupported ) {
 				assert.ignore();
 			}
-
-			// IE doesn't support File constructor, so there is a need to mimic it.
-			if ( typeof MSBlobBuilder === 'function' )
-				createFileMock();
 
 			// FormData in IE & Chrome 47- supports only adding data, not getting it, so mocking (polyfilling?) is required.
 			// Note that mocking is needed only for tests, as CKEditor.fileTools uses only append method
@@ -1224,7 +1216,7 @@
 			assert.isTrue( loader.isFinished() );
 		},
 
-		'text custom XHR headers': function() {
+		'test custom XHR headers': function() {
 			var loader = new FileLoader( editorMock, pngBase64 );
 
 			createXMLHttpRequestMock( [ 'load' ] );

--- a/tests/plugins/filetools/static.js
+++ b/tests/plugins/filetools/static.js
@@ -1,0 +1,12 @@
+/* bender-tags: editor,clipboard,filetools */
+/* bender-ckeditor-plugins: filetools,clipboard */
+
+( function() {
+	'use strict';
+
+	bender.test( {
+		'test fileTools.isFileUploadSupported': function() {
+			assert.areSame( CKEDITOR.env.ie && CKEDITOR.env.version < 10 ? false : true, CKEDITOR.fileTools.isFileUploadSupported );
+		}
+	} );
+} )();


### PR DESCRIPTION
## What is the purpose of this pull request?

New feature

## Does your PR contain necessary tests?

All patches which change the editor code must include tests. You can always read more
on [PR testing](https://docs.ckeditor.com/ckeditor4/docs/#!/guide/dev_contributing_code-section-tests),
[how to set the testing environment](https://docs.ckeditor.com/ckeditor4/docs/#!/guide/dev_tests) and
[how to create tests](https://docs.ckeditor.com/ckeditor4/docs/#!/guide/dev_tests-section-creating-your-own-test)
in the official CKEditor documentation.

### This PR contains

- [x] Unit tests
- [x] Manual tests

## What changes did you make?

- change way how filebrowser upload files - prefer using XHR
- allow on providing custom headers to XHR used when files are uploaded
- add config flag which will force to use `form submit` behaviour when files are uploaded

Closes #643.