### PR TITLE
Certain Easy Image commands should force selection check

### DIFF
--- a/plugins/easyimage/plugin.js
+++ b/plugins/easyimage/plugin.js
@@ -33,7 +33,7 @@
 			};
 		}
 
-		function createCommand( exec, refreshCheck ) {
+		function createCommand( exec, refreshCheck, forceSelectionCheck ) {
 			return {
 				startDisabled: true,
 				contextSensitive: true,
@@ -43,9 +43,12 @@
 
 					exec( widget );
 
-					// We have to manually force refresh commands as refresh seems
-					// to be executed prior to exec.
-					editor.forceNextSelectionCheck();
+					if ( forceSelectionCheck ) {
+						// We have to manually force refresh commands as refresh seems to be executed prior to exec.
+						// Without this command states would be outdated.
+						editor.forceNextSelectionCheck();
+						editor.selectionChange( true );
+					}
 				},
 
 				refresh: createCommandRefresh( refreshCheck )
@@ -56,13 +59,13 @@
 			widget.setData( 'type', 'full' );
 		}, function( widget ) {
 			return isFullImage( widget );
-		} ) );
+		}, true ) );
 
 		editor.addCommand( 'easyimageSide', createCommand( function( widget ) {
 			widget.setData( 'type', 'side' );
 		}, function( widget ) {
 			return isSideImage( widget );
-		} ) );
+		}, true ) );
 
 		editor.addCommand( 'easyimageAlt', new CKEDITOR.dialogCommand( 'easyimageAlt', {
 			startDisabled: true,
@@ -183,9 +186,6 @@
 					} else {
 						this.removeClass( editor.config.easyimage_sideClass );
 					}
-
-					editor.getCommand( 'easyimageFull' ).refresh( editor );
-					editor.getCommand( 'easyimageSide' ).refresh( editor );
 				}
 			};
 


### PR DESCRIPTION
## What is the purpose of this pull request?

Pull Request corrections

## Does your PR contain necessary tests?

All patches which change the editor code must include tests. You can always read more
on [PR testing](https://docs.ckeditor.com/ckeditor4/docs/#!/guide/dev_contributing_code-section-tests),
[how to set the testing environment](https://docs.ckeditor.com/ckeditor4/docs/#!/guide/dev_tests) and
[how to create tests](https://docs.ckeditor.com/ckeditor4/docs/#!/guide/dev_tests-section-creating-your-own-test)
in the official CKEditor documentation.

### This PR contains

- [x] Unit tests
- [x] Manual tests

(both tests wre developed in original PR, and are still valid)

## What changes did you make?

This PR contains coorections to the #1382 PR.

There was one aspect that keept bugging me in the original solution: https://github.com/ckeditor/ckeditor-dev/pull/1382#discussion_r158825176

I took a look on it, and the solution was rather simple.

You see, so far in [widget.data method we're adding/removnig CSS classes](https://github.com/ckeditor/ckeditor-dev/blob/60143a3/plugins/easyimage/plugin.js#L184-L188) which is not recognized as "selection modification", as we have the selection still in the same element. So editor sees no difference in DOM after executing the command, thus not updating commands state.

As a result after applying a "full image" command, we're left with outdated command state.