### PR TITLE
Prevent image stretching in Easy Image

### DIFF
--- a/plugins/easyimage/plugin.js
+++ b/plugins/easyimage/plugin.js
@@ -115,7 +115,7 @@
 					},
 
 					img: {
-						attributes: '!src,srcset,alt'
+						attributes: '!src,srcset,alt,width,sizes'
 					}
 				},
 
@@ -197,10 +197,11 @@
 			},
 
 			onUploaded: function( upload ) {
-				var srcset = CKEDITOR.plugins.easyimage._parseSrcSet( upload.responseData.response );
+				var srcset = CKEDITOR.plugins.easyimage._parseSrcSet( upload.responseData.response ),
+					width = this.parts.img.$.naturalWidth;
 
 				this.replaceWith( '<figure class="' + ( editor.config.easyimage_class || '' ) + '"><img src="' +
-					upload.responseData.response[ 'default' ] + '" srcset="' + srcset + '" sizes="100vw"><figcaption></figcaption></figure>' );
+					upload.responseData.response[ 'default' ] + '" srcset="' + srcset + '" sizes="100vw" width="' + width + '"><figcaption></figcaption></figure>' );
 			}
 		};
 

--- a/tests/plugins/easyimage/manual/_helpers/tools.js
+++ b/tests/plugins/easyimage/manual/_helpers/tools.js
@@ -1,0 +1,42 @@
+/* exported getToken */
+/* global console */
+
+// WARNING: The URL below should not be used for any other purpose than Easy Image plugin development.
+// Images uploaded using the testing token service may be deleted automatically at any moment.
+// If you would like to try the Easy Image service, please wait until the official launch of Easy Image and sign up for a free trial.
+// Images uploaded during the free trial will not be deleted for the whole trial period and additionally the trial service can be converted
+// into a subscription at any moment, allowing you to preserve all uploaded images.
+var CLOUD_SERVICES_TOKEN_URL = 'https://j2sns7jmy0.execute-api.eu-central-1.amazonaws.com/prod/token';
+
+function getToken( callback ) {
+	function uid() {
+		var uuid = 'e'; // Make sure that id does not start with number.
+
+		for ( var i = 0; i < 8; i++ ) {
+			uuid += Math.floor( ( 1 + Math.random() ) * 0x10000 ).toString( 16 ).substring( 1 );
+		}
+
+		return uuid;
+	}
+
+	var xhr = new XMLHttpRequest(),
+		userId = uid();
+
+	xhr.open( 'GET', CLOUD_SERVICES_TOKEN_URL + '?user.id=' + userId );
+
+	xhr.onload = function() {
+		if ( xhr.status >= 200 && xhr.status < 300 ) {
+			var response = JSON.parse( xhr.responseText );
+
+			callback( response.token );
+		} else {
+			console.error( xhr.status );
+		}
+	};
+
+	xhr.onerror = function( error ) {
+		console.error( error );
+	};
+
+	xhr.send( null );
+}

--- a/tests/plugins/easyimage/manual/imagestretch.html
+++ b/tests/plugins/easyimage/manual/imagestretch.html
@@ -21,49 +21,10 @@
 	<p>Go on, put some content here.</p>
 </div>
 
+<script src="_helpers/tools.js"></script>
 <script>
 	if ( CKEDITOR.env.ie && CKEDITOR.env.version < 11 ) {
 		bender.ignore();
-	}
-
-	// WARNING: The URL below should not be used for any other purpose than Easy Image plugin development.
-	// Images uploaded using the testing token service may be deleted automatically at any moment.
-	// If you would like to try the Easy Image service, please wait until the official launch of Easy Image and sign up for a free trial.
-	// Images uploaded during the free trial will not be deleted for the whole trial period and additionally the trial service can be converted
-	// into a subscription at any moment, allowing you to preserve all uploaded images.
-	var CLOUD_SERVICES_TOKEN_URL = 'https://j2sns7jmy0.execute-api.eu-central-1.amazonaws.com/prod/token';
-
-	function getToken( callback ) {
-		function uid() {
-			var uuid = 'e'; // Make sure that id does not start with number.
-
-			for ( var i = 0; i < 8; i++ ) {
-				uuid += Math.floor( ( 1 + Math.random() ) * 0x10000 ).toString( 16 ).substring( 1 );
-			}
-
-			return uuid;
-		}
-
-		var xhr = new XMLHttpRequest(),
-			userId = uid();
-
-		xhr.open( 'GET', CLOUD_SERVICES_TOKEN_URL + '?user.id=' + userId );
-
-		xhr.onload = function() {
-			if ( xhr.status >= 200 && xhr.status < 300 ) {
-				var response = JSON.parse( xhr.responseText );
-
-				callback( response.token );
-			} else {
-				console.error( xhr.status );
-			}
-		};
-
-		xhr.onerror = function( error ) {
-			console.error( error );
-		}
-
-		xhr.send( null );
 	}
 
 	getToken( function( token ) {

--- a/tests/plugins/easyimage/manual/imagestretch.html
+++ b/tests/plugins/easyimage/manual/imagestretch.html
@@ -1,0 +1,81 @@
+<p>Note, this test uses a real Cloud Service connection, so you might want to be on-line 😉.</p>
+
+<h2>Classic editor</h2>
+
+<div id="classic">
+	<h1>Sample editor</h1>
+	<p>Go on, put some content here.</p>
+</div>
+
+<h2>Divarea editor</h2>
+
+<div id="divarea">
+	<h1>Sample editor</h1>
+	<p>Go on, put some content here.</p>
+</div>
+
+<h2>Inline editor</h2>
+
+<div id="inline" contenteditable="true">
+	<h1>Sample editor</h1>
+	<p>Go on, put some content here.</p>
+</div>
+
+<script>
+	if ( CKEDITOR.env.ie && CKEDITOR.env.version < 11 ) {
+		bender.ignore();
+	}
+
+	// WARNING: The URL below should not be used for any other purpose than Easy Image plugin development.
+	// Images uploaded using the testing token service may be deleted automatically at any moment.
+	// If you would like to try the Easy Image service, please wait until the official launch of Easy Image and sign up for a free trial.
+	// Images uploaded during the free trial will not be deleted for the whole trial period and additionally the trial service can be converted
+	// into a subscription at any moment, allowing you to preserve all uploaded images.
+	var CLOUD_SERVICES_TOKEN_URL = 'https://j2sns7jmy0.execute-api.eu-central-1.amazonaws.com/prod/token';
+
+	function getToken( callback ) {
+		function uid() {
+			var uuid = 'e'; // Make sure that id does not start with number.
+
+			for ( var i = 0; i < 8; i++ ) {
+				uuid += Math.floor( ( 1 + Math.random() ) * 0x10000 ).toString( 16 ).substring( 1 );
+			}
+
+			return uuid;
+		}
+
+		var xhr = new XMLHttpRequest(),
+			userId = uid();
+
+		xhr.open( 'GET', CLOUD_SERVICES_TOKEN_URL + '?user.id=' + userId );
+
+		xhr.onload = function() {
+			if ( xhr.status >= 200 && xhr.status < 300 ) {
+				var response = JSON.parse( xhr.responseText );
+
+				callback( response.token );
+			} else {
+				console.error( xhr.status );
+			}
+		};
+
+		xhr.onerror = function( error ) {
+			console.error( error );
+		}
+
+		xhr.send( null );
+	}
+
+	getToken( function( token ) {
+		var commonConfig = {
+				cloudServices_url: 'https://files.cke-cs.com/upload/',
+				cloudServices_token: token
+			};
+
+		CKEDITOR.replace( 'classic', commonConfig );
+		CKEDITOR.replace( 'divarea', CKEDITOR.tools.extend( {
+			extraPlugins: 'divarea'
+		}, commonConfig ) );
+		CKEDITOR.inline( 'inline', commonConfig );
+	} );
+</script>

--- a/tests/plugins/easyimage/manual/imagestretch.md
+++ b/tests/plugins/easyimage/manual/imagestretch.md
@@ -1,0 +1,15 @@
+@bender-tags: 4.9.0, feature, 932, tp3301
+@bender-ui: collapsed
+@bender-ckeditor-plugins: sourcearea, wysiwygarea, floatingspace, toolbar, easyimage
+
+## Easy Image Upload
+
+Upload some small image, e.g. [`foo.png`](%BASE_PATH%plugins/image2/_assets/foo.png).
+
+### Expected
+
+Image has its natural dimensions.
+
+### Unexpected
+
+Image is stretched to fill whole editor's width.

--- a/tests/plugins/easyimage/manual/upload.html
+++ b/tests/plugins/easyimage/manual/upload.html
@@ -21,49 +21,10 @@
 	<p>Go on, put some content here.</p>
 </div>
 
+<script src="_helpers/tools.js"></script>
 <script>
 	if ( CKEDITOR.env.ie && CKEDITOR.env.version < 11 ) {
 		bender.ignore();
-	}
-
-	// WARNING: The URL below should not be used for any other purpose than Easy Image plugin development.
-	// Images uploaded using the testing token service may be deleted automatically at any moment.
-	// If you would like to try the Easy Image service, please wait until the official launch of Easy Image and sign up for a free trial.
-	// Images uploaded during the free trial will not be deleted for the whole trial period and additionally the trial service can be converted
-	// into a subscription at any moment, allowing you to preserve all uploaded images.
-	var CLOUD_SERVICES_TOKEN_URL = 'https://j2sns7jmy0.execute-api.eu-central-1.amazonaws.com/prod/token';
-
-	function getToken( callback ) {
-		function uid() {
-			var uuid = 'e'; // Make sure that id does not start with number.
-
-			for ( var i = 0; i < 8; i++ ) {
-				uuid += Math.floor( ( 1 + Math.random() ) * 0x10000 ).toString( 16 ).substring( 1 );
-			}
-
-			return uuid;
-		}
-
-		var xhr = new XMLHttpRequest(),
-			userId = uid();
-
-		xhr.open( 'GET', CLOUD_SERVICES_TOKEN_URL + '?user.id=' + userId );
-
-		xhr.onload = function() {
-			if ( xhr.status >= 200 && xhr.status < 300 ) {
-				var response = JSON.parse( xhr.responseText );
-
-				callback( response.token );
-			} else {
-				console.error( xhr.status );
-			}
-		};
-
-		xhr.onerror = function( error ) {
-			console.error( error );
-		}
-
-		xhr.send( null );
 	}
 
 	getToken( function( token ) {

--- a/tests/plugins/easyimage/uploadwidget.js
+++ b/tests/plugins/easyimage/uploadwidget.js
@@ -12,7 +12,7 @@
 		DATA_IMG = 'data:',
 		BLOB_IMG = 'blob:',
 		WIDGET_HTML = '<figure class="easyimage">' +
-				'<img src="' + IMG_URL + '" srcset="' + IMG_URL + ' 100w, ' + IMG_URL + ' 200w" />' +
+				'<img src="' + IMG_URL + '" srcset="' + IMG_URL + ' 100w, ' + IMG_URL + ' 200w" sizes="100vw" width="1" />' +
 				'<figcaption></figcaption>' +
 			'</figure>',
 		commonConfig = {
@@ -141,7 +141,7 @@
 				loader.url = IMG_URL;
 				loader.changeStatus( 'uploaded' );
 
-				assert.sameData( WIDGET_HTML, editor.getData() );
+				assert.beautified.html( WIDGET_HTML, editor.getData() );
 				assert.areSame( 1, editor.editable().find( '[data-widget="easyimage"]' ).count(), 'Easy Image widgets count' );
 
 				assert.areSame( 0, loadAndUploadCount );
@@ -170,7 +170,7 @@
 					loader.url = IMG_URL;
 					loader.changeStatus( 'uploaded' );
 
-					assert.sameData( '<p>x</p>' + WIDGET_HTML + '<p>x</p>', editor.getData() );
+					assert.beautified.html( '<p>x</p>' + WIDGET_HTML + '<p>x</p>', editor.getData() );
 					assert.areSame( 1, editor.editable().find( '[data-widget="easyimage"]' ).count() );
 
 					assert.areSame( 0, loadAndUploadCount );


### PR DESCRIPTION
## What is the purpose of this pull request?

Bug fix

## Does your PR contain necessary tests?

All patches which change the editor code must include tests. You can always read more
on [PR testing](https://docs.ckeditor.com/ckeditor4/docs/#!/guide/dev_contributing_code-section-tests),
[how to set the testing environment](https://docs.ckeditor.com/ckeditor4/docs/#!/guide/dev_tests) and
[how to create tests](https://docs.ckeditor.com/ckeditor4/docs/#!/guide/dev_tests-section-creating-your-own-test)
in the official CKEditor documentation.

### This PR contains

- [x] Unit tests
- [x] Manual tests

## What changes did you make?

I've added `[width]` attribute with natural dimensions of the image to the widget, which prevents stretching image if it's too small to fit editor's width.
