### PR TITLE
Fixed bug with parsing border colors

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -16,6 +16,7 @@ Fixed Issues:
 * [#889](https://github.com/ckeditor/ckeditor-dev/issues/889): Fixed: Unclear error message for width and height fields in [Image](https://ckeditor.com/cke4/addon/image) and [Enhanced Image](https://ckeditor.com/cke4/addon/image2) plugins.
 * [#859](https://github.com/ckeditor/ckeditor-dev/issues/859): Fixed: Can't edit link after double click on text in link.
 * [#1013](https://github.com/ckeditor/ckeditor-dev/issues/1013): Fixed: [Paste from Word](https://ckeditor.com/cke4/addon/pastefromword) does not work correctly with [`config.forcePasteAsPlainText`](https://docs.ckeditor.com/ckeditor4/docs/#!/api/CKEDITOR.config-cfg-forcePasteAsPlainText) property.
+* [#1356](https://github.com/ckeditor/ckeditor-dev/issues/1356): Fixed: [Border parse function](https://docs.ckeditor.com/ckeditor4/docs/#!/api/CKEDITOR.tools.style.parse-method-border) should allow spaces in the color value.
 
 ## CKEditor 4.8
 

--- a/core/tools.js
+++ b/core/tools.js
@@ -1877,7 +1877,9 @@
 				 */
 				border: function( value ) {
 					var ret = {},
-						input = value.split( /\s+/ );
+						// remove every white space after comma from color eg. rbg(10, 20, 30, .75)
+						trimmedValue = value.replace( /,\s+/g, ',' ),
+						input = trimmedValue.split( /\s+/ );
 
 					CKEDITOR.tools.array.forEach( input, function( val ) {
 						if ( !ret.color ) {

--- a/core/tools.js
+++ b/core/tools.js
@@ -1877,7 +1877,7 @@
 				 */
 				border: function( value ) {
 					var ret = {},
-						// remove every white space after comma from color eg. rbg(10, 20, 30, .75)
+						// Remove every white space after comma from color eg. rbg(10, 20, 30, .75) to rbg(10,20,30,.75).
 						trimmedValue = value.replace( /,\s+/g, ',' ),
 						input = trimmedValue.split( /\s+/ );
 

--- a/core/tools.js
+++ b/core/tools.js
@@ -1877,11 +1877,11 @@
 				 */
 				border: function( value ) {
 					var ret = {},
-						input = value.split( /\s+/g );
+						input = value.split( /\s+/g ),
+						parseColor = CKEDITOR.tools.style.parse._findColor( value );
 
-					var parseColor = CKEDITOR.tools.style.parse._findColor( value );
 					if ( parseColor.length ) {
-						ret.color = parseColor[0];
+						ret.color = parseColor[ 0 ];
 					}
 
 					CKEDITOR.tools.array.forEach( input, function( val ) {

--- a/tests/core/tools/style.js
+++ b/tests/core/tools/style.js
@@ -168,6 +168,10 @@
 
 		'test style.parse.border with style and hsla color': function() {
 			objectAssert.areEqual( { style: 'dotted', color: 'hsla(10,30%,30%,1)' }, CKEDITOR.tools.style.parse.border( 'dotted hsla(10,30%,30%,1)' ) );
+		},
+
+		'test style.parse.border with color white spaces': function() {
+			objectAssert.areEqual( { style: 'solid', color: 'rgba(10,20,30,.75)', width: '1px' }, CKEDITOR.tools.style.parse.border( '1px solid rgba(10,  20, 30,  .75)' ) );
 		}
 
 	} );

--- a/tests/core/tools/style.js
+++ b/tests/core/tools/style.js
@@ -171,7 +171,7 @@
 		},
 
 		'test style.parse.border with color white spaces': function() {
-			objectAssert.areEqual( { style: 'solid', color: 'rgba(10,20,30,.75)', width: '1px' }, CKEDITOR.tools.style.parse.border( '1px solid rgba(10,  20, 30,  .75)' ) );
+			objectAssert.areEqual( { style: 'solid', color: 'rgba(10,20,30,.75)', width: '1px' }, CKEDITOR.tools.style.parse.border( '1px solid rgba(10, 20, 30, .75)' ) );
 		}
 
 	} );


### PR DESCRIPTION
## What is the purpose of this pull request?

Bug fix

## Does your PR contain necessary tests?

All patches which change the editor code must include tests. You can always read more
on [PR testing](https://docs.ckeditor.com/ckeditor4/docs/#!/guide/dev_contributing_code-section-tests),
[how to set the testing environment](https://docs.ckeditor.com/ckeditor4/docs/#!/guide/dev_tests) and
[how to create tests](https://docs.ckeditor.com/ckeditor4/docs/#!/guide/dev_tests-section-creating-your-own-test)
in the official CKEditor documentation.

### This PR contains

- [x] Unit tests
- [ ] Manual tests

## What changes did you make?

Added regex to remove whitespaces from color model syntax to CKEDITOR.tools.style.parse.border() function.

Closes #1356

#1356: Fixed: [Border shorthand converter](https://docs.ckeditor.com/ckeditor4/docs/#!/api/CKEDITOR.tools.style.parse-method-border) should allow on space in color.