### PR TITLE
Fix for processing border shorthand in filter transformation

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -18,6 +18,7 @@ Fixed Issues:
 * [#1013](https://github.com/ckeditor/ckeditor-dev/issues/1013): Fixed: [Paste from Word](https://ckeditor.com/cke4/addon/pastefromword) does not work correctly with [`config.forcePasteAsPlainText`](https://docs.ckeditor.com/ckeditor4/docs/#!/api/CKEDITOR.config-cfg-forcePasteAsPlainText) property.
 * [#1356](https://github.com/ckeditor/ckeditor-dev/issues/1356): Fixed: [Border parse function](https://docs.ckeditor.com/ckeditor4/docs/#!/api/CKEDITOR.tools.style.parse-method-border) should allow spaces in the color value.
 * [#1426](https://github.com/ckeditor/ckeditor-dev/issues/1426): [IE8-9] Fixed: Missing balloon toolbar background in Kama skin. Thanks to [Christian Elmer](https://github.com/keinkurt)!
+* [#1010](https://github.com/ckeditor/ckeditor-dev/issues/1010): Fixed: CSS `border` shorthand property was incorrectly expanded ignoring `border-color` style.
 
 API Changes:
 

--- a/core/filter.js
+++ b/core/filter.js
@@ -2160,35 +2160,13 @@
 				return;
 			}
 
-			var widths = element.styles.border.match( /([\.\d]+\w+)/g ) || [ '0px' ];
-			switch ( widths.length ) {
-				case 1:
-					element.styles[ 'border-width' ] = widths[0];
-					break;
-				case 2:
-					mapStyles( [ 0, 1, 0, 1 ] );
-					break;
-				case 3:
-					mapStyles( [ 0, 1, 2, 1 ] );
-					break;
-				case 4:
-					mapStyles( [ 0, 1, 2, 3 ] );
-					break;
-			}
+			var borderSplittedStyles = CKEDITOR.tools.style.parse.border( element.styles.border ) ;
 
-			element.styles[ 'border-style' ] = element.styles[ 'border-style' ] ||
-				( element.styles.border.match( /(none|hidden|dotted|dashed|solid|double|groove|ridge|inset|outset|initial|inherit)/ ) || [] )[ 0 ];
-			if ( !element.styles[ 'border-style' ] )
-				delete element.styles[ 'border-style' ];
+			element.styles[ 'border-color' ] = borderSplittedStyles.color;
+			element.styles[ 'border-style' ] = borderSplittedStyles.style;
+			element.styles[ 'border-width' ] = borderSplittedStyles.width;
 
 			delete element.styles.border;
-
-			function mapStyles( map ) {
-				element.styles['border-top-width'] = widths[ map[0] ];
-				element.styles['border-right-width'] = widths[ map[1] ];
-				element.styles['border-bottom-width'] = widths[ map[2] ];
-				element.styles['border-left-width'] = widths[ map[3] ];
-			}
 		},
 
 		listTypeToStyle: function( element ) {

--- a/core/filter.js
+++ b/core/filter.js
@@ -2162,9 +2162,15 @@
 
 			var borderSplittedStyles = CKEDITOR.tools.style.parse.border( element.styles.border ) ;
 
-			element.styles[ 'border-color' ] = borderSplittedStyles.color;
-			element.styles[ 'border-style' ] = borderSplittedStyles.style;
-			element.styles[ 'border-width' ] = borderSplittedStyles.width;
+			if ( borderSplittedStyles.color ) {
+				element.styles[ 'border-color' ] = borderSplittedStyles.color;
+			}
+			if ( borderSplittedStyles.style ) {
+				element.styles[ 'border-style' ] = borderSplittedStyles.style;
+			}
+			if ( borderSplittedStyles.width ) {
+				element.styles[ 'border-width' ] = borderSplittedStyles.width;
+			}
 
 			delete element.styles.border;
 		},

--- a/core/filter.js
+++ b/core/filter.js
@@ -2160,7 +2160,7 @@
 				return;
 			}
 
-			var borderSplittedStyles = CKEDITOR.tools.style.parse.border( element.styles.border ) ;
+			var borderSplittedStyles = CKEDITOR.tools.style.parse.border( element.styles.border );
 
 			if ( borderSplittedStyles.color ) {
 				element.styles[ 'border-color' ] = borderSplittedStyles.color;

--- a/tests/core/filter/manual/bordershorthandtransformation.html
+++ b/tests/core/filter/manual/bordershorthandtransformation.html
@@ -8,17 +8,10 @@
 </table></textarea>
 
 <textarea id="editor1">
-<table style="width:500px">
-	<tbody>
-		<tr>
-			<td style="border:2pt solid red;">&nbsp;</td>
-			<td>&nbsp;</td>
-		</tr>
-	</tbody>
-</table>
+<p>Replace this text in source mode.</p>
 </textarea>
 <script>
 	var editor = CKEDITOR.replace( 'editor1', {
-		extraAllowedContent: 'td{border,border-*}',
+		extraAllowedContent: 'td{border,border-*}'
 	} );
 </script>

--- a/tests/core/filter/manual/bordershorthandtransformation.html
+++ b/tests/core/filter/manual/bordershorthandtransformation.html
@@ -1,0 +1,24 @@
+<textarea cols="60" rows="8" readonly><table style="width:500px">
+	<tbody>
+		<tr>
+			<td style="border:2pt solid red;">&nbsp;</td>
+			<td>&nbsp;</td>
+		</tr>
+	</tbody>
+</table></textarea>
+
+<textarea id="editor1">
+<table style="width:500px">
+	<tbody>
+		<tr>
+			<td style="border:2pt solid red;">&nbsp;</td>
+			<td>&nbsp;</td>
+		</tr>
+	</tbody>
+</table>
+</textarea>
+<script>
+	var editor = CKEDITOR.replace( 'editor1', {
+		extraAllowedContent: 'td{border,border-*}',
+	} );
+</script>

--- a/tests/core/filter/manual/bordershorthandtransformation.md
+++ b/tests/core/filter/manual/bordershorthandtransformation.md
@@ -1,0 +1,13 @@
+@bender-tags: bug, 1010, 4.8.1, bug
+@bender-ui: collapsed
+@bender-ckeditor-plugins: wysiwygarea, toolbar, sourcearea, table, tabletools, contextmenu, dialogadvtab
+
+----
+
+1. Copy-paste table to editor.
+2. Switch between sourcemode and wysiwyg.
+3. Check TD element's style
+
+**Expected:** Border color (red) is preserved during pasting and switching between sourcemode and wysiwygarea.
+
+**Unexpected:** Border color is browser's defualt (grey). In source mode there is no border-color style.

--- a/tests/core/filter/manual/bordershorthandtransformation.md
+++ b/tests/core/filter/manual/bordershorthandtransformation.md
@@ -9,6 +9,6 @@
 3. Switch to wysiwyg mode.
 4. Check TD element's style.
 
-**Expected:** Border color (red) is preserved during pasting and switching between sourcemode and wysiwygarea.
+**Expected:** Border color (red) is preserved during pasting and switching between source mode and wysiwygarea.
 
 **Unexpected:** Border color has default color (grey / black). In source mode there is no border-color style.

--- a/tests/core/filter/manual/bordershorthandtransformation.md
+++ b/tests/core/filter/manual/bordershorthandtransformation.md
@@ -1,13 +1,14 @@
-@bender-tags: bug, 1010, 4.8.1, bug
+@bender-tags: bug, 1010, 4.8.1
 @bender-ui: collapsed
 @bender-ckeditor-plugins: wysiwygarea, toolbar, sourcearea, table, tabletools, contextmenu, dialogadvtab
 
 ----
 
-1. Copy-paste table to editor.
-2. Switch between sourcemode and wysiwyg.
-3. Check TD element's style
+1. Enter source mode in editor.
+2. Copy-paste table's HTML to editor. _Table's html code is located above the editor._
+3. Switch to wysiwyg mode.
+4. Check TD element's style.
 
 **Expected:** Border color (red) is preserved during pasting and switching between sourcemode and wysiwygarea.
 
-**Unexpected:** Border color is browser's defualt (grey). In source mode there is no border-color style.
+**Unexpected:** Border color has default color (grey / black). In source mode there is no border-color style.

--- a/tests/core/filter/transformations.js
+++ b/tests/core/filter/transformations.js
@@ -450,6 +450,8 @@
 					'<p style="border-color:#172d59; border-style:dashed; border-width:20%">A</p>', 'border split shorthand 2' );
 				assertToHtml( editor, '<p style="border: 2em dotted #345678">A</p>',
 					'<p style="border-color:#345678; border-style:dotted; border-width:2em">A</p>', 'border split shorthand 3' );
+				assertToHtml( editor, '<p style="border: 3px double">A</p>',
+					'<p style="border-style:double; border-width:3px">A</p>', 'border split shorthand 4' );
 			} );
 		}
 	} );

--- a/tests/core/filter/transformations.js
+++ b/tests/core/filter/transformations.js
@@ -429,6 +429,28 @@
 					'<h1 style="margin-left:4px; margin-top:1px">A</h1>',
 					'margin shortcut 4 members' );
 			} );
+		},
+
+		'test splitBorderShorthand transformation': function() {
+			bender.editorBot.create( {
+				name: 'test_splitBorderShorthand_transformation',
+				config: {
+					extraAllowedContent: 'p{border,border-*}'
+				}
+			}, function( bot ) {
+				var editor = bot.editor;
+
+				editor.filter.addTransformations( [
+					[ 'p: splitBorderShorthand' ]
+				] );
+
+				assertToHtml( editor, '<p style="border: 1px solid red">A</p>',
+					'<p style="border-color:red; border-style:solid; border-width:1px">A</p>', 'border split shorthand 1' );
+				assertToHtml( editor, '<p style="border: 20% dashed rgb(23, 45, 89)">A</p>',
+					'<p style="border-color:#172d59; border-style:dashed; border-width:20%">A</p>', 'border split shorthand 2' );
+				assertToHtml( editor, '<p style="border: 2em dotted #345678">A</p>',
+					'<p style="border-color:#345678; border-style:dotted; border-width:2em">A</p>', 'border split shorthand 3' );
+			} );
 		}
 	} );
 } )();

--- a/tests/core/filter/transformations.js
+++ b/tests/core/filter/transformations.js
@@ -15,8 +15,7 @@
 	function assertToBeautifiedHtml( editor, input, html, msg ) {
 		var result = bender.tools.compatHtml( editor.dataProcessor.toHtml( input ), 0, 1 );
 		if ( CKEDITOR.env.ie && CKEDITOR.env.version === 11 ) {
-			// IE11 adds `border-image: none;` to styles. We need to fix it before assertion check.
-			// It's an upstream issue: #473, https://developer.microsoft.com/en-us/microsoft-edge/platform/issues/12263408/.
+			// IE11 adds `border-image: none;` to styles. We need to fix it before assertion check. It's an upstream issue: #473, https://developer.microsoft.com/en-us/microsoft-edge/platform/issues/12263408/.
 			result = result.replace( 'border-image:none; ', '' );
 		}
 		assert.beautified.html( html, result, msg + ' - toBeautifiedHtml' );
@@ -443,7 +442,7 @@
 		},
 
 		'test splitBorderShorthand transformation': function() {
-			if ( CKEDITOR.env.ie && CKEDITOR.env.ver < 9 ) {
+			if ( CKEDITOR.env.ie && CKEDITOR.env.version < 9 ) {
 				// IE8 has a browser "feature" which split up border into border-top, border-left, border-bottom, border-right styles.
 				// That's why this change does not affect IE8 browser.
 				assert.ignore();
@@ -468,6 +467,10 @@
 					'<p style="border-color:#345678; border-style:dotted; border-width:2em">A</p>', 'border split shorthand 3' );
 				assertToBeautifiedHtml( editor, '<p style="border: 3px double">A</p>',
 					'<p style="border-style:double; border-width:3px">A</p>', 'border split shorthand 4' );
+				assertToBeautifiedHtml( editor, '<p style="border:3px">A</p>',
+					'<p style="border-width:3px">A</p>', 'border split shorthand 5' );
+				assertToBeautifiedHtml( editor, '<p style="border:thick ridge hsla(50, 100%, 50%, 0.7)">A</p>',
+					'<p style="border-color:hsla(50, 100%, 50%, 0.7); border-style:ridge; border-width:thick">A</p>', 'border split shorthand 6' );
 			} );
 		}
 	} );

--- a/tests/plugins/pastefromword/generated/_fixtures/Tickets/11477Table_in_word/word2013/expected_ie11.html
+++ b/tests/plugins/pastefromword/generated/_fixtures/Tickets/11477Table_in_word/word2013/expected_ie11.html
@@ -20,8 +20,8 @@
 				<p style="margin-left:0in; margin-right:0in; text-align:center">
 					<span style="line-height:normal">
 						<strong>
-							<span style="font-size:10pt">
-								<span style="color:#000000">column 1</span>
+							<span style="color:#000000">
+								<span style="font-size:10pt">column 1</span>
 							</span>
 						</strong>
 					</span>
@@ -31,8 +31,8 @@
 				<p style="margin-left:0in; margin-right:0in; text-align:center">
 					<span style="line-height:normal">
 						<strong>
-							<span style="font-size:10pt">
-								<span style="color:#000000">column 2</span>
+							<span style="color:#000000">
+								<span style="font-size:10pt">column 2</span>
 							</span>
 						</strong>
 					</span>
@@ -42,8 +42,8 @@
 				<p style="margin-left:0in; margin-right:0in; text-align:center">
 					<span style="line-height:normal">
 						<strong>
-							<span style="font-size:10pt">
-								<span style="color:#000000">column 3</span>
+							<span style="color:#000000">
+								<span style="font-size:10pt">column 3</span>
 							</span>
 						</strong>
 					</span>
@@ -53,8 +53,8 @@
 				<p style="margin-left:0in; margin-right:0in; text-align:center">
 					<span style="line-height:normal">
 						<strong>
-							<span style="font-size:10pt">
-								<span style="color:#000000">column 4</span>
+							<span style="color:#000000">
+								<span style="font-size:10pt">column 4</span>
 							</span>
 						</strong>
 					</span>
@@ -64,8 +64,8 @@
 				<p style="margin-left:0in; margin-right:0in; text-align:center">
 					<span style="line-height:normal">
 						<strong>
-							<span style="font-size:10pt">
-								<span style="color:#000000">column 5</span>
+							<span style="color:#000000">
+								<span style="font-size:10pt">column 5</span>
 							</span>
 						</strong>
 					</span>
@@ -75,8 +75,8 @@
 				<p style="margin-left:0in; margin-right:0in; text-align:center">
 					<span style="line-height:normal">
 						<strong>
-							<span style="font-size:10pt">
-								<span style="color:#000000">column 6</span>
+							<span style="color:#000000">
+								<span style="font-size:10pt">column 6</span>
 							</span>
 						</strong>
 					</span>
@@ -86,8 +86,8 @@
 				<p style="margin-left:0in; margin-right:0in; text-align:center">
 					<span style="line-height:normal">
 						<strong>
-							<span style="font-size:10pt">
-								<span style="color:#000000">column 7</span>
+							<span style="color:#000000">
+								<span style="font-size:10pt">column 7</span>
 							</span>
 						</strong>
 					</span>
@@ -95,737 +95,737 @@
 			</td>
 		</tr>
 		<tr>
-			<td style="background-color:#cdcee1; width:73.55pt" valign="top">
+			<td style="background-color:#cdcee1; border-color:#000000; width:73.55pt" valign="top">
 				<p style="margin-left:0in; margin-right:0in; text-align:center">
 					<span style="line-height:normal">
 						<strong>
-							<span style="font-size:10pt">
-								<span style="color:#353859">row</span>
+							<span style="color:#353859">
+								<span style="font-size:10pt">row</span>
 							</span>
 						</strong>
 					</span>
 				</p>
 			</td>
-			<td style="background-color:#cdcee1; width:73.55pt" valign="top">
+			<td style="background-color:#cdcee1; border-color:#000000; width:73.55pt" valign="top">
 				<p style="margin-left:0in; margin-right:0in; text-align:center">
-					<span style="line-height:normal">
+					<span style="color:#353859">
 						<span style="font-size:10pt">
-							<span style="color:#353859">table data</span>
+							<span style="line-height:normal">table data</span>
 						</span>
 					</span>
 				</p>
 			</td>
-			<td style="background-color:#cdcee1; width:73.45pt" valign="top">
+			<td style="background-color:#cdcee1; border-color:#000000; width:73.45pt" valign="top">
 				<p style="margin-left:0in; margin-right:0in; text-align:center">
-					<span style="line-height:normal">
+					<span style="color:#353859">
 						<span style="font-size:10pt">
-							<span style="color:#353859">table data</span>
+							<span style="line-height:normal">table data</span>
 						</span>
 					</span>
 				</p>
 			</td>
-			<td style="background-color:#cdcee1; width:73.45pt" valign="top">
+			<td style="background-color:#cdcee1; border-color:#000000; width:73.45pt" valign="top">
 				<p style="margin-left:0in; margin-right:0in; text-align:center">
-					<span style="line-height:normal">
+					<span style="color:#353859">
 						<span style="font-size:10pt">
-							<span style="color:#353859">table data</span>
+							<span style="line-height:normal">table data</span>
 						</span>
 					</span>
 				</p>
 			</td>
-			<td style="background-color:#cdcee1; width:73.5pt" valign="top">
+			<td style="background-color:#cdcee1; border-color:#000000; width:73.5pt" valign="top">
 				<p style="margin-left:0in; margin-right:0in; text-align:center">
-					<span style="line-height:normal">
+					<span style="color:#353859">
 						<span style="font-size:10pt">
-							<span style="color:#353859">table data</span>
+							<span style="line-height:normal">table data</span>
 						</span>
 					</span>
 				</p>
 			</td>
-			<td style="background-color:#cdcee1; width:55.65pt" valign="top">
+			<td style="background-color:#cdcee1; border-color:#000000; width:55.65pt" valign="top">
 				<p style="margin-left:0in; margin-right:0in; text-align:center">
-					<span style="line-height:normal">
+					<span style="color:#353859">
 						<span style="font-size:10pt">
-							<span style="color:#353859">table data</span>
+							<span style="line-height:normal">table data</span>
 						</span>
 					</span>
 				</p>
 			</td>
-			<td style="background-color:#cdcee1; width:55.65pt" valign="top">
+			<td style="background-color:#cdcee1; border-color:#000000; width:55.65pt" valign="top">
 				<p style="margin-left:0in; margin-right:0in; text-align:center">
-					<span style="line-height:normal">
+					<span style="color:#353859">
 						<span style="font-size:10pt">
-							<span style="color:#353859">table data</span>
+							<span style="line-height:normal">table data</span>
 						</span>
 					</span>
 				</p>
 			</td>
 		</tr>
 		<tr>
-			<td style="width:73.55pt" valign="top">
+			<td style="border-color:#000000; width:73.55pt" valign="top">
 				<p style="margin-left:0in; margin-right:0in; text-align:center">
 					<span style="line-height:normal">
 						<strong>
-							<span style="font-size:10pt">
-								<span style="color:#353859">row</span>
+							<span style="color:#353859">
+								<span style="font-size:10pt">row</span>
 							</span>
 						</strong>
 					</span>
 				</p>
 			</td>
-			<td style="width:73.55pt" valign="top">
+			<td style="border-color:#000000; width:73.55pt" valign="top">
 				<p style="margin-left:0in; margin-right:0in; text-align:center">
-					<span style="line-height:normal">
+					<span style="color:#353859">
 						<span style="font-size:10pt">
-							<span style="color:#353859">table data</span>
+							<span style="line-height:normal">table data</span>
 						</span>
 					</span>
 				</p>
 			</td>
-			<td style="width:73.45pt" valign="top">
+			<td style="border-color:#000000; width:73.45pt" valign="top">
 				<p style="margin-left:0in; margin-right:0in; text-align:center">
-					<span style="line-height:normal">
+					<span style="color:#353859">
 						<span style="font-size:10pt">
-							<span style="color:#353859">table data</span>
+							<span style="line-height:normal">table data</span>
 						</span>
 					</span>
 				</p>
 			</td>
-			<td style="width:73.45pt" valign="top">
+			<td style="border-color:#000000; width:73.45pt" valign="top">
 				<p style="margin-left:0in; margin-right:0in; text-align:center">
-					<span style="line-height:normal">
+					<span style="color:#353859">
 						<span style="font-size:10pt">
-							<span style="color:#353859">table data</span>
+							<span style="line-height:normal">table data</span>
 						</span>
 					</span>
 				</p>
 			</td>
-			<td style="width:73.5pt" valign="top">
+			<td style="border-color:#000000; width:73.5pt" valign="top">
 				<p style="margin-left:0in; margin-right:0in; text-align:center">
-					<span style="line-height:normal">
+					<span style="color:#353859">
 						<span style="font-size:10pt">
-							<span style="color:#353859">table data</span>
+							<span style="line-height:normal">table data</span>
 						</span>
 					</span>
 				</p>
 			</td>
-			<td style="width:55.65pt" valign="top">
+			<td style="border-color:#000000; width:55.65pt" valign="top">
 				<p style="margin-left:0in; margin-right:0in; text-align:center">
-					<span style="line-height:normal">
+					<span style="color:#353859">
 						<span style="font-size:10pt">
-							<span style="color:#353859">table data</span>
+							<span style="line-height:normal">table data</span>
 						</span>
 					</span>
 				</p>
 			</td>
-			<td style="width:55.65pt" valign="top">
+			<td style="border-color:#000000; width:55.65pt" valign="top">
 				<p style="margin-left:0in; margin-right:0in; text-align:center">
-					<span style="line-height:normal">
+					<span style="color:#353859">
 						<span style="font-size:10pt">
-							<span style="color:#353859">table data</span>
+							<span style="line-height:normal">table data</span>
 						</span>
 					</span>
 				</p>
 			</td>
 		</tr>
 		<tr>
-			<td style="background-color:#cdcee1; width:73.55pt" valign="top">
+			<td style="background-color:#cdcee1; border-color:#000000; width:73.55pt" valign="top">
 				<p style="margin-left:0in; margin-right:0in; text-align:center">
 					<span style="line-height:normal">
 						<strong>
-							<span style="font-size:10pt">
-								<span style="color:#353859">row</span>
+							<span style="color:#353859">
+								<span style="font-size:10pt">row</span>
 							</span>
 						</strong>
 					</span>
 				</p>
 			</td>
-			<td style="background-color:#cdcee1; width:73.55pt" valign="top">
+			<td style="background-color:#cdcee1; border-color:#000000; width:73.55pt" valign="top">
 				<p style="margin-left:0in; margin-right:0in; text-align:center">
-					<span style="line-height:normal">
+					<span style="color:#353859">
 						<span style="font-size:10pt">
-							<span style="color:#353859">table data</span>
+							<span style="line-height:normal">table data</span>
 						</span>
 					</span>
 				</p>
 			</td>
-			<td style="background-color:#cdcee1; width:73.45pt" valign="top">
+			<td style="background-color:#cdcee1; border-color:#000000; width:73.45pt" valign="top">
 				<p style="margin-left:0in; margin-right:0in; text-align:center">
-					<span style="line-height:normal">
+					<span style="color:#353859">
 						<span style="font-size:10pt">
-							<span style="color:#353859">table data</span>
+							<span style="line-height:normal">table data</span>
 						</span>
 					</span>
 				</p>
 			</td>
-			<td style="background-color:#cdcee1; width:73.45pt" valign="top">
+			<td style="background-color:#cdcee1; border-color:#000000; width:73.45pt" valign="top">
 				<p style="margin-left:0in; margin-right:0in; text-align:center">
-					<span style="line-height:normal">
+					<span style="color:#353859">
 						<span style="font-size:10pt">
-							<span style="color:#353859">table data</span>
+							<span style="line-height:normal">table data</span>
 						</span>
 					</span>
 				</p>
 			</td>
-			<td style="background-color:#cdcee1; width:73.5pt" valign="top">
+			<td style="background-color:#cdcee1; border-color:#000000; width:73.5pt" valign="top">
 				<p style="margin-left:0in; margin-right:0in; text-align:center">
-					<span style="line-height:normal">
+					<span style="color:#353859">
 						<span style="font-size:10pt">
-							<span style="color:#353859">table data</span>
+							<span style="line-height:normal">table data</span>
 						</span>
 					</span>
 				</p>
 			</td>
-			<td style="background-color:#cdcee1; width:55.65pt" valign="top">
+			<td style="background-color:#cdcee1; border-color:#000000; width:55.65pt" valign="top">
 				<p style="margin-left:0in; margin-right:0in; text-align:center">
-					<span style="line-height:normal">
+					<span style="color:#353859">
 						<span style="font-size:10pt">
-							<span style="color:#353859">table data</span>
+							<span style="line-height:normal">table data</span>
 						</span>
 					</span>
 				</p>
 			</td>
-			<td style="background-color:#cdcee1; width:55.65pt" valign="top">
+			<td style="background-color:#cdcee1; border-color:#000000; width:55.65pt" valign="top">
 				<p style="margin-left:0in; margin-right:0in; text-align:center">
-					<span style="line-height:normal">
+					<span style="color:#353859">
 						<span style="font-size:10pt">
-							<span style="color:#353859">table data</span>
+							<span style="line-height:normal">table data</span>
 						</span>
 					</span>
 				</p>
 			</td>
 		</tr>
 		<tr>
-			<td style="width:73.55pt" valign="top">
+			<td style="border-color:#000000; width:73.55pt" valign="top">
 				<p style="margin-left:0in; margin-right:0in; text-align:center">
 					<span style="line-height:normal">
 						<strong>
-							<span style="font-size:10pt">
-								<span style="color:#353859">row</span>
+							<span style="color:#353859">
+								<span style="font-size:10pt">row</span>
 							</span>
 						</strong>
 					</span>
 				</p>
 			</td>
-			<td style="width:73.55pt" valign="top">
+			<td style="border-color:#000000; width:73.55pt" valign="top">
 				<p style="margin-left:0in; margin-right:0in; text-align:center">
-					<span style="line-height:normal">
+					<span style="color:#353859">
 						<span style="font-size:10pt">
-							<span style="color:#353859">table data</span>
+							<span style="line-height:normal">table data</span>
 						</span>
 					</span>
 				</p>
 			</td>
-			<td style="width:73.45pt" valign="top">
+			<td style="border-color:#000000; width:73.45pt" valign="top">
 				<p style="margin-left:0in; margin-right:0in; text-align:center">
-					<span style="line-height:normal">
+					<span style="color:#353859">
 						<span style="font-size:10pt">
-							<span style="color:#353859">table data</span>
+							<span style="line-height:normal">table data</span>
 						</span>
 					</span>
 				</p>
 			</td>
-			<td style="width:73.45pt" valign="top">
+			<td style="border-color:#000000; width:73.45pt" valign="top">
 				<p style="margin-left:0in; margin-right:0in; text-align:center">
-					<span style="line-height:normal">
+					<span style="color:#353859">
 						<span style="font-size:10pt">
-							<span style="color:#353859">table data</span>
+							<span style="line-height:normal">table data</span>
 						</span>
 					</span>
 				</p>
 			</td>
-			<td style="width:73.5pt" valign="top">
+			<td style="border-color:#000000; width:73.5pt" valign="top">
 				<p style="margin-left:0in; margin-right:0in; text-align:center">
-					<span style="line-height:normal">
+					<span style="color:#353859">
 						<span style="font-size:10pt">
-							<span style="color:#353859">table data</span>
+							<span style="line-height:normal">table data</span>
 						</span>
 					</span>
 				</p>
 			</td>
-			<td style="width:55.65pt" valign="top">
+			<td style="border-color:#000000; width:55.65pt" valign="top">
 				<p style="margin-left:0in; margin-right:0in; text-align:center">
-					<span style="line-height:normal">
+					<span style="color:#353859">
 						<span style="font-size:10pt">
-							<span style="color:#353859">table data</span>
+							<span style="line-height:normal">table data</span>
 						</span>
 					</span>
 				</p>
 			</td>
-			<td style="width:55.65pt" valign="top">
+			<td style="border-color:#000000; width:55.65pt" valign="top">
 				<p style="margin-left:0in; margin-right:0in; text-align:center">
-					<span style="line-height:normal">
+					<span style="color:#353859">
 						<span style="font-size:10pt">
-							<span style="color:#353859">table data</span>
+							<span style="line-height:normal">table data</span>
 						</span>
 					</span>
 				</p>
 			</td>
 		</tr>
 		<tr>
-			<td style="background-color:#cdcee1; width:73.55pt" valign="top">
+			<td style="background-color:#cdcee1; border-color:#000000; width:73.55pt" valign="top">
 				<p style="margin-left:0in; margin-right:0in; text-align:center">
 					<span style="line-height:normal">
 						<strong>
-							<span style="font-size:10pt">
-								<span style="color:#353859">row</span>
+							<span style="color:#353859">
+								<span style="font-size:10pt">row</span>
 							</span>
 						</strong>
 					</span>
 				</p>
 			</td>
-			<td style="background-color:#cdcee1; width:73.55pt" valign="top">
+			<td style="background-color:#cdcee1; border-color:#000000; width:73.55pt" valign="top">
 				<p style="margin-left:0in; margin-right:0in; text-align:center">
-					<span style="line-height:normal">
+					<span style="color:#353859">
 						<span style="font-size:10pt">
-							<span style="color:#353859">table data</span>
+							<span style="line-height:normal">table data</span>
 						</span>
 					</span>
 				</p>
 			</td>
-			<td style="background-color:#cdcee1; width:73.45pt" valign="top">
+			<td style="background-color:#cdcee1; border-color:#000000; width:73.45pt" valign="top">
 				<p style="margin-left:0in; margin-right:0in; text-align:center">
-					<span style="line-height:normal">
+					<span style="color:#353859">
 						<span style="font-size:10pt">
-							<span style="color:#353859">table data</span>
+							<span style="line-height:normal">table data</span>
 						</span>
 					</span>
 				</p>
 			</td>
-			<td style="background-color:#cdcee1; width:73.45pt" valign="top">
+			<td style="background-color:#cdcee1; border-color:#000000; width:73.45pt" valign="top">
 				<p style="margin-left:0in; margin-right:0in; text-align:center">
-					<span style="line-height:normal">
+					<span style="color:#353859">
 						<span style="font-size:10pt">
-							<span style="color:#353859">table data</span>
+							<span style="line-height:normal">table data</span>
 						</span>
 					</span>
 				</p>
 			</td>
-			<td style="background-color:#cdcee1; width:73.5pt" valign="top">
+			<td style="background-color:#cdcee1; border-color:#000000; width:73.5pt" valign="top">
 				<p style="margin-left:0in; margin-right:0in; text-align:center">
-					<span style="line-height:normal">
+					<span style="color:#353859">
 						<span style="font-size:10pt">
-							<span style="color:#353859">table data</span>
+							<span style="line-height:normal">table data</span>
 						</span>
 					</span>
 				</p>
 			</td>
-			<td style="background-color:#cdcee1; width:55.65pt" valign="top">
+			<td style="background-color:#cdcee1; border-color:#000000; width:55.65pt" valign="top">
 				<p style="margin-left:0in; margin-right:0in; text-align:center">
-					<span style="line-height:normal">
+					<span style="color:#353859">
 						<span style="font-size:10pt">
-							<span style="color:#353859">table data</span>
+							<span style="line-height:normal">table data</span>
 						</span>
 					</span>
 				</p>
 			</td>
-			<td style="background-color:#cdcee1; width:55.65pt" valign="top">
+			<td style="background-color:#cdcee1; border-color:#000000; width:55.65pt" valign="top">
 				<p style="margin-left:0in; margin-right:0in; text-align:center">
-					<span style="line-height:normal">
+					<span style="color:#353859">
 						<span style="font-size:10pt">
-							<span style="color:#353859">table data</span>
+							<span style="line-height:normal">table data</span>
 						</span>
 					</span>
 				</p>
 			</td>
 		</tr>
 		<tr>
-			<td style="width:73.55pt" valign="top">
+			<td style="border-color:#000000; width:73.55pt" valign="top">
 				<p style="margin-left:0in; margin-right:0in; text-align:center">
 					<span style="line-height:normal">
 						<strong>
-							<span style="font-size:10pt">
-								<span style="color:#353859">row</span>
+							<span style="color:#353859">
+								<span style="font-size:10pt">row</span>
 							</span>
 						</strong>
 					</span>
 				</p>
 			</td>
-			<td style="width:73.55pt" valign="top">
+			<td style="border-color:#000000; width:73.55pt" valign="top">
 				<p style="margin-left:0in; margin-right:0in; text-align:center">
-					<span style="line-height:normal">
+					<span style="color:#353859">
 						<span style="font-size:10pt">
-							<span style="color:#353859">table data</span>
+							<span style="line-height:normal">table data</span>
 						</span>
 					</span>
 				</p>
 			</td>
-			<td style="width:73.45pt" valign="top">
+			<td style="border-color:#000000; width:73.45pt" valign="top">
 				<p style="margin-left:0in; margin-right:0in; text-align:center">
-					<span style="line-height:normal">
+					<span style="color:#353859">
 						<span style="font-size:10pt">
-							<span style="color:#353859">table data</span>
+							<span style="line-height:normal">table data</span>
 						</span>
 					</span>
 				</p>
 			</td>
-			<td style="width:73.45pt" valign="top">
+			<td style="border-color:#000000; width:73.45pt" valign="top">
 				<p style="margin-left:0in; margin-right:0in; text-align:center">
-					<span style="line-height:normal">
+					<span style="color:#353859">
 						<span style="font-size:10pt">
-							<span style="color:#353859">table data</span>
+							<span style="line-height:normal">table data</span>
 						</span>
 					</span>
 				</p>
 			</td>
-			<td style="width:73.5pt" valign="top">
+			<td style="border-color:#000000; width:73.5pt" valign="top">
 				<p style="margin-left:0in; margin-right:0in; text-align:center">
-					<span style="line-height:normal">
+					<span style="color:#353859">
 						<span style="font-size:10pt">
-							<span style="color:#353859">table data</span>
+							<span style="line-height:normal">table data</span>
 						</span>
 					</span>
 				</p>
 			</td>
-			<td style="width:55.65pt" valign="top">
+			<td style="border-color:#000000; width:55.65pt" valign="top">
 				<p style="margin-left:0in; margin-right:0in; text-align:center">
-					<span style="line-height:normal">
+					<span style="color:#353859">
 						<span style="font-size:10pt">
-							<span style="color:#353859">table data</span>
+							<span style="line-height:normal">table data</span>
 						</span>
 					</span>
 				</p>
 			</td>
-			<td style="width:55.65pt" valign="top">
+			<td style="border-color:#000000; width:55.65pt" valign="top">
 				<p style="margin-left:0in; margin-right:0in; text-align:center">
-					<span style="line-height:normal">
+					<span style="color:#353859">
 						<span style="font-size:10pt">
-							<span style="color:#353859">table data</span>
+							<span style="line-height:normal">table data</span>
 						</span>
 					</span>
 				</p>
 			</td>
 		</tr>
 		<tr>
-			<td style="background-color:#cdcee1; width:73.55pt" valign="top">
+			<td style="background-color:#cdcee1; border-color:#000000; width:73.55pt" valign="top">
 				<p style="margin-left:0in; margin-right:0in; text-align:center">
 					<span style="line-height:normal">
 						<strong>
-							<span style="font-size:10pt">
-								<span style="color:#353859">row</span>
+							<span style="color:#353859">
+								<span style="font-size:10pt">row</span>
 							</span>
 						</strong>
 					</span>
 				</p>
 			</td>
-			<td style="background-color:#cdcee1; width:73.55pt" valign="top">
+			<td style="background-color:#cdcee1; border-color:#000000; width:73.55pt" valign="top">
 				<p style="margin-left:0in; margin-right:0in; text-align:center">
-					<span style="line-height:normal">
+					<span style="color:#353859">
 						<span style="font-size:10pt">
-							<span style="color:#353859">table data</span>
+							<span style="line-height:normal">table data</span>
 						</span>
 					</span>
 				</p>
 			</td>
-			<td style="background-color:#cdcee1; width:73.45pt" valign="top">
+			<td style="background-color:#cdcee1; border-color:#000000; width:73.45pt" valign="top">
 				<p style="margin-left:0in; margin-right:0in; text-align:center">
-					<span style="line-height:normal">
+					<span style="color:#353859">
 						<span style="font-size:10pt">
-							<span style="color:#353859">table data</span>
+							<span style="line-height:normal">table data</span>
 						</span>
 					</span>
 				</p>
 			</td>
-			<td style="background-color:#cdcee1; width:73.45pt" valign="top">
+			<td style="background-color:#cdcee1; border-color:#000000; width:73.45pt" valign="top">
 				<p style="margin-left:0in; margin-right:0in; text-align:center">
-					<span style="line-height:normal">
+					<span style="color:#353859">
 						<span style="font-size:10pt">
-							<span style="color:#353859">table data</span>
+							<span style="line-height:normal">table data</span>
 						</span>
 					</span>
 				</p>
 			</td>
-			<td style="background-color:#cdcee1; width:73.5pt" valign="top">
+			<td style="background-color:#cdcee1; border-color:#000000; width:73.5pt" valign="top">
 				<p style="margin-left:0in; margin-right:0in; text-align:center">
-					<span style="line-height:normal">
+					<span style="color:#353859">
 						<span style="font-size:10pt">
-							<span style="color:#353859">table data</span>
+							<span style="line-height:normal">table data</span>
 						</span>
 					</span>
 				</p>
 			</td>
-			<td style="background-color:#cdcee1; width:55.65pt" valign="top">
+			<td style="background-color:#cdcee1; border-color:#000000; width:55.65pt" valign="top">
 				<p style="margin-left:0in; margin-right:0in; text-align:center">
-					<span style="line-height:normal">
+					<span style="color:#353859">
 						<span style="font-size:10pt">
-							<span style="color:#353859">table data</span>
+							<span style="line-height:normal">table data</span>
 						</span>
 					</span>
 				</p>
 			</td>
-			<td style="background-color:#cdcee1; width:55.65pt" valign="top">
+			<td style="background-color:#cdcee1; border-color:#000000; width:55.65pt" valign="top">
 				<p style="margin-left:0in; margin-right:0in; text-align:center">
-					<span style="line-height:normal">
+					<span style="color:#353859">
 						<span style="font-size:10pt">
-							<span style="color:#353859">table data</span>
+							<span style="line-height:normal">table data</span>
 						</span>
 					</span>
 				</p>
 			</td>
 		</tr>
 		<tr>
-			<td style="width:73.55pt" valign="top">
+			<td style="border-color:#000000; width:73.55pt" valign="top">
 				<p style="margin-left:0in; margin-right:0in; text-align:center">
 					<span style="line-height:normal">
 						<strong>
-							<span style="font-size:10pt">
-								<span style="color:#353859">row</span>
+							<span style="color:#353859">
+								<span style="font-size:10pt">row</span>
 							</span>
 						</strong>
 					</span>
 				</p>
 			</td>
-			<td style="width:73.55pt" valign="top">
+			<td style="border-color:#000000; width:73.55pt" valign="top">
 				<p style="margin-left:0in; margin-right:0in; text-align:center">
-					<span style="line-height:normal">
+					<span style="color:#353859">
 						<span style="font-size:10pt">
-							<span style="color:#353859">table data</span>
+							<span style="line-height:normal">table data</span>
 						</span>
 					</span>
 				</p>
 			</td>
-			<td style="width:73.45pt" valign="top">
+			<td style="border-color:#000000; width:73.45pt" valign="top">
 				<p style="margin-left:0in; margin-right:0in; text-align:center">
-					<span style="line-height:normal">
+					<span style="color:#353859">
 						<span style="font-size:10pt">
-							<span style="color:#353859">table data</span>
+							<span style="line-height:normal">table data</span>
 						</span>
 					</span>
 				</p>
 			</td>
-			<td style="width:73.45pt" valign="top">
+			<td style="border-color:#000000; width:73.45pt" valign="top">
 				<p style="margin-left:0in; margin-right:0in; text-align:center">
-					<span style="line-height:normal">
+					<span style="color:#353859">
 						<span style="font-size:10pt">
-							<span style="color:#353859">table data</span>
+							<span style="line-height:normal">table data</span>
 						</span>
 					</span>
 				</p>
 			</td>
-			<td style="width:73.5pt" valign="top">
+			<td style="border-color:#000000; width:73.5pt" valign="top">
 				<p style="margin-left:0in; margin-right:0in; text-align:center">
-					<span style="line-height:normal">
+					<span style="color:#353859">
 						<span style="font-size:10pt">
-							<span style="color:#353859">table data</span>
+							<span style="line-height:normal">table data</span>
 						</span>
 					</span>
 				</p>
 			</td>
-			<td style="width:55.65pt" valign="top">
+			<td style="border-color:#000000; width:55.65pt" valign="top">
 				<p style="margin-left:0in; margin-right:0in; text-align:center">
-					<span style="line-height:normal">
+					<span style="color:#353859">
 						<span style="font-size:10pt">
-							<span style="color:#353859">table data</span>
+							<span style="line-height:normal">table data</span>
 						</span>
 					</span>
 				</p>
 			</td>
-			<td style="width:55.65pt" valign="top">
+			<td style="border-color:#000000; width:55.65pt" valign="top">
 				<p style="margin-left:0in; margin-right:0in; text-align:center">
-					<span style="line-height:normal">
+					<span style="color:#353859">
 						<span style="font-size:10pt">
-							<span style="color:#353859">table data</span>
+							<span style="line-height:normal">table data</span>
 						</span>
 					</span>
 				</p>
 			</td>
 		</tr>
 		<tr>
-			<td style="background-color:#cdcee1; width:73.55pt" valign="top">
+			<td style="background-color:#cdcee1; border-color:#000000; width:73.55pt" valign="top">
 				<p style="margin-left:0in; margin-right:0in; text-align:center">
 					<span style="line-height:normal">
 						<strong>
-							<span style="font-size:10pt">
-								<span style="color:#353859">row</span>
+							<span style="color:#353859">
+								<span style="font-size:10pt">row</span>
 							</span>
 						</strong>
 					</span>
 				</p>
 			</td>
-			<td style="background-color:#cdcee1; width:73.55pt" valign="top">
+			<td style="background-color:#cdcee1; border-color:#000000; width:73.55pt" valign="top">
 				<p style="margin-left:0in; margin-right:0in; text-align:center">
-					<span style="line-height:normal">
+					<span style="color:#353859">
 						<span style="font-size:10pt">
-							<span style="color:#353859">table data</span>
+							<span style="line-height:normal">table data</span>
 						</span>
 					</span>
 				</p>
 			</td>
-			<td style="background-color:#cdcee1; width:73.45pt" valign="top">
+			<td style="background-color:#cdcee1; border-color:#000000; width:73.45pt" valign="top">
 				<p style="margin-left:0in; margin-right:0in; text-align:center">
-					<span style="line-height:normal">
+					<span style="color:#353859">
 						<span style="font-size:10pt">
-							<span style="color:#353859">table data</span>
+							<span style="line-height:normal">table data</span>
 						</span>
 					</span>
 				</p>
 			</td>
-			<td style="background-color:#cdcee1; width:73.45pt" valign="top">
+			<td style="background-color:#cdcee1; border-color:#000000; width:73.45pt" valign="top">
 				<p style="margin-left:0in; margin-right:0in; text-align:center">
-					<span style="line-height:normal">
+					<span style="color:#353859">
 						<span style="font-size:10pt">
-							<span style="color:#353859">table data</span>
+							<span style="line-height:normal">table data</span>
 						</span>
 					</span>
 				</p>
 			</td>
-			<td style="background-color:#cdcee1; width:73.5pt" valign="top">
+			<td style="background-color:#cdcee1; border-color:#000000; width:73.5pt" valign="top">
 				<p style="margin-left:0in; margin-right:0in; text-align:center">
-					<span style="line-height:normal">
+					<span style="color:#353859">
 						<span style="font-size:10pt">
-							<span style="color:#353859">table data</span>
+							<span style="line-height:normal">table data</span>
 						</span>
 					</span>
 				</p>
 			</td>
-			<td style="background-color:#cdcee1; width:55.65pt" valign="top">
+			<td style="background-color:#cdcee1; border-color:#000000; width:55.65pt" valign="top">
 				<p style="margin-left:0in; margin-right:0in; text-align:center">
-					<span style="line-height:normal">
+					<span style="color:#353859">
 						<span style="font-size:10pt">
-							<span style="color:#353859">table data</span>
+							<span style="line-height:normal">table data</span>
 						</span>
 					</span>
 				</p>
 			</td>
-			<td style="background-color:#cdcee1; width:55.65pt" valign="top">
+			<td style="background-color:#cdcee1; border-color:#000000; width:55.65pt" valign="top">
 				<p style="margin-left:0in; margin-right:0in; text-align:center">
-					<span style="line-height:normal">
+					<span style="color:#353859">
 						<span style="font-size:10pt">
-							<span style="color:#353859">table data</span>
+							<span style="line-height:normal">table data</span>
 						</span>
 					</span>
 				</p>
 			</td>
 		</tr>
 		<tr>
-			<td style="width:73.55pt" valign="top">
+			<td style="border-color:#000000; width:73.55pt" valign="top">
 				<p style="margin-left:0in; margin-right:0in; text-align:center">
 					<span style="line-height:normal">
 						<strong>
-							<span style="font-size:10pt">
-								<span style="color:#353859">row</span>
+							<span style="color:#353859">
+								<span style="font-size:10pt">row</span>
 							</span>
 						</strong>
 					</span>
 				</p>
 			</td>
-			<td style="width:73.55pt" valign="top">
+			<td style="border-color:#000000; width:73.55pt" valign="top">
 				<p style="margin-left:0in; margin-right:0in; text-align:center">
-					<span style="line-height:normal">
+					<span style="color:#353859">
 						<span style="font-size:10pt">
-							<span style="color:#353859">table data</span>
+							<span style="line-height:normal">table data</span>
 						</span>
 					</span>
 				</p>
 			</td>
-			<td style="width:73.45pt" valign="top">
+			<td style="border-color:#000000; width:73.45pt" valign="top">
 				<p style="margin-left:0in; margin-right:0in; text-align:center">
-					<span style="line-height:normal">
+					<span style="color:#353859">
 						<span style="font-size:10pt">
-							<span style="color:#353859">table data</span>
+							<span style="line-height:normal">table data</span>
 						</span>
 					</span>
 				</p>
 			</td>
-			<td style="width:73.45pt" valign="top">
+			<td style="border-color:#000000; width:73.45pt" valign="top">
 				<p style="margin-left:0in; margin-right:0in; text-align:center">
-					<span style="line-height:normal">
+					<span style="color:#353859">
 						<span style="font-size:10pt">
-							<span style="color:#353859">table data</span>
+							<span style="line-height:normal">table data</span>
 						</span>
 					</span>
 				</p>
 			</td>
-			<td style="width:73.5pt" valign="top">
+			<td style="border-color:#000000; width:73.5pt" valign="top">
 				<p style="margin-left:0in; margin-right:0in; text-align:center">
-					<span style="line-height:normal">
+					<span style="color:#353859">
 						<span style="font-size:10pt">
-							<span style="color:#353859">table data</span>
+							<span style="line-height:normal">table data</span>
 						</span>
 					</span>
 				</p>
 			</td>
-			<td style="width:55.65pt" valign="top">
+			<td style="border-color:#000000; width:55.65pt" valign="top">
 				<p style="margin-left:0in; margin-right:0in; text-align:center">
-					<span style="line-height:normal">
+					<span style="color:#353859">
 						<span style="font-size:10pt">
-							<span style="color:#353859">table data</span>
+							<span style="line-height:normal">table data</span>
 						</span>
 					</span>
 				</p>
 			</td>
-			<td style="width:55.65pt" valign="top">
+			<td style="border-color:#000000; width:55.65pt" valign="top">
 				<p style="margin-left:0in; margin-right:0in; text-align:center">
-					<span style="line-height:normal">
+					<span style="color:#353859">
 						<span style="font-size:10pt">
-							<span style="color:#353859">table data</span>
+							<span style="line-height:normal">table data</span>
 						</span>
 					</span>
 				</p>
 			</td>
 		</tr>
 		<tr>
-			<td style="background-color:#cdcee1; width:73.55pt" valign="top">
+			<td style="background-color:#cdcee1; border-color:#000000; width:73.55pt" valign="top">
 				<p style="margin-left:0in; margin-right:0in; text-align:center">
 					<span style="line-height:normal">
 						<strong>
-							<span style="font-size:10pt">
-								<span style="color:#353859">row</span>
+							<span style="color:#353859">
+								<span style="font-size:10pt">row</span>
 							</span>
 						</strong>
 					</span>
 				</p>
 			</td>
-			<td style="background-color:#cdcee1; width:73.55pt" valign="top">
+			<td style="background-color:#cdcee1; border-color:#000000; width:73.55pt" valign="top">
 				<p style="margin-left:0in; margin-right:0in; text-align:center">
-					<span style="line-height:normal">
+					<span style="color:#353859">
 						<span style="font-size:10pt">
-							<span style="color:#353859">table data</span>
+							<span style="line-height:normal">table data</span>
 						</span>
 					</span>
 				</p>
 			</td>
-			<td style="background-color:#cdcee1; width:73.45pt" valign="top">
+			<td style="background-color:#cdcee1; border-color:#000000; width:73.45pt" valign="top">
 				<p style="margin-left:0in; margin-right:0in; text-align:center">
-					<span style="line-height:normal">
+					<span style="color:#353859">
 						<span style="font-size:10pt">
-							<span style="color:#353859">table data</span>
+							<span style="line-height:normal">table data</span>
 						</span>
 					</span>
 				</p>
 			</td>
-			<td style="background-color:#cdcee1; width:73.45pt" valign="top">
+			<td style="background-color:#cdcee1; border-color:#000000; width:73.45pt" valign="top">
 				<p style="margin-left:0in; margin-right:0in; text-align:center">
-					<span style="line-height:normal">
+					<span style="color:#353859">
 						<span style="font-size:10pt">
-							<span style="color:#353859">table data</span>
+							<span style="line-height:normal">table data</span>
 						</span>
 					</span>
 				</p>
 			</td>
-			<td style="background-color:#cdcee1; width:73.5pt" valign="top">
+			<td style="background-color:#cdcee1; border-color:#000000; width:73.5pt" valign="top">
 				<p style="margin-left:0in; margin-right:0in; text-align:center">
-					<span style="line-height:normal">
+					<span style="color:#353859">
 						<span style="font-size:10pt">
-							<span style="color:#353859">table data</span>
+							<span style="line-height:normal">table data</span>
 						</span>
 					</span>
 				</p>
 			</td>
-			<td style="background-color:#cdcee1; width:55.65pt" valign="top">
+			<td style="background-color:#cdcee1; border-color:#000000; width:55.65pt" valign="top">
 				<p style="margin-left:0in; margin-right:0in; text-align:center">
-					<span style="line-height:normal">
+					<span style="color:#353859">
 						<span style="font-size:10pt">
-							<span style="color:#353859">table data</span>
+							<span style="line-height:normal">table data</span>
 						</span>
 					</span>
 				</p>
 			</td>
-			<td style="background-color:#cdcee1; width:55.65pt" valign="top">
+			<td style="background-color:#cdcee1; border-color:#000000; width:55.65pt" valign="top">
 				<p style="margin-left:0in; margin-right:0in; text-align:center">
-					<span style="line-height:normal">
+					<span style="color:#353859">
 						<span style="font-size:10pt">
-							<span style="color:#353859">table data</span>
+							<span style="line-height:normal">table data</span>
 						</span>
 					</span>
 				</p>
@@ -836,8 +836,8 @@
 				<p style="margin-left:0in; margin-right:0in; text-align:center">
 					<span style="line-height:normal">
 						<strong>
-							<span style="font-size:10pt">
-								<span style="color:#353859">row</span>
+							<span style="color:#353859">
+								<span style="font-size:10pt">row</span>
 							</span>
 						</strong>
 					</span>
@@ -845,54 +845,54 @@
 			</td>
 			<td style="border-color:#000000 #000000 #474b78; width:73.55pt" valign="top">
 				<p style="margin-left:0in; margin-right:0in; text-align:center">
-					<span style="line-height:normal">
+					<span style="color:#353859">
 						<span style="font-size:10pt">
-							<span style="color:#353859">table data</span>
+							<span style="line-height:normal">table data</span>
 						</span>
 					</span>
 				</p>
 			</td>
 			<td style="border-color:#000000 #000000 #474b78; width:73.45pt" valign="top">
 				<p style="margin-left:0in; margin-right:0in; text-align:center">
-					<span style="line-height:normal">
+					<span style="color:#353859">
 						<span style="font-size:10pt">
-							<span style="color:#353859">table data</span>
+							<span style="line-height:normal">table data</span>
 						</span>
 					</span>
 				</p>
 			</td>
 			<td style="border-color:#000000 #000000 #474b78; width:73.45pt" valign="top">
 				<p style="margin-left:0in; margin-right:0in; text-align:center">
-					<span style="line-height:normal">
+					<span style="color:#353859">
 						<span style="font-size:10pt">
-							<span style="color:#353859">table data</span>
+							<span style="line-height:normal">table data</span>
 						</span>
 					</span>
 				</p>
 			</td>
 			<td style="border-color:#000000 #000000 #474b78; width:73.5pt" valign="top">
 				<p style="margin-left:0in; margin-right:0in; text-align:center">
-					<span style="line-height:normal">
+					<span style="color:#353859">
 						<span style="font-size:10pt">
-							<span style="color:#353859">table data</span>
+							<span style="line-height:normal">table data</span>
 						</span>
 					</span>
 				</p>
 			</td>
 			<td style="border-color:#000000 #000000 #474b78; width:55.65pt" valign="top">
 				<p style="margin-left:0in; margin-right:0in; text-align:center">
-					<span style="line-height:normal">
+					<span style="color:#353859">
 						<span style="font-size:10pt">
-							<span style="color:#353859">table data</span>
+							<span style="line-height:normal">table data</span>
 						</span>
 					</span>
 				</p>
 			</td>
 			<td style="border-color:#000000 #000000 #474b78; width:55.65pt" valign="top">
 				<p style="margin-left:0in; margin-right:0in; text-align:center">
-					<span style="line-height:normal">
+					<span style="color:#353859">
 						<span style="font-size:10pt">
-							<span style="color:#353859">table data</span>
+							<span style="line-height:normal">table data</span>
 						</span>
 					</span>
 				</p>

--- a/tests/plugins/pastefromword/generated/_fixtures/Tickets/11529Table_OO/expected.html
+++ b/tests/plugins/pastefromword/generated/_fixtures/Tickets/11529Table_OO/expected.html
@@ -1,1 +1,163 @@
-<table cellspacing="0"><tbody><tr><td style="width:1.0in" valign="top"><p><span style="line-height:normal"><strong><span style="color:#5f497a">mes </span></strong></span></p></td><td style="width:1.0in" valign="top"><p><span style="line-height:normal"><strong><span style="color:#5f497a">enero</span></strong></span></p></td><td style="width:72.05pt" valign="top"><p><span style="line-height:normal"><strong><span style="color:#5f497a">febrero</span></strong></span></p></td><td style="width:72.05pt" valign="top"><p><span style="line-height:normal"><strong><span style="color:#5f497a">marzo</span></strong></span></p></td><td style="width:72.05pt" valign="top"><p><br /></p></td><td style="width:72.05pt" valign="top"><p><br /></p></td></tr><tr><td style="background-color:#dfd8e8; width:1.0in" valign="top"><p><span style="line-height:normal"><strong><span style="color:#5f497a">1</span></strong></span></p></td><td style="background-color:#dfd8e8; width:1.0in" valign="top"><p><br /></p></td><td style="background-color:#dfd8e8; width:72.05pt" valign="top"><p><br /></p></td><td style="background-color:#dfd8e8; width:72.05pt" valign="top"><p><br /></p></td><td style="background-color:#dfd8e8; width:72.05pt" valign="top"><p><br /></p></td><td style="background-color:#dfd8e8; width:72.05pt" valign="top"><p><br /></p></td></tr><tr><td style="width:1.0in" valign="top"><p><span style="line-height:normal"><strong><span style="color:#5f497a">2</span></strong></span></p></td><td style="width:1.0in" valign="top"><p><br /></p></td><td style="width:72.05pt" valign="top"><p><br /></p></td><td style="width:72.05pt" valign="top"><p><br /></p></td><td style="width:72.05pt" valign="top"><p><br /></p></td><td style="width:72.05pt" valign="top"><p><br /></p></td></tr><tr><td style="background-color:#dfd8e8; width:1.0in" valign="top"><p><span style="line-height:normal"><strong><span style="color:#5f497a">3</span></strong></span></p></td><td style="background-color:#dfd8e8; width:1.0in" valign="top"><p><br /></p></td><td style="background-color:#dfd8e8; width:72.05pt" valign="top"><p><br /></p></td><td style="background-color:#dfd8e8; width:72.05pt" valign="top"><p><br /></p></td><td style="background-color:#dfd8e8; width:72.05pt" valign="top"><p><br /></p></td><td style="background-color:#dfd8e8; width:72.05pt" valign="top"><p><br /></p></td></tr></tbody></table><p><br /></p>
+<table cellspacing="0">
+	<tbody>
+		<tr>
+			<td style="width:1.0in" valign="top">
+				<p>
+					<span style="line-height:normal">
+						<strong>
+							<span style="color:#5f497a">mes </span>
+						</strong>
+					</span>
+				</p>
+			</td>
+			<td style="width:1.0in" valign="top">
+				<p>
+					<span style="line-height:normal">
+						<strong>
+							<span style="color:#5f497a">enero</span>
+						</strong>
+					</span>
+				</p>
+			</td>
+			<td style="width:72.05pt" valign="top">
+				<p>
+					<span style="line-height:normal">
+						<strong>
+							<span style="color:#5f497a">febrero</span>
+						</strong>
+					</span>
+				</p>
+			</td>
+			<td style="width:72.05pt" valign="top">
+				<p>
+					<span style="line-height:normal">
+						<strong>
+							<span style="color:#5f497a">marzo</span>
+						</strong>
+					</span>
+				</p>
+			</td>
+			<td style="width:72.05pt" valign="top">
+				<p>
+					<br />
+				</p>
+			</td>
+			<td style="width:72.05pt" valign="top">
+				<p>
+					<br />
+				</p>
+			</td>
+		</tr>
+		<tr>
+			<td style="background-color:#dfd8e8; width:1.0in" valign="top">
+				<p>
+					<span style="line-height:normal">
+						<strong>
+							<span style="color:#5f497a">1</span>
+						</strong>
+					</span>
+				</p>
+			</td>
+			<td style="background-color:#dfd8e8; width:1.0in" valign="top">
+				<p>
+					<br />
+				</p>
+			</td>
+			<td style="background-color:#dfd8e8; width:72.05pt" valign="top">
+				<p>
+					<br />
+				</p>
+			</td>
+			<td style="background-color:#dfd8e8; width:72.05pt" valign="top">
+				<p>
+					<br />
+				</p>
+			</td>
+			<td style="background-color:#dfd8e8; width:72.05pt" valign="top">
+				<p>
+					<br />
+				</p>
+			</td>
+			<td style="background-color:#dfd8e8; width:72.05pt" valign="top">
+				<p>
+					<br />
+				</p>
+			</td>
+		</tr>
+		<tr>
+			<td style="width:1.0in" valign="top">
+				<p>
+					<span style="line-height:normal">
+						<strong>
+							<span style="color:#5f497a">2</span>
+						</strong>
+					</span>
+				</p>
+			</td>
+			<td style="width:1.0in" valign="top">
+				<p>
+					<br />
+				</p>
+			</td>
+			<td style="width:72.05pt" valign="top">
+				<p>
+					<br />
+				</p>
+			</td>
+			<td style="width:72.05pt" valign="top">
+				<p>
+					<br />
+				</p>
+			</td>
+			<td style="width:72.05pt" valign="top">
+				<p>
+					<br />
+				</p>
+			</td>
+			<td style="width:72.05pt" valign="top">
+				<p>
+					<br />
+				</p>
+			</td>
+		</tr>
+		<tr>
+			<td style="background-color:#dfd8e8; width:1.0in" valign="top">
+				<p>
+					<span style="line-height:normal">
+						<strong>
+							<span style="color:#5f497a">3</span>
+						</strong>
+					</span>
+				</p>
+			</td>
+			<td style="background-color:#dfd8e8; width:1.0in" valign="top">
+				<p>
+					<br />
+				</p>
+			</td>
+			<td style="background-color:#dfd8e8; width:72.05pt" valign="top">
+				<p>
+					<br />
+				</p>
+			</td>
+			<td style="background-color:#dfd8e8; width:72.05pt" valign="top">
+				<p>
+					<br />
+				</p>
+			</td>
+			<td style="background-color:#dfd8e8; width:72.05pt" valign="top">
+				<p>
+					<br />
+				</p>
+			</td>
+			<td style="background-color:#dfd8e8; width:72.05pt" valign="top">
+				<p>
+					<br />
+				</p>
+			</td>
+		</tr>
+	</tbody>
+</table>
+<p>
+	<br />
+</p>

--- a/tests/plugins/pastefromword/generated/_fixtures/Tickets/11529Table_OO/word2013/expected_ie11.html
+++ b/tests/plugins/pastefromword/generated/_fixtures/Tickets/11529Table_OO/word2013/expected_ie11.html
@@ -81,7 +81,7 @@
 			</td>
 		</tr>
 		<tr>
-			<td style="background-color:#dfd8e8; width:1in" valign="top">
+			<td style="background-color:#dfd8e8; border-color:#000000; width:1in" valign="top">
 				<p style="margin-left:0in; margin-right:0in">
 					<span style="line-height:normal">
 						<strong>
@@ -94,56 +94,56 @@
 					</span>
 				</p>
 			</td>
-			<td style="background-color:#dfd8e8; width:1in" valign="top">
+			<td style="background-color:#dfd8e8; border-color:#000000; width:1in" valign="top">
 				<p style="margin-left:0in; margin-right:0in">
-					<span style="line-height:normal">
-						<span style="color:#5f497a">
-							<span style="font-family:calibri">
-								<span style="font-size:medium">&nbsp;</span>
+					<span style="color:#5f497a">
+						<span style="font-family:calibri">
+							<span style="font-size:medium">
+								<span style="line-height:normal">&nbsp;</span>
 							</span>
 						</span>
 					</span>
 				</p>
 			</td>
-			<td style="background-color:#dfd8e8; width:72.05pt" valign="top">
+			<td style="background-color:#dfd8e8; border-color:#000000; width:72.05pt" valign="top">
 				<p style="margin-left:0in; margin-right:0in">
-					<span style="line-height:normal">
-						<span style="color:#5f497a">
-							<span style="font-family:calibri">
-								<span style="font-size:medium">&nbsp;</span>
+					<span style="color:#5f497a">
+						<span style="font-family:calibri">
+							<span style="font-size:medium">
+								<span style="line-height:normal">&nbsp;</span>
 							</span>
 						</span>
 					</span>
 				</p>
 			</td>
-			<td style="background-color:#dfd8e8; width:72.05pt" valign="top">
+			<td style="background-color:#dfd8e8; border-color:#000000; width:72.05pt" valign="top">
 				<p style="margin-left:0in; margin-right:0in">
-					<span style="line-height:normal">
-						<span style="color:#5f497a">
-							<span style="font-family:calibri">
-								<span style="font-size:medium">&nbsp;</span>
+					<span style="color:#5f497a">
+						<span style="font-family:calibri">
+							<span style="font-size:medium">
+								<span style="line-height:normal">&nbsp;</span>
 							</span>
 						</span>
 					</span>
 				</p>
 			</td>
-			<td style="background-color:#dfd8e8; width:72.05pt" valign="top">
+			<td style="background-color:#dfd8e8; border-color:#000000; width:72.05pt" valign="top">
 				<p style="margin-left:0in; margin-right:0in">
-					<span style="line-height:normal">
-						<span style="color:#5f497a">
-							<span style="font-family:calibri">
-								<span style="font-size:medium">&nbsp;</span>
+					<span style="color:#5f497a">
+						<span style="font-family:calibri">
+							<span style="font-size:medium">
+								<span style="line-height:normal">&nbsp;</span>
 							</span>
 						</span>
 					</span>
 				</p>
 			</td>
-			<td style="background-color:#dfd8e8; width:72.05pt" valign="top">
+			<td style="background-color:#dfd8e8; border-color:#000000; width:72.05pt" valign="top">
 				<p style="margin-left:0in; margin-right:0in">
-					<span style="line-height:normal">
-						<span style="color:#5f497a">
-							<span style="font-family:calibri">
-								<span style="font-size:medium">&nbsp;</span>
+					<span style="color:#5f497a">
+						<span style="font-family:calibri">
+							<span style="font-size:medium">
+								<span style="line-height:normal">&nbsp;</span>
 							</span>
 						</span>
 					</span>
@@ -151,7 +151,7 @@
 			</td>
 		</tr>
 		<tr>
-			<td style="width:1in" valign="top">
+			<td style="border-color:#000000; width:1in" valign="top">
 				<p style="margin-left:0in; margin-right:0in">
 					<span style="line-height:normal">
 						<strong>
@@ -164,56 +164,56 @@
 					</span>
 				</p>
 			</td>
-			<td style="width:1in" valign="top">
+			<td style="border-color:#000000; width:1in" valign="top">
 				<p style="margin-left:0in; margin-right:0in">
-					<span style="line-height:normal">
-						<span style="color:#5f497a">
-							<span style="font-family:calibri">
-								<span style="font-size:medium">&nbsp;</span>
+					<span style="color:#5f497a">
+						<span style="font-family:calibri">
+							<span style="font-size:medium">
+								<span style="line-height:normal">&nbsp;</span>
 							</span>
 						</span>
 					</span>
 				</p>
 			</td>
-			<td style="width:72.05pt" valign="top">
+			<td style="border-color:#000000; width:72.05pt" valign="top">
 				<p style="margin-left:0in; margin-right:0in">
-					<span style="line-height:normal">
-						<span style="color:#5f497a">
-							<span style="font-family:calibri">
-								<span style="font-size:medium">&nbsp;</span>
+					<span style="color:#5f497a">
+						<span style="font-family:calibri">
+							<span style="font-size:medium">
+								<span style="line-height:normal">&nbsp;</span>
 							</span>
 						</span>
 					</span>
 				</p>
 			</td>
-			<td style="width:72.05pt" valign="top">
+			<td style="border-color:#000000; width:72.05pt" valign="top">
 				<p style="margin-left:0in; margin-right:0in">
-					<span style="line-height:normal">
-						<span style="color:#5f497a">
-							<span style="font-family:calibri">
-								<span style="font-size:medium">&nbsp;</span>
+					<span style="color:#5f497a">
+						<span style="font-family:calibri">
+							<span style="font-size:medium">
+								<span style="line-height:normal">&nbsp;</span>
 							</span>
 						</span>
 					</span>
 				</p>
 			</td>
-			<td style="width:72.05pt" valign="top">
+			<td style="border-color:#000000; width:72.05pt" valign="top">
 				<p style="margin-left:0in; margin-right:0in">
-					<span style="line-height:normal">
-						<span style="color:#5f497a">
-							<span style="font-family:calibri">
-								<span style="font-size:medium">&nbsp;</span>
+					<span style="color:#5f497a">
+						<span style="font-family:calibri">
+							<span style="font-size:medium">
+								<span style="line-height:normal">&nbsp;</span>
 							</span>
 						</span>
 					</span>
 				</p>
 			</td>
-			<td style="width:72.05pt" valign="top">
+			<td style="border-color:#000000; width:72.05pt" valign="top">
 				<p style="margin-left:0in; margin-right:0in">
-					<span style="line-height:normal">
-						<span style="color:#5f497a">
-							<span style="font-family:calibri">
-								<span style="font-size:medium">&nbsp;</span>
+					<span style="color:#5f497a">
+						<span style="font-family:calibri">
+							<span style="font-size:medium">
+								<span style="line-height:normal">&nbsp;</span>
 							</span>
 						</span>
 					</span>
@@ -236,10 +236,10 @@
 			</td>
 			<td style="background-color:#dfd8e8; border-color:#000000 #000000 #8064a2; width:1in" valign="top">
 				<p style="margin-left:0in; margin-right:0in">
-					<span style="line-height:normal">
-						<span style="color:#5f497a">
-							<span style="font-family:calibri">
-								<span style="font-size:medium">&nbsp;</span>
+					<span style="color:#5f497a">
+						<span style="font-family:calibri">
+							<span style="font-size:medium">
+								<span style="line-height:normal">&nbsp;</span>
 							</span>
 						</span>
 					</span>
@@ -247,10 +247,10 @@
 			</td>
 			<td style="background-color:#dfd8e8; border-color:#000000 #000000 #8064a2; width:72.05pt" valign="top">
 				<p style="margin-left:0in; margin-right:0in">
-					<span style="line-height:normal">
-						<span style="color:#5f497a">
-							<span style="font-family:calibri">
-								<span style="font-size:medium">&nbsp;</span>
+					<span style="color:#5f497a">
+						<span style="font-family:calibri">
+							<span style="font-size:medium">
+								<span style="line-height:normal">&nbsp;</span>
 							</span>
 						</span>
 					</span>
@@ -258,10 +258,10 @@
 			</td>
 			<td style="background-color:#dfd8e8; border-color:#000000 #000000 #8064a2; width:72.05pt" valign="top">
 				<p style="margin-left:0in; margin-right:0in">
-					<span style="line-height:normal">
-						<span style="color:#5f497a">
-							<span style="font-family:calibri">
-								<span style="font-size:medium">&nbsp;</span>
+					<span style="color:#5f497a">
+						<span style="font-family:calibri">
+							<span style="font-size:medium">
+								<span style="line-height:normal">&nbsp;</span>
 							</span>
 						</span>
 					</span>
@@ -269,10 +269,10 @@
 			</td>
 			<td style="background-color:#dfd8e8; border-color:#000000 #000000 #8064a2; width:72.05pt" valign="top">
 				<p style="margin-left:0in; margin-right:0in">
-					<span style="line-height:normal">
-						<span style="color:#5f497a">
-							<span style="font-family:calibri">
-								<span style="font-size:medium">&nbsp;</span>
+					<span style="color:#5f497a">
+						<span style="font-family:calibri">
+							<span style="font-size:medium">
+								<span style="line-height:normal">&nbsp;</span>
 							</span>
 						</span>
 					</span>
@@ -280,10 +280,10 @@
 			</td>
 			<td style="background-color:#dfd8e8; border-color:#000000 #000000 #8064a2; width:72.05pt" valign="top">
 				<p style="margin-left:0in; margin-right:0in">
-					<span style="line-height:normal">
-						<span style="color:#5f497a">
-							<span style="font-family:calibri">
-								<span style="font-size:medium">&nbsp;</span>
+					<span style="color:#5f497a">
+						<span style="font-family:calibri">
+							<span style="font-size:medium">
+								<span style="line-height:normal">&nbsp;</span>
 							</span>
 						</span>
 					</span>

--- a/tests/plugins/pastefromword/generated/_fixtures/Tickets/11950Test_Table/expected.html
+++ b/tests/plugins/pastefromword/generated/_fixtures/Tickets/11950Test_Table/expected.html
@@ -122,7 +122,7 @@
 			</td>
 		</tr>
 		<tr>
-			<td style="height:15.0pt; width:48.0pt" valign="bottom">
+			<td style="border-color:#5b9bd5; height:15.0pt; width:48.0pt" valign="bottom">
 				<p>
 					<span style="color:black">
 						<span style="line-height:normal">data 4a</span>
@@ -136,7 +136,7 @@
 					</span>
 				</p>
 			</td>
-			<td style="height:15.0pt; width:48.0pt" valign="bottom">
+			<td style="border-color:#5b9bd5; height:15.0pt; width:48.0pt" valign="bottom">
 				<p>
 					<span style="color:black">
 						<span style="line-height:normal">data 4c</span>

--- a/tests/plugins/pastefromword/generated/_fixtures/Tickets/12406Doc1/expected.html
+++ b/tests/plugins/pastefromword/generated/_fixtures/Tickets/12406Doc1/expected.html
@@ -1085,7 +1085,7 @@
 					</span>
 				</p>
 			</td>
-			<td style="width:85.5pt" valign="top">
+			<td style="border-color:black; width:85.5pt" valign="top">
 				<p style="text-align:center">
 					<strong>
 						<span style="color:black">
@@ -1098,7 +1098,7 @@
 			</td>
 		</tr>
 		<tr>
-			<td style="height:21.0pt; width:157.5pt">
+			<td style="border-color:black; height:21.0pt; width:157.5pt">
 				<p style="text-align:center">
 					<span style="color:black">
 						<span style="font-family:&quot;verdana&quot;,sans-serif">
@@ -1118,7 +1118,7 @@
 			</td>
 		</tr>
 		<tr>
-			<td style="height:21.75pt; width:157.5pt">
+			<td style="border-color:black; height:21.75pt; width:157.5pt">
 				<p style="text-align:center">
 					<span style="color:black">
 						<span style="font-family:&quot;verdana&quot;,sans-serif">
@@ -1154,7 +1154,7 @@
 			<td style="height:15.0pt; width:157.5pt" valign="top">
 				<br />
 			</td>
-			<td style="height:15.0pt; width:85.5pt">
+			<td style="border-color:black; height:15.0pt; width:85.5pt">
 				<p style="text-align:center">
 					<strong>
 						<span style="color:black">
@@ -1165,7 +1165,7 @@
 					</strong>
 				</p>
 			</td>
-			<td style="height:15.0pt; width:81.0pt">
+			<td style="border-color:black; height:15.0pt; width:81.0pt">
 				<p style="text-align:center">
 					<strong>
 						<span style="color:black">
@@ -1178,7 +1178,7 @@
 			</td>
 		</tr>
 		<tr>
-			<td style="height:21.75pt; width:157.5pt">
+			<td style="border-color:black; height:21.75pt; width:157.5pt">
 				<p style="text-align:center">
 					<span style="color:black">
 						<span style="font-family:&quot;verdana&quot;,sans-serif">
@@ -1225,7 +1225,7 @@
 			<td style="width:157.5pt" valign="top">
 				<br />
 			</td>
-			<td style="width:85.5pt" valign="top">
+			<td style="border-color:black; width:85.5pt" valign="top">
 				<p style="text-align:center">
 					<strong>
 						<span style="color:#333333">
@@ -1238,7 +1238,7 @@
 			</td>
 		</tr>
 		<tr>
-			<td style="height:16.5pt; width:157.5pt">
+			<td style="border-color:black; height:16.5pt; width:157.5pt">
 				<p style="text-align:center">
 					<span style="color:#333333">
 						<span style="font-family:&quot;verdana&quot;,sans-serif">
@@ -1258,7 +1258,7 @@
 			</td>
 		</tr>
 		<tr>
-			<td style="height:17.25pt; width:157.5pt">
+			<td style="border-color:black; height:17.25pt; width:157.5pt">
 				<p style="text-align:center">
 					<span style="color:#333333">
 						<span style="font-family:&quot;verdana&quot;,sans-serif">
@@ -1278,7 +1278,7 @@
 			</td>
 		</tr>
 		<tr>
-			<td style="height:17.25pt; width:157.5pt">
+			<td style="border-color:black; height:17.25pt; width:157.5pt">
 				<p style="text-align:center">
 					<span style="color:#333333">
 						<span style="font-family:&quot;verdana&quot;,sans-serif">
@@ -1324,7 +1324,7 @@
 			<td style="width:157.5pt" valign="top">
 				<br />
 			</td>
-			<td style="width:85.5pt" valign="top">
+			<td style="border-color:black; width:85.5pt" valign="top">
 				<p style="text-align:center">
 					<strong>
 						<span style="color:black">
@@ -1337,7 +1337,7 @@
 			</td>
 		</tr>
 		<tr>
-			<td style="height:18.75pt; width:157.5pt">
+			<td style="border-color:black; height:18.75pt; width:157.5pt">
 				<p style="text-align:center">
 					<span style="color:red">
 						<span style="font-family:&quot;verdana&quot;,sans-serif">
@@ -1383,7 +1383,7 @@
 					</strong>
 				</p>
 			</td>
-			<td style="background-color:white; height:12.75pt; width:85.5pt">
+			<td style="background-color:white; border-color:black; height:12.75pt; width:85.5pt">
 				<p style="text-align:center">
 					<strong>
 						<span style="color:#333333">
@@ -1394,7 +1394,7 @@
 					</strong>
 				</p>
 			</td>
-			<td style="background-color:white; height:12.75pt; width:81.0pt">
+			<td style="background-color:white; border-color:black; height:12.75pt; width:81.0pt">
 				<p style="text-align:center">
 					<strong>
 						<span style="color:#333333">
@@ -1407,7 +1407,7 @@
 			</td>
 		</tr>
 		<tr>
-			<td style="background-color:white; height:16.5pt; width:157.5pt">
+			<td style="background-color:white; border-color:black; height:16.5pt; width:157.5pt">
 				<p style="text-align:center">
 					<span style="color:#333333">
 						<span style="font-family:&quot;verdana&quot;,sans-serif">
@@ -1456,7 +1456,7 @@
 			</td>
 		</tr>
 		<tr>
-			<td style="background-color:white; height:17.25pt; width:157.5pt">
+			<td style="background-color:white; border-color:black; height:17.25pt; width:157.5pt">
 				<p style="text-align:center">
 					<br />
 				</p>
@@ -1528,7 +1528,7 @@
 					</li>
 				</ul>
 			</td>
-			<td style="height:78.65pt; width:1.0in">
+			<td style="border-color:black; height:78.65pt; width:1.0in">
 				<p style="text-align:center">
 					<span style="color:#333333">
 						<span style="font-family:&quot;verdana&quot;,sans-serif">
@@ -1537,7 +1537,7 @@
 					</span>
 				</p>
 			</td>
-			<td rowspan="2" style="height:78.65pt; width:84.75pt">
+			<td rowspan="2" style="border-color:black; height:78.65pt; width:84.75pt">
 				<p>
 					<span style="color:#333333">
 						<span style="font-family:&quot;verdana&quot;,sans-serif">
@@ -1552,7 +1552,7 @@
 			</td>
 		</tr>
 		<tr>
-			<td style="height:66.75pt; width:311.25pt">
+			<td style="border-color:black; height:66.75pt; width:311.25pt">
 				<p>
 					<strong>
 						<span style="color:#333333">
@@ -1638,7 +1638,7 @@
 					</strong>
 				</p>
 			</td>
-			<td style="height:21.0pt; width:166.5pt">
+			<td style="border-color:black; height:21.0pt; width:166.5pt">
 				<p style="text-align:center">
 					<strong>
 						<span style="color:#333333">
@@ -1649,7 +1649,7 @@
 					</strong>
 				</p>
 			</td>
-			<td style="height:21.0pt; width:85.5pt">
+			<td style="border-color:black; height:21.0pt; width:85.5pt">
 				<p style="text-align:center">
 					<strong>
 						<span style="color:#333333">
@@ -1662,7 +1662,7 @@
 			</td>
 		</tr>
 		<tr>
-			<td style="height:32.25pt; width:3.0in">
+			<td style="border-color:black; height:32.25pt; width:3.0in">
 				<p>
 					<span style="color:black">
 						<span style="font-family:&quot;verdana&quot;,sans-serif">
@@ -1717,7 +1717,7 @@
 					</strong>
 				</p>
 			</td>
-			<td style="height:26.25pt; width:103.5pt">
+			<td style="border-color:black; height:26.25pt; width:103.5pt">
 				<p style="text-align:center">
 					<strong>
 						<span style="color:#333333">
@@ -1728,7 +1728,7 @@
 					</strong>
 				</p>
 			</td>
-			<td style="height:26.25pt; width:67.5pt">
+			<td style="border-color:black; height:26.25pt; width:67.5pt">
 				<p style="text-align:center">
 					<strong>
 						<span style="color:#333333">
@@ -1739,7 +1739,7 @@
 					</strong>
 				</p>
 			</td>
-			<td style="height:26.25pt; width:73.0pt">
+			<td style="border-color:black; height:26.25pt; width:73.0pt">
 				<p style="text-align:center">
 					<strong>
 						<span style="color:#333333">
@@ -1750,7 +1750,7 @@
 					</strong>
 				</p>
 			</td>
-			<td style="height:26.25pt; width:80.0pt">
+			<td style="border-color:black; height:26.25pt; width:80.0pt">
 				<p style="text-align:center">
 					<strong>
 						<span style="color:#333333">
@@ -1763,7 +1763,7 @@
 			</td>
 		</tr>
 		<tr>
-			<td style="height:42.0pt; width:3.0in">
+			<td style="border-color:black; height:42.0pt; width:3.0in">
 				<p style="text-align:center">
 					<span style="color:#333333">
 						<span style="font-family:&quot;verdana&quot;,sans-serif">
@@ -1811,7 +1811,7 @@
 			</td>
 		</tr>
 		<tr>
-			<td style="height:30.75pt; width:3.0in">
+			<td style="border-color:black; height:30.75pt; width:3.0in">
 				<p style="text-align:center">
 					<span style="color:#333333">
 						<span style="font-family:&quot;verdana&quot;,sans-serif">
@@ -1858,7 +1858,7 @@
 			</td>
 		</tr>
 		<tr>
-			<td style="height:17.25pt; width:3.0in">
+			<td style="border-color:black; height:17.25pt; width:3.0in">
 				<p style="text-align:center">
 					<span style="color:red">
 						<span style="font-family:&quot;verdana&quot;,sans-serif">

--- a/tests/plugins/pastefromword/generated/_fixtures/Tickets/12406Doc1/word2013/expected_firefox.html
+++ b/tests/plugins/pastefromword/generated/_fixtures/Tickets/12406Doc1/word2013/expected_firefox.html
@@ -1087,7 +1087,7 @@
 					</span>
 				</p>
 			</td>
-			<td style="width:85.5pt" valign="top">
+			<td style="border-color:black; width:85.5pt" valign="top">
 				<p style="text-align:center">
 					<strong>
 						<span style="color:black">
@@ -1100,7 +1100,7 @@
 			</td>
 		</tr>
 		<tr>
-			<td style="height:21.0pt; width:157.5pt">
+			<td style="border-color:black; height:21.0pt; width:157.5pt">
 				<p style="text-align:center">
 					<span style="color:black">
 						<span style="font-family:&quot;verdana&quot;,sans-serif">
@@ -1120,7 +1120,7 @@
 			</td>
 		</tr>
 		<tr>
-			<td style="height:21.75pt; width:157.5pt">
+			<td style="border-color:black; height:21.75pt; width:157.5pt">
 				<p style="text-align:center">
 					<span style="color:black">
 						<span style="font-family:&quot;verdana&quot;,sans-serif">
@@ -1156,7 +1156,7 @@
 			<td style="height:15.0pt; width:157.5pt" valign="top">
 				<br />
 			</td>
-			<td style="height:15.0pt; width:85.5pt">
+			<td style="border-color:black; height:15.0pt; width:85.5pt">
 				<p style="text-align:center">
 					<strong>
 						<span style="color:black">
@@ -1167,7 +1167,7 @@
 					</strong>
 				</p>
 			</td>
-			<td style="height:15.0pt; width:81.0pt">
+			<td style="border-color:black; height:15.0pt; width:81.0pt">
 				<p style="text-align:center">
 					<strong>
 						<span style="color:black">
@@ -1180,7 +1180,7 @@
 			</td>
 		</tr>
 		<tr>
-			<td style="height:21.75pt; width:157.5pt">
+			<td style="border-color:black; height:21.75pt; width:157.5pt">
 				<p style="text-align:center">
 					<span style="color:black">
 						<span style="font-family:&quot;verdana&quot;,sans-serif">
@@ -1227,7 +1227,7 @@
 			<td style="width:157.5pt" valign="top">
 				<br />
 			</td>
-			<td style="width:85.5pt" valign="top">
+			<td style="border-color:black; width:85.5pt" valign="top">
 				<p style="text-align:center">
 					<strong>
 						<span style="color:#333333">
@@ -1240,7 +1240,7 @@
 			</td>
 		</tr>
 		<tr>
-			<td style="height:16.5pt; width:157.5pt">
+			<td style="border-color:black; height:16.5pt; width:157.5pt">
 				<p style="text-align:center">
 					<span style="color:#333333">
 						<span style="font-family:&quot;verdana&quot;,sans-serif">
@@ -1260,7 +1260,7 @@
 			</td>
 		</tr>
 		<tr>
-			<td style="height:17.25pt; width:157.5pt">
+			<td style="border-color:black; height:17.25pt; width:157.5pt">
 				<p style="text-align:center">
 					<span style="color:#333333">
 						<span style="font-family:&quot;verdana&quot;,sans-serif">
@@ -1280,7 +1280,7 @@
 			</td>
 		</tr>
 		<tr>
-			<td style="height:17.25pt; width:157.5pt">
+			<td style="border-color:black; height:17.25pt; width:157.5pt">
 				<p style="text-align:center">
 					<span style="color:#333333">
 						<span style="font-family:&quot;verdana&quot;,sans-serif">
@@ -1326,7 +1326,7 @@
 			<td style="width:157.5pt" valign="top">
 				<br />
 			</td>
-			<td style="width:85.5pt" valign="top">
+			<td style="border-color:black; width:85.5pt" valign="top">
 				<p style="text-align:center">
 					<strong>
 						<span style="color:black">
@@ -1339,7 +1339,7 @@
 			</td>
 		</tr>
 		<tr>
-			<td style="height:18.75pt; width:157.5pt">
+			<td style="border-color:black; height:18.75pt; width:157.5pt">
 				<p style="text-align:center">
 					<span style="color:red">
 						<span style="font-family:&quot;verdana&quot;,sans-serif">
@@ -1385,7 +1385,7 @@
 					</strong>
 				</p>
 			</td>
-			<td style="background-color:white; height:12.75pt; width:85.5pt">
+			<td style="background-color:white; border-color:black; height:12.75pt; width:85.5pt">
 				<p style="text-align:center">
 					<strong>
 						<span style="color:#333333">
@@ -1396,7 +1396,7 @@
 					</strong>
 				</p>
 			</td>
-			<td style="background-color:white; height:12.75pt; width:81.0pt">
+			<td style="background-color:white; border-color:black; height:12.75pt; width:81.0pt">
 				<p style="text-align:center">
 					<strong>
 						<span style="color:#333333">
@@ -1409,7 +1409,7 @@
 			</td>
 		</tr>
 		<tr>
-			<td style="background-color:white; height:16.5pt; width:157.5pt">
+			<td style="background-color:white; border-color:black; height:16.5pt; width:157.5pt">
 				<p style="text-align:center">
 					<span style="color:#333333">
 						<span style="font-family:&quot;verdana&quot;,sans-serif">
@@ -1458,7 +1458,7 @@
 			</td>
 		</tr>
 		<tr>
-			<td style="background-color:white; height:17.25pt; width:157.5pt">
+			<td style="background-color:white; border-color:black; height:17.25pt; width:157.5pt">
 				<p style="text-align:center">
 					<br />
 				</p>
@@ -1530,7 +1530,7 @@
 					</li>
 				</ul>
 			</td>
-			<td style="height:78.65pt; width:1.0in">
+			<td style="border-color:black; height:78.65pt; width:1.0in">
 				<p style="text-align:center">
 					<span style="color:#333333">
 						<span style="font-family:&quot;verdana&quot;,sans-serif">
@@ -1539,7 +1539,7 @@
 					</span>
 				</p>
 			</td>
-			<td rowspan="2" style="height:78.65pt; width:84.75pt">
+			<td rowspan="2" style="border-color:black; height:78.65pt; width:84.75pt">
 				<p>
 					<span style="color:#333333">
 						<span style="font-family:&quot;verdana&quot;,sans-serif">
@@ -1554,7 +1554,7 @@
 			</td>
 		</tr>
 		<tr>
-			<td style="height:66.75pt; width:311.25pt">
+			<td style="border-color:black; height:66.75pt; width:311.25pt">
 				<p>
 					<strong>
 						<span style="color:#333333">
@@ -1640,7 +1640,7 @@
 					</strong>
 				</p>
 			</td>
-			<td style="height:21.0pt; width:166.5pt">
+			<td style="border-color:black; height:21.0pt; width:166.5pt">
 				<p style="text-align:center">
 					<strong>
 						<span style="color:#333333">
@@ -1651,7 +1651,7 @@
 					</strong>
 				</p>
 			</td>
-			<td style="height:21.0pt; width:85.5pt">
+			<td style="border-color:black; height:21.0pt; width:85.5pt">
 				<p style="text-align:center">
 					<strong>
 						<span style="color:#333333">
@@ -1664,7 +1664,7 @@
 			</td>
 		</tr>
 		<tr>
-			<td style="height:32.25pt; width:3.0in">
+			<td style="border-color:black; height:32.25pt; width:3.0in">
 				<p>
 					<span style="color:black">
 						<span style="font-family:&quot;verdana&quot;,sans-serif">
@@ -1719,7 +1719,7 @@
 					</strong>
 				</p>
 			</td>
-			<td style="height:26.25pt; width:103.5pt">
+			<td style="border-color:black; height:26.25pt; width:103.5pt">
 				<p style="text-align:center">
 					<strong>
 						<span style="color:#333333">
@@ -1730,7 +1730,7 @@
 					</strong>
 				</p>
 			</td>
-			<td style="height:26.25pt; width:67.5pt">
+			<td style="border-color:black; height:26.25pt; width:67.5pt">
 				<p style="text-align:center">
 					<strong>
 						<span style="color:#333333">
@@ -1741,7 +1741,7 @@
 					</strong>
 				</p>
 			</td>
-			<td style="height:26.25pt; width:73.0pt">
+			<td style="border-color:black; height:26.25pt; width:73.0pt">
 				<p style="text-align:center">
 					<strong>
 						<span style="color:#333333">
@@ -1752,7 +1752,7 @@
 					</strong>
 				</p>
 			</td>
-			<td style="height:26.25pt; width:80.0pt">
+			<td style="border-color:black; height:26.25pt; width:80.0pt">
 				<p style="text-align:center">
 					<strong>
 						<span style="color:#333333">
@@ -1765,7 +1765,7 @@
 			</td>
 		</tr>
 		<tr>
-			<td style="height:42.0pt; width:3.0in">
+			<td style="border-color:black; height:42.0pt; width:3.0in">
 				<p style="text-align:center">
 					<span style="color:#333333">
 						<span style="font-family:&quot;verdana&quot;,sans-serif">
@@ -1813,7 +1813,7 @@
 			</td>
 		</tr>
 		<tr>
-			<td style="height:30.75pt; width:3.0in">
+			<td style="border-color:black; height:30.75pt; width:3.0in">
 				<p style="text-align:center">
 					<span style="color:#333333">
 						<span style="font-family:&quot;verdana&quot;,sans-serif">
@@ -1860,7 +1860,7 @@
 			</td>
 		</tr>
 		<tr>
-			<td style="height:17.25pt; width:3.0in">
+			<td style="border-color:black; height:17.25pt; width:3.0in">
 				<p style="text-align:center">
 					<span style="color:red">
 						<span style="font-family:&quot;verdana&quot;,sans-serif">

--- a/tests/plugins/pastefromword/generated/_fixtures/Tickets/12406Document1_(3)/expected.html
+++ b/tests/plugins/pastefromword/generated/_fixtures/Tickets/12406Document1_(3)/expected.html
@@ -49,7 +49,7 @@
 					</li>
 				</ul>
 			</td>
-			<td style="height:78.65pt; width:1.0in">
+			<td style="border-color:black; height:78.65pt; width:1.0in">
 				<p style="text-align:center">
 					<span style="color:#333333">
 						<span style="font-family:&quot;verdana&quot;,sans-serif">
@@ -74,7 +74,7 @@
 					</span>
 				</p>
 			</td>
-			<td rowspan="2" style="height:78.65pt; width:84.75pt">
+			<td rowspan="2" style="border-color:black; height:78.65pt; width:84.75pt">
 				<p>
 					<span style="color:#333333">
 						<span style="font-family:&quot;verdana&quot;,sans-serif">
@@ -89,7 +89,7 @@
 			</td>
 		</tr>
 		<tr>
-			<td style="height:66.75pt; width:311.25pt">
+			<td style="border-color:black; height:66.75pt; width:311.25pt">
 				<p>
 					<strong>
 						<span style="color:#333333">
@@ -175,7 +175,7 @@
 					</strong>
 				</p>
 			</td>
-			<td style="height:21.0pt; width:166.5pt">
+			<td style="border-color:black; height:21.0pt; width:166.5pt">
 				<p style="text-align:center">
 					<strong>
 						<span style="color:#333333">
@@ -186,7 +186,7 @@
 					</strong>
 				</p>
 			</td>
-			<td style="height:21.0pt; width:85.5pt">
+			<td style="border-color:black; height:21.0pt; width:85.5pt">
 				<p style="text-align:center">
 					<strong>
 						<span style="color:#333333">
@@ -199,7 +199,7 @@
 			</td>
 		</tr>
 		<tr>
-			<td style="height:32.25pt; width:3.0in">
+			<td style="border-color:black; height:32.25pt; width:3.0in">
 				<p>
 					<span style="color:black">
 						<span style="font-family:&quot;verdana&quot;,sans-serif">
@@ -254,7 +254,7 @@
 					</strong>
 				</p>
 			</td>
-			<td style="height:26.25pt; width:103.5pt">
+			<td style="border-color:black; height:26.25pt; width:103.5pt">
 				<p style="text-align:center">
 					<strong>
 						<span style="color:#333333">
@@ -265,7 +265,7 @@
 					</strong>
 				</p>
 			</td>
-			<td style="height:26.25pt; width:67.5pt">
+			<td style="border-color:black; height:26.25pt; width:67.5pt">
 				<p style="text-align:center">
 					<strong>
 						<span style="color:#333333">
@@ -276,7 +276,7 @@
 					</strong>
 				</p>
 			</td>
-			<td style="height:26.25pt; width:73.0pt">
+			<td style="border-color:black; height:26.25pt; width:73.0pt">
 				<p style="text-align:center">
 					<strong>
 						<span style="color:#333333">
@@ -287,7 +287,7 @@
 					</strong>
 				</p>
 			</td>
-			<td style="height:26.25pt; width:80.0pt">
+			<td style="border-color:black; height:26.25pt; width:80.0pt">
 				<p style="text-align:center">
 					<strong>
 						<span style="color:#333333">
@@ -300,7 +300,7 @@
 			</td>
 		</tr>
 		<tr>
-			<td style="height:42.0pt; width:3.0in">
+			<td style="border-color:black; height:42.0pt; width:3.0in">
 				<p style="text-align:center">
 					<span style="color:#333333">
 						<span style="font-family:&quot;verdana&quot;,sans-serif">
@@ -348,7 +348,7 @@
 			</td>
 		</tr>
 		<tr>
-			<td style="height:30.75pt; width:3.0in">
+			<td style="border-color:black; height:30.75pt; width:3.0in">
 				<p style="text-align:center">
 					<span style="color:#333333">
 						<span style="font-family:&quot;verdana&quot;,sans-serif">
@@ -395,7 +395,7 @@
 			</td>
 		</tr>
 		<tr>
-			<td style="height:17.25pt; width:3.0in">
+			<td style="border-color:black; height:17.25pt; width:3.0in">
 				<p style="text-align:center">
 					<span style="color:red">
 						<span style="font-family:&quot;verdana&quot;,sans-serif">
@@ -504,7 +504,7 @@
 					</li>
 				</ul>
 			</td>
-			<td style="height:78.65pt; width:1.0in">
+			<td style="border-color:black; height:78.65pt; width:1.0in">
 				<p style="text-align:center">
 					<span style="color:#333333">
 						<span style="font-family:&quot;verdana&quot;,sans-serif">
@@ -529,7 +529,7 @@
 					</span>
 				</p>
 			</td>
-			<td rowspan="2" style="height:78.65pt; width:84.75pt">
+			<td rowspan="2" style="border-color:black; height:78.65pt; width:84.75pt">
 				<p>
 					<span style="color:#333333">
 						<span style="font-family:&quot;verdana&quot;,sans-serif">
@@ -543,7 +543,7 @@
 			</td>
 		</tr>
 		<tr>
-			<td style="height:66.75pt; width:311.25pt">
+			<td style="border-color:black; height:66.75pt; width:311.25pt">
 				<p>
 					<strong>
 						<span style="color:#333333">
@@ -636,7 +636,7 @@
 					</strong>
 				</p>
 			</td>
-			<td style="height:21.0pt; width:166.5pt">
+			<td style="border-color:black; height:21.0pt; width:166.5pt">
 				<p style="text-align:center">
 					<strong>
 						<span style="color:#333333">
@@ -647,7 +647,7 @@
 					</strong>
 				</p>
 			</td>
-			<td style="height:21.0pt; width:85.5pt">
+			<td style="border-color:black; height:21.0pt; width:85.5pt">
 				<p style="text-align:center">
 					<strong>
 						<span style="color:#333333">
@@ -660,7 +660,7 @@
 			</td>
 		</tr>
 		<tr>
-			<td style="height:32.25pt; width:3.0in">
+			<td style="border-color:black; height:32.25pt; width:3.0in">
 				<p>
 					<span style="color:black">
 						<span style="font-family:&quot;verdana&quot;,sans-serif">
@@ -715,7 +715,7 @@
 					</strong>
 				</p>
 			</td>
-			<td style="height:26.25pt; width:103.5pt">
+			<td style="border-color:black; height:26.25pt; width:103.5pt">
 				<p style="text-align:center">
 					<strong>
 						<span style="color:#333333">
@@ -726,7 +726,7 @@
 					</strong>
 				</p>
 			</td>
-			<td style="height:26.25pt; width:67.5pt">
+			<td style="border-color:black; height:26.25pt; width:67.5pt">
 				<p style="text-align:center">
 					<strong>
 						<span style="color:#333333">
@@ -737,7 +737,7 @@
 					</strong>
 				</p>
 			</td>
-			<td style="height:26.25pt; width:73.0pt">
+			<td style="border-color:black; height:26.25pt; width:73.0pt">
 				<p style="text-align:center">
 					<strong>
 						<span style="color:#333333">
@@ -748,7 +748,7 @@
 					</strong>
 				</p>
 			</td>
-			<td style="height:26.25pt; width:80.0pt">
+			<td style="border-color:black; height:26.25pt; width:80.0pt">
 				<p style="text-align:center">
 					<strong>
 						<span style="color:#333333">
@@ -761,7 +761,7 @@
 			</td>
 		</tr>
 		<tr>
-			<td style="height:42.0pt; width:3.0in">
+			<td style="border-color:black; height:42.0pt; width:3.0in">
 				<p style="text-align:center">
 					<span style="color:#333333">
 						<span style="font-family:&quot;verdana&quot;,sans-serif">
@@ -809,7 +809,7 @@
 			</td>
 		</tr>
 		<tr>
-			<td style="height:30.75pt; width:3.0in">
+			<td style="border-color:black; height:30.75pt; width:3.0in">
 				<p style="text-align:center">
 					<span style="color:#333333">
 						<span style="font-family:&quot;verdana&quot;,sans-serif">
@@ -856,7 +856,7 @@
 			</td>
 		</tr>
 		<tr>
-			<td style="height:17.25pt; width:3.0in">
+			<td style="border-color:black; height:17.25pt; width:3.0in">
 				<p style="text-align:center">
 					<span style="color:red">
 						<span style="font-family:&quot;verdana&quot;,sans-serif">

--- a/tests/plugins/pastefromword/generated/_fixtures/Tickets/3039blog_test_2003_(2)/expected.html
+++ b/tests/plugins/pastefromword/generated/_fixtures/Tickets/3039blog_test_2003_(2)/expected.html
@@ -5,7 +5,6 @@
 		</span>
 	</strong>
 </p>
-
 <p>
 	<span style="line-height:115%">some lists</span>
 </p>
@@ -25,12 +24,10 @@
 	</li>
 	<li>
 		<em>
-			<span style="line-height:115%">asdfjkalsdjf kasdf askl;dfj lsajdkflajslkdfaskldfjlasdjflasjdfl;kjasddlfjskl;dfjklsajdfklajdsfljasldfjaslkdfjlkasdjflkasdjfklsjdflkajsdlfjszdkl:fjaslkdfjlkasdjflk;asjdflkajsdl;fjsalkfdjlafsjdlkajsfdlkjasdlkfjslkdfjlad
-				kajsldfjl;dfkjalsd sakldjl ajsdfl sdflk jaslkf jasdlkfjalk jlzjf lkasdfj 904quoi jkzlnjvxjncvlnkzx;vlbjxnkl;n</span>
+			<span style="line-height:115%">asdfjkalsdjf kasdf askl;dfj lsajdkflajslkdfaskldfjlasdjflasjdfl;kjasddlfjskl;dfjklsajdfklajdsfljasldfjaslkdfjlkasdjflkasdjfklsjdflkajsdlfjszdkl:fjaslkdfjlkasdjflk;asjdflkajsdl;fjsalkfdjlafsjdlkajsfdlkjasdlkfjslkdfjlad kajsldfjl;dfkjalsd sakldjl ajsdfl sdflk jaslkf jasdlkfjalk jlzjf lkasdfj 904quoi jkzlnjvxjncvlnkzx;vlbjxnkl;n</span>
 		</em>
 	</li>
 </ul>
-
 <p>
 	<span style="line-height:115%">some number</span>
 </p>
@@ -44,75 +41,73 @@
 		</span>
 	</li>
 </ol>
-
 <p>
-	<span style="font-size:14.0pt">
-		<span style="line-height:115%">
-			<span style="font-family:楷体">天将晚的时候，十二门徒来到他跟前，说：</span>
+	<span style="font-family:楷体">
+		<span style="font-size:14.0pt">
+			<span style="line-height:115%">天将晚的时候，十二门徒来到他跟前，说：</span>
 		</span>
 	</span>
 	<span style="font-size:14.0pt">
 		<span style="line-height:115%">“</span>
 	</span>
-	<span style="font-size:14.0pt">
-		<span style="line-height:115%">
-			<span style="font-family:楷体">请解散众人，好让他们往周围的田舍村庄，去找地方住，找东西吃，因为我们这里是旷野。</span>
+	<span style="font-family:楷体">
+		<span style="font-size:14.0pt">
+			<span style="line-height:115%">请解散众人，好让他们往周围的田舍村庄，去找地方住，找东西吃，因为我们这里是旷野。</span>
 		</span>
 	</span>
 	<span style="font-size:14.0pt">
 		<span style="line-height:115%">”</span>
 	</span>
-	<span style="font-size:14.0pt">
-		<span style="line-height:115%">
-			<span style="font-family:楷体">路</span>
+	<span style="font-family:楷体">
+		<span style="font-size:14.0pt">
+			<span style="line-height:115%">路</span>
 		</span>
 	</span>
 	<span style="font-size:14.0pt">
 		<span style="line-height:115%">9</span>
 	</span>
-	<span style="font-size:14.0pt">
-		<span style="line-height:115%">
-			<span style="font-family:楷体">：</span>
+	<span style="font-family:楷体">
+		<span style="font-size:14.0pt">
+			<span style="line-height:115%">：</span>
 		</span>
 	</span>
 	<span style="font-size:14.0pt">
 		<span style="line-height:115%">12</span>
 	</span>
 </p>
-
 <p>
 	<sup>
 		<span style="font-size:14.0pt">
 			<span style="line-height:115%">16</span>
 		</span>
 	</sup>
-	<span style="font-size:14.0pt">
-		<span style="line-height:115%">
-			<span style="font-family:楷体">耶稣回答：</span>
+	<span style="font-family:楷体">
+		<span style="font-size:14.0pt">
+			<span style="line-height:115%">耶稣回答：</span>
 		</span>
 	</span>
 	<span style="font-size:14.0pt">
 		<span style="line-height:115%">“</span>
 	</span>
-	<span style="font-size:14.0pt">
-		<span style="line-height:115%">
-			<span style="font-family:楷体">他们用不着离开，你们给他们吃吧！</span>
+	<span style="font-family:楷体">
+		<span style="font-size:14.0pt">
+			<span style="line-height:115%">他们用不着离开，你们给他们吃吧！</span>
 		</span>
 	</span>
 	<span style="font-size:14.0pt">
 		<span style="line-height:115%">”</span>
 	</span>
-	<span style="font-size:14.0pt">
-		<span style="line-height:115%">
-			<span style="font-family:楷体">太</span>
+	<span style="font-family:楷体">
+		<span style="font-size:14.0pt">
+			<span style="line-height:115%">太</span>
 		</span>
 	</span>
 	<span style="font-size:14.0pt">
 		<span style="line-height:115%">14</span>
 	</span>
-	<span style="font-size:14.0pt">
-		<span style="line-height:115%">
-			<span style="font-family:楷体">：</span>
+	<span style="font-family:楷体">
+		<span style="font-size:14.0pt">
+			<span style="line-height:115%">：</span>
 		</span>
 	</span>
 	<span style="font-size:14.0pt">
@@ -121,24 +116,24 @@
 </p>
 <ol>
 	<li>
-		<span style="font-size:14.0pt">
-			<span style="line-height:115%">
-				<span style="font-family:楷体">
-					<span style="color:black">就对腓力说：</span>
+		<span style="color:black">
+			<span style="font-family:楷体">
+				<span style="font-size:14.0pt">
+					<span style="line-height:115%">就对腓力说：</span>
 				</span>
 			</span>
 		</span>
-		<span style="font-size:14.0pt">
-			<span style="line-height:115%">
-				<span style="font-family:????">
-					<span style="color:black">“</span>
+		<span style="color:black">
+			<span style="font-family:????">
+				<span style="font-size:14.0pt">
+					<span style="line-height:115%">“</span>
 				</span>
 			</span>
 		</span>
-		<span style="font-size:14.0pt">
-			<span style="line-height:115%">
-				<span style="font-family:楷体">
-					<span style="color:black">我们从哪里买饼给这些人吃呢？</span>
+		<span style="color:black">
+			<span style="font-family:楷体">
+				<span style="font-size:14.0pt">
+					<span style="line-height:115%">我们从哪里买饼给这些人吃呢？</span>
 				</span>
 			</span>
 		</span>
@@ -150,35 +145,30 @@
 		</ul>
 	</li>
 </ol>
-
 <p>
 	<span style="line-height:115%">some tables</span>
 </p>
 <table cellspacing="0">
 	<tbody>
 		<tr>
-			<td colspan="2" style="width:319.2pt" valign="top">
-
+			<td colspan="2" style="border-color:black; width:319.2pt" valign="top">
 				<p>
 					<span style="line-height:normal">this is to confuse the hell out of the </span>
 				</p>
 			</td>
-			<td style="width:159.6pt" valign="top">
-
+			<td style="border-color:black; width:159.6pt" valign="top">
 				<p>
 					<span style="line-height:normal">fck editor</span>
 				</p>
 			</td>
 		</tr>
 		<tr>
-			<td style="width:159.6pt" valign="top">
-
+			<td style="border-color:black; width:159.6pt" valign="top">
 				<p>
 					<span style="line-height:normal">to see</span>
 				</p>
 			</td>
 			<td colspan="2" style="width:319.2pt" valign="top">
-
 				<p>
 					<span style="line-height:normal">if the text can get messed up</span>
 				</p>
@@ -197,14 +187,9 @@
 		</tr>
 	</tbody>
 </table>
-
 <p>
 	<br />
 </p>
-
 <p>
-	<span style="line-height:115%">
-		<img data-cke-saved-src="file:///c:\users\foobar\appdata\local\temp\msohtmlclip1\01\clip_image001.jpg" src="file:///c:\users\foobar\appdata\local\temp\msohtmlclip1\01\clip_image001.jpg"
-			style="height:135px; width:155px" /></span>
+	<span style="line-height:115%"><img data-cke-saved-src="file:///c:\users\foobar\appdata\local\temp\msohtmlclip1\01\clip_image001.jpg" src="file:///c:\users\foobar\appdata\local\temp\msohtmlclip1\01\clip_image001.jpg" style="height:135px; width:155px" /></span>
 </p>
-

--- a/tests/plugins/pastefromword/generated/_fixtures/Tickets/3039blog_test_2003_(2)/word2013/expected_ie11.html
+++ b/tests/plugins/pastefromword/generated/_fixtures/Tickets/3039blog_test_2003_(2)/word2013/expected_ie11.html
@@ -1,19 +1,19 @@
 <p style="margin-left:0in; margin-right:0in">
 	<strong>
-		<span style="font-size:16pt">
-			<span style="line-height:115%">
-				<span style="color:#000000">
-					<span style="font-family:calibri">this is a stress test document</span>
+		<span style="color:#000000">
+			<span style="font-family:calibri">
+				<span style="font-size:16pt">
+					<span style="line-height:115%">this is a stress test document</span>
 				</span>
 			</span>
 		</span>
 	</strong>
 </p>
 <p style="margin-left:0in; margin-right:0in">
-	<span style="line-height:115%">
-		<span style="color:#000000">
-			<span style="font-family:calibri">
-				<span style="font-size:medium">some lists</span>
+	<span style="color:#000000">
+		<span style="font-family:calibri">
+			<span style="font-size:medium">
+				<span style="line-height:115%">some lists</span>
 			</span>
 		</span>
 	</span>
@@ -27,12 +27,12 @@
 		</span>
 	</li>
 	<li>
-		<span style="font-size:20pt">
-			<span style="color:#000000">
-				<span style="font-family:&quot;calibri&quot;,sans-serif">
-					<span style="font-style:normal">
-						<span style="font-weight:normal">
-							<span style="font-size:20pt">
+		<span style="color:#000000">
+			<span style="font-family:&quot;calibri&quot;,sans-serif">
+				<span style="font-size:20pt">
+					<span style="font-size:20pt">
+						<span style="font-style:normal">
+							<span style="font-weight:normal">
 								<span style="line-height:115%">asd</span>
 							</span>
 						</span>
@@ -42,9 +42,9 @@
 		</span>
 	</li>
 	<li>
-		<span style="font-size:11pt">
-			<span style="color:#000000">
-				<span style="font-family:&quot;calibri&quot;,sans-serif">
+		<span style="color:#000000">
+			<span style="font-family:&quot;calibri&quot;,sans-serif">
+				<span style="font-size:11pt">
 					<span style="font-style:normal">
 						<strong>
 							<strong>
@@ -57,9 +57,9 @@
 		</span>
 	</li>
 	<li>
-		<span style="font-size:11pt">
-			<span style="color:#000000">
-				<span style="font-family:&quot;calibri&quot;,sans-serif">
+		<span style="color:#000000">
+			<span style="font-family:&quot;calibri&quot;,sans-serif">
+				<span style="font-size:11pt">
 					<em>
 						<span style="font-weight:normal">
 							<em>
@@ -73,22 +73,22 @@
 	</li>
 </ul>
 <p style="margin-left:0in; margin-right:0in">
-	<span style="line-height:115%">
-		<span style="color:#000000">
-			<span style="font-family:calibri">
-				<span style="font-size:medium">some number</span>
+	<span style="color:#000000">
+		<span style="font-family:calibri">
+			<span style="font-size:medium">
+				<span style="line-height:115%">some number</span>
 			</span>
 		</span>
 	</span>
 </p>
 <ol>
 	<li>
-		<span style="font-style:normal">
-			<span style="font-weight:normal">
-				<span style="font-size:24pt">
+		<span style="font-size:18pt">
+			<span style="font-size:24pt">
+				<span style="font-weight:normal">
 					<span style="line-height:115%">asdas</span>
 				</span>
-				<span style="font-size:18pt">
+				<span style="font-style:normal">
 					<span style="line-height:115%">dasd</span>
 				</span>
 			</span>
@@ -97,44 +97,44 @@
 </ol>
 <p style="margin-left:0in; margin-right:0in">
 	<span style="color:#000000">
-		<span style="font-size:14pt">
-			<span style="line-height:115%">
-				<span style="font-family:楷体">天将晚的时候，十二门徒来到他跟前，说：</span>
+		<span style="font-family:楷体">
+			<span style="font-size:14pt">
+				<span style="line-height:115%">天将晚的时候，十二门徒来到他跟前，说：</span>
 			</span>
 		</span>
-		<span style="font-size:14pt">
-			<span style="line-height:115%">
-				<span style="font-family:calibri">“</span>
+		<span style="font-family:calibri">
+			<span style="font-size:14pt">
+				<span style="line-height:115%">“</span>
 			</span>
 		</span>
-		<span style="font-size:14pt">
-			<span style="line-height:115%">
-				<span style="font-family:楷体">请解散众人，好让他们往周围的田舍村庄，去找地方住，找东西吃，因为我们这里是旷野。</span>
+		<span style="font-family:楷体">
+			<span style="font-size:14pt">
+				<span style="line-height:115%">请解散众人，好让他们往周围的田舍村庄，去找地方住，找东西吃，因为我们这里是旷野。</span>
 			</span>
 		</span>
-		<span style="font-size:14pt">
-			<span style="line-height:115%">
-				<span style="font-family:calibri">”</span>
+		<span style="font-family:calibri">
+			<span style="font-size:14pt">
+				<span style="line-height:115%">”</span>
 			</span>
 		</span>
-		<span style="font-size:14pt">
-			<span style="line-height:115%">
-				<span style="font-family:楷体">路</span>
+		<span style="font-family:楷体">
+			<span style="font-size:14pt">
+				<span style="line-height:115%">路</span>
 			</span>
 		</span>
-		<span style="font-size:14pt">
-			<span style="line-height:115%">
-				<span style="font-family:calibri">9</span>
+		<span style="font-family:calibri">
+			<span style="font-size:14pt">
+				<span style="line-height:115%">9</span>
 			</span>
 		</span>
-		<span style="font-size:14pt">
-			<span style="line-height:115%">
-				<span style="font-family:楷体">：</span>
+		<span style="font-family:楷体">
+			<span style="font-size:14pt">
+				<span style="line-height:115%">：</span>
 			</span>
 		</span>
-		<span style="font-size:14pt">
-			<span style="line-height:115%">
-				<span style="font-family:calibri">12</span>
+		<span style="font-family:calibri">
+			<span style="font-size:14pt">
+				<span style="line-height:115%">12</span>
 			</span>
 		</span>
 	</span>
@@ -142,74 +142,74 @@
 <p style="margin-left:0in; margin-right:0in">
 	<span style="color:#000000">
 		<sup>
-			<span style="font-size:14pt">
-				<span style="line-height:115%">
-					<span style="font-family:calibri">16</span>
+			<span style="font-family:calibri">
+				<span style="font-size:14pt">
+					<span style="line-height:115%">16</span>
 				</span>
 			</span>
 		</sup>
-		<span style="font-size:14pt">
-			<span style="line-height:115%">
-				<span style="font-family:楷体">耶稣回答：</span>
+		<span style="font-family:楷体">
+			<span style="font-size:14pt">
+				<span style="line-height:115%">耶稣回答：</span>
 			</span>
 		</span>
-		<span style="font-size:14pt">
-			<span style="line-height:115%">
-				<span style="font-family:calibri">“</span>
+		<span style="font-family:calibri">
+			<span style="font-size:14pt">
+				<span style="line-height:115%">“</span>
 			</span>
 		</span>
-		<span style="font-size:14pt">
-			<span style="line-height:115%">
-				<span style="font-family:楷体">他们用不着离开，你们给他们吃吧！</span>
+		<span style="font-family:楷体">
+			<span style="font-size:14pt">
+				<span style="line-height:115%">他们用不着离开，你们给他们吃吧！</span>
 			</span>
 		</span>
-		<span style="font-size:14pt">
-			<span style="line-height:115%">
-				<span style="font-family:calibri">”</span>
+		<span style="font-family:calibri">
+			<span style="font-size:14pt">
+				<span style="line-height:115%">”</span>
 			</span>
 		</span>
-		<span style="font-size:14pt">
-			<span style="line-height:115%">
-				<span style="font-family:楷体">太</span>
+		<span style="font-family:楷体">
+			<span style="font-size:14pt">
+				<span style="line-height:115%">太</span>
 			</span>
 		</span>
-		<span style="font-size:14pt">
-			<span style="line-height:115%">
-				<span style="font-family:calibri">14</span>
+		<span style="font-family:calibri">
+			<span style="font-size:14pt">
+				<span style="line-height:115%">14</span>
 			</span>
 		</span>
-		<span style="font-size:14pt">
-			<span style="line-height:115%">
-				<span style="font-family:楷体">：</span>
+		<span style="font-family:楷体">
+			<span style="font-size:14pt">
+				<span style="line-height:115%">：</span>
 			</span>
 		</span>
-		<span style="font-size:14pt">
-			<span style="line-height:115%">
-				<span style="font-family:calibri">16</span>
+		<span style="font-family:calibri">
+			<span style="font-size:14pt">
+				<span style="line-height:115%">16</span>
 			</span>
 		</span>
 	</span>
 </p>
 <ol>
 	<li>
-		<span style="font-style:normal">
-			<span style="font-weight:normal">
+		<span style="color:black">
+			<span style="color:black">
 				<span style="font-size:14pt">
-					<span style="color:black">
-						<span style="line-height:115%">
-							<span style="font-family:楷体">就对腓力说：</span>
+					<span style="font-style:normal">
+						<span style="font-weight:normal">
+							<span style="line-height:115%">就对腓力说：</span>
 						</span>
 					</span>
 				</span>
-				<span style="font-size:14pt">
-					<span style="color:black">
+				<span style="font-family:楷体">
+					<span style="font-size:14pt">
 						<span style="line-height:115%">“</span>
 					</span>
 				</span>
-				<span style="font-size:14pt">
-					<span style="color:black">
-						<span style="line-height:115%">
-							<span style="font-family:楷体">我们从哪里买饼给这些人吃呢？</span>
+				<span style="color:black">
+					<span style="font-family:楷体">
+						<span style="font-size:14pt">
+							<span style="line-height:115%">我们从哪里买饼给这些人吃呢？</span>
 						</span>
 					</span>
 				</span>
@@ -218,9 +218,9 @@
 		</span>
 		<ul style="list-style-type:circle">
 			<li>
-				<span style="font-size:11pt">
-					<span style="color:#000000">
-						<span style="font-family:&quot;calibri&quot;,sans-serif">
+				<span style="color:#000000">
+					<span style="font-family:&quot;calibri&quot;,sans-serif">
+						<span style="font-size:11pt">
 							<span style="font-style:normal">
 								<span style="font-weight:normal">
 									<span style="line-height:115%">asd</span>
@@ -234,10 +234,10 @@
 	</li>
 </ol>
 <p style="margin-left:0in; margin-right:0in">
-	<span style="line-height:115%">
-		<span style="color:#000000">
-			<span style="font-family:calibri">
-				<span style="font-size:medium">some tables</span>
+	<span style="color:#000000">
+		<span style="font-family:calibri">
+			<span style="font-size:medium">
+				<span style="line-height:115%">some tables</span>
 			</span>
 		</span>
 	</span>
@@ -245,12 +245,12 @@
 <table cellspacing="0">
 	<tbody>
 		<tr>
-			<td colspan="2" style="width:319.2pt" valign="top">
+			<td colspan="2" style="border-color:black; width:319.2pt" valign="top">
 				<p style="margin-left:0in; margin-right:0in">
-					<span style="line-height:normal">
-						<span style="color:#000000">
-							<span style="font-family:calibri">
-								<span style="font-size:medium">this is to confuse the hell out of the </span>
+					<span style="color:#000000">
+						<span style="font-family:calibri">
+							<span style="font-size:medium">
+								<span style="line-height:normal">this is to confuse the hell out of the </span>
 							</span>
 						</span>
 					</span>
@@ -258,10 +258,10 @@
 			</td>
 			<td style="border-color:black black black #000000; width:159.6pt" valign="top">
 				<p style="margin-left:0in; margin-right:0in">
-					<span style="line-height:normal">
-						<span style="color:#000000">
-							<span style="font-family:calibri">
-								<span style="font-size:medium">fck editor</span>
+					<span style="color:#000000">
+						<span style="font-family:calibri">
+							<span style="font-size:medium">
+								<span style="line-height:normal">fck editor</span>
 							</span>
 						</span>
 					</span>
@@ -271,10 +271,10 @@
 		<tr>
 			<td style="border-color:#000000 black black; width:159.6pt" valign="top">
 				<p style="margin-left:0in; margin-right:0in">
-					<span style="line-height:normal">
-						<span style="color:#000000">
-							<span style="font-family:calibri">
-								<span style="font-size:medium">to see</span>
+					<span style="color:#000000">
+						<span style="font-family:calibri">
+							<span style="font-size:medium">
+								<span style="line-height:normal">to see</span>
 							</span>
 						</span>
 					</span>
@@ -282,10 +282,10 @@
 			</td>
 			<td colspan="2" style="border-color:#000000 black black #000000; width:319.2pt" valign="top">
 				<p style="margin-left:0in; margin-right:0in">
-					<span style="line-height:normal">
-						<span style="color:#000000">
-							<span style="font-family:calibri">
-								<span style="font-size:medium">if the text can get messed up</span>
+					<span style="color:#000000">
+						<span style="font-family:calibri">
+							<span style="font-size:medium">
+								<span style="line-height:normal">if the text can get messed up</span>
 							</span>
 						</span>
 					</span>
@@ -293,33 +293,32 @@
 			</td>
 		</tr>
 		<tr>
-			<td>
+			<td style="border-color:#000000">
 				<br />
 			</td>
-			<td>
+			<td style="border-color:#000000">
 				<br />
 			</td>
-			<td>
+			<td style="border-color:#000000">
 				<br />
 			</td>
 		</tr>
 	</tbody>
 </table>
 <p style="margin-left:0in; margin-right:0in">
-	<span style="line-height:115%">
-		<span style="color:#000000">
-			<span style="font-family:calibri">
-				<span style="font-size:medium">&nbsp;</span>
+	<span style="color:#000000">
+		<span style="font-family:calibri">
+			<span style="font-size:medium">
+				<span style="line-height:115%">&nbsp;</span>
 			</span>
 		</span>
 	</span>
 </p>
 <p style="margin-left:0in; margin-right:0in">
-	<span style="line-height:115%">
-		<span style="color:#000000">
-			<span style="font-family:times new roman">
-				<span style="font-size:medium">
-					<img data-cke-saved-src="data:image/png;base64,/9j/4aaqskzjrgabagaazabkaad/7aarrhvja3kaaqaeaaaapaaa/+4adkfkb2jlagtaaaaaaf/baiqabgqebauebgufbgkgbqyjcwggbggldaokcwokdbamdawmdawqda4pea8odbmtfbqtexwbgxschx8fhx8fhx8fhwehbwcnda0yebayghurfrofhx8fhx8fhx8fhx8fhx8fhx8fhx8fhx8fhx8fhx8fhx8fhx8fhx8fhx8fhx8fhx8f/8aaeqgahwcbaweraairaqmraf/eakuaaaeeaweaaaaaaaaaaaaaaaacawqfaqyhcaebaaidaqeaaaaaaaaaaaaaaaedagugbacqaaedaweebwugbgidaaaaaaeaagmrbauhmvesbkfhcsiyewebkuijfkgxwvjioufym6mvcijt8gm0eqacaqieagcfbgcbaaaaaaaaaqirayexbavrekfhgbeimgzx0efie5ghwujsgvbykimzfcqv/9oadambaairaxeapwd1sgbacaeaiaqagbacaeavcaxxhaheebmoqagbacaeaiaqagbacaeaiaqagbacabkldqgipujzdsjhd0vgz37ebjyr8uao0aipndb1fayivms4nmrq04rqe3raauzwkuieanpltraoxxjhdkaknka5alqagbacaeaiaqagbacaeaibqauncaimjluncrpdbsj2e9imeunji2bjbqdaek9zvbkbdvjubvbudqcckg6eftzmkylsreslb5dpyufe3rzkzaz9pdq6tpmsg7q+5zget7lrxufasqaoaqagbacaeaiaqagmfwcayluwtg1armsku3begegjndpyebmlmxtdroxoob2kqtqsn/ua7ffckiw8vo5wa49biqlkgxvqszqlsaugnuq0srlmaxom8wwmsjdu2pltqttqqpwshzqpa8gbacaeaiaqagamgqeo6uc3ut1cdaagmmtgmlxznjk1q3a33elguqael2tb3qgmb0dqlbyqgvk14zh7e6niihjui5fnwyfcxuwn1bzxmqn3loqpqiquh48f698yznmo/ubi4me872swkmdegn3gntq/lsslvu7s9rswoz7mwf5d3ocx9zdil1lcwza7elhfvlrtusmy6arghnr1rirudrrrgzvkihnqgg6g6efzxkcfgpiuhqivckfppscfycc01caygbacaeaiaqhofuz1rvovspby2xs4rmawhz5nzoca1rnfja0n/kpsgntxfrhlzcra/xyua275gsk8t7+nocqojvfosotadm4+i1ptsvpsqrshmwrhgorlneigyt2av2kcojir8rjompjlrgxjh090wsed1rrmojmw06o5dyh/rzybyzmv8vdtfxswu47si6tg7redvbrzsrf1zsowd7juooy5udzvlndgaanbua0xoxd/uyfhveeug3qsxllg3/1tef3de2tfzqt7te4ruxx86nfqtn9n4zm4lzn/sjk31avstbcx2ohxgpc9470z4x3mgjeqtnotvkirhbotxq73yxn487y7jszekmvywyu3eoysugmoqfai96sjyovi/bxiempwqqlqagbacaeaidghrgq7nmih4bcef3jsgniiabcqedziw/uca9qxdw6gxfmwveg1c8gsvu3zljz0llfttuklyntkye8ry57ysvwn3wxzurkzo46ekyrgxuv5yo/2blfmx9cpav9tkrq80t/yunyyzh0y8bgxtjp5fcafmvlds36aop8aesuowos8doirnu92qfp9oiwy2m/9k+n0spjrlfnbffhmfnd/af15oypqhoy1irjlybztde7gkkld+3q1nnbck9j6o5exsgfwopw8brhywnij3ub0qts8cmxdq/iyswzjibwtdnc0evbxihsk0vybki8kkc0aicnzvnegwkkud9i4stcrwmaxknbpxedyf4nzuvnttkbxz6dppll1nxwrpx+tsmjbi4sp2txh4mgtoojok9njuqux5onsrvctsg6svgsvcvgdia8+es7ulnt36bsefuefxqglocgclz8jb92qa9qq8e1mwejkkbfcqqjruk4vjimmmms0abkbawxu3xp8disw7wvnet0j09xxfydxpryuwtwyy2reuuagxzjhsnedp2+ytsgqqcdkfwfb7vnolxmevk1r1lzi0k4qg7yltghi0mzhesgutwltftyrmxemi+tr18syahkfulk7f3w17hg/bsfnrzer0rtyb/kx1ry1bnnkray1xmrj3qgzrm3ezzeeyacmnh36abxiyj0z7qaugeyv8un8hbiyc6g2mgroszsom+bkvxq4tlbi4zgwnvbiodi7hjyfgy3rrfz96+w6/wyv3xn9p3lor2em06twuunwtyomubpztptpx8tdsvanjh2quxqrlmvytxkzxlmbio1vg5yl1mys23zcxlp2c7ibld/ozut9i67qepiy8n5u+zzdqnhqdpaxt/ybvddw9zbtnt5wzqvfwymic0+0lp7dym1zrduaeuxf0aozz76shzufrlrqasigzqkvjbxabx3lmylpzfy/9bzwzmcxtkz8yvq6ia9aymtixlo6u2gm/scpzgufnvmgbjhdbsp8+9b4y4aolt+o7grn961wmcowtrncdb7bzvkxmlspwaljc5c87pcyotp5bdt/mdtk4yv2mr0at1hthzi7csoywsogjvclnkrwbknfuiejcy+4kfbn8zv7cwodvptx3fxqnzkptkfgtgyliwcryku1mhefhmcx3e00p3qyzflblzrzkrltsvhkw1tctnaanh9ixc7zus1eapczzuq0rtv5s/tm+xa1vstiygzen4omsg6xgh7doriuqjjfuatcya6gbaa7nes7dif1xbutbw6lzr3hn9tr94xp7l6ftaisoec59z9q/e2ek3odrcxiiavfwt9j5fpsnaqnjjnrt1td0ri9vprunlyxo9vuz0nm7c6ua2ydcy1kjs+i8bptc8ztvooklvloeaxj73k4iyy2e7ogt34jrg7+zp09u1ejsbjdsoshtq6pskr+lhcvjkpfs5j5eyqjz2lzjcaarztah0i3e0ef1wm9uqapdi0+kxnle2as8jr7ru+v5mbgkwf1pd4y3r1h9w0xouepdolhzs7peuq2i83jrdpu5bmbmzeggf30dqdplinhedb9vsc53w77evylwr4l3m202127el8uush47byskbjnolx2lu27c7rpfhvlkmfixsvrywfoiefchrrak69qxtjat2c/fpgedzncy8mrwrscu+js1xcwrhvsq2gfqps7f6nrt+plfsurajw95vz1dlpli6viv7zmtokcfna2lavc40wypssr1svwoob1sqgig62qdwqmpg0tlcdwuyyzv3fq0xo0tyubsxhop579toltn2du6k7gvo6q0mct1glz/wcengnc5403gaqycoistbijqsgooaqaggbuztbyb0fze2wj21rhukm/yhdjyzslfmdu5kdrf0zpwy5jvlnzrneum0i1nut32j9j+ifaum3d05ctnzspmj+np+pedbpd1jpw3chx6pga4tfpvsjflmgh0pqn4xonqbo1srtlwowkiktqaafustiwkjentwk0gpuktyow9jiywbjn4r0ly6frp4zpldv0wiwcvvfxvirjghggjp3cg9m9bwzpb1/w2lyw/u/w4nhu6i3axm6y4fzjcpz2pfadjchxtv1cezcf0ug2m1p8v4p/qefwnhqtwuxshhhgiw0ipqebjqtpngzxkk6wumual8qattixhv7zyuzo9vrw3yzmrn8m2p/pslo3lwt9oqflz7o7zlpqkcnebljtovd9n/mwf+z1d0pktgn5kxlr0lkhpqp5pgmt4fqi1s8ry2hrg3id+yraatabfnjvz4b2tuxmgwdbxva37vslieuw93nxaakgoprjhrwofvastwcgqckaiaqasggkmggpj2idm/oxrthss99lhg3j37hcmkgj+njioolh4ynzfeghmfkspz3in3tkwwuatgbpcek0rqfiaehy0w8bldux5o4xv08ep+82wg3cvl0emo72gvoe8eskbdmkgg7qroqvnmqrb5o6tuzq/znbxcbtgvunsrvld19bfwjrvtplkl14jsoaxoc7rtg7sepddtgiv9c8vj0lj8dq7hqxbfjhzdxqtfwi2zlnrushdev4wstpzgb8fbsofy1r9y6xqsvean1ez0pe5rg5w0bd4+4zcqo+jh1b3og1p6iooyujwcfafvkcoahtqkzwimgfb/qfahacrroejqptliijm7u7gjess4okxzq8lasysagbacao+aec8byzaefk5+grw+tbm70sh/s38togofc4+p/mxnhhbrk4/foqppi3vc8f+1+hpyno1au+k5wvrtvg1nlwgf1h6d2ida/syyvbxns3da/iihmrxiatqslttp0bwbqg0c1rsh5jvy2ig4mup1vy1x+0r5hvltr1dxlin9qtox26tdinf4xibklwadtk1xm0j20xfepud9a8nwemyc2cv8zuhnghbwf1hhcx0x1parshp4l5uctrjc16t6zmnpi33ubzewlzpgjot2lynncwvcxgr76nhzptbgaohwuanaoadhbggdt5u9wmzkog1zabj73y2un5d/8akfaep3vwdiyng/b5oc01b1bwjatri7sntsgoobohipsuaz5jr4r7vjiufhkc5zz8tgq49qupvcfitxpxu+wzuxjq3+1wgzyrtoeapacatkhmn4jdwvlsgo20nncgplebxgypnd3zzsv02s89zjjpstxvpe11txulpqb0ic9tcnh8u5gmre3zibhcwf1xhygtfsubuwj5c5mzybjkn/4fhhzawa3lm9nhz7anqqhrmfy3hsfbgdg2zyq7+pj4nvo97zqubz3nyfvnd3uc2j39sd8f839rrpq5ddo5hwbu/wcwu3vkmc0j9i0jsjqfqxrsddbxbbpapia0tca6glftc+vavutrxyruofvos37watzl6r2nyx3vls4tjx3jb6mik67b3mf+ak8qod5s0ywnk+lz9k5orrlwbuhra8ah71jjayhl0tlazccdssbnoe+ivqhwftg0v7plwh66r0nnpmtre6plixacldd+rh2qurgzbdmdgfb1kcdad70frqcsq0cpoibk2zobg21z4numvunocssm0sreemafji+gbacaebp/ofpvy8yx1tkg3lrg9hoywzja/waymgobfw0ckmhqfry9ydg8eytpd5l04fnvjjxzo/5fcnnjabaxaaeby3nxvdzvifzqxh7x+c+eepv/1p8alr1o0p8as9rkw41jpvc51g1z2ocfptirtay37gvsnlebexhcxpm/amvtnrv8ym0cpcemhvhgmzw2oyebra/gy7zncxzasd7dvrqihqvz6pyz10h280kvmxb77iegnxbrtvvib6ubsoxn0wbrgjhakadqug5yteubupva+hsucpfb5mlut4iankoukr2cvqdnielh/fzkjkiyti3vczjdv7tsssjingucaygbacaeaiaqagbacx9qm05nb320z/c8l5/6nx/t+xd7on2f/d+5/gucrxvyckvlae0rnylfg2k8dteq4ymdc0d7f9ggqjhbyzmlokyii81s142ibimz21q0f8etgbke9eqax/kjv+j938eafxzv/oabq/wqb9fl/wbh7v4idej5lkna6pgadxvrxo7ebkhjdqgheaiaqagbacaeaiaqggc/wdpm1doysgpgax0bpy2phc5xb4xuaagu3qxd+p9pkv6mk4+xlminm+lr0ez3urbttz4n9xxtwc1zcwjzpjt6fgl3zqgcii18dt7fqzwj3jwt5y5zzhl/ue1xyxjklx+2xuoodyvpxx4iaqchbnsqge8mw8e8ia4yt494qbwx7x7wgfndoghalqagbacaeb//2q==" src="data:image/png;base64,/9j/4aaqskzjrgabagaazabkaad/7aarrhvja3kaaqaeaaaapaaa/+4adkfkb2jlagtaaaaaaf/baiqabgqebauebgufbgkgbqyjcwggbggldaokcwokdbamdawmdawqda4pea8odbmtfbqtexwbgxschx8fhx8fhx8fhwehbwcnda0yebayghurfrofhx8fhx8fhx8fhx8fhx8fhx8fhx8fhx8fhx8fhx8fhx8fhx8fhx8fhx8fhx8fhx8f/8aaeqgahwcbaweraairaqmraf/eakuaaaeeaweaaaaaaaaaaaaaaaacawqfaqyhcaebaaidaqeaaaaaaaaaaaaaaaedagugbacqaaedaweebwugbgidaaaaaaeaagmrbauhmvesbkfhcsiyewebkuijfkgxwvjioufym6mvcijt8gm0eqacaqieagcfbgcbaaaaaaaaaqirayexbavrekfhgbeimgzx0efie5ghwujsgvbykimzfcqv/9oadambaairaxeapwd1sgbacaeaiaqagbacaeavcaxxhaheebmoqagbacaeaiaqagbacaeaiaqagbacabkldqgipujzdsjhd0vgz37ebjyr8uao0aipndb1fayivms4nmrq04rqe3raauzwkuieanpltraoxxjhdkaknka5alqagbacaeaiaqagbacaeaibqauncaimjluncrpdbsj2e9imeunji2bjbqdaek9zvbkbdvjubvbudqcckg6eftzmkylsreslb5dpyufe3rzkzaz9pdq6tpmsg7q+5zget7lrxufasqaoaqagbacaeaiaqagmfwcayluwtg1armsku3begegjndpyebmlmxtdroxoob2kqtqsn/ua7ffckiw8vo5wa49biqlkgxvqszqlsaugnuq0srlmaxom8wwmsjdu2pltqttqqpwshzqpa8gbacaeaiaqagamgqeo6uc3ut1cdaagmmtgmlxznjk1q3a33elguqael2tb3qgmb0dqlbyqgvk14zh7e6niihjui5fnwyfcxuwn1bzxmqn3loqpqiquh48f698yznmo/ubi4me872swkmdegn3gntq/lsslvu7s9rswoz7mwf5d3ocx9zdil1lcwza7elhfvlrtusmy6arghnr1rirudrrrgzvkihnqgg6g6efzxkcfgpiuhqivckfppscfycc01caygbacaeaiaqhofuz1rvovspby2xs4rmawhz5nzoca1rnfja0n/kpsgntxfrhlzcra/xyua275gsk8t7+nocqojvfosotadm4+i1ptsvpsqrshmwrhgorlneigyt2av2kcojir8rjompjlrgxjh090wsed1rrmojmw06o5dyh/rzybyzmv8vdtfxswu47si6tg7redvbrzsrf1zsowd7juooy5udzvlndgaanbua0xoxd/uyfhveeug3qsxllg3/1tef3de2tfzqt7te4ruxx86nfqtn9n4zm4lzn/sjk31avstbcx2ohxgpc9470z4x3mgjeqtnotvkirhbotxq73yxn487y7jszekmvywyu3eoysugmoqfai96sjyovi/bxiempwqqlqagbacaeaidghrgq7nmih4bcef3jsgniiabcqedziw/uca9qxdw6gxfmwveg1c8gsvu3zljz0llfttuklyntkye8ry57ysvwn3wxzurkzo46ekyrgxuv5yo/2blfmx9cpav9tkrq80t/yunyyzh0y8bgxtjp5fcafmvlds36aop8aesuowos8doirnu92qfp9oiwy2m/9k+n0spjrlfnbffhmfnd/af15oypqhoy1irjlybztde7gkkld+3q1nnbck9j6o5exsgfwopw8brhywnij3ub0qts8cmxdq/iyswzjibwtdnc0evbxihsk0vybki8kkc0aicnzvnegwkkud9i4stcrwmaxknbpxedyf4nzuvnttkbxz6dppll1nxwrpx+tsmjbi4sp2txh4mgtoojok9njuqux5onsrvctsg6svgsvcvgdia8+es7ulnt36bsefuefxqglocgclz8jb92qa9qq8e1mwejkkbfcqqjruk4vjimmmms0abkbawxu3xp8disw7wvnet0j09xxfydxpryuwtwyy2reuuagxzjhsnedp2+ytsgqqcdkfwfb7vnolxmevk1r1lzi0k4qg7yltghi0mzhesgutwltftyrmxemi+tr18syahkfulk7f3w17hg/bsfnrzer0rtyb/kx1ry1bnnkray1xmrj3qgzrm3ezzeeyacmnh36abxiyj0z7qaugeyv8un8hbiyc6g2mgroszsom+bkvxq4tlbi4zgwnvbiodi7hjyfgy3rrfz96+w6/wyv3xn9p3lor2em06twuunwtyomubpztptpx8tdsvanjh2quxqrlmvytxkzxlmbio1vg5yl1mys23zcxlp2c7ibld/ozut9i67qepiy8n5u+zzdqnhqdpaxt/ybvddw9zbtnt5wzqvfwymic0+0lp7dym1zrduaeuxf0aozz76shzufrlrqasigzqkvjbxabx3lmylpzfy/9bzwzmcxtkz8yvq6ia9aymtixlo6u2gm/scpzgufnvmgbjhdbsp8+9b4y4aolt+o7grn961wmcowtrncdb7bzvkxmlspwaljc5c87pcyotp5bdt/mdtk4yv2mr0at1hthzi7csoywsogjvclnkrwbknfuiejcy+4kfbn8zv7cwodvptx3fxqnzkptkfgtgyliwcryku1mhefhmcx3e00p3qyzflblzrzkrltsvhkw1tctnaanh9ixc7zus1eapczzuq0rtv5s/tm+xa1vstiygzen4omsg6xgh7doriuqjjfuatcya6gbaa7nes7dif1xbutbw6lzr3hn9tr94xp7l6ftaisoec59z9q/e2ek3odrcxiiavfwt9j5fpsnaqnjjnrt1td0ri9vprunlyxo9vuz0nm7c6ua2ydcy1kjs+i8bptc8ztvooklvloeaxj73k4iyy2e7ogt34jrg7+zp09u1ejsbjdsoshtq6pskr+lhcvjkpfs5j5eyqjz2lzjcaarztah0i3e0ef1wm9uqapdi0+kxnle2as8jr7ru+v5mbgkwf1pd4y3r1h9w0xouepdolhzs7peuq2i83jrdpu5bmbmzeggf30dqdplinhedb9vsc53w77evylwr4l3m202127el8uush47byskbjnolx2lu27c7rpfhvlkmfixsvrywfoiefchrrak69qxtjat2c/fpgedzncy8mrwrscu+js1xcwrhvsq2gfqps7f6nrt+plfsurajw95vz1dlpli6viv7zmtokcfna2lavc40wypssr1svwoob1sqgig62qdwqmpg0tlcdwuyyzv3fq0xo0tyubsxhop579toltn2du6k7gvo6q0mct1glz/wcengnc5403gaqycoistbijqsgooaqaggbuztbyb0fze2wj21rhukm/yhdjyzslfmdu5kdrf0zpwy5jvlnzrneum0i1nut32j9j+ifaum3d05ctnzspmj+np+pedbpd1jpw3chx6pga4tfpvsjflmgh0pqn4xonqbo1srtlwowkiktqaafustiwkjentwk0gpuktyow9jiywbjn4r0ly6frp4zpldv0wiwcvvfxvirjghggjp3cg9m9bwzpb1/w2lyw/u/w4nhu6i3axm6y4fzjcpz2pfadjchxtv1cezcf0ug2m1p8v4p/qefwnhqtwuxshhhgiw0ipqebjqtpngzxkk6wumual8qattixhv7zyuzo9vrw3yzmrn8m2p/pslo3lwt9oqflz7o7zlpqkcnebljtovd9n/mwf+z1d0pktgn5kxlr0lkhpqp5pgmt4fqi1s8ry2hrg3id+yraatabfnjvz4b2tuxmgwdbxva37vslieuw93nxaakgoprjhrwofvastwcgqckaiaqasggkmggpj2idm/oxrthss99lhg3j37hcmkgj+njioolh4ynzfeghmfkspz3in3tkwwuatgbpcek0rqfiaehy0w8bldux5o4xv08ep+82wg3cvl0emo72gvoe8eskbdmkgg7qroqvnmqrb5o6tuzq/znbxcbtgvunsrvld19bfwjrvtplkl14jsoaxoc7rtg7sepddtgiv9c8vj0lj8dq7hqxbfjhzdxqtfwi2zlnrushdev4wstpzgb8fbsofy1r9y6xqsvean1ez0pe5rg5w0bd4+4zcqo+jh1b3og1p6iooyujwcfafvkcoahtqkzwimgfb/qfahacrroejqptliijm7u7gjess4okxzq8lasysagbacao+aec8byzaefk5+grw+tbm70sh/s38togofc4+p/mxnhhbrk4/foqppi3vc8f+1+hpyno1au+k5wvrtvg1nlwgf1h6d2ida/syyvbxns3da/iihmrxiatqslttp0bwbqg0c1rsh5jvy2ig4mup1vy1x+0r5hvltr1dxlin9qtox26tdinf4xibklwadtk1xm0j20xfepud9a8nwemyc2cv8zuhnghbwf1hhcx0x1parshp4l5uctrjc16t6zmnpi33ubzewlzpgjot2lynncwvcxgr76nhzptbgaohwuanaoadhbggdt5u9wmzkog1zabj73y2un5d/8akfaep3vwdiyng/b5oc01b1bwjatri7sntsgoobohipsuaz5jr4r7vjiufhkc5zz8tgq49qupvcfitxpxu+wzuxjq3+1wgzyrtoeapacatkhmn4jdwvlsgo20nncgplebxgypnd3zzsv02s89zjjpstxvpe11txulpqb0ic9tcnh8u5gmre3zibhcwf1xhygtfsubuwj5c5mzybjkn/4fhhzawa3lm9nhz7anqqhrmfy3hsfbgdg2zyq7+pj4nvo97zqubz3nyfvnd3uc2j39sd8f839rrpq5ddo5hwbu/wcwu3vkmc0j9i0jsjqfqxrsddbxbbpapia0tca6glftc+vavutrxyruofvos37watzl6r2nyx3vls4tjx3jb6mik67b3mf+ak8qod5s0ywnk+lz9k5orrlwbuhra8ah71jjayhl0tlazccdssbnoe+ivqhwftg0v7plwh66r0nnpmtre6plixacldd+rh2qurgzbdmdgfb1kcdad70frqcsq0cpoibk2zobg21z4numvunocssm0sreemafji+gbacaebp/ofpvy8yx1tkg3lrg9hoywzja/waymgobfw0ckmhqfry9ydg8eytpd5l04fnvjjxzo/5fcnnjabaxaaeby3nxvdzvifzqxh7x+c+eepv/1p8alr1o0p8as9rkw41jpvc51g1z2ocfptirtay37gvsnlebexhcxpm/amvtnrv8ym0cpcemhvhgmzw2oyebra/gy7zncxzasd7dvrqihqvz6pyz10h280kvmxb77iegnxbrtvvib6ubsoxn0wbrgjhakadqug5yteubupva+hsucpfb5mlut4iankoukr2cvqdnielh/fzkjkiyti3vczjdv7tsssjingucaygbacaeaiaqagbacx9qm05nb320z/c8l5/6nx/t+xd7on2f/d+5/gucrxvyckvlae0rnylfg2k8dteq4ymdc0d7f9ggqjhbyzmlokyii81s142ibimz21q0f8etgbke9eqax/kjv+j938eafxzv/oabq/wqb9fl/wbh7v4idej5lkna6pgadxvrxo7ebkhjdqgheaiaqagbacaeaiaqggc/wdpm1doysgpgax0bpy2phc5xb4xuaagu3qxd+p9pkv6mk4+xlminm+lr0ez3urbttz4n9xxtwc1zcwjzpjt6fgl3zqgcii18dt7fqzwj3jwt5y5zzhl/ue1xyxjklx+2xuoodyvpxx4iaqchbnsqge8mw8e8ia4yt494qbwx7x7wgfndoghalqagbacaeb//2q==" style="height:135px; width:155px" /></span>
+	<span style="color:#000000">
+		<span style="font-family:times new roman">
+			<span style="font-size:medium">
+				<span style="line-height:115%"><img data-cke-saved-src="data:image/png;base64,/9j/4aaqskzjrgabagaazabkaad/7aarrhvja3kaaqaeaaaapaaa/+4adkfkb2jlagtaaaaaaf/baiqabgqebauebgufbgkgbqyjcwggbggldaokcwokdbamdawmdawqda4pea8odbmtfbqtexwbgxschx8fhx8fhx8fhwehbwcnda0yebayghurfrofhx8fhx8fhx8fhx8fhx8fhx8fhx8fhx8fhx8fhx8fhx8fhx8fhx8fhx8fhx8fhx8f/8aaeqgahwcbaweraairaqmraf/eakuaaaeeaweaaaaaaaaaaaaaaaacawqfaqyhcaebaaidaqeaaaaaaaaaaaaaaaedagugbacqaaedaweebwugbgidaaaaaaeaagmrbauhmvesbkfhcsiyewebkuijfkgxwvjioufym6mvcijt8gm0eqacaqieagcfbgcbaaaaaaaaaqirayexbavrekfhgbeimgzx0efie5ghwujsgvbykimzfcqv/9oadambaairaxeapwd1sgbacaeaiaqagbacaeavcaxxhaheebmoqagbacaeaiaqagbacaeaiaqagbacabkldqgipujzdsjhd0vgz37ebjyr8uao0aipndb1fayivms4nmrq04rqe3raauzwkuieanpltraoxxjhdkaknka5alqagbacaeaiaqagbacaeaibqauncaimjluncrpdbsj2e9imeunji2bjbqdaek9zvbkbdvjubvbudqcckg6eftzmkylsreslb5dpyufe3rzkzaz9pdq6tpmsg7q+5zget7lrxufasqaoaqagbacaeaiaqagmfwcayluwtg1armsku3begegjndpyebmlmxtdroxoob2kqtqsn/ua7ffckiw8vo5wa49biqlkgxvqszqlsaugnuq0srlmaxom8wwmsjdu2pltqttqqpwshzqpa8gbacaeaiaqagamgqeo6uc3ut1cdaagmmtgmlxznjk1q3a33elguqael2tb3qgmb0dqlbyqgvk14zh7e6niihjui5fnwyfcxuwn1bzxmqn3loqpqiquh48f698yznmo/ubi4me872swkmdegn3gntq/lsslvu7s9rswoz7mwf5d3ocx9zdil1lcwza7elhfvlrtusmy6arghnr1rirudrrrgzvkihnqgg6g6efzxkcfgpiuhqivckfppscfycc01caygbacaeaiaqhofuz1rvovspby2xs4rmawhz5nzoca1rnfja0n/kpsgntxfrhlzcra/xyua275gsk8t7+nocqojvfosotadm4+i1ptsvpsqrshmwrhgorlneigyt2av2kcojir8rjompjlrgxjh090wsed1rrmojmw06o5dyh/rzybyzmv8vdtfxswu47si6tg7redvbrzsrf1zsowd7juooy5udzvlndgaanbua0xoxd/uyfhveeug3qsxllg3/1tef3de2tfzqt7te4ruxx86nfqtn9n4zm4lzn/sjk31avstbcx2ohxgpc9470z4x3mgjeqtnotvkirhbotxq73yxn487y7jszekmvywyu3eoysugmoqfai96sjyovi/bxiempwqqlqagbacaeaidghrgq7nmih4bcef3jsgniiabcqedziw/uca9qxdw6gxfmwveg1c8gsvu3zljz0llfttuklyntkye8ry57ysvwn3wxzurkzo46ekyrgxuv5yo/2blfmx9cpav9tkrq80t/yunyyzh0y8bgxtjp5fcafmvlds36aop8aesuowos8doirnu92qfp9oiwy2m/9k+n0spjrlfnbffhmfnd/af15oypqhoy1irjlybztde7gkkld+3q1nnbck9j6o5exsgfwopw8brhywnij3ub0qts8cmxdq/iyswzjibwtdnc0evbxihsk0vybki8kkc0aicnzvnegwkkud9i4stcrwmaxknbpxedyf4nzuvnttkbxz6dppll1nxwrpx+tsmjbi4sp2txh4mgtoojok9njuqux5onsrvctsg6svgsvcvgdia8+es7ulnt36bsefuefxqglocgclz8jb92qa9qq8e1mwejkkbfcqqjruk4vjimmmms0abkbawxu3xp8disw7wvnet0j09xxfydxpryuwtwyy2reuuagxzjhsnedp2+ytsgqqcdkfwfb7vnolxmevk1r1lzi0k4qg7yltghi0mzhesgutwltftyrmxemi+tr18syahkfulk7f3w17hg/bsfnrzer0rtyb/kx1ry1bnnkray1xmrj3qgzrm3ezzeeyacmnh36abxiyj0z7qaugeyv8un8hbiyc6g2mgroszsom+bkvxq4tlbi4zgwnvbiodi7hjyfgy3rrfz96+w6/wyv3xn9p3lor2em06twuunwtyomubpztptpx8tdsvanjh2quxqrlmvytxkzxlmbio1vg5yl1mys23zcxlp2c7ibld/ozut9i67qepiy8n5u+zzdqnhqdpaxt/ybvddw9zbtnt5wzqvfwymic0+0lp7dym1zrduaeuxf0aozz76shzufrlrqasigzqkvjbxabx3lmylpzfy/9bzwzmcxtkz8yvq6ia9aymtixlo6u2gm/scpzgufnvmgbjhdbsp8+9b4y4aolt+o7grn961wmcowtrncdb7bzvkxmlspwaljc5c87pcyotp5bdt/mdtk4yv2mr0at1hthzi7csoywsogjvclnkrwbknfuiejcy+4kfbn8zv7cwodvptx3fxqnzkptkfgtgyliwcryku1mhefhmcx3e00p3qyzflblzrzkrltsvhkw1tctnaanh9ixc7zus1eapczzuq0rtv5s/tm+xa1vstiygzen4omsg6xgh7doriuqjjfuatcya6gbaa7nes7dif1xbutbw6lzr3hn9tr94xp7l6ftaisoec59z9q/e2ek3odrcxiiavfwt9j5fpsnaqnjjnrt1td0ri9vprunlyxo9vuz0nm7c6ua2ydcy1kjs+i8bptc8ztvooklvloeaxj73k4iyy2e7ogt34jrg7+zp09u1ejsbjdsoshtq6pskr+lhcvjkpfs5j5eyqjz2lzjcaarztah0i3e0ef1wm9uqapdi0+kxnle2as8jr7ru+v5mbgkwf1pd4y3r1h9w0xouepdolhzs7peuq2i83jrdpu5bmbmzeggf30dqdplinhedb9vsc53w77evylwr4l3m202127el8uush47byskbjnolx2lu27c7rpfhvlkmfixsvrywfoiefchrrak69qxtjat2c/fpgedzncy8mrwrscu+js1xcwrhvsq2gfqps7f6nrt+plfsurajw95vz1dlpli6viv7zmtokcfna2lavc40wypssr1svwoob1sqgig62qdwqmpg0tlcdwuyyzv3fq0xo0tyubsxhop579toltn2du6k7gvo6q0mct1glz/wcengnc5403gaqycoistbijqsgooaqaggbuztbyb0fze2wj21rhukm/yhdjyzslfmdu5kdrf0zpwy5jvlnzrneum0i1nut32j9j+ifaum3d05ctnzspmj+np+pedbpd1jpw3chx6pga4tfpvsjflmgh0pqn4xonqbo1srtlwowkiktqaafustiwkjentwk0gpuktyow9jiywbjn4r0ly6frp4zpldv0wiwcvvfxvirjghggjp3cg9m9bwzpb1/w2lyw/u/w4nhu6i3axm6y4fzjcpz2pfadjchxtv1cezcf0ug2m1p8v4p/qefwnhqtwuxshhhgiw0ipqebjqtpngzxkk6wumual8qattixhv7zyuzo9vrw3yzmrn8m2p/pslo3lwt9oqflz7o7zlpqkcnebljtovd9n/mwf+z1d0pktgn5kxlr0lkhpqp5pgmt4fqi1s8ry2hrg3id+yraatabfnjvz4b2tuxmgwdbxva37vslieuw93nxaakgoprjhrwofvastwcgqckaiaqasggkmggpj2idm/oxrthss99lhg3j37hcmkgj+njioolh4ynzfeghmfkspz3in3tkwwuatgbpcek0rqfiaehy0w8bldux5o4xv08ep+82wg3cvl0emo72gvoe8eskbdmkgg7qroqvnmqrb5o6tuzq/znbxcbtgvunsrvld19bfwjrvtplkl14jsoaxoc7rtg7sepddtgiv9c8vj0lj8dq7hqxbfjhzdxqtfwi2zlnrushdev4wstpzgb8fbsofy1r9y6xqsvean1ez0pe5rg5w0bd4+4zcqo+jh1b3og1p6iooyujwcfafvkcoahtqkzwimgfb/qfahacrroejqptliijm7u7gjess4okxzq8lasysagbacao+aec8byzaefk5+grw+tbm70sh/s38togofc4+p/mxnhhbrk4/foqppi3vc8f+1+hpyno1au+k5wvrtvg1nlwgf1h6d2ida/syyvbxns3da/iihmrxiatqslttp0bwbqg0c1rsh5jvy2ig4mup1vy1x+0r5hvltr1dxlin9qtox26tdinf4xibklwadtk1xm0j20xfepud9a8nwemyc2cv8zuhnghbwf1hhcx0x1parshp4l5uctrjc16t6zmnpi33ubzewlzpgjot2lynncwvcxgr76nhzptbgaohwuanaoadhbggdt5u9wmzkog1zabj73y2un5d/8akfaep3vwdiyng/b5oc01b1bwjatri7sntsgoobohipsuaz5jr4r7vjiufhkc5zz8tgq49qupvcfitxpxu+wzuxjq3+1wgzyrtoeapacatkhmn4jdwvlsgo20nncgplebxgypnd3zzsv02s89zjjpstxvpe11txulpqb0ic9tcnh8u5gmre3zibhcwf1xhygtfsubuwj5c5mzybjkn/4fhhzawa3lm9nhz7anqqhrmfy3hsfbgdg2zyq7+pj4nvo97zqubz3nyfvnd3uc2j39sd8f839rrpq5ddo5hwbu/wcwu3vkmc0j9i0jsjqfqxrsddbxbbpapia0tca6glftc+vavutrxyruofvos37watzl6r2nyx3vls4tjx3jb6mik67b3mf+ak8qod5s0ywnk+lz9k5orrlwbuhra8ah71jjayhl0tlazccdssbnoe+ivqhwftg0v7plwh66r0nnpmtre6plixacldd+rh2qurgzbdmdgfb1kcdad70frqcsq0cpoibk2zobg21z4numvunocssm0sreemafji+gbacaebp/ofpvy8yx1tkg3lrg9hoywzja/waymgobfw0ckmhqfry9ydg8eytpd5l04fnvjjxzo/5fcnnjabaxaaeby3nxvdzvifzqxh7x+c+eepv/1p8alr1o0p8as9rkw41jpvc51g1z2ocfptirtay37gvsnlebexhcxpm/amvtnrv8ym0cpcemhvhgmzw2oyebra/gy7zncxzasd7dvrqihqvz6pyz10h280kvmxb77iegnxbrtvvib6ubsoxn0wbrgjhakadqug5yteubupva+hsucpfb5mlut4iankoukr2cvqdnielh/fzkjkiyti3vczjdv7tsssjingucaygbacaeaiaqagbacx9qm05nb320z/c8l5/6nx/t+xd7on2f/d+5/gucrxvyckvlae0rnylfg2k8dteq4ymdc0d7f9ggqjhbyzmlokyii81s142ibimz21q0f8etgbke9eqax/kjv+j938eafxzv/oabq/wqb9fl/wbh7v4idej5lkna6pgadxvrxo7ebkhjdqgheaiaqagbacaeaiaqggc/wdpm1doysgpgax0bpy2phc5xb4xuaagu3qxd+p9pkv6mk4+xlminm+lr0ez3urbttz4n9xxtwc1zcwjzpjt6fgl3zqgcii18dt7fqzwj3jwt5y5zzhl/ue1xyxjklx+2xuoodyvpxx4iaqchbnsqge8mw8e8ia4yt494qbwx7x7wgfndoghalqagbacaeb//2q==" src="data:image/png;base64,/9j/4aaqskzjrgabagaazabkaad/7aarrhvja3kaaqaeaaaapaaa/+4adkfkb2jlagtaaaaaaf/baiqabgqebauebgufbgkgbqyjcwggbggldaokcwokdbamdawmdawqda4pea8odbmtfbqtexwbgxschx8fhx8fhx8fhwehbwcnda0yebayghurfrofhx8fhx8fhx8fhx8fhx8fhx8fhx8fhx8fhx8fhx8fhx8fhx8fhx8fhx8fhx8fhx8f/8aaeqgahwcbaweraairaqmraf/eakuaaaeeaweaaaaaaaaaaaaaaaacawqfaqyhcaebaaidaqeaaaaaaaaaaaaaaaedagugbacqaaedaweebwugbgidaaaaaaeaagmrbauhmvesbkfhcsiyewebkuijfkgxwvjioufym6mvcijt8gm0eqacaqieagcfbgcbaaaaaaaaaqirayexbavrekfhgbeimgzx0efie5ghwujsgvbykimzfcqv/9oadambaairaxeapwd1sgbacaeaiaqagbacaeavcaxxhaheebmoqagbacaeaiaqagbacaeaiaqagbacabkldqgipujzdsjhd0vgz37ebjyr8uao0aipndb1fayivms4nmrq04rqe3raauzwkuieanpltraoxxjhdkaknka5alqagbacaeaiaqagbacaeaibqauncaimjluncrpdbsj2e9imeunji2bjbqdaek9zvbkbdvjubvbudqcckg6eftzmkylsreslb5dpyufe3rzkzaz9pdq6tpmsg7q+5zget7lrxufasqaoaqagbacaeaiaqagmfwcayluwtg1armsku3begegjndpyebmlmxtdroxoob2kqtqsn/ua7ffckiw8vo5wa49biqlkgxvqszqlsaugnuq0srlmaxom8wwmsjdu2pltqttqqpwshzqpa8gbacaeaiaqagamgqeo6uc3ut1cdaagmmtgmlxznjk1q3a33elguqael2tb3qgmb0dqlbyqgvk14zh7e6niihjui5fnwyfcxuwn1bzxmqn3loqpqiquh48f698yznmo/ubi4me872swkmdegn3gntq/lsslvu7s9rswoz7mwf5d3ocx9zdil1lcwza7elhfvlrtusmy6arghnr1rirudrrrgzvkihnqgg6g6efzxkcfgpiuhqivckfppscfycc01caygbacaeaiaqhofuz1rvovspby2xs4rmawhz5nzoca1rnfja0n/kpsgntxfrhlzcra/xyua275gsk8t7+nocqojvfosotadm4+i1ptsvpsqrshmwrhgorlneigyt2av2kcojir8rjompjlrgxjh090wsed1rrmojmw06o5dyh/rzybyzmv8vdtfxswu47si6tg7redvbrzsrf1zsowd7juooy5udzvlndgaanbua0xoxd/uyfhveeug3qsxllg3/1tef3de2tfzqt7te4ruxx86nfqtn9n4zm4lzn/sjk31avstbcx2ohxgpc9470z4x3mgjeqtnotvkirhbotxq73yxn487y7jszekmvywyu3eoysugmoqfai96sjyovi/bxiempwqqlqagbacaeaidghrgq7nmih4bcef3jsgniiabcqedziw/uca9qxdw6gxfmwveg1c8gsvu3zljz0llfttuklyntkye8ry57ysvwn3wxzurkzo46ekyrgxuv5yo/2blfmx9cpav9tkrq80t/yunyyzh0y8bgxtjp5fcafmvlds36aop8aesuowos8doirnu92qfp9oiwy2m/9k+n0spjrlfnbffhmfnd/af15oypqhoy1irjlybztde7gkkld+3q1nnbck9j6o5exsgfwopw8brhywnij3ub0qts8cmxdq/iyswzjibwtdnc0evbxihsk0vybki8kkc0aicnzvnegwkkud9i4stcrwmaxknbpxedyf4nzuvnttkbxz6dppll1nxwrpx+tsmjbi4sp2txh4mgtoojok9njuqux5onsrvctsg6svgsvcvgdia8+es7ulnt36bsefuefxqglocgclz8jb92qa9qq8e1mwejkkbfcqqjruk4vjimmmms0abkbawxu3xp8disw7wvnet0j09xxfydxpryuwtwyy2reuuagxzjhsnedp2+ytsgqqcdkfwfb7vnolxmevk1r1lzi0k4qg7yltghi0mzhesgutwltftyrmxemi+tr18syahkfulk7f3w17hg/bsfnrzer0rtyb/kx1ry1bnnkray1xmrj3qgzrm3ezzeeyacmnh36abxiyj0z7qaugeyv8un8hbiyc6g2mgroszsom+bkvxq4tlbi4zgwnvbiodi7hjyfgy3rrfz96+w6/wyv3xn9p3lor2em06twuunwtyomubpztptpx8tdsvanjh2quxqrlmvytxkzxlmbio1vg5yl1mys23zcxlp2c7ibld/ozut9i67qepiy8n5u+zzdqnhqdpaxt/ybvddw9zbtnt5wzqvfwymic0+0lp7dym1zrduaeuxf0aozz76shzufrlrqasigzqkvjbxabx3lmylpzfy/9bzwzmcxtkz8yvq6ia9aymtixlo6u2gm/scpzgufnvmgbjhdbsp8+9b4y4aolt+o7grn961wmcowtrncdb7bzvkxmlspwaljc5c87pcyotp5bdt/mdtk4yv2mr0at1hthzi7csoywsogjvclnkrwbknfuiejcy+4kfbn8zv7cwodvptx3fxqnzkptkfgtgyliwcryku1mhefhmcx3e00p3qyzflblzrzkrltsvhkw1tctnaanh9ixc7zus1eapczzuq0rtv5s/tm+xa1vstiygzen4omsg6xgh7doriuqjjfuatcya6gbaa7nes7dif1xbutbw6lzr3hn9tr94xp7l6ftaisoec59z9q/e2ek3odrcxiiavfwt9j5fpsnaqnjjnrt1td0ri9vprunlyxo9vuz0nm7c6ua2ydcy1kjs+i8bptc8ztvooklvloeaxj73k4iyy2e7ogt34jrg7+zp09u1ejsbjdsoshtq6pskr+lhcvjkpfs5j5eyqjz2lzjcaarztah0i3e0ef1wm9uqapdi0+kxnle2as8jr7ru+v5mbgkwf1pd4y3r1h9w0xouepdolhzs7peuq2i83jrdpu5bmbmzeggf30dqdplinhedb9vsc53w77evylwr4l3m202127el8uush47byskbjnolx2lu27c7rpfhvlkmfixsvrywfoiefchrrak69qxtjat2c/fpgedzncy8mrwrscu+js1xcwrhvsq2gfqps7f6nrt+plfsurajw95vz1dlpli6viv7zmtokcfna2lavc40wypssr1svwoob1sqgig62qdwqmpg0tlcdwuyyzv3fq0xo0tyubsxhop579toltn2du6k7gvo6q0mct1glz/wcengnc5403gaqycoistbijqsgooaqaggbuztbyb0fze2wj21rhukm/yhdjyzslfmdu5kdrf0zpwy5jvlnzrneum0i1nut32j9j+ifaum3d05ctnzspmj+np+pedbpd1jpw3chx6pga4tfpvsjflmgh0pqn4xonqbo1srtlwowkiktqaafustiwkjentwk0gpuktyow9jiywbjn4r0ly6frp4zpldv0wiwcvvfxvirjghggjp3cg9m9bwzpb1/w2lyw/u/w4nhu6i3axm6y4fzjcpz2pfadjchxtv1cezcf0ug2m1p8v4p/qefwnhqtwuxshhhgiw0ipqebjqtpngzxkk6wumual8qattixhv7zyuzo9vrw3yzmrn8m2p/pslo3lwt9oqflz7o7zlpqkcnebljtovd9n/mwf+z1d0pktgn5kxlr0lkhpqp5pgmt4fqi1s8ry2hrg3id+yraatabfnjvz4b2tuxmgwdbxva37vslieuw93nxaakgoprjhrwofvastwcgqckaiaqasggkmggpj2idm/oxrthss99lhg3j37hcmkgj+njioolh4ynzfeghmfkspz3in3tkwwuatgbpcek0rqfiaehy0w8bldux5o4xv08ep+82wg3cvl0emo72gvoe8eskbdmkgg7qroqvnmqrb5o6tuzq/znbxcbtgvunsrvld19bfwjrvtplkl14jsoaxoc7rtg7sepddtgiv9c8vj0lj8dq7hqxbfjhzdxqtfwi2zlnrushdev4wstpzgb8fbsofy1r9y6xqsvean1ez0pe5rg5w0bd4+4zcqo+jh1b3og1p6iooyujwcfafvkcoahtqkzwimgfb/qfahacrroejqptliijm7u7gjess4okxzq8lasysagbacao+aec8byzaefk5+grw+tbm70sh/s38togofc4+p/mxnhhbrk4/foqppi3vc8f+1+hpyno1au+k5wvrtvg1nlwgf1h6d2ida/syyvbxns3da/iihmrxiatqslttp0bwbqg0c1rsh5jvy2ig4mup1vy1x+0r5hvltr1dxlin9qtox26tdinf4xibklwadtk1xm0j20xfepud9a8nwemyc2cv8zuhnghbwf1hhcx0x1parshp4l5uctrjc16t6zmnpi33ubzewlzpgjot2lynncwvcxgr76nhzptbgaohwuanaoadhbggdt5u9wmzkog1zabj73y2un5d/8akfaep3vwdiyng/b5oc01b1bwjatri7sntsgoobohipsuaz5jr4r7vjiufhkc5zz8tgq49qupvcfitxpxu+wzuxjq3+1wgzyrtoeapacatkhmn4jdwvlsgo20nncgplebxgypnd3zzsv02s89zjjpstxvpe11txulpqb0ic9tcnh8u5gmre3zibhcwf1xhygtfsubuwj5c5mzybjkn/4fhhzawa3lm9nhz7anqqhrmfy3hsfbgdg2zyq7+pj4nvo97zqubz3nyfvnd3uc2j39sd8f839rrpq5ddo5hwbu/wcwu3vkmc0j9i0jsjqfqxrsddbxbbpapia0tca6glftc+vavutrxyruofvos37watzl6r2nyx3vls4tjx3jb6mik67b3mf+ak8qod5s0ywnk+lz9k5orrlwbuhra8ah71jjayhl0tlazccdssbnoe+ivqhwftg0v7plwh66r0nnpmtre6plixacldd+rh2qurgzbdmdgfb1kcdad70frqcsq0cpoibk2zobg21z4numvunocssm0sreemafji+gbacaebp/ofpvy8yx1tkg3lrg9hoywzja/waymgobfw0ckmhqfry9ydg8eytpd5l04fnvjjxzo/5fcnnjabaxaaeby3nxvdzvifzqxh7x+c+eepv/1p8alr1o0p8as9rkw41jpvc51g1z2ocfptirtay37gvsnlebexhcxpm/amvtnrv8ym0cpcemhvhgmzw2oyebra/gy7zncxzasd7dvrqihqvz6pyz10h280kvmxb77iegnxbrtvvib6ubsoxn0wbrgjhakadqug5yteubupva+hsucpfb5mlut4iankoukr2cvqdnielh/fzkjkiyti3vczjdv7tsssjingucaygbacaeaiaqagbacx9qm05nb320z/c8l5/6nx/t+xd7on2f/d+5/gucrxvyckvlae0rnylfg2k8dteq4ymdc0d7f9ggqjhbyzmlokyii81s142ibimz21q0f8etgbke9eqax/kjv+j938eafxzv/oabq/wqb9fl/wbh7v4idej5lkna6pgadxvrxo7ebkhjdqgheaiaqagbacaeaiaqggc/wdpm1doysgpgax0bpy2phc5xb4xuaagu3qxd+p9pkv6mk4+xlminm+lr0ez3urbttz4n9xxtwc1zcwjzpjt6fgl3zqgcii18dt7fqzwj3jwt5y5zzhl/ue1xyxjklx+2xuoodyvpxx4iaqchbnsqge8mw8e8ia4yt494qbwx7x7wgfndoghalqagbacaeb//2q==" style="height:135px; width:155px" /></span>
 			</span>
 		</span>
 	</span>

--- a/tests/plugins/pastefromword/generated/_fixtures/Tickets/3959Test_doc_with_date/word2013/expected_ie11.html
+++ b/tests/plugins/pastefromword/generated/_fixtures/Tickets/3959Test_doc_with_date/word2013/expected_ie11.html
@@ -1402,34 +1402,34 @@
 			</td>
 		</tr>
 		<tr>
-			<td>
+			<td style="border-color:#000000">
 				<br />
 			</td>
-			<td>
+			<td style="border-color:#000000">
 				<br />
 			</td>
-			<td>
+			<td style="border-color:#000000">
 				<br />
 			</td>
-			<td>
+			<td style="border-color:#000000">
 				<br />
 			</td>
-			<td>
+			<td style="border-color:#000000">
 				<br />
 			</td>
-			<td>
+			<td style="border-color:#000000">
 				<br />
 			</td>
-			<td>
+			<td style="border-color:#000000">
 				<br />
 			</td>
-			<td>
+			<td style="border-color:#000000">
 				<br />
 			</td>
-			<td>
+			<td style="border-color:#000000">
 				<br />
 			</td>
-			<td>
+			<td style="border-color:#000000">
 				<br />
 			</td>
 		</tr>

--- a/tests/plugins/pastefromword/generated/_fixtures/Tickets/4427test-document/word2013/expected_ie11.html
+++ b/tests/plugins/pastefromword/generated/_fixtures/Tickets/4427test-document/word2013/expected_ie11.html
@@ -9,20 +9,20 @@
 </h1>
 <p style="margin-left:0in; margin-right:0in; text-align:left">
 	<span style="color:#000000">
-		<span style="font-size:12pt">
-			<span style="font-family:simsun">this document contains various markup features commonly used by content editors or "</span>
+		<span style="font-family:simsun">
+			<span style="font-size:12pt">this document contains various markup features commonly used by content editors or "</span>
 		</span>
-		<span style="font-size:12pt">
-			<span style="font-family:simsun">rédacteurs de contenu</span>
+		<span style="font-family:simsun">
+			<span style="font-size:12pt">rédacteurs de contenu</span>
 		</span>
 	</span>
-	<span style="font-size:12pt">
-		<span style="font-family:simsun">
-			<span style="color:#000000">" as they are called in </span>
+	<span style="color:#000000">
+		<span style="color:#000000">
+			<span style="font-size:12pt">" as they are called in </span>
 			<a data-cke-saved-href="http://en.wikipedia.org/wiki/france" href="http://en.wikipedia.org/wiki/france" title="wikipedia article about france">
 				<span style="color:blue">france</span>
 			</a>
-			<span style="color:#000000">.</span>
+			<span style="font-family:simsun">.</span>
 			<br />
 			<span style="color:#000000">it is important that a wysiwyg tool has features that are easily available for the editor. if not, there is a risk that content won't receive </span>
 			<strong>
@@ -34,33 +34,33 @@
 </p>
 <ol>
 	<li style="text-align:left">
-		<span style="font-style:normal">
-			<span style="font-weight:normal">
-				<span style="tab-stops:list .5in">
-					<span style="font-size:12pt">
-						<span style="font-family:simsun">level1</span>
+		<span style="font-family:simsun">
+			<span style="font-size:12pt">
+				<span style="font-style:normal">
+					<span style="font-weight:normal">
+						<span style="tab-stops:list .5in">level1</span>
 					</span>
 				</span>
 			</span>
 		</span>
 	</li>
 	<li style="text-align:left">
-		<span style="font-style:normal">
-			<span style="font-weight:normal">
-				<span style="tab-stops:list .5in">
-					<span style="font-size:12pt">
-						<span style="font-family:simsun">leve1</span>
+		<span style="font-family:simsun">
+			<span style="font-size:12pt">
+				<span style="font-style:normal">
+					<span style="font-weight:normal">
+						<span style="tab-stops:list .5in">leve1</span>
 					</span>
 				</span>
 			</span>
 		</span>
 		<ol>
 			<li style="text-align:left">
-				<span style="font-style:normal">
-					<span style="font-weight:normal">
-						<span style="tab-stops:list 1.0in">
-							<span style="font-size:12pt">
-								<span style="font-family:simsun">level2</span>
+				<span style="font-family:simsun">
+					<span style="font-size:12pt">
+						<span style="font-style:normal">
+							<span style="font-weight:normal">
+								<span style="tab-stops:list 1.0in">level2</span>
 							</span>
 						</span>
 					</span>
@@ -75,41 +75,41 @@
 <p style="margin-left:0in; margin-right:0in; text-align:left">
 	<span style="background:silver">
 		<strong>
-			<span style="font-size:18pt">
+			<span style="color:#000000">
 				<span style="font-family:simsun">
-					<span style="color:#000000">test procedure </span>
+					<span style="font-size:18pt">test procedure </span>
 				</span>
 			</span>
 		</strong>
 	</span>
 </p>
 <p style="margin-left:0in; margin-right:0in; text-align:left">
-	<span style="font-size:12pt">
+	<span style="color:#000000">
 		<span style="font-family:simsun">
-			<span style="color:#000000">text </span>
+			<span style="font-size:12pt">text </span>
 		</span>
 	</span>
 </p>
 <p style="margin-left:0in; margin-right:0in; text-align:left">
-	<span style="font-size:12pt">
+	<span style="color:#000000">
 		<span style="font-family:simsun">
-			<span style="color:#000000">paragraph1</span>
+			<span style="font-size:12pt">paragraph1</span>
 		</span>
 	</span>
 </p>
 <p style="margin-left:0in; margin-right:0in; text-align:left">
-	<span style="font-size:12pt">
+	<span style="color:#000000">
 		<span style="font-family:simsun">
-			<span style="color:#000000">paragraph2</span>
+			<span style="font-size:12pt">paragraph2</span>
 		</span>
 	</span>
 </p>
 <p style="margin-left:0in; margin-right:0in; text-align:left">
-	<span style="font-size:12pt">
-		<span style="font-family:simsun">
-			<span style="color:#000000">this text has no block tag.</span>
+	<span style="color:#000000">
+		<span style="color:#000000">
+			<span style="font-size:12pt">this text has no block tag.</span>
 			<br />
-			<span style="color:#000000">it should be corrected when working with the enter key set to "p" or "div" tags. the </span>
+			<span style="font-family:simsun">it should be corrected when working with the enter key set to "p" or "div" tags. the </span>
 			<strong>
 				<span style="color:#000000">"br" configuration</span>
 			</strong>
@@ -121,46 +121,46 @@
 	</span>
 </p>
 <p style="margin-left:0in; margin-right:0in; text-align:left">
-	<span style="font-size:12pt">
-		<span style="font-family:simsun">
-			<span style="color:#000000">in the test we will try to recreate this document using the editor tools. to make sure tables can be inserted
+	<span style="color:#000000">
+		<span style="color:#000000">
+			<span style="font-size:12pt">in the test we will try to recreate this document using the editor tools. to make sure tables can be inserted
 				<em>properly</em>
 			</span>
-			<span style="color:#000000"> we re-visit banana import statistics from 1998. </span>
+			<span style="font-family:simsun"> we re-visit banana import statistics from 1998. </span>
 		</span>
 	</span>
 </p>
 <table>
 	<tbody>
 		<tr>
-			<td colspan="2">
+			<td colspan="2" style="border-color:#000000">
 				<p style="margin-left:0in; margin-right:0in; text-align:center">
-					<span style="font-size:12pt">
+					<span style="color:#000000">
 						<span style="font-family:simsun">
-							<span style="color:#000000">top banana importers 1998 (value of banana imports in millions of us dollars per million people)</span>
+							<span style="font-size:12pt">top banana importers 1998 (value of banana imports in millions of us dollars per million people)</span>
 						</span>
 					</span>
 				</p>
 			</td>
 		</tr>
 		<tr>
-			<td>
+			<td style="border-color:#000000">
 				<p style="margin-left:0in; margin-right:0in; text-align:center">
 					<strong>
-						<span style="font-size:12pt">
+						<span style="color:#000000">
 							<span style="font-family:simsun">
-								<span style="color:#000000">country</span>
+								<span style="font-size:12pt">country</span>
 							</span>
 						</span>
 					</strong>
 				</p>
 			</td>
-			<td>
+			<td style="border-color:#000000">
 				<p style="margin-left:0in; margin-right:0in; text-align:center">
 					<strong>
-						<span style="font-size:12pt">
+						<span style="color:#000000">
 							<span style="font-family:simsun">
-								<span style="color:#000000">millions of us dollars per million people</span>
+								<span style="font-size:12pt">millions of us dollars per million people</span>
 							</span>
 						</span>
 					</strong>
@@ -168,100 +168,100 @@
 			</td>
 		</tr>
 		<tr>
-			<td>
+			<td style="border-color:#000000">
 				<p style="margin-left:0in; margin-right:0in; text-align:left">
-					<span style="font-size:12pt">
+					<span style="color:#000000">
 						<span style="font-family:simsun">
-							<span style="color:#000000">sweden</span>
+							<span style="font-size:12pt">sweden</span>
 						</span>
 					</span>
 				</p>
 			</td>
-			<td>
+			<td style="border-color:#000000">
 				<p style="margin-left:0in; margin-right:0in; text-align:left">
-					<span style="font-size:12pt">
+					<span style="color:#000000">
 						<span style="font-family:simsun">
-							<span style="color:#000000">17.12</span>
-						</span>
-					</span>
-				</p>
-			</td>
-		</tr>
-		<tr>
-			<td>
-				<p style="margin-left:0in; margin-right:0in; text-align:left">
-					<span style="font-size:12pt">
-						<span style="font-family:simsun">
-							<span style="color:#000000">united&nbsp;kingdom</span>
-						</span>
-					</span>
-				</p>
-			</td>
-			<td>
-				<p style="margin-left:0in; margin-right:0in; text-align:left">
-					<span style="font-size:12pt">
-						<span style="font-family:simsun">
-							<span style="color:#000000">8.88</span>
+							<span style="font-size:12pt">17.12</span>
 						</span>
 					</span>
 				</p>
 			</td>
 		</tr>
 		<tr>
-			<td>
+			<td style="border-color:#000000">
 				<p style="margin-left:0in; margin-right:0in; text-align:left">
-					<span style="font-size:12pt">
+					<span style="color:#000000">
 						<span style="font-family:simsun">
-							<span style="color:#000000">germany</span>
+							<span style="font-size:12pt">united&nbsp;kingdom</span>
 						</span>
 					</span>
 				</p>
 			</td>
-			<td>
+			<td style="border-color:#000000">
 				<p style="margin-left:0in; margin-right:0in; text-align:left">
-					<span style="font-size:12pt">
+					<span style="color:#000000">
 						<span style="font-family:simsun">
-							<span style="color:#000000">8.36</span>
-						</span>
-					</span>
-				</p>
-			</td>
-		</tr>
-		<tr>
-			<td>
-				<p style="margin-left:0in; margin-right:0in; text-align:left">
-					<span style="font-size:12pt">
-						<span style="font-family:simsun">
-							<span style="color:#000000">italy</span>
-						</span>
-					</span>
-				</p>
-			</td>
-			<td>
-				<p style="margin-left:0in; margin-right:0in; text-align:left">
-					<span style="font-size:12pt">
-						<span style="font-family:simsun">
-							<span style="color:#000000">5.96</span>
+							<span style="font-size:12pt">8.88</span>
 						</span>
 					</span>
 				</p>
 			</td>
 		</tr>
 		<tr>
-			<td>
+			<td style="border-color:#000000">
 				<p style="margin-left:0in; margin-right:0in; text-align:left">
-					<span style="font-size:12pt">
+					<span style="color:#000000">
 						<span style="font-family:simsun">
-							<span style="color:#000000">united states</span>
+							<span style="font-size:12pt">germany</span>
 						</span>
 					</span>
 				</p>
 			</td>
-			<td>
+			<td style="border-color:#000000">
 				<p style="margin-left:0in; margin-right:0in; text-align:left">
-					<span style="font-size:12pt">
+					<span style="color:#000000">
 						<span style="font-family:simsun">
-							<span style="color:#000000">4.78</span>
+							<span style="font-size:12pt">8.36</span>
+						</span>
+					</span>
+				</p>
+			</td>
+		</tr>
+		<tr>
+			<td style="border-color:#000000">
+				<p style="margin-left:0in; margin-right:0in; text-align:left">
+					<span style="color:#000000">
+						<span style="font-family:simsun">
+							<span style="font-size:12pt">italy</span>
+						</span>
+					</span>
+				</p>
+			</td>
+			<td style="border-color:#000000">
+				<p style="margin-left:0in; margin-right:0in; text-align:left">
+					<span style="color:#000000">
+						<span style="font-family:simsun">
+							<span style="font-size:12pt">5.96</span>
+						</span>
+					</span>
+				</p>
+			</td>
+		</tr>
+		<tr>
+			<td style="border-color:#000000">
+				<p style="margin-left:0in; margin-right:0in; text-align:left">
+					<span style="color:#000000">
+						<span style="font-family:simsun">
+							<span style="font-size:12pt">united states</span>
+						</span>
+					</span>
+				</p>
+			</td>
+			<td style="border-color:#000000">
+				<p style="margin-left:0in; margin-right:0in; text-align:left">
+					<span style="color:#000000">
+						<span style="font-family:simsun">
+							<span style="font-size:12pt">4.78</span>
 						</span>
 					</span>
 				</p>
@@ -270,35 +270,34 @@
 	</tbody>
 </table>
 <p style="margin-left:0in; margin-right:0in; text-align:left">
-	<span style="font-size:12pt">
-		<span style="font-family:simsun">
-			<span style="color:#000000">for block quotes we will have a look at </span>
+	<span style="color:#000000">
+		<span style="color:#000000">
+			<span style="font-size:12pt">for block quotes we will have a look at </span>
 			<a data-cke-saved-href="http://fawny.org/rhcp.html" href="http://fawny.org/rhcp.html">
 				<span style="color:blue">what joe clark says about redheads</span>
 			</a>
-			<span style="color:#000000">:</span>
+			<span style="font-family:simsun">:</span>
 		</span>
 	</span>
 </p>
 <p style="margin-left:0in; margin-right:0in; text-align:left">
-	<span style="font-size:12pt">
+	<span style="color:#000000">
 		<span style="font-family:simsun">
-			<span style="color:#000000">"since boyhood i’ve always believed, at the deepest level, that redheads are standard-bearers of the grandest and most wondrous human beauty."</span>
+			<span style="font-size:12pt">"since boyhood i’ve always believed, at the deepest level, that redheads are standard-bearers of the grandest and most wondrous human beauty."</span>
 		</span>
 	</span>
 </p>
 <p style="margin-left:0in; margin-right:0in; text-align:left">
 	<span style="color:#000000">
 		<span style="font-family:times new roman">
-			<span style="font-size:medium">
-				<img alt="fckeditor development web site" data-cke-saved-src="data:image/png;base64,r0lgodlhzwarapuwapumtixmsnnnw8dawlozhubaqpbz8ycagozm4epz0pzzwkcaz2yzc8azphlnkonzof3gpqmndrymlf/28raqepdw8kcgoplwh9dq0pp5ltdas3bagvypebcwscagip7j0/uww2bgyfbquodg4p7s4jawmpqdpfugapcqkhbwcp3qtfy8l/7zxpyziplmeaaaap///waaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaach/c01tt0zgsunfos4wgaaaaaxtc09qtvnprkzjq0u5ljbaauuukgah/wtnu09grkldrtkumbgaaaamy21quepdbxawnzeyaaaaa0gac7waifkeaqaamaasaaaaam8akwaabv9amhbilbqpykryyww6n9codeqtwq/yrhblrxia4lb4hp4kj5awouwiqtyaiwkoucez3aggadmkpgspgk0nchliac6ki4yniy1hlccojitelzqurpoufxnegoywee0gdu4jak57mboefadoggtpaaphelmmqomzvnffhl6nijezrsy+eeqjdxj/eakgzkjcbhipatmw2n23bgiicwu3qwnvmagirh7x2dvq5jb/fepl5qgg+uo28/pbahiee9ktt76d3ip0c6et1zbkru48bgqmihghjtiuaebgwskgcgg4ugugwiiauysic0aaqbmi2wcelclht4bx1kyi7gmyqgd/pntwtkrgukgaat8jqpz5chvmuwrg0oprz0hiktaimcag4gvmayea7feqwce0r+ewsesaceiifkmwuv1kr4hcr0sszyjbpn+opw0uwjca00e1vjjvixdqz0mdpllxciesxddlwuazc1ewceaexakjehjvznqgrjd5qwiawpcozyozc9gwtybzgatykyjndxlburyefjjlkljdy0n+kwlw9xypvgoe/nxwd/kgnwfinwatzdsr6np33gjf3voqvqsgel9mvyb3iv2eqyz1/scexii918/emxdxriyiwcl/ar5neqwq+gkgex7jh1tnckf2g3w3dsfzg0qs0fl5/cew/2edtkrniqwnkfuzau+p9lqhpexiegt5vejih8q50mknooz4iwwtpaqabzruacbeqmsqyqlikbclgwi8yag6ctcw1qltgckbagzs8icetjznzdrcogmadp1f2r2wtkfthhdzahobyckked+lqmxgcafugokfzn7hweu8utbybas+npdjendrbaohnbrxraizqzaaiwdtjfoahgtgmqekgkkbugys4bpbj6wkgqilikdupn1hsijzt6qmraoxqkqabnpqwkqef0hqogybdklpikzoy6kur3lwklvilsemjcu0ksgjrwycyshyzqtteoiyuaojtey7ykkzelltuehi2//tesovkg0mexhjytlp1mvvftuou6byzivrbsbu5lhbaaqpumeqfhwwwl0mo5gvl8bx+4s4ilywv7ydvkdxcwvdumdgbzqsmrf/kvkxxe5qpay9h2s8cccbv1daydqx8xczejlywcsz1kgrti5r3defg4taracpenbxzfxe7ei0mkyqcbii7qum0df3bahrhmawrnzm2+t0i5yiozcj1/olkc9yv6we2ggnozyjvfvssaahvg3r2y6wniqfirrqqagwhfebciiuiiifqxmsrmihkaxdwjghepkirgbwgoafplc0ecnelrkfgsetri0spk666hflypzerjqqyc9iyod/qcwal3dwebgqhbpvqgvxscyhd4+74zbuimlxmu8oq9ahhlcx6sqfuatfjfinhmpcmdpv7cdjxglv4tpfsfhfm+94bswo/4luqgr9+/tuh7gut1crwx21lnbehpeigeahgfc4j8xmawwyn9smsdwypmb47xoc16s3sqjsrnlxu1/97ncsjmcpgfqrwv7ilqntwqadg/paedpqnbimigyfofgfihg+kh1tgcmlmdgef7odne4fiehaatd4kq4yiwe+aaeeflqrivhvbky4qavfj0wnuwbymcncbheivhsgtwgs3jjxwbizdjwvziejigetx4r4zeucakdxcen4psis/899gonbfv9wxse0roynfalc9bgzilqajwfcmbbvadmjmueddnplguyig0hmjg8mxcmhc0eep/iwkday5b5fuareno6ra3tieydplp0nsvfx8uxayhdhfycqc7jcpmac58lmpjguobyl81c4sckdepxbcgqtwpkqjl2swksygcuzys4hogbj40ncgdwggigmepav+cuit6ixiy7sa8dezizz+iqjdcgtdyebjeupyyg8ejsdgmhalndn5ixpcynahth/atwkoaafmfmgbry2aodnljf5voc6hyhjklagx3mbpztllbeaus+bepxif4vaqbbtu30ds6devcaxknyaa9cyywtu6mlogdyleros5fhgcip24y4cchyoh4+nnfvryigqvaf3gjgblmlha6qjgglwt7ojticqq2pi43y6mqqeyjf6dcggsirufsoqec/tqvfbmlrkfpadfzwoetbamcuqzhlroovnojkansqvcqby6l8hs9gicgkwhu1sys8aqrse6bgqjaxkj0vzylr2spi1rgkhulloevazoa2tzzcrbnga9rsote1dsasd1br2tbdtlgtjs9va2lyrrmwqbnfl29769rfada5whytcdqybads=" src="data:image/png;base64,r0lgodlhzwarapuwapumtixmsnnnw8dawlozhubaqpbz8ycagozm4epz0pzzwkcaz2yzc8azphlnkonzof3gpqmndrymlf/28raqepdw8kcgoplwh9dq0pp5ltdas3bagvypebcwscagip7j0/uww2bgyfbquodg4p7s4jawmpqdpfugapcqkhbwcp3qtfy8l/7zxpyziplmeaaaap///waaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaach/c01tt0zgsunfos4wgaaaaaxtc09qtvnprkzjq0u5ljbaauuukgah/wtnu09grkldrtkumbgaaaamy21quepdbxawnzeyaaaaa0gac7waifkeaqaamaasaaaaam8akwaabv9amhbilbqpykryyww6n9codeqtwq/yrhblrxia4lb4hp4kj5awouwiqtyaiwkoucez3aggadmkpgspgk0nchliac6ki4yniy1hlccojitelzqurpoufxnegoywee0gdu4jak57mboefadoggtpaaphelmmqomzvnffhl6nijezrsy+eeqjdxj/eakgzkjcbhipatmw2n23bgiicwu3qwnvmagirh7x2dvq5jb/fepl5qgg+uo28/pbahiee9ktt76d3ip0c6et1zbkru48bgqmihghjtiuaebgwskgcgg4ugugwiiauysic0aaqbmi2wcelclht4bx1kyi7gmyqgd/pntwtkrgukgaat8jqpz5chvmuwrg0oprz0hiktaimcag4gvmayea7feqwce0r+ewsesaceiifkmwuv1kr4hcr0sszyjbpn+opw0uwjca00e1vjjvixdqz0mdpllxciesxddlwuazc1ewceaexakjehjvznqgrjd5qwiawpcozyozc9gwtybzgatykyjndxlburyefjjlkljdy0n+kwlw9xypvgoe/nxwd/kgnwfinwatzdsr6np33gjf3voqvqsgel9mvyb3iv2eqyz1/scexii918/emxdxriyiwcl/ar5neqwq+gkgex7jh1tnckf2g3w3dsfzg0qs0fl5/cew/2edtkrniqwnkfuzau+p9lqhpexiegt5vejih8q50mknooz4iwwtpaqabzruacbeqmsqyqlikbclgwi8yag6ctcw1qltgckbagzs8icetjznzdrcogmadp1f2r2wtkfthhdzahobyckked+lqmxgcafugokfzn7hweu8utbybas+npdjendrbaohnbrxraizqzaaiwdtjfoahgtgmqekgkkbugys4bpbj6wkgqilikdupn1hsijzt6qmraoxqkqabnpqwkqef0hqogybdklpikzoy6kur3lwklvilsemjcu0ksgjrwycyshyzqtteoiyuaojtey7ykkzelltuehi2//tesovkg0mexhjytlp1mvvftuou6byzivrbsbu5lhbaaqpumeqfhwwwl0mo5gvl8bx+4s4ilywv7ydvkdxcwvdumdgbzqsmrf/kvkxxe5qpay9h2s8cccbv1daydqx8xczejlywcsz1kgrti5r3defg4taracpenbxzfxe7ei0mkyqcbii7qum0df3bahrhmawrnzm2+t0i5yiozcj1/olkc9yv6we2ggnozyjvfvssaahvg3r2y6wniqfirrqqagwhfebciiuiiifqxmsrmihkaxdwjghepkirgbwgoafplc0ecnelrkfgsetri0spk666hflypzerjqqyc9iyod/qcwal3dwebgqhbpvqgvxscyhd4+74zbuimlxmu8oq9ahhlcx6sqfuatfjfinhmpcmdpv7cdjxglv4tpfsfhfm+94bswo/4luqgr9+/tuh7gut1crwx21lnbehpeigeahgfc4j8xmawwyn9smsdwypmb47xoc16s3sqjsrnlxu1/97ncsjmcpgfqrwv7ilqntwqadg/paedpqnbimigyfofgfihg+kh1tgcmlmdgef7odne4fiehaatd4kq4yiwe+aaeeflqrivhvbky4qavfj0wnuwbymcncbheivhsgtwgs3jjxwbizdjwvziejigetx4r4zeucakdxcen4psis/899gonbfv9wxse0roynfalc9bgzilqajwfcmbbvadmjmueddnplguyig0hmjg8mxcmhc0eep/iwkday5b5fuareno6ra3tieydplp0nsvfx8uxayhdhfycqc7jcpmac58lmpjguobyl81c4sckdepxbcgqtwpkqjl2swksygcuzys4hogbj40ncgdwggigmepav+cuit6ixiy7sa8dezizz+iqjdcgtdyebjeupyyg8ejsdgmhalndn5ixpcynahth/atwkoaafmfmgbry2aodnljf5voc6hyhjklagx3mbpztllbeaus+bepxif4vaqbbtu30ds6devcaxknyaa9cyywtu6mlogdyleros5fhgcip24y4cchyoh4+nnfvryigqvaf3gjgblmlha6qjgglwt7ojticqq2pi43y6mqqeyjf6dcggsirufsoqec/tqvfbmlrkfpadfzwoetbamcuqzhlroovnojkansqvcqby6l8hs9gicgkwhu1sys8aqrse6bgqjaxkj0vzylr2spi1rgkhulloevazoa2tzzcrbnga9rsote1dsasd1br2tbdtlgtjs9va2lyrrmwqbnfl29769rfada5whytcdqybads=" style="height:43px; width:207px" /></span>
+			<span style="font-size:medium"><img alt="fckeditor development web site" data-cke-saved-src="data:image/png;base64,r0lgodlhzwarapuwapumtixmsnnnw8dawlozhubaqpbz8ycagozm4epz0pzzwkcaz2yzc8azphlnkonzof3gpqmndrymlf/28raqepdw8kcgoplwh9dq0pp5ltdas3bagvypebcwscagip7j0/uww2bgyfbquodg4p7s4jawmpqdpfugapcqkhbwcp3qtfy8l/7zxpyziplmeaaaap///waaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaach/c01tt0zgsunfos4wgaaaaaxtc09qtvnprkzjq0u5ljbaauuukgah/wtnu09grkldrtkumbgaaaamy21quepdbxawnzeyaaaaa0gac7waifkeaqaamaasaaaaam8akwaabv9amhbilbqpykryyww6n9codeqtwq/yrhblrxia4lb4hp4kj5awouwiqtyaiwkoucez3aggadmkpgspgk0nchliac6ki4yniy1hlccojitelzqurpoufxnegoywee0gdu4jak57mboefadoggtpaaphelmmqomzvnffhl6nijezrsy+eeqjdxj/eakgzkjcbhipatmw2n23bgiicwu3qwnvmagirh7x2dvq5jb/fepl5qgg+uo28/pbahiee9ktt76d3ip0c6et1zbkru48bgqmihghjtiuaebgwskgcgg4ugugwiiauysic0aaqbmi2wcelclht4bx1kyi7gmyqgd/pntwtkrgukgaat8jqpz5chvmuwrg0oprz0hiktaimcag4gvmayea7feqwce0r+ewsesaceiifkmwuv1kr4hcr0sszyjbpn+opw0uwjca00e1vjjvixdqz0mdpllxciesxddlwuazc1ewceaexakjehjvznqgrjd5qwiawpcozyozc9gwtybzgatykyjndxlburyefjjlkljdy0n+kwlw9xypvgoe/nxwd/kgnwfinwatzdsr6np33gjf3voqvqsgel9mvyb3iv2eqyz1/scexii918/emxdxriyiwcl/ar5neqwq+gkgex7jh1tnckf2g3w3dsfzg0qs0fl5/cew/2edtkrniqwnkfuzau+p9lqhpexiegt5vejih8q50mknooz4iwwtpaqabzruacbeqmsqyqlikbclgwi8yag6ctcw1qltgckbagzs8icetjznzdrcogmadp1f2r2wtkfthhdzahobyckked+lqmxgcafugokfzn7hweu8utbybas+npdjendrbaohnbrxraizqzaaiwdtjfoahgtgmqekgkkbugys4bpbj6wkgqilikdupn1hsijzt6qmraoxqkqabnpqwkqef0hqogybdklpikzoy6kur3lwklvilsemjcu0ksgjrwycyshyzqtteoiyuaojtey7ykkzelltuehi2//tesovkg0mexhjytlp1mvvftuou6byzivrbsbu5lhbaaqpumeqfhwwwl0mo5gvl8bx+4s4ilywv7ydvkdxcwvdumdgbzqsmrf/kvkxxe5qpay9h2s8cccbv1daydqx8xczejlywcsz1kgrti5r3defg4taracpenbxzfxe7ei0mkyqcbii7qum0df3bahrhmawrnzm2+t0i5yiozcj1/olkc9yv6we2ggnozyjvfvssaahvg3r2y6wniqfirrqqagwhfebciiuiiifqxmsrmihkaxdwjghepkirgbwgoafplc0ecnelrkfgsetri0spk666hflypzerjqqyc9iyod/qcwal3dwebgqhbpvqgvxscyhd4+74zbuimlxmu8oq9ahhlcx6sqfuatfjfinhmpcmdpv7cdjxglv4tpfsfhfm+94bswo/4luqgr9+/tuh7gut1crwx21lnbehpeigeahgfc4j8xmawwyn9smsdwypmb47xoc16s3sqjsrnlxu1/97ncsjmcpgfqrwv7ilqntwqadg/paedpqnbimigyfofgfihg+kh1tgcmlmdgef7odne4fiehaatd4kq4yiwe+aaeeflqrivhvbky4qavfj0wnuwbymcncbheivhsgtwgs3jjxwbizdjwvziejigetx4r4zeucakdxcen4psis/899gonbfv9wxse0roynfalc9bgzilqajwfcmbbvadmjmueddnplguyig0hmjg8mxcmhc0eep/iwkday5b5fuareno6ra3tieydplp0nsvfx8uxayhdhfycqc7jcpmac58lmpjguobyl81c4sckdepxbcgqtwpkqjl2swksygcuzys4hogbj40ncgdwggigmepav+cuit6ixiy7sa8dezizz+iqjdcgtdyebjeupyyg8ejsdgmhalndn5ixpcynahth/atwkoaafmfmgbry2aodnljf5voc6hyhjklagx3mbpztllbeaus+bepxif4vaqbbtu30ds6devcaxknyaa9cyywtu6mlogdyleros5fhgcip24y4cchyoh4+nnfvryigqvaf3gjgblmlha6qjgglwt7ojticqq2pi43y6mqqeyjf6dcggsirufsoqec/tqvfbmlrkfpadfzwoetbamcuqzhlroovnojkansqvcqby6l8hs9gicgkwhu1sys8aqrse6bgqjaxkj0vzylr2spi1rgkhulloevazoa2tzzcrbnga9rsote1dsasd1br2tbdtlgtjs9va2lyrrmwqbnfl29769rfada5whytcdqybads=" src="data:image/png;base64,r0lgodlhzwarapuwapumtixmsnnnw8dawlozhubaqpbz8ycagozm4epz0pzzwkcaz2yzc8azphlnkonzof3gpqmndrymlf/28raqepdw8kcgoplwh9dq0pp5ltdas3bagvypebcwscagip7j0/uww2bgyfbquodg4p7s4jawmpqdpfugapcqkhbwcp3qtfy8l/7zxpyziplmeaaaap///waaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaach/c01tt0zgsunfos4wgaaaaaxtc09qtvnprkzjq0u5ljbaauuukgah/wtnu09grkldrtkumbgaaaamy21quepdbxawnzeyaaaaa0gac7waifkeaqaamaasaaaaam8akwaabv9amhbilbqpykryyww6n9codeqtwq/yrhblrxia4lb4hp4kj5awouwiqtyaiwkoucez3aggadmkpgspgk0nchliac6ki4yniy1hlccojitelzqurpoufxnegoywee0gdu4jak57mboefadoggtpaaphelmmqomzvnffhl6nijezrsy+eeqjdxj/eakgzkjcbhipatmw2n23bgiicwu3qwnvmagirh7x2dvq5jb/fepl5qgg+uo28/pbahiee9ktt76d3ip0c6et1zbkru48bgqmihghjtiuaebgwskgcgg4ugugwiiauysic0aaqbmi2wcelclht4bx1kyi7gmyqgd/pntwtkrgukgaat8jqpz5chvmuwrg0oprz0hiktaimcag4gvmayea7feqwce0r+ewsesaceiifkmwuv1kr4hcr0sszyjbpn+opw0uwjca00e1vjjvixdqz0mdpllxciesxddlwuazc1ewceaexakjehjvznqgrjd5qwiawpcozyozc9gwtybzgatykyjndxlburyefjjlkljdy0n+kwlw9xypvgoe/nxwd/kgnwfinwatzdsr6np33gjf3voqvqsgel9mvyb3iv2eqyz1/scexii918/emxdxriyiwcl/ar5neqwq+gkgex7jh1tnckf2g3w3dsfzg0qs0fl5/cew/2edtkrniqwnkfuzau+p9lqhpexiegt5vejih8q50mknooz4iwwtpaqabzruacbeqmsqyqlikbclgwi8yag6ctcw1qltgckbagzs8icetjznzdrcogmadp1f2r2wtkfthhdzahobyckked+lqmxgcafugokfzn7hweu8utbybas+npdjendrbaohnbrxraizqzaaiwdtjfoahgtgmqekgkkbugys4bpbj6wkgqilikdupn1hsijzt6qmraoxqkqabnpqwkqef0hqogybdklpikzoy6kur3lwklvilsemjcu0ksgjrwycyshyzqtteoiyuaojtey7ykkzelltuehi2//tesovkg0mexhjytlp1mvvftuou6byzivrbsbu5lhbaaqpumeqfhwwwl0mo5gvl8bx+4s4ilywv7ydvkdxcwvdumdgbzqsmrf/kvkxxe5qpay9h2s8cccbv1daydqx8xczejlywcsz1kgrti5r3defg4taracpenbxzfxe7ei0mkyqcbii7qum0df3bahrhmawrnzm2+t0i5yiozcj1/olkc9yv6we2ggnozyjvfvssaahvg3r2y6wniqfirrqqagwhfebciiuiiifqxmsrmihkaxdwjghepkirgbwgoafplc0ecnelrkfgsetri0spk666hflypzerjqqyc9iyod/qcwal3dwebgqhbpvqgvxscyhd4+74zbuimlxmu8oq9ahhlcx6sqfuatfjfinhmpcmdpv7cdjxglv4tpfsfhfm+94bswo/4luqgr9+/tuh7gut1crwx21lnbehpeigeahgfc4j8xmawwyn9smsdwypmb47xoc16s3sqjsrnlxu1/97ncsjmcpgfqrwv7ilqntwqadg/paedpqnbimigyfofgfihg+kh1tgcmlmdgef7odne4fiehaatd4kq4yiwe+aaeeflqrivhvbky4qavfj0wnuwbymcncbheivhsgtwgs3jjxwbizdjwvziejigetx4r4zeucakdxcen4psis/899gonbfv9wxse0roynfalc9bgzilqajwfcmbbvadmjmueddnplguyig0hmjg8mxcmhc0eep/iwkday5b5fuareno6ra3tieydplp0nsvfx8uxayhdhfycqc7jcpmac58lmpjguobyl81c4sckdepxbcgqtwpkqjl2swksygcuzys4hogbj40ncgdwggigmepav+cuit6ixiy7sa8dezizz+iqjdcgtdyebjeupyyg8ejsdgmhalndn5ixpcynahth/atwkoaafmfmgbry2aodnljf5voc6hyhjklagx3mbpztllbeaus+bepxif4vaqbbtu30ds6devcaxknyaa9cyywtu6mlogdyleros5fhgcip24y4cchyoh4+nnfvryigqvaf3gjgblmlha6qjgglwt7ojticqq2pi43y6mqqeyjf6dcggsirufsoqec/tqvfbmlrkfpadfzwoetbamcuqzhlroovnojkansqvcqby6l8hs9gicgkwhu1sys8aqrse6bgqjaxkj0vzylr2spi1rgkhulloevazoa2tzzcrbnga9rsote1dsasd1br2tbdtlgtjs9va2lyrrmwqbnfl29769rfada5whytcdqybads=" style="height:43px; width:207px" /></span>
 		</span>
 	</span>
 </p>
 <p style="margin-left:0in; margin-right:0in; text-align:left">
-	<span style="font-size:12pt">
+	<span style="color:#000000">
 		<span style="font-family:simsun">
-			<span style="color:#000000">the above is the fckeditor logo loaded from the fckeditor.net web site.</span>
+			<span style="font-size:12pt">the above is the fckeditor logo loaded from the fckeditor.net web site.</span>
 		</span>
 	</span>
 </p>

--- a/tests/plugins/pastefromword/generated/_fixtures/Tickets/6449Sample/word2013/expected_ie11.html
+++ b/tests/plugins/pastefromword/generated/_fixtures/Tickets/6449Sample/word2013/expected_ie11.html
@@ -1,160 +1,160 @@
 <p style="margin-left:0in; margin-right:0in">
 	<u>
-		<span style="font-size:10pt">
+		<span style="color:#000000">
 			<span style="font-family:&quot;times new roman&quot;,serif">
-				<span style="color:#000000">top line 1 of 1</span>
+				<span style="font-size:10pt">top line 1 of 1</span>
 			</span>
 		</span>
 	</u>
 </p>
 <p style="margin-left:0in; margin-right:0in">
 	<u>
-		<span style="font-size:10pt">
-			<span style="font-family:&quot;times new roman&quot;,serif">
-				<span style="color:#000000">top line 2 sample ksajksa &nbsp;</span>
-				<span style="color:#000000">of 2</span>
+		<span style="color:#000000">
+			<span style="color:#000000">
+				<span style="font-size:10pt">top line 2 sample ksajksa &nbsp;</span>
+				<span style="font-family:&quot;times new roman&quot;,serif">of 2</span>
 			</span>
 		</span>
 	</u>
 </p>
 <p style="margin-left:0in; margin-right:0in">
 	<u>
-		<span style="font-size:10pt">
+		<span style="color:#000000">
 			<span style="font-family:&quot;times new roman&quot;,serif">
-				<span style="color:#000000">top line 3 of 3 asnabsnabskajsasjkas asalksas </span>
+				<span style="font-size:10pt">top line 3 of 3 asnabsnabskajsasjkas asalksas </span>
 			</span>
 		</span>
 	</u>
 </p>
 <p style="margin-left:0in; margin-right:0in; text-align:left">
-	<span style="font-size:10pt">
+	<span style="color:#000000">
 		<span style="font-family:&quot;times new roman&quot;,serif">
-			<span style="color:#000000">&nbsp;</span>
+			<span style="font-size:10pt">&nbsp;</span>
 		</span>
 	</span>
 </p>
 <table cellspacing="0">
 	<tbody>
 		<tr>
-			<td style="width:311.4pt" valign="top">
+			<td style="border-color:#000000; width:311.4pt" valign="top">
 				<p style="margin-left:0in; margin-right:0in; text-align:left">
-					<span style="font-size:10pt">
+					<span style="color:#000000">
 						<span style="font-family:&quot;times new roman&quot;,serif">
-							<span style="color:#000000">name: my name</span>
+							<span style="font-size:10pt">name: my name</span>
 						</span>
 					</span>
 				</p>
 			</td>
-			<td style="width:99pt" valign="top">
+			<td style="border-color:#000000; width:99pt" valign="top">
 				<p style="margin-left:0in; margin-right:0in">
-					<span style="font-size:10pt">
+					<span style="color:#000000">
 						<span style="font-family:&quot;times new roman&quot;,serif">
-							<span style="color:#000000">&nbsp;</span>
+							<span style="font-size:10pt">&nbsp;</span>
 						</span>
 					</span>
 				</p>
 			</td>
-			<td style="width:13.5pt" valign="top">
+			<td style="border-color:#000000; width:13.5pt" valign="top">
 				<p style="margin-left:0in; margin-right:0in; text-align:right">
-					<span style="font-size:10pt">
+					<span style="color:#000000">
 						<span style="font-family:&quot;times new roman&quot;,serif">
-							<span style="color:#000000">&nbsp;</span>
+							<span style="font-size:10pt">&nbsp;</span>
 						</span>
 					</span>
 				</p>
 			</td>
-			<td style="width:49.5pt" valign="top">
+			<td style="border-color:#000000; width:49.5pt" valign="top">
 				<p style="margin-left:0in; margin-right:0in">
-					<span style="font-size:10pt">
+					<span style="color:#000000">
 						<span style="font-family:&quot;times new roman&quot;,serif">
-							<span style="color:#000000">&nbsp;</span>
+							<span style="font-size:10pt">&nbsp;</span>
 						</span>
 					</span>
 				</p>
 			</td>
-			<td style="width:13.5pt" valign="top">
+			<td style="border-color:#000000; width:13.5pt" valign="top">
 				<p style="margin-left:0in; margin-right:0in">
-					<span style="font-size:10pt">
+					<span style="color:#000000">
 						<span style="font-family:&quot;times new roman&quot;,serif">
-							<span style="color:#000000">&nbsp;</span>
+							<span style="font-size:10pt">&nbsp;</span>
 						</span>
 					</span>
 				</p>
 			</td>
-			<td style="width:46.9pt" valign="top">
+			<td style="border-color:#000000; width:46.9pt" valign="top">
 				<p style="margin-left:0in; margin-right:0in">
-					<span style="font-size:10pt">
+					<span style="color:#000000">
 						<span style="font-family:&quot;times new roman&quot;,serif">
-							<span style="color:#000000">&nbsp;</span>
+							<span style="font-size:10pt">&nbsp;</span>
 						</span>
 					</span>
 				</p>
 			</td>
 		</tr>
 		<tr>
-			<td style="width:311.4pt" valign="top">
+			<td style="border-color:#000000; width:311.4pt" valign="top">
 				<p style="margin-left:0in; margin-right:0in; text-align:left">
-					<span style="font-size:10pt">
+					<span style="color:#000000">
 						<span style="font-family:&quot;times new roman&quot;,serif">
-							<span style="color:#000000">summary of address</span>
+							<span style="font-size:10pt">summary of address</span>
 						</span>
 					</span>
 				</p>
 			</td>
-			<td style="width:99pt" valign="top">
+			<td style="border-color:#000000; width:99pt" valign="top">
 				<p style="margin-left:0in; margin-right:0in">
-					<span style="font-size:10pt">
+					<span style="color:#000000">
 						<span style="font-family:&quot;times new roman&quot;,serif">
-							<span style="color:#000000">&nbsp;</span>
+							<span style="font-size:10pt">&nbsp;</span>
 						</span>
 					</span>
 				</p>
 			</td>
-			<td style="width:13.5pt" valign="top">
+			<td style="border-color:#000000; width:13.5pt" valign="top">
 				<p style="margin-left:0in; margin-right:0in; text-align:right">
-					<span style="font-size:10pt">
+					<span style="color:#000000">
 						<span style="font-family:&quot;times new roman&quot;,serif">
-							<span style="color:#000000">&nbsp;</span>
+							<span style="font-size:10pt">&nbsp;</span>
 						</span>
 					</span>
 				</p>
 			</td>
-			<td style="width:49.5pt" valign="top">
+			<td style="border-color:#000000; width:49.5pt" valign="top">
 				<p style="margin-left:0in; margin-right:0in">
-					<span style="font-size:10pt">
+					<span style="color:#000000">
 						<span style="font-family:&quot;times new roman&quot;,serif">
-							<span style="color:#000000">&nbsp;</span>
+							<span style="font-size:10pt">&nbsp;</span>
 						</span>
 					</span>
 				</p>
 			</td>
-			<td style="width:13.5pt" valign="top">
+			<td style="border-color:#000000; width:13.5pt" valign="top">
 				<p style="margin-left:0in; margin-right:0in">
-					<span style="font-size:10pt">
+					<span style="color:#000000">
 						<span style="font-family:&quot;times new roman&quot;,serif">
-							<span style="color:#000000">&nbsp;</span>
+							<span style="font-size:10pt">&nbsp;</span>
 						</span>
 					</span>
 				</p>
 			</td>
-			<td style="width:46.9pt" valign="top">
+			<td style="border-color:#000000; width:46.9pt" valign="top">
 				<p style="margin-left:0in; margin-right:0in">
-					<span style="font-size:10pt">
+					<span style="color:#000000">
 						<span style="font-family:&quot;times new roman&quot;,serif">
-							<span style="color:#000000">&nbsp;</span>
+							<span style="font-size:10pt">&nbsp;</span>
 						</span>
 					</span>
 				</p>
 			</td>
 		</tr>
 		<tr>
-			<td style="width:311.4pt" valign="bottom">
+			<td style="border-color:#000000; width:311.4pt" valign="bottom">
 				<p style="margin-left:0in; margin-right:0in; text-align:left">
 					<strong>
-						<span style="font-size:10pt">
-							<span style="font-family:&quot;times new roman&quot;,serif">
-								<span style="color:#000000">&nbsp;</span>
-								<span style="color:#000000">text in bold</span>
+						<span style="color:#000000">
+							<span style="color:#000000">
+								<span style="font-size:10pt">&nbsp;</span>
+								<span style="font-family:&quot;times new roman&quot;,serif">text in bold</span>
 							</span>
 						</span>
 					</strong>
@@ -163,724 +163,724 @@
 			<td style="border-color:#000000 #000000 black; width:99pt" valign="bottom">
 				<p style="margin-left:0in; margin-right:0in">
 					<em>
-						<span style="font-size:10pt">
+						<span style="color:#000000">
 							<span style="font-family:&quot;times new roman&quot;,serif">
-								<span style="color:#000000">date </span>
+								<span style="font-size:10pt">date </span>
 							</span>
 						</span>
 					</em>
 				</p>
 			</td>
-			<td style="width:13.5pt" valign="bottom">
+			<td style="border-color:#000000; width:13.5pt" valign="bottom">
 				<p style="margin-left:0in; margin-right:0in; text-align:right">
-					<span style="font-size:10pt">
+					<span style="color:#000000">
 						<span style="font-family:&quot;times new roman&quot;,serif">
-							<span style="color:#000000">&nbsp;</span>
+							<span style="font-size:10pt">&nbsp;</span>
 						</span>
 					</span>
 				</p>
 			</td>
 			<td style="border-color:#000000 #000000 black; width:49.5pt" valign="bottom">
 				<p style="margin-left:0in; margin-right:0in">
-					<span style="font-size:10pt">
+					<span style="color:#000000">
 						<span style="font-family:&quot;times new roman&quot;,serif">
-							<span style="color:#000000">personal data</span>
+							<span style="font-size:10pt">personal data</span>
 						</span>
 					</span>
 				</p>
 			</td>
-			<td style="width:13.5pt" valign="bottom">
+			<td style="border-color:#000000; width:13.5pt" valign="bottom">
 				<p style="margin-left:0in; margin-right:0in">
-					<span style="font-size:10pt">
+					<span style="color:#000000">
 						<span style="font-family:&quot;times new roman&quot;,serif">
-							<span style="color:#000000">&nbsp;</span>
+							<span style="font-size:10pt">&nbsp;</span>
 						</span>
 					</span>
 				</p>
 			</td>
 			<td style="border-color:#000000 #000000 black; width:46.9pt" valign="bottom">
 				<p style="margin-left:0in; margin-right:0in">
-					<span style="font-size:10pt">
+					<span style="color:#000000">
 						<span style="font-family:&quot;times new roman&quot;,serif">
-							<span style="color:#000000">2009 2008</span>
+							<span style="font-size:10pt">2009 2008</span>
 						</span>
 					</span>
 				</p>
 			</td>
 		</tr>
 		<tr>
-			<td style="width:311.4pt" valign="top">
+			<td style="border-color:#000000; width:311.4pt" valign="top">
 				<p style="margin-left:0in; margin-right:0in; text-align:left">
 					<em>
-						<span style="font-size:10pt">
-							<span style="font-family:&quot;times new roman&quot;,serif">
-								<span style="color:#000000">&nbsp;</span>
-								<span style="color:#000000">sample italic text:</span>
+						<span style="color:#000000">
+							<span style="color:#000000">
+								<span style="font-size:10pt">&nbsp;</span>
+								<span style="font-family:&quot;times new roman&quot;,serif">sample italic text:</span>
 							</span>
 						</span>
 					</em>
 				</p>
 			</td>
-			<td style="width:99pt" valign="top">
+			<td style="border-color:#000000; width:99pt" valign="top">
 				<p style="margin-left:0in; margin-right:0in">
-					<span style="font-size:10pt">
+					<span style="color:#000000">
 						<span style="font-family:&quot;times new roman&quot;,serif">
-							<span style="color:#000000">&nbsp;</span>
+							<span style="font-size:10pt">&nbsp;</span>
 						</span>
 					</span>
 				</p>
 			</td>
-			<td style="width:13.5pt" valign="top">
+			<td style="border-color:#000000; width:13.5pt" valign="top">
 				<p style="margin-left:0in; margin-right:0in; text-align:right">
-					<span style="font-size:10pt">
+					<span style="color:#000000">
 						<span style="font-family:&quot;times new roman&quot;,serif">
-							<span style="color:#000000">&nbsp;</span>
+							<span style="font-size:10pt">&nbsp;</span>
 						</span>
 					</span>
 				</p>
 			</td>
-			<td style="width:49.5pt" valign="top">
+			<td style="border-color:#000000; width:49.5pt" valign="top">
 				<p style="margin-left:0in; margin-right:0in">
-					<span style="font-size:10pt">
+					<span style="color:#000000">
 						<span style="font-family:&quot;times new roman&quot;,serif">
-							<span style="color:#000000">&nbsp;</span>
+							<span style="font-size:10pt">&nbsp;</span>
 						</span>
 					</span>
 				</p>
 			</td>
-			<td style="width:13.5pt" valign="top">
+			<td style="border-color:#000000; width:13.5pt" valign="top">
 				<p style="margin-left:0in; margin-right:0in">
-					<span style="font-size:10pt">
+					<span style="color:#000000">
 						<span style="font-family:&quot;times new roman&quot;,serif">
-							<span style="color:#000000">&nbsp;</span>
+							<span style="font-size:10pt">&nbsp;</span>
 						</span>
 					</span>
 				</p>
 			</td>
-			<td style="width:46.9pt" valign="top">
+			<td style="border-color:#000000; width:46.9pt" valign="top">
 				<p style="margin-left:0in; margin-right:0in">
-					<span style="font-size:10pt">
+					<span style="color:#000000">
 						<span style="font-family:&quot;times new roman&quot;,serif">
-							<span style="color:#000000">&nbsp;</span>
+							<span style="font-size:10pt">&nbsp;</span>
 						</span>
 					</span>
 				</p>
 			</td>
 		</tr>
 		<tr>
-			<td style="width:311.4pt" valign="top">
+			<td style="border-color:#000000; width:311.4pt" valign="top">
 				<p style="margin-left:0in; margin-right:0in; text-align:left">
-					<span style="font-size:10pt">
-						<span style="font-family:&quot;times new roman&quot;,serif">
-							<span style="color:#000000">&nbsp;</span>
-							<span style="color:#000000">sample ( text )</span>
+					<span style="color:#000000">
+						<span style="color:#000000">
+							<span style="font-size:10pt">&nbsp;</span>
+							<span style="font-family:&quot;times new roman&quot;,serif">sample ( text )</span>
 						</span>
 					</span>
 				</p>
 			</td>
-			<td style="width:99pt" valign="top">
+			<td style="border-color:#000000; width:99pt" valign="top">
 				<p style="margin-left:0in; margin-right:0in; text-align:left">
-					<span style="font-size:10pt">
+					<span style="color:#000000">
 						<span style="font-family:&quot;times new roman&quot;,serif">
-							<span style="color:#000000">march 2008</span>
+							<span style="font-size:10pt">march 2008</span>
 						</span>
 					</span>
 				</p>
 			</td>
-			<td style="width:13.5pt" valign="top">
+			<td style="border-color:#000000; width:13.5pt" valign="top">
 				<p style="margin-left:0in; margin-right:0in; text-align:right">
-					<span style="font-size:10pt">
+					<span style="color:#000000">
 						<span style="font-family:&quot;times new roman&quot;,serif">
-							<span style="color:#000000">$</span>
+							<span style="font-size:10pt">$</span>
 						</span>
 					</span>
 				</p>
 			</td>
-			<td style="width:49.5pt" valign="top">
+			<td style="border-color:#000000; width:49.5pt" valign="top">
 				<p style="margin-left:0in; margin-right:0in; text-align:right">
-					<span style="font-size:10pt">
+					<span style="color:#000000">
 						<span style="font-family:&quot;times new roman&quot;,serif">
-							<span style="color:#000000">[[federa.ukman(ro.2.1.5sdsd23)]]</span>
+							<span style="font-size:10pt">[[federa.ukman(ro.2.1.5sdsd23)]]</span>
 						</span>
 					</span>
 				</p>
 			</td>
-			<td style="width:13.5pt" valign="top">
+			<td style="border-color:#000000; width:13.5pt" valign="top">
 				<p style="margin-left:0in; margin-right:0in; text-align:right">
-					<span style="font-size:10pt">
+					<span style="color:#000000">
 						<span style="font-family:&quot;times new roman&quot;,serif">
-							<span style="color:#000000">$</span>
+							<span style="font-size:10pt">$</span>
 						</span>
 					</span>
 				</p>
 			</td>
-			<td style="width:46.9pt" valign="top">
+			<td style="border-color:#000000; width:46.9pt" valign="top">
 				<p style="margin-left:0in; margin-right:0in; text-align:right">
-					<span style="font-size:10pt">
+					<span style="color:#000000">
 						<span style="font-family:&quot;times new roman&quot;,serif">
-							<span style="color:#000000">&nbsp;</span>
+							<span style="font-size:10pt">&nbsp;</span>
 						</span>
 					</span>
 				</p>
 			</td>
 		</tr>
 		<tr>
-			<td style="width:311.4pt" valign="top">
+			<td style="border-color:#000000; width:311.4pt" valign="top">
 				<p style="margin-left:0in; margin-right:0in; text-align:left">
-					<span style="font-size:10pt">
+					<span style="color:#000000">
 						<span style="font-family:&quot;times new roman&quot;,serif">
-							<span style="color:#000000">20texedd (note a)</span>
+							<span style="font-size:10pt">20texedd (note a)</span>
 						</span>
 					</span>
 				</p>
 			</td>
-			<td style="width:99pt" valign="top">
+			<td style="border-color:#000000; width:99pt" valign="top">
 				<p style="margin-left:0in; margin-right:0in; text-align:left">
-					<span style="font-size:10pt">
+					<span style="color:#000000">
 						<span style="font-family:&quot;times new roman&quot;,serif">
-							<span style="color:#000000">january 2009</span>
+							<span style="font-size:10pt">january 2009</span>
 						</span>
 					</span>
 				</p>
 			</td>
-			<td style="width:13.5pt" valign="top">
+			<td style="border-color:#000000; width:13.5pt" valign="top">
 				<p style="margin-left:0in; margin-right:0in; text-align:right">
-					<span style="font-size:10pt">
+					<span style="color:#000000">
 						<span style="font-family:&quot;times new roman&quot;,serif">
-							<span style="color:#000000">&nbsp;</span>
+							<span style="font-size:10pt">&nbsp;</span>
 						</span>
 					</span>
 				</p>
 			</td>
-			<td style="width:49.5pt" valign="top">
+			<td style="border-color:#000000; width:49.5pt" valign="top">
 				<p style="margin-left:0in; margin-right:0in; text-align:right">
-					<span style="font-size:10pt">
+					<span style="color:#000000">
 						<span style="font-family:&quot;times new roman&quot;,serif">
-							<span style="color:#000000">[[data(1234)]]</span>
+							<span style="font-size:10pt">[[data(1234)]]</span>
 						</span>
 					</span>
 				</p>
 			</td>
-			<td style="width:13.5pt" valign="top">
+			<td style="border-color:#000000; width:13.5pt" valign="top">
 				<p style="margin-left:0in; margin-right:0in; text-align:right">
-					<span style="font-size:10pt">
+					<span style="color:#000000">
 						<span style="font-family:&quot;times new roman&quot;,serif">
-							<span style="color:#000000">&nbsp;</span>
+							<span style="font-size:10pt">&nbsp;</span>
 						</span>
 					</span>
 				</p>
 			</td>
-			<td style="width:46.9pt" valign="top">
+			<td style="border-color:#000000; width:46.9pt" valign="top">
 				<p style="margin-left:0in; margin-right:0in; text-align:right">
-					<span style="font-size:10pt">
+					<span style="color:#000000">
 						<span style="font-family:&quot;times new roman&quot;,serif">
-							<span style="color:#000000">[[data2(ro.)]]</span>
+							<span style="font-size:10pt">[[data2(ro.)]]</span>
 						</span>
 					</span>
 				</p>
 			</td>
 		</tr>
 		<tr>
-			<td style="width:311.4pt" valign="top">
+			<td style="border-color:#000000; width:311.4pt" valign="top">
 				<p style="margin-left:0in; margin-right:0in; text-align:left">
-					<span style="font-size:10pt">
+					<span style="color:#000000">
 						<span style="font-family:&quot;times new roman&quot;,serif">
-							<span style="color:#000000">2008 tax, installment payment</span>
+							<span style="font-size:10pt">2008 tax, installment payment</span>
 						</span>
 					</span>
 				</p>
 			</td>
-			<td style="width:99pt" valign="top">
+			<td style="border-color:#000000; width:99pt" valign="top">
 				<p style="margin-left:0in; margin-right:0in; text-align:left">
-					<span style="font-size:10pt">
+					<span style="color:#000000">
 						<span style="font-family:&quot;times new roman&quot;,serif">
-							<span style="color:#000000">january 2009</span>
+							<span style="font-size:10pt">january 2009</span>
 						</span>
 					</span>
 				</p>
 			</td>
-			<td style="width:13.5pt" valign="top">
+			<td style="border-color:#000000; width:13.5pt" valign="top">
 				<p style="margin-left:0in; margin-right:0in; text-align:right">
-					<span style="font-size:10pt">
+					<span style="color:#000000">
 						<span style="font-family:&quot;times new roman&quot;,serif">
-							<span style="color:#000000">&nbsp;</span>
+							<span style="font-size:10pt">&nbsp;</span>
 						</span>
 					</span>
 				</p>
 			</td>
 			<td style="border-color:#000000 #000000 black; width:49.5pt" valign="top">
 				<p style="margin-left:0in; margin-right:0in; text-align:right">
-					<span style="font-size:10pt">
+					<span style="color:#000000">
 						<span style="font-family:&quot;times new roman&quot;,serif">
-							<span style="color:#000000">[[fedrik.1stinsttaj(po.2.1.149)]]</span>
+							<span style="font-size:10pt">[[fedrik.1stinsttaj(po.2.1.149)]]</span>
 						</span>
 					</span>
 				</p>
 			</td>
-			<td style="width:13.5pt" valign="top">
+			<td style="border-color:#000000; width:13.5pt" valign="top">
 				<p style="margin-left:0in; margin-right:0in; text-align:right">
-					<span style="font-size:10pt">
+					<span style="color:#000000">
 						<span style="font-family:&quot;times new roman&quot;,serif">
-							<span style="color:#000000">&nbsp;</span>
+							<span style="font-size:10pt">&nbsp;</span>
 						</span>
 					</span>
 				</p>
 			</td>
-			<td style="width:46.9pt" valign="top">
+			<td style="border-color:#000000; width:46.9pt" valign="top">
 				<p style="margin-left:0in; margin-right:0in; text-align:right">
-					<span style="font-size:10pt">
+					<span style="color:#000000">
 						<span style="font-family:&quot;times new roman&quot;,serif">
-							<span style="color:#000000">[[fedoram.1stinsttax(ro.2.1.149)]]</span>
+							<span style="font-size:10pt">[[fedoram.1stinsttax(ro.2.1.149)]]</span>
 						</span>
 					</span>
 				</p>
 			</td>
 		</tr>
 		<tr>
-			<td style="width:311.4pt" valign="top">
+			<td style="border-color:#000000; width:311.4pt" valign="top">
 				<p style="margin-left:0in; margin-right:0in; text-align:left">
-					<span style="font-size:10pt">
+					<span style="color:#000000">
 						<span style="font-family:&quot;times new roman&quot;,serif">
-							<span style="color:#000000">&nbsp;</span>
+							<span style="font-size:10pt">&nbsp;</span>
 						</span>
 					</span>
 				</p>
 			</td>
-			<td style="width:99pt" valign="top">
+			<td style="border-color:#000000; width:99pt" valign="top">
 				<p style="margin-left:0in; margin-right:0in; text-align:left">
-					<span style="font-size:10pt">
+					<span style="color:#000000">
 						<span style="font-family:&quot;times new roman&quot;,serif">
-							<span style="color:#000000">&nbsp;</span>
+							<span style="font-size:10pt">&nbsp;</span>
 						</span>
 					</span>
 				</p>
 			</td>
-			<td style="width:13.5pt" valign="top">
+			<td style="border-color:#000000; width:13.5pt" valign="top">
 				<p style="margin-left:0in; margin-right:0in; text-align:right">
-					<span style="font-size:10pt">
+					<span style="color:#000000">
 						<span style="font-family:&quot;times new roman&quot;,serif">
-							<span style="color:#000000">&nbsp;</span>
+							<span style="font-size:10pt">&nbsp;</span>
 						</span>
 					</span>
 				</p>
 			</td>
 			<td style="border-color:#000000 #000000 black; width:49.5pt" valign="top">
 				<p style="margin-left:0in; margin-right:0in; text-align:right">
-					<span style="font-size:10pt">
+					<span style="color:#000000">
 						<span style="font-family:&quot;times new roman&quot;,serif">
-							<span style="color:#000000">some data</span>
+							<span style="font-size:10pt">some data</span>
 						</span>
 					</span>
 				</p>
 			</td>
-			<td style="width:13.5pt" valign="top">
+			<td style="border-color:#000000; width:13.5pt" valign="top">
 				<p style="margin-left:0in; margin-right:0in; text-align:right">
-					<span style="font-size:10pt">
+					<span style="color:#000000">
 						<span style="font-family:&quot;times new roman&quot;,serif">
-							<span style="color:#000000">&nbsp;</span>
+							<span style="font-size:10pt">&nbsp;</span>
 						</span>
 					</span>
 				</p>
 			</td>
-			<td style="width:46.9pt" valign="top">
+			<td style="border-color:#000000; width:46.9pt" valign="top">
 				<p style="margin-left:0in; margin-right:0in; text-align:right">
-					<span style="font-size:10pt">
+					<span style="color:#000000">
 						<span style="font-family:&quot;times new roman&quot;,serif">
-							<span style="color:#000000">&nbsp;</span>
+							<span style="font-size:10pt">&nbsp;</span>
 						</span>
 					</span>
 				</p>
 			</td>
 		</tr>
 		<tr>
-			<td style="width:311.4pt" valign="top">
+			<td style="border-color:#000000; width:311.4pt" valign="top">
 				<p style="margin-left:0in; margin-right:0in; text-align:left">
 					<strong>
-						<span style="font-size:10pt">
+						<span style="color:#000000">
 							<span style="font-family:&quot;times new roman&quot;,serif">
-								<span style="color:#000000">&nbsp;</span>
+								<span style="font-size:10pt">&nbsp;</span>
 							</span>
 						</span>
 					</strong>
 				</p>
 			</td>
-			<td style="width:99pt" valign="top">
+			<td style="border-color:#000000; width:99pt" valign="top">
 				<p style="margin-left:0in; margin-right:0in; text-align:left">
-					<span style="font-size:10pt">
+					<span style="color:#000000">
 						<span style="font-family:&quot;times new roman&quot;,serif">
-							<span style="color:#000000">&nbsp;</span>
+							<span style="font-size:10pt">&nbsp;</span>
 						</span>
 					</span>
 				</p>
 			</td>
-			<td style="width:13.5pt" valign="top">
+			<td style="border-color:#000000; width:13.5pt" valign="top">
 				<p style="margin-left:0in; margin-right:0in; text-align:right">
-					<span style="font-size:10pt">
+					<span style="color:#000000">
 						<span style="font-family:&quot;times new roman&quot;,serif">
-							<span style="color:#000000">&nbsp;</span>
+							<span style="font-size:10pt">&nbsp;</span>
 						</span>
 					</span>
 				</p>
 			</td>
 			<td style="border-color:#000000 #000000 windowtext; width:49.5pt" valign="top">
 				<p style="margin-left:0in; margin-right:0in; text-align:right">
-					<span style="font-size:10pt">
+					<span style="color:#000000">
 						<span style="font-family:&quot;times new roman&quot;,serif">
-							<span style="color:#000000">data</span>
+							<span style="font-size:10pt">data</span>
 						</span>
 					</span>
 				</p>
 			</td>
-			<td style="width:13.5pt" valign="top">
+			<td style="border-color:#000000; width:13.5pt" valign="top">
 				<p style="margin-left:0in; margin-right:0in; text-align:right">
-					<span style="font-size:10pt">
+					<span style="color:#000000">
 						<span style="font-family:&quot;times new roman&quot;,serif">
-							<span style="color:#000000">&nbsp;</span>
+							<span style="font-size:10pt">&nbsp;</span>
 						</span>
 					</span>
 				</p>
 			</td>
-			<td style="width:46.9pt" valign="top">
+			<td style="border-color:#000000; width:46.9pt" valign="top">
 				<p style="margin-left:0in; margin-right:0in; text-align:right">
-					<span style="font-size:10pt">
+					<span style="color:#000000">
 						<span style="font-family:&quot;times new roman&quot;,serif">
-							<span style="color:#000000">&nbsp;</span>
+							<span style="font-size:10pt">&nbsp;</span>
 						</span>
 					</span>
 				</p>
 			</td>
 		</tr>
 		<tr>
-			<td style="width:311.4pt" valign="top">
+			<td style="border-color:#000000; width:311.4pt" valign="top">
 				<p style="margin-left:0in; margin-right:0in; text-align:left">
-					<span style="font-size:10pt">
+					<span style="color:#000000">
 						<span style="font-family:&quot;times new roman&quot;,serif">
-							<span style="color:#000000">&nbsp;</span>
+							<span style="font-size:10pt">&nbsp;</span>
 						</span>
 					</span>
 				</p>
 			</td>
-			<td style="width:99pt" valign="top">
+			<td style="border-color:#000000; width:99pt" valign="top">
 				<p style="margin-left:0in; margin-right:0in; text-align:left">
-					<span style="font-size:10pt">
+					<span style="color:#000000">
 						<span style="font-family:&quot;times new roman&quot;,serif">
-							<span style="color:#000000">&nbsp;</span>
+							<span style="font-size:10pt">&nbsp;</span>
 						</span>
 					</span>
 				</p>
 			</td>
-			<td style="width:13.5pt" valign="top">
+			<td style="border-color:#000000; width:13.5pt" valign="top">
 				<p style="margin-left:0in; margin-right:0in; text-align:right">
-					<span style="font-size:10pt">
+					<span style="color:#000000">
 						<span style="font-family:&quot;times new roman&quot;,serif">
-							<span style="color:#000000">&nbsp;</span>
+							<span style="font-size:10pt">&nbsp;</span>
 						</span>
 					</span>
 				</p>
 			</td>
 			<td style="border-color:#000000 #000000 black; width:49.5pt" valign="top">
 				<p style="margin-left:0in; margin-right:0in; text-align:right">
-					<span style="font-size:10pt">
+					<span style="color:#000000">
 						<span style="font-family:&quot;times new roman&quot;,serif">
-							<span style="color:#000000">data</span>
+							<span style="font-size:10pt">data</span>
 						</span>
 					</span>
 				</p>
 			</td>
-			<td style="width:13.5pt" valign="top">
+			<td style="border-color:#000000; width:13.5pt" valign="top">
 				<p style="margin-left:0in; margin-right:0in; text-align:right">
-					<span style="font-size:10pt">
+					<span style="color:#000000">
 						<span style="font-family:&quot;times new roman&quot;,serif">
-							<span style="color:#000000">&nbsp;</span>
+							<span style="font-size:10pt">&nbsp;</span>
 						</span>
 					</span>
 				</p>
 			</td>
-			<td style="width:46.9pt" valign="top">
+			<td style="border-color:#000000; width:46.9pt" valign="top">
 				<p style="margin-left:0in; margin-right:0in; text-align:right">
-					<span style="font-size:10pt">
+					<span style="color:#000000">
 						<span style="font-family:&quot;times new roman&quot;,serif">
-							<span style="color:#000000">&nbsp;</span>
+							<span style="font-size:10pt">&nbsp;</span>
 						</span>
 					</span>
 				</p>
 			</td>
 		</tr>
 		<tr>
-			<td style="width:311.4pt" valign="top">
+			<td style="border-color:#000000; width:311.4pt" valign="top">
 				<p style="margin-left:0in; margin-right:0in; text-align:left">
-					<span style="font-size:10pt">
+					<span style="color:#000000">
 						<span style="font-family:&quot;times new roman&quot;,serif">
-							<span style="color:#000000">&nbsp;</span>
+							<span style="font-size:10pt">&nbsp;</span>
 						</span>
 					</span>
 				</p>
 			</td>
-			<td style="width:99pt" valign="top">
+			<td style="border-color:#000000; width:99pt" valign="top">
 				<p style="margin-left:0in; margin-right:0in; text-align:left">
-					<span style="font-size:10pt">
+					<span style="color:#000000">
 						<span style="font-family:&quot;times new roman&quot;,serif">
-							<span style="color:#000000">&nbsp;</span>
+							<span style="font-size:10pt">&nbsp;</span>
 						</span>
 					</span>
 				</p>
 			</td>
-			<td style="width:13.5pt" valign="top">
+			<td style="border-color:#000000; width:13.5pt" valign="top">
 				<p style="margin-left:0in; margin-right:0in; text-align:right">
-					<span style="font-size:10pt">
+					<span style="color:#000000">
 						<span style="font-family:&quot;times new roman&quot;,serif">
-							<span style="color:#000000">&nbsp;</span>
+							<span style="font-size:10pt">&nbsp;</span>
 						</span>
 					</span>
 				</p>
 			</td>
 			<td style="border-color:#000000 #000000 black; width:49.5pt" valign="top">
 				<p style="margin-left:0in; margin-right:0in; text-align:right">
-					<span style="font-size:10pt">
+					<span style="color:#000000">
 						<span style="font-family:&quot;times new roman&quot;,serif">
-							<span style="color:#000000">data</span>
+							<span style="font-size:10pt">data</span>
 						</span>
 					</span>
 				</p>
 			</td>
-			<td style="width:13.5pt" valign="top">
+			<td style="border-color:#000000; width:13.5pt" valign="top">
 				<p style="margin-left:0in; margin-right:0in; text-align:right">
-					<span style="font-size:10pt">
+					<span style="color:#000000">
 						<span style="font-family:&quot;times new roman&quot;,serif">
-							<span style="color:#000000">&nbsp;</span>
+							<span style="font-size:10pt">&nbsp;</span>
 						</span>
 					</span>
 				</p>
 			</td>
-			<td style="width:46.9pt" valign="top">
+			<td style="border-color:#000000; width:46.9pt" valign="top">
 				<p style="margin-left:0in; margin-right:0in; text-align:right">
-					<span style="font-size:10pt">
+					<span style="color:#000000">
 						<span style="font-family:&quot;times new roman&quot;,serif">
-							<span style="color:#000000">&nbsp;</span>
+							<span style="font-size:10pt">&nbsp;</span>
 						</span>
 					</span>
 				</p>
 			</td>
 		</tr>
 		<tr>
-			<td style="width:311.4pt" valign="top">
+			<td style="border-color:#000000; width:311.4pt" valign="top">
 				<p style="margin-left:0in; margin-right:0in; text-align:left">
-					<span style="font-size:10pt">
+					<span style="color:#000000">
 						<span style="font-family:&quot;times new roman&quot;,serif">
-							<span style="color:#000000">&nbsp;</span>
+							<span style="font-size:10pt">&nbsp;</span>
 						</span>
 					</span>
 				</p>
 			</td>
-			<td style="width:99pt" valign="top">
+			<td style="border-color:#000000; width:99pt" valign="top">
 				<p style="margin-left:0in; margin-right:0in; text-align:left">
-					<span style="font-size:10pt">
+					<span style="color:#000000">
 						<span style="font-family:&quot;times new roman&quot;,serif">
-							<span style="color:#000000">&nbsp;</span>
+							<span style="font-size:10pt">&nbsp;</span>
 						</span>
 					</span>
 				</p>
 			</td>
-			<td style="width:13.5pt" valign="top">
+			<td style="border-color:#000000; width:13.5pt" valign="top">
 				<p style="margin-left:0in; margin-right:0in; text-align:right">
-					<span style="font-size:10pt">
+					<span style="color:#000000">
 						<span style="font-family:&quot;times new roman&quot;,serif">
-							<span style="color:#000000">&nbsp;</span>
+							<span style="font-size:10pt">&nbsp;</span>
 						</span>
 					</span>
 				</p>
 			</td>
-			<td style="width:49.5pt" valign="top">
+			<td style="border-color:#000000; width:49.5pt" valign="top">
 				<p style="margin-left:0in; margin-right:0in; text-align:justify">
-					<span style="font-size:10pt">
+					<span style="color:#000000">
 						<span style="font-family:&quot;times new roman&quot;,serif">
-							<span style="color:#000000">&nbsp;</span>
+							<span style="font-size:10pt">&nbsp;</span>
 						</span>
 					</span>
 				</p>
 			</td>
-			<td style="width:13.5pt" valign="top">
+			<td style="border-color:#000000; width:13.5pt" valign="top">
 				<p style="margin-left:0in; margin-right:0in; text-align:right">
-					<span style="font-size:10pt">
+					<span style="color:#000000">
 						<span style="font-family:&quot;times new roman&quot;,serif">
-							<span style="color:#000000">&nbsp;</span>
+							<span style="font-size:10pt">&nbsp;</span>
 						</span>
 					</span>
 				</p>
 			</td>
-			<td style="width:46.9pt" valign="top">
+			<td style="border-color:#000000; width:46.9pt" valign="top">
 				<p style="margin-left:0in; margin-right:0in; text-align:right">
-					<span style="font-size:10pt">
+					<span style="color:#000000">
 						<span style="font-family:&quot;times new roman&quot;,serif">
-							<span style="color:#000000">&nbsp;</span>
+							<span style="font-size:10pt">&nbsp;</span>
 						</span>
 					</span>
 				</p>
 			</td>
 		</tr>
 		<tr>
-			<td style="width:311.4pt" valign="top">
+			<td style="border-color:#000000; width:311.4pt" valign="top">
 				<p style="margin-left:0in; margin-right:0in; text-align:left">
-					<span style="font-size:10pt">
+					<span style="color:#000000">
 						<span style="font-family:&quot;times new roman&quot;,serif">
-							<span style="color:#000000">&nbsp;</span>
+							<span style="font-size:10pt">&nbsp;</span>
 						</span>
 					</span>
 				</p>
 			</td>
-			<td style="width:99pt" valign="top">
+			<td style="border-color:#000000; width:99pt" valign="top">
 				<p style="margin-left:0in; margin-right:0in; text-align:left">
-					<span style="font-size:10pt">
+					<span style="color:#000000">
 						<span style="font-family:&quot;times new roman&quot;,serif">
-							<span style="color:#000000">&nbsp;</span>
+							<span style="font-size:10pt">&nbsp;</span>
 						</span>
 					</span>
 				</p>
 			</td>
-			<td style="width:13.5pt" valign="top">
+			<td style="border-color:#000000; width:13.5pt" valign="top">
 				<p style="margin-left:0in; margin-right:0in; text-align:right">
-					<span style="font-size:10pt">
+					<span style="color:#000000">
 						<span style="font-family:&quot;times new roman&quot;,serif">
-							<span style="color:#000000">&nbsp;</span>
+							<span style="font-size:10pt">&nbsp;</span>
 						</span>
 					</span>
 				</p>
 			</td>
 			<td style="border-color:#000000 #000000 black; width:49.5pt" valign="top">
 				<p style="margin-left:0in; margin-right:0in">
-					<span style="font-size:10pt">
+					<span style="color:#000000">
 						<span style="font-family:&quot;times new roman&quot;,serif">
-							<span style="color:#000000">meddle data</span>
+							<span style="font-size:10pt">meddle data</span>
 						</span>
 					</span>
 				</p>
 			</td>
-			<td style="width:13.5pt" valign="top">
+			<td style="border-color:#000000; width:13.5pt" valign="top">
 				<p style="margin-left:0in; margin-right:0in; text-align:right">
-					<span style="font-size:10pt">
+					<span style="color:#000000">
 						<span style="font-family:&quot;times new roman&quot;,serif">
-							<span style="color:#000000">&nbsp;</span>
+							<span style="font-size:10pt">&nbsp;</span>
 						</span>
 					</span>
 				</p>
 			</td>
-			<td style="width:46.9pt" valign="top">
+			<td style="border-color:#000000; width:46.9pt" valign="top">
 				<p style="margin-left:0in; margin-right:0in; text-align:right">
-					<span style="font-size:10pt">
+					<span style="color:#000000">
 						<span style="font-family:&quot;times new roman&quot;,serif">
-							<span style="color:#000000">&nbsp;</span>
+							<span style="font-size:10pt">&nbsp;</span>
 						</span>
 					</span>
 				</p>
 			</td>
 		</tr>
 		<tr>
-			<td style="width:311.4pt" valign="top">
+			<td style="border-color:#000000; width:311.4pt" valign="top">
 				<p style="margin-left:0in; margin-right:0in; text-align:left">
-					<span style="font-size:10pt">
+					<span style="color:#000000">
 						<span style="font-family:&quot;times new roman&quot;,serif">
-							<span style="color:#000000">&nbsp;</span>
+							<span style="font-size:10pt">&nbsp;</span>
 						</span>
 					</span>
 				</p>
 			</td>
-			<td style="width:99pt" valign="top">
+			<td style="border-color:#000000; width:99pt" valign="top">
 				<p style="margin-left:0in; margin-right:0in; text-align:left">
-					<span style="font-size:10pt">
+					<span style="color:#000000">
 						<span style="font-family:&quot;times new roman&quot;,serif">
-							<span style="color:#000000">&nbsp;</span>
+							<span style="font-size:10pt">&nbsp;</span>
 						</span>
 					</span>
 				</p>
 			</td>
-			<td style="width:13.5pt" valign="top">
+			<td style="border-color:#000000; width:13.5pt" valign="top">
 				<p style="margin-left:0in; margin-right:0in; text-align:right">
-					<span style="font-size:10pt">
+					<span style="color:#000000">
 						<span style="font-family:&quot;times new roman&quot;,serif">
-							<span style="color:#000000">&nbsp;</span>
+							<span style="font-size:10pt">&nbsp;</span>
 						</span>
 					</span>
 				</p>
 			</td>
 			<td style="border-color:#000000 #000000 black; width:49.5pt" valign="top">
 				<p style="margin-left:0in; margin-right:0in; text-align:right">
-					<span style="font-size:10pt">
+					<span style="color:#000000">
 						<span style="font-family:&quot;times new roman&quot;,serif">
-							<span style="color:#000000">middle data</span>
+							<span style="font-size:10pt">middle data</span>
 						</span>
 					</span>
 				</p>
 			</td>
-			<td style="width:13.5pt" valign="top">
+			<td style="border-color:#000000; width:13.5pt" valign="top">
 				<p style="margin-left:0in; margin-right:0in; text-align:right">
-					<span style="font-size:10pt">
+					<span style="color:#000000">
 						<span style="font-family:&quot;times new roman&quot;,serif">
-							<span style="color:#000000">&nbsp;</span>
+							<span style="font-size:10pt">&nbsp;</span>
 						</span>
 					</span>
 				</p>
 			</td>
-			<td style="width:46.9pt" valign="top">
+			<td style="border-color:#000000; width:46.9pt" valign="top">
 				<p style="margin-left:0in; margin-right:0in; text-align:right">
-					<span style="font-size:10pt">
+					<span style="color:#000000">
 						<span style="font-family:&quot;times new roman&quot;,serif">
-							<span style="color:#000000">&nbsp;</span>
+							<span style="font-size:10pt">&nbsp;</span>
 						</span>
 					</span>
 				</p>
 			</td>
 		</tr>
 		<tr>
-			<td style="width:311.4pt" valign="top">
+			<td style="border-color:#000000; width:311.4pt" valign="top">
 				<p style="margin-left:0in; margin-right:0in; text-align:left">
-					<span style="font-size:10pt">
+					<span style="color:#000000">
 						<span style="font-family:&quot;times new roman&quot;,serif">
-							<span style="color:#000000">&nbsp;</span>
+							<span style="font-size:10pt">&nbsp;</span>
 						</span>
 					</span>
 				</p>
 			</td>
-			<td style="width:99pt" valign="top">
+			<td style="border-color:#000000; width:99pt" valign="top">
 				<p style="margin-left:0in; margin-right:0in; text-align:left">
-					<span style="font-size:10pt">
+					<span style="color:#000000">
 						<span style="font-family:&quot;times new roman&quot;,serif">
-							<span style="color:#000000">&nbsp;</span>
+							<span style="font-size:10pt">&nbsp;</span>
 						</span>
 					</span>
 				</p>
 			</td>
-			<td style="width:13.5pt" valign="top">
+			<td style="border-color:#000000; width:13.5pt" valign="top">
 				<p style="margin-left:0in; margin-right:0in; text-align:right">
-					<span style="font-size:10pt">
+					<span style="color:#000000">
 						<span style="font-family:&quot;times new roman&quot;,serif">
-							<span style="color:#000000">&nbsp;</span>
+							<span style="font-size:10pt">&nbsp;</span>
 						</span>
 					</span>
 				</p>
 			</td>
 			<td style="border-color:#000000 #000000 black; width:49.5pt" valign="top">
 				<p style="margin-left:0in; margin-right:0in; text-align:right">
-					<span style="font-size:10pt">
+					<span style="color:#000000">
 						<span style="font-family:&quot;times new roman&quot;,serif">
-							<span style="color:#000000">&nbsp;</span>
+							<span style="font-size:10pt">&nbsp;</span>
 						</span>
 					</span>
 				</p>
 			</td>
-			<td style="width:13.5pt" valign="top">
+			<td style="border-color:#000000; width:13.5pt" valign="top">
 				<p style="margin-left:0in; margin-right:0in; text-align:right">
-					<span style="font-size:10pt">
+					<span style="color:#000000">
 						<span style="font-family:&quot;times new roman&quot;,serif">
-							<span style="color:#000000">&nbsp;</span>
+							<span style="font-size:10pt">&nbsp;</span>
 						</span>
 					</span>
 				</p>
 			</td>
 			<td style="border-color:#000000 #000000 black; width:46.9pt" valign="top">
 				<p style="margin-left:0in; margin-right:0in; text-align:right">
-					<span style="font-size:10pt">
+					<span style="color:#000000">
 						<span style="font-family:&quot;times new roman&quot;,serif">
-							<span style="color:#000000">side data</span>
+							<span style="font-size:10pt">side data</span>
 						</span>
 					</span>
 				</p>
@@ -890,9 +890,9 @@
 			<td style="border-color:windowtext #000000 #000000 windowtext; width:311.4pt" valign="top">
 				<p style="margin-left:0in; margin-right:0in; text-align:left">
 					<strong>
-						<span style="font-size:10pt">
+						<span style="color:#000000">
 							<span style="font-family:&quot;times new roman&quot;,serif">
-								<span style="color:#000000">in border content:</span>
+								<span style="font-size:10pt">in border content:</span>
 							</span>
 						</span>
 					</strong>
@@ -900,45 +900,45 @@
 			</td>
 			<td style="border-color:windowtext #000000 #000000; width:99pt" valign="top">
 				<p style="margin-left:0in; margin-right:0in; text-align:left">
-					<span style="font-size:10pt">
+					<span style="color:#000000">
 						<span style="font-family:&quot;times new roman&quot;,serif">
-							<span style="color:#000000">&nbsp;</span>
+							<span style="font-size:10pt">&nbsp;</span>
 						</span>
 					</span>
 				</p>
 			</td>
 			<td style="border-color:windowtext #000000 #000000; width:13.5pt" valign="top">
 				<p style="margin-left:0in; margin-right:0in; text-align:right">
-					<span style="font-size:10pt">
+					<span style="color:#000000">
 						<span style="font-family:&quot;times new roman&quot;,serif">
-							<span style="color:#000000">&nbsp;</span>
+							<span style="font-size:10pt">&nbsp;</span>
 						</span>
 					</span>
 				</p>
 			</td>
-			<td style="width:49.5pt" valign="top">
+			<td style="border-color:#000000; width:49.5pt" valign="top">
 				<p style="margin-left:0in; margin-right:0in; text-align:right">
-					<span style="font-size:10pt">
+					<span style="color:#000000">
 						<span style="font-family:&quot;times new roman&quot;,serif">
-							<span style="color:#000000">&nbsp;</span>
+							<span style="font-size:10pt">&nbsp;</span>
 						</span>
 					</span>
 				</p>
 			</td>
 			<td style="border-color:windowtext #000000 #000000; width:13.5pt" valign="top">
 				<p style="margin-left:0in; margin-right:0in; text-align:right">
-					<span style="font-size:10pt">
+					<span style="color:#000000">
 						<span style="font-family:&quot;times new roman&quot;,serif">
-							<span style="color:#000000">&nbsp;</span>
+							<span style="font-size:10pt">&nbsp;</span>
 						</span>
 					</span>
 				</p>
 			</td>
 			<td style="border-color:#000000 windowtext #000000 #000000; width:46.9pt" valign="top">
 				<p style="margin-left:0in; margin-right:0in; text-align:right">
-					<span style="font-size:10pt">
+					<span style="color:#000000">
 						<span style="font-family:&quot;times new roman&quot;,serif">
-							<span style="color:#000000">&nbsp;</span>
+							<span style="font-size:10pt">&nbsp;</span>
 						</span>
 					</span>
 				</p>
@@ -947,54 +947,54 @@
 		<tr>
 			<td style="border-color:#000000 #000000 #000000 windowtext; width:311.4pt" valign="top">
 				<p style="margin-left:0in; margin-right:0in; text-align:left">
-					<span style="font-size:10pt">
+					<span style="color:#000000">
 						<span style="font-family:&quot;times new roman&quot;,serif">
-							<span style="color:#000000">sample text:</span>
+							<span style="font-size:10pt">sample text:</span>
 						</span>
 					</span>
 				</p>
 			</td>
-			<td style="width:99pt" valign="top">
+			<td style="border-color:#000000; width:99pt" valign="top">
 				<p style="margin-left:0in; margin-right:0in; text-align:left">
-					<span style="font-size:10pt">
+					<span style="color:#000000">
 						<span style="font-family:&quot;times new roman&quot;,serif">
-							<span style="color:#000000">&nbsp;</span>
+							<span style="font-size:10pt">&nbsp;</span>
 						</span>
 					</span>
 				</p>
 			</td>
-			<td style="width:13.5pt" valign="top">
+			<td style="border-color:#000000; width:13.5pt" valign="top">
 				<p style="margin-left:0in; margin-right:0in; text-align:right">
-					<span style="font-size:10pt">
+					<span style="color:#000000">
 						<span style="font-family:&quot;times new roman&quot;,serif">
-							<span style="color:#000000">&nbsp;</span>
+							<span style="font-size:10pt">&nbsp;</span>
 						</span>
 					</span>
 				</p>
 			</td>
-			<td style="width:49.5pt" valign="top">
+			<td style="border-color:#000000; width:49.5pt" valign="top">
 				<p style="margin-left:0in; margin-right:0in; text-align:right">
-					<span style="font-size:10pt">
+					<span style="color:#000000">
 						<span style="font-family:&quot;times new roman&quot;,serif">
-							<span style="color:#000000">&nbsp;</span>
+							<span style="font-size:10pt">&nbsp;</span>
 						</span>
 					</span>
 				</p>
 			</td>
-			<td style="width:13.5pt" valign="top">
+			<td style="border-color:#000000; width:13.5pt" valign="top">
 				<p style="margin-left:0in; margin-right:0in; text-align:right">
-					<span style="font-size:10pt">
+					<span style="color:#000000">
 						<span style="font-family:&quot;times new roman&quot;,serif">
-							<span style="color:#000000">&nbsp;</span>
+							<span style="font-size:10pt">&nbsp;</span>
 						</span>
 					</span>
 				</p>
 			</td>
 			<td style="border-color:#000000 windowtext #000000 #000000; width:46.9pt" valign="top">
 				<p style="margin-left:0in; margin-right:0in; text-align:right">
-					<span style="font-size:10pt">
+					<span style="color:#000000">
 						<span style="font-family:&quot;times new roman&quot;,serif">
-							<span style="color:#000000">&nbsp;</span>
+							<span style="font-size:10pt">&nbsp;</span>
 						</span>
 					</span>
 				</p>
@@ -1003,54 +1003,54 @@
 		<tr>
 			<td style="border-color:#000000 #000000 #000000 windowtext; width:311.4pt" valign="top">
 				<p style="margin-left:0in; margin-right:0in; text-align:left">
-					<span style="font-size:10pt">
+					<span style="color:#000000">
 						<span style="font-family:&quot;times new roman&quot;,serif">
-							<span style="color:#000000">payment</span>
+							<span style="font-size:10pt">payment</span>
 						</span>
 					</span>
 				</p>
 			</td>
-			<td style="width:99pt" valign="top">
+			<td style="border-color:#000000; width:99pt" valign="top">
 				<p style="margin-left:0in; margin-right:0in; text-align:left">
-					<span style="font-size:10pt">
+					<span style="color:#000000">
 						<span style="font-family:&quot;times new roman&quot;,serif">
-							<span style="color:#000000">&nbsp;</span>
+							<span style="font-size:10pt">&nbsp;</span>
 						</span>
 					</span>
 				</p>
 			</td>
-			<td style="width:13.5pt" valign="top">
+			<td style="border-color:#000000; width:13.5pt" valign="top">
 				<p style="margin-left:0in; margin-right:0in; text-align:right">
-					<span style="font-size:10pt">
+					<span style="color:#000000">
 						<span style="font-family:&quot;times new roman&quot;,serif">
-							<span style="color:#000000">$</span>
+							<span style="font-size:10pt">$</span>
 						</span>
 					</span>
 				</p>
 			</td>
-			<td style="width:49.5pt" valign="top">
+			<td style="border-color:#000000; width:49.5pt" valign="top">
 				<p style="margin-left:0in; margin-right:0in; text-align:right">
-					<span style="font-size:10pt">
+					<span style="color:#000000">
 						<span style="font-family:&quot;times new roman&quot;,serif">
-							<span style="color:#000000">[[data data)]]</span>
+							<span style="font-size:10pt">[[data data)]]</span>
 						</span>
 					</span>
 				</p>
 			</td>
-			<td style="width:13.5pt" valign="top">
+			<td style="border-color:#000000; width:13.5pt" valign="top">
 				<p style="margin-left:0in; margin-right:0in; text-align:right">
-					<span style="font-size:10pt">
+					<span style="color:#000000">
 						<span style="font-family:&quot;times new roman&quot;,serif">
-							<span style="color:#000000">&nbsp;</span>
+							<span style="font-size:10pt">&nbsp;</span>
 						</span>
 					</span>
 				</p>
 			</td>
 			<td style="border-color:#000000 windowtext #000000 #000000; width:46.9pt" valign="top">
 				<p style="margin-left:0in; margin-right:0in; text-align:right">
-					<span style="font-size:10pt">
+					<span style="color:#000000">
 						<span style="font-family:&quot;times new roman&quot;,serif">
-							<span style="color:#000000">&nbsp;</span>
+							<span style="font-size:10pt">&nbsp;</span>
 						</span>
 					</span>
 				</p>
@@ -1059,54 +1059,54 @@
 		<tr>
 			<td style="border-color:#000000 #000000 #000000 windowtext; width:311.4pt" valign="top">
 				<p style="margin-left:0in; margin-right:0in; text-align:left">
-					<span style="font-size:10pt">
+					<span style="color:#000000">
 						<span style="font-family:&quot;times new roman&quot;,serif">
-							<span style="color:#000000">&nbsp;</span>
+							<span style="font-size:10pt">&nbsp;</span>
 						</span>
 					</span>
 				</p>
 			</td>
-			<td style="width:99pt" valign="top">
+			<td style="border-color:#000000; width:99pt" valign="top">
 				<p style="margin-left:0in; margin-right:0in; text-align:left">
-					<span style="font-size:10pt">
+					<span style="color:#000000">
 						<span style="font-family:&quot;times new roman&quot;,serif">
-							<span style="color:#000000">&nbsp;</span>
+							<span style="font-size:10pt">&nbsp;</span>
 						</span>
 					</span>
 				</p>
 			</td>
-			<td style="width:13.5pt" valign="top">
+			<td style="border-color:#000000; width:13.5pt" valign="top">
 				<p style="margin-left:0in; margin-right:0in; text-align:right">
-					<span style="font-size:10pt">
+					<span style="color:#000000">
 						<span style="font-family:&quot;times new roman&quot;,serif">
-							<span style="color:#000000">&nbsp;</span>
+							<span style="font-size:10pt">&nbsp;</span>
 						</span>
 					</span>
 				</p>
 			</td>
 			<td style="border-color:#000000 #000000 black; width:49.5pt" valign="top">
 				<p style="margin-left:0in; margin-right:0in; text-align:right">
-					<span style="font-size:10pt">
+					<span style="color:#000000">
 						<span style="font-family:&quot;times new roman&quot;,serif">
-							<span style="color:#000000">middle data</span>
+							<span style="font-size:10pt">middle data</span>
 						</span>
 					</span>
 				</p>
 			</td>
-			<td style="width:13.5pt" valign="top">
+			<td style="border-color:#000000; width:13.5pt" valign="top">
 				<p style="margin-left:0in; margin-right:0in; text-align:right">
-					<span style="font-size:10pt">
+					<span style="color:#000000">
 						<span style="font-family:&quot;times new roman&quot;,serif">
-							<span style="color:#000000">&nbsp;</span>
+							<span style="font-size:10pt">&nbsp;</span>
 						</span>
 					</span>
 				</p>
 			</td>
 			<td style="border-color:#000000 windowtext #000000 #000000; width:46.9pt" valign="top">
 				<p style="margin-left:0in; margin-right:0in; text-align:right">
-					<span style="font-size:10pt">
+					<span style="color:#000000">
 						<span style="font-family:&quot;times new roman&quot;,serif">
-							<span style="color:#000000">&nbsp;</span>
+							<span style="font-size:10pt">&nbsp;</span>
 						</span>
 					</span>
 				</p>
@@ -1115,54 +1115,54 @@
 		<tr>
 			<td style="border-color:#000000 #000000 #000000 windowtext; width:311.4pt" valign="top">
 				<p style="margin-left:0in; margin-right:0in; text-align:left">
-					<span style="font-size:10pt">
+					<span style="color:#000000">
 						<span style="font-family:&quot;times new roman&quot;,serif">
-							<span style="color:#000000">&nbsp;</span>
+							<span style="font-size:10pt">&nbsp;</span>
 						</span>
 					</span>
 				</p>
 			</td>
-			<td style="width:99pt" valign="top">
+			<td style="border-color:#000000; width:99pt" valign="top">
 				<p style="margin-left:0in; margin-right:0in; text-align:left">
-					<span style="font-size:10pt">
+					<span style="color:#000000">
 						<span style="font-family:&quot;times new roman&quot;,serif">
-							<span style="color:#000000">&nbsp;</span>
+							<span style="font-size:10pt">&nbsp;</span>
 						</span>
 					</span>
 				</p>
 			</td>
-			<td style="width:13.5pt" valign="top">
+			<td style="border-color:#000000; width:13.5pt" valign="top">
 				<p style="margin-left:0in; margin-right:0in; text-align:right">
-					<span style="font-size:10pt">
+					<span style="color:#000000">
 						<span style="font-family:&quot;times new roman&quot;,serif">
-							<span style="color:#000000">&nbsp;</span>
+							<span style="font-size:10pt">&nbsp;</span>
 						</span>
 					</span>
 				</p>
 			</td>
 			<td style="border-color:#000000 #000000 windowtext; width:49.5pt" valign="top">
 				<p style="margin-left:0in; margin-right:0in; text-align:right">
-					<span style="font-size:10pt">
+					<span style="color:#000000">
 						<span style="font-family:&quot;times new roman&quot;,serif">
-							<span style="color:#000000">middle data</span>
+							<span style="font-size:10pt">middle data</span>
 						</span>
 					</span>
 				</p>
 			</td>
-			<td style="width:13.5pt" valign="top">
+			<td style="border-color:#000000; width:13.5pt" valign="top">
 				<p style="margin-left:0in; margin-right:0in; text-align:right">
-					<span style="font-size:10pt">
+					<span style="color:#000000">
 						<span style="font-family:&quot;times new roman&quot;,serif">
-							<span style="color:#000000">&nbsp;</span>
+							<span style="font-size:10pt">&nbsp;</span>
 						</span>
 					</span>
 				</p>
 			</td>
 			<td style="border-color:#000000 windowtext #000000 #000000; width:46.9pt" valign="top">
 				<p style="margin-left:0in; margin-right:0in; text-align:right">
-					<span style="font-size:10pt">
+					<span style="color:#000000">
 						<span style="font-family:&quot;times new roman&quot;,serif">
-							<span style="color:#000000">&nbsp;</span>
+							<span style="font-size:10pt">&nbsp;</span>
 						</span>
 					</span>
 				</p>
@@ -1171,54 +1171,54 @@
 		<tr>
 			<td style="border-color:#000000 #000000 #000000 windowtext; width:311.4pt" valign="top">
 				<p style="margin-left:0in; margin-right:0in; text-align:left">
-					<span style="font-size:10pt">
+					<span style="color:#000000">
 						<span style="font-family:&quot;times new roman&quot;,serif">
-							<span style="color:#000000">&nbsp;</span>
+							<span style="font-size:10pt">&nbsp;</span>
 						</span>
 					</span>
 				</p>
 			</td>
-			<td style="width:99pt" valign="top">
+			<td style="border-color:#000000; width:99pt" valign="top">
 				<p style="margin-left:0in; margin-right:0in; text-align:left">
-					<span style="font-size:10pt">
+					<span style="color:#000000">
 						<span style="font-family:&quot;times new roman&quot;,serif">
-							<span style="color:#000000">&nbsp;</span>
+							<span style="font-size:10pt">&nbsp;</span>
 						</span>
 					</span>
 				</p>
 			</td>
-			<td style="width:13.5pt" valign="top">
+			<td style="border-color:#000000; width:13.5pt" valign="top">
 				<p style="margin-left:0in; margin-right:0in; text-align:right">
-					<span style="font-size:10pt">
+					<span style="color:#000000">
 						<span style="font-family:&quot;times new roman&quot;,serif">
-							<span style="color:#000000">&nbsp;</span>
+							<span style="font-size:10pt">&nbsp;</span>
 						</span>
 					</span>
 				</p>
 			</td>
 			<td style="border-color:#000000 #000000 black; width:49.5pt" valign="top">
 				<p style="margin-left:0in; margin-right:0in; text-align:right">
-					<span style="font-size:10pt">
+					<span style="color:#000000">
 						<span style="font-family:&quot;times new roman&quot;,serif">
-							<span style="color:#000000">middle</span>
+							<span style="font-size:10pt">middle</span>
 						</span>
 					</span>
 				</p>
 			</td>
-			<td style="width:13.5pt" valign="top">
+			<td style="border-color:#000000; width:13.5pt" valign="top">
 				<p style="margin-left:0in; margin-right:0in; text-align:right">
-					<span style="font-size:10pt">
+					<span style="color:#000000">
 						<span style="font-family:&quot;times new roman&quot;,serif">
-							<span style="color:#000000">&nbsp;</span>
+							<span style="font-size:10pt">&nbsp;</span>
 						</span>
 					</span>
 				</p>
 			</td>
 			<td style="border-color:#000000 windowtext #000000 #000000; width:46.9pt" valign="top">
 				<p style="margin-left:0in; margin-right:0in; text-align:right">
-					<span style="font-size:10pt">
+					<span style="color:#000000">
 						<span style="font-family:&quot;times new roman&quot;,serif">
-							<span style="color:#000000">&nbsp;</span>
+							<span style="font-size:10pt">&nbsp;</span>
 						</span>
 					</span>
 				</p>
@@ -1227,54 +1227,54 @@
 		<tr>
 			<td style="border-color:#000000 #000000 #000000 windowtext; width:311.4pt" valign="top">
 				<p style="margin-left:0in; margin-right:0in; text-align:left">
-					<span style="font-size:10pt">
+					<span style="color:#000000">
 						<span style="font-family:&quot;times new roman&quot;,serif">
-							<span style="color:#000000">&nbsp;</span>
+							<span style="font-size:10pt">&nbsp;</span>
 						</span>
 					</span>
 				</p>
 			</td>
-			<td style="width:99pt" valign="top">
+			<td style="border-color:#000000; width:99pt" valign="top">
 				<p style="margin-left:0in; margin-right:0in; text-align:left">
-					<span style="font-size:10pt">
+					<span style="color:#000000">
 						<span style="font-family:&quot;times new roman&quot;,serif">
-							<span style="color:#000000">&nbsp;</span>
+							<span style="font-size:10pt">&nbsp;</span>
 						</span>
 					</span>
 				</p>
 			</td>
-			<td style="width:13.5pt" valign="top">
+			<td style="border-color:#000000; width:13.5pt" valign="top">
 				<p style="margin-left:0in; margin-right:0in; text-align:right">
-					<span style="font-size:10pt">
+					<span style="color:#000000">
 						<span style="font-family:&quot;times new roman&quot;,serif">
-							<span style="color:#000000">&nbsp;</span>
+							<span style="font-size:10pt">&nbsp;</span>
 						</span>
 					</span>
 				</p>
 			</td>
 			<td style="border-color:#000000 #000000 windowtext; width:49.5pt" valign="top">
 				<p style="margin-left:0in; margin-right:0in; text-align:right">
-					<span style="font-size:10pt">
+					<span style="color:#000000">
 						<span style="font-family:&quot;times new roman&quot;,serif">
-							<span style="color:#000000">middle</span>
+							<span style="font-size:10pt">middle</span>
 						</span>
 					</span>
 				</p>
 			</td>
-			<td style="width:13.5pt" valign="top">
+			<td style="border-color:#000000; width:13.5pt" valign="top">
 				<p style="margin-left:0in; margin-right:0in; text-align:right">
-					<span style="font-size:10pt">
+					<span style="color:#000000">
 						<span style="font-family:&quot;times new roman&quot;,serif">
-							<span style="color:#000000">&nbsp;</span>
+							<span style="font-size:10pt">&nbsp;</span>
 						</span>
 					</span>
 				</p>
 			</td>
 			<td style="border-color:#000000 windowtext #000000 #000000; width:46.9pt" valign="top">
 				<p style="margin-left:0in; margin-right:0in; text-align:right">
-					<span style="font-size:10pt">
+					<span style="color:#000000">
 						<span style="font-family:&quot;times new roman&quot;,serif">
-							<span style="color:#000000">&nbsp;</span>
+							<span style="font-size:10pt">&nbsp;</span>
 						</span>
 					</span>
 				</p>
@@ -1283,54 +1283,54 @@
 		<tr>
 			<td style="border-color:#000000 #000000 #000000 windowtext; width:311.4pt" valign="top">
 				<p style="margin-left:0in; margin-right:0in; text-align:left">
-					<span style="font-size:10pt">
+					<span style="color:#000000">
 						<span style="font-family:&quot;times new roman&quot;,serif">
-							<span style="color:#000000">&nbsp;</span>
+							<span style="font-size:10pt">&nbsp;</span>
 						</span>
 					</span>
 				</p>
 			</td>
-			<td style="width:99pt" valign="top">
+			<td style="border-color:#000000; width:99pt" valign="top">
 				<p style="margin-left:0in; margin-right:0in">
-					<span style="font-size:10pt">
+					<span style="color:#000000">
 						<span style="font-family:&quot;times new roman&quot;,serif">
-							<span style="color:#000000">&nbsp;</span>
+							<span style="font-size:10pt">&nbsp;</span>
 						</span>
 					</span>
 				</p>
 			</td>
-			<td style="width:13.5pt" valign="top">
+			<td style="border-color:#000000; width:13.5pt" valign="top">
 				<p style="margin-left:0in; margin-right:0in; text-align:right">
-					<span style="font-size:10pt">
+					<span style="color:#000000">
 						<span style="font-family:&quot;times new roman&quot;,serif">
-							<span style="color:#000000">&nbsp;</span>
+							<span style="font-size:10pt">&nbsp;</span>
 						</span>
 					</span>
 				</p>
 			</td>
-			<td style="width:49.5pt" valign="top">
+			<td style="border-color:#000000; width:49.5pt" valign="top">
 				<p style="margin-left:0in; margin-right:0in">
-					<span style="font-size:10pt">
+					<span style="color:#000000">
 						<span style="font-family:&quot;times new roman&quot;,serif">
-							<span style="color:#000000">&nbsp;</span>
+							<span style="font-size:10pt">&nbsp;</span>
 						</span>
 					</span>
 				</p>
 			</td>
-			<td style="width:13.5pt" valign="top">
+			<td style="border-color:#000000; width:13.5pt" valign="top">
 				<p style="margin-left:0in; margin-right:0in">
-					<span style="font-size:10pt">
+					<span style="color:#000000">
 						<span style="font-family:&quot;times new roman&quot;,serif">
-							<span style="color:#000000">&nbsp;</span>
+							<span style="font-size:10pt">&nbsp;</span>
 						</span>
 					</span>
 				</p>
 			</td>
 			<td style="border-color:#000000 windowtext #000000 #000000; width:46.9pt" valign="top">
 				<p style="margin-left:0in; margin-right:0in">
-					<span style="font-size:10pt">
+					<span style="color:#000000">
 						<span style="font-family:&quot;times new roman&quot;,serif">
-							<span style="color:#000000">&nbsp;</span>
+							<span style="font-size:10pt">&nbsp;</span>
 						</span>
 					</span>
 				</p>
@@ -1339,9 +1339,9 @@
 		<tr>
 			<td colspan="6" style="border-color:#000000 windowtext windowtext; width:533.8pt" valign="top">
 				<p style="margin-left:0in; margin-right:0in; text-align:left">
-					<span style="font-size:10pt">
+					<span style="color:#000000">
 						<span style="font-family:&quot;times new roman&quot;,serif">
-							<span style="color:#000000">c – last content hjhjj</span>
+							<span style="font-size:10pt">c – last content hjhjj</span>
 						</span>
 					</span>
 				</p>
@@ -1350,16 +1350,16 @@
 	</tbody>
 </table>
 <p style="margin-left:0in; margin-right:0in; text-align:left">
-	<span style="font-size:10pt">
+	<span style="color:#000000">
 		<span style="font-family:&quot;times new roman&quot;,serif">
-			<span style="color:#000000">&nbsp;</span>
+			<span style="font-size:10pt">&nbsp;</span>
 		</span>
 	</span>
 </p>
 <p style="margin-left:0in; margin-right:0in; text-align:left">
-	<span style="font-size:10pt">
+	<span style="color:#000000">
 		<span style="font-family:&quot;times new roman&quot;,serif">
-			<span style="color:#000000">&nbsp;</span>
+			<span style="font-size:10pt">&nbsp;</span>
 		</span>
 	</span>
 </p>


### PR DESCRIPTION
## What is the purpose of this pull request?

Bug fix

### This PR contains

- [x] Unit tests
- [x] Manual tests

## What changes did you make?
- change filter transformation `splitBorderShorthand` to properly split the border style and use tools method instead of having own logic,
- there exist an issue with processing border color with space which is an upstream here: #1356 

close #1010