### PR TITLE
Balloon toolbar cssSelector should also consider selected element (if any)

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -9,6 +9,7 @@ New Features:
 
 Fixed Issues:
 
+* [#1274](https://github.com/ckeditor/ckeditor-dev/issues/1274): Fixed: [Balloon Toolbar](https://ckeditor.com/cke4/addon/balloontoolbar) does not match a single selected image using [`contextDefinition.cssSelector`](https://docs.ckeditor.com/ckeditor4/docs/#!/api/CKEDITOR.plugins.balloontoolbar.contextDefinition-property-cssSelector) matcher.
 * [#1232](https://github.com/ckeditor/ckeditor-dev/issues/1232): Fixed: [Balloon Toolbar](https://ckeditor.com/cke4/addon/balloontoolbar) buttons should be registered as focusable elements.
 * [#1342](https://github.com/ckeditor/ckeditor-dev/issues/1342): Fixed: [Balloon Toolbar](https://ckeditor.com/cke4/addon/balloontoolbar) should be re-positioned after a [change](https://docs.ckeditor.com/ckeditor4/docs/#!/api/CKEDITOR.editor-event-change) event.
 * [#1048](https://github.com/ckeditor/ckeditor-dev/issues/1048): Fixed: [Balloon Panel](https://ckeditor.com/cke4/addon/balloonpanel) is not properly positioned when margin added to its non-static parent.

--- a/plugins/balloontoolbar/plugin.js
+++ b/plugins/balloontoolbar/plugin.js
@@ -421,7 +421,7 @@
 				selection = this.editor.getSelection();
 
 				// Shrink the selection so that we're ensured innermost elements are available, so that path for
-				// selection like `foo [<em>bar</em>] baz` also contains `em` element
+				// selection like `foo [<em>bar</em>] baz` also contains `em` element.
 				CKEDITOR.tools.array.forEach( selection.getRanges(), function( range ) {
 					range.shrink( CKEDITOR.SHRINK_ELEMENT, true );
 				} );

--- a/plugins/balloontoolbar/plugin.js
+++ b/plugins/balloontoolbar/plugin.js
@@ -468,6 +468,12 @@
 
 			// Match element selectors.
 			if ( path ) {
+				var selectedElem = selection.getSelectedElement();
+
+				if ( selectedElem && !selectedElem.isReadOnly() ) {
+					matchEachContext( this._contexts, elementsMatcher, selectedElem );
+				}
+
 				for ( var i = 0; i < path.elements.length; i++ ) {
 					var curElement = path.elements[ i ];
 					// Skip non-editable elements (e.g. widget internal structure).

--- a/plugins/balloontoolbar/plugin.js
+++ b/plugins/balloontoolbar/plugin.js
@@ -420,7 +420,8 @@
 			if ( !selection ) {
 				selection = this.editor.getSelection();
 
-				// Shrink the selection so that we're ensured innermost elements are available.
+				// Shrink the selection so that we're ensured innermost elements are available, so that path for
+				// selection like `foo [<em>bar</em>] baz` also contains `em` element
 				CKEDITOR.tools.array.forEach( selection.getRanges(), function( range ) {
 					range.shrink( CKEDITOR.SHRINK_ELEMENT, true );
 				} );

--- a/plugins/balloontoolbar/plugin.js
+++ b/plugins/balloontoolbar/plugin.js
@@ -468,6 +468,8 @@
 
 			// Match element selectors.
 			if ( path ) {
+				// First check the outermost element (if any was selected), since the selection got shrinked
+				// it would be otherwise skipped (#1274).
 				var selectedElem = selection.getSelectedElement();
 
 				if ( selectedElem && !selectedElem.isReadOnly() ) {

--- a/tests/plugins/balloontoolbar/context/cssselector.js
+++ b/tests/plugins/balloontoolbar/context/cssselector.js
@@ -88,6 +88,7 @@
 			contextTools._assertToolbarVisible( false, context );
 		},
 
+		// #1274
 		'test matching images': function() {
 			var context = this._getContextStub( 'img' );
 

--- a/tests/plugins/balloontoolbar/context/cssselector.js
+++ b/tests/plugins/balloontoolbar/context/cssselector.js
@@ -88,6 +88,22 @@
 			contextTools._assertToolbarVisible( false, context );
 		},
 
+		'test matching images': function() {
+			var context = this._getContextStub( 'img' );
+
+			this.editorBot.setHtmlWithSelection( '<p>foo [<img src="%BASE_PATH%_assets/lena.jpg" alt="">] bar</p>' );
+
+			contextTools._assertToolbarVisible( true, context );
+		},
+
+		'test matching link': function() {
+			var context = this._getContextStub( 'a' );
+
+			this.editorBot.setHtmlWithSelection( '<p>foo [<a href="#">bar</a>] baz</p>' );
+
+			contextTools._assertToolbarVisible( true, context );
+		},
+
 		/*
 		 * @param {String} selector A selector to be used as `options.elements`.
 		 * @returns {CKEDITOR.plugins.balloontoolbar.context} Context instance with `selector` used as a CSS selector.

--- a/tests/plugins/balloontoolbar/context/manual/imgselect.html
+++ b/tests/plugins/balloontoolbar/context/manual/imgselect.html
@@ -1,0 +1,45 @@
+<style>
+	body {
+		/* (#1048) */
+		margin-left: 0px;
+		padding-left: 400px;
+	}
+
+</style>
+
+<textarea id="editor1" cols="10" rows="10">
+	<p>Sample image:</p>
+
+	<img src="%BASE_PATH%_assets/lena.jpg" alt="Sample image">
+</textarea>
+
+<div id="editor2" contenteditable="true" style="width: 500px">
+	<p>Sample image:</p>
+
+	<img src="%BASE_PATH%_assets/lena.jpg" alt="Sample image">
+</div>
+
+<script>
+	if ( CKEDITOR.env.ie && CKEDITOR.env.version === 8 ) {
+		bender.ignore();
+	}
+
+	CKEDITOR.disableAutoInline = true;
+
+	var config = {
+		height: 300,
+		width: 500,
+		on: {
+			instanceReady: function( evt ) {
+				evt.editor.balloonToolbars.create( {
+					buttons: 'Link,Unlink',
+					cssSelector: 'img'
+				} );
+			}
+		}
+	};
+
+	CKEDITOR.replace( 'editor1', config );
+	CKEDITOR.inline( 'editor2', config );
+
+</script>

--- a/tests/plugins/balloontoolbar/context/manual/imgselect.html
+++ b/tests/plugins/balloontoolbar/context/manual/imgselect.html
@@ -1,12 +1,3 @@
-<style>
-	body {
-		/* (#1048) */
-		margin-left: 0px;
-		padding-left: 400px;
-	}
-
-</style>
-
 <textarea id="editor1" cols="10" rows="10">
 	<p>Sample image:</p>
 
@@ -41,5 +32,4 @@
 
 	CKEDITOR.replace( 'editor1', config );
 	CKEDITOR.inline( 'editor2', config );
-
 </script>

--- a/tests/plugins/balloontoolbar/context/manual/imgselect.md
+++ b/tests/plugins/balloontoolbar/context/manual/imgselect.md
@@ -1,0 +1,15 @@
+@bender-ui: collapsed
+@bender-tags: 4.8.1, bug, balloontoolbar, 1274
+@bender-ckeditor-plugins: wysiwygarea, toolbar, undo, floatingspace, balloontoolbar, sourcearea, link, elementspath, image
+
+# Image Selection
+
+1. Select an image.
+
+## Expected
+
+Toolbar is shown.
+
+## Unexpected
+
+No toolbar is visible.

--- a/tests/plugins/balloontoolbar/context/manual/imgselect.md
+++ b/tests/plugins/balloontoolbar/context/manual/imgselect.md
@@ -1,5 +1,5 @@
 @bender-ui: collapsed
-@bender-tags: 4.8.1, bug, balloontoolbar, 1274
+@bender-tags: 4.8.1, bug, 1274, balloontoolbar
 @bender-ckeditor-plugins: wysiwygarea, toolbar, undo, floatingspace, balloontoolbar, sourcearea, link, elementspath, image
 
 # Image Selection
@@ -12,4 +12,4 @@ Toolbar is shown.
 
 ## Unexpected
 
-No toolbar is visible.
+No toolbar is not visible.


### PR DESCRIPTION
## What is the purpose of this pull request?

Bug fix

## Does your PR contain necessary tests?

All patches which change the editor code must include tests. You can always read more
on [PR testing](https://docs.ckeditor.com/ckeditor4/docs/#!/guide/dev_contributing_code-section-tests),
[how to set the testing environment](https://docs.ckeditor.com/ckeditor4/docs/#!/guide/dev_tests) and
[how to create tests](https://docs.ckeditor.com/ckeditor4/docs/#!/guide/dev_tests-section-creating-your-own-test)
in the official CKEditor documentation.

### This PR contains

- [x] Unit tests
- [x] Manual tests

## What changes did you make?

This PR fixes a case when fully selected element was not considered by [`contextDefinition.cssSelector`](https://docs.ckeditor.com/ckeditor4/docs/#!/api/CKEDITOR.plugins.balloontoolbar.contextDefinition-property-cssSelector) matchers.

Reason for this is that selection is being shrinked at the beginning of execution, so that probed path for selection like `foo [<em>bar</em>] baz` contains also `em` element.

Closes #1274.