### PR TITLE
Set a relative path to images sprite for Kama skin in balloon toolbar

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -17,6 +17,7 @@ Fixed Issues:
 * [#859](https://github.com/ckeditor/ckeditor-dev/issues/859): Fixed: Can't edit link after double click on text in link.
 * [#1013](https://github.com/ckeditor/ckeditor-dev/issues/1013): Fixed: [Paste from Word](https://ckeditor.com/cke4/addon/pastefromword) does not work correctly with [`config.forcePasteAsPlainText`](https://docs.ckeditor.com/ckeditor4/docs/#!/api/CKEDITOR.config-cfg-forcePasteAsPlainText) property.
 * [#1356](https://github.com/ckeditor/ckeditor-dev/issues/1356): Fixed: [Border parse function](https://docs.ckeditor.com/ckeditor4/docs/#!/api/CKEDITOR.tools.style.parse-method-border) should allow spaces in the color value.
+* [#1426](https://github.com/ckeditor/ckeditor-dev/issues/1426): [IE8-9] Fixed: Missing balloon toolbar background in Kama skin. Thanks to [Christian Elmer](https://github.com/keinkurt)!
 
 ## CKEditor 4.8
 

--- a/plugins/balloontoolbar/skins/kama/balloontoolbar.css
+++ b/plugins/balloontoolbar/skins/kama/balloontoolbar.css
@@ -6,7 +6,7 @@ For licensing, see LICENSE.md or http://ckeditor.com/license
 .cke_balloon.cke_balloontoolbar
 {
 	border: 1px solid #D3D3D3;
-	background: #fff url(images/sprites.png) repeat-x 0 -500px;
+	background: #fff url(../../../../skins/kama/images/sprites.png) repeat-x 0 -500px;
 	background: linear-gradient(to bottom, #fff, #d3d3d3 20px);
 	padding: 0px;
 }

--- a/plugins/balloontoolbar/skins/kama/balloontoolbar.css
+++ b/plugins/balloontoolbar/skins/kama/balloontoolbar.css
@@ -6,7 +6,7 @@ For licensing, see LICENSE.md or http://ckeditor.com/license
 .cke_balloon.cke_balloontoolbar
 {
 	border: 1px solid #D3D3D3;
-	background: #fff url(../../../../skins/kama/images/sprites.png) repeat-x 0 -500px;
+	background: #fff url(../../../../skins/kama/images/sprites.png) repeat-x 0 -150px;
 	background: linear-gradient(to bottom, #fff, #d3d3d3 20px);
 	padding: 0px;
 }


### PR DESCRIPTION
## What is the purpose of this pull request?

Fix issue if automated static file collection process the ballontoolbar.css and doesn't find sprites.png

## Does your PR contain necessary tests?

No.

### This PR contains

- [ ] Unit tests
- [ ] Manual tests

## What changes did you make?

Correct path to image file. Same like https://github.com/ckeditor/ckeditor-dev/commit/65f487e20f4a73c8cc45d314b4dab856d1b1ecd5

 Closes #1426.