### PR TITLE
Corrections to Easy Image stretching issue

### DIFF
--- a/plugins/easyimage/plugin.js
+++ b/plugins/easyimage/plugin.js
@@ -216,8 +216,11 @@
 					widget = this;
 
 				getNaturalWidth( widget.parts.img, function( width ) {
-					widget.replaceWith( '<figure class="' + ( editor.config.easyimage_class || '' ) + '"><img src="' +
-					upload.responseData.response[ 'default' ] + '" srcset="' + srcset + '" sizes="100vw" width="' + width + '"><figcaption></figcaption></figure>' );
+					widget.replaceWith( '<figure class="' + ( editor.config.easyimage_class || '' ) + '">' +
+							'<img src="' + upload.responseData.response[ 'default' ] + '" srcset="' + srcset +
+								'" sizes="100vw" width="' + width + '">' +
+							'<figcaption></figcaption>' +
+						'</figure>' );
 				} );
 			}
 		};


### PR DESCRIPTION
## What is the purpose of this pull request?

Review Corrections

### This PR contains

- [x] Unit tests
- [x] Manual tests

## What changes did you make?

The original PR did not contain a TC for case desribed in review: https://github.com/ckeditor/ckeditor-dev/pull/1387#pullrequestreview-85952913

We can't skip unit tests for that, as otherwise it could come back at some point, and it was critical for IE11, Edge and Safari.

This PR contains fixes to Easy Image upload widget test suite, it also contains a fix for widget image src testing, as the former test was just checking a part of it.

Also reformatted HTML in `getNaturalWidth` callback, to be a bit more readable.