### PR TITLE
Fix exception thrown by removing link with data callback after

### DIFF
--- a/plugins/imagebase/plugin.js
+++ b/plugins/imagebase/plugin.js
@@ -175,6 +175,9 @@
 				if ( link === null ) {
 					this.parts.link.remove( true );
 					this.parts.link = null;
+
+					// Reset link state (#tp3298).
+					delete evt.data.link;
 				} else {
 					this.parts.link = createLink( editor, img, link );
 				}

--- a/tests/plugins/imagebase/features/link.js
+++ b/tests/plugins/imagebase/features/link.js
@@ -85,7 +85,7 @@
 		widget = assertLinkWidgetStatus( options );
 
 		assert.isNull( widget.parts.link, 'Widget does not have link part' );
-		assert.isNull( widget.data.link, 'Widget does not have link data' );
+		assert.isUndefined( widget.data.link, 'Widget does not have link data' );
 	}
 
 	function testLinkCommand( options ) {
@@ -410,6 +410,33 @@
 				}
 			} );
 		},
+
+		// #tp3298
+		'test unlink with data callback after it': function( editor, bot ) {
+			addTestWidget( editor );
+
+			testUnlinkCommand( {
+				bot: bot,
+				html: '<figure><a href="http://foo"><img src="%BASE_PATH%_assets/logo.png"></a></figure>',
+
+				callback: function( evt, widget ) {
+					assertUnlinkWidget( {
+						widget: widget,
+						editor: editor
+					} );
+
+					widget.once( 'data', function( evt ) {
+						resume( function() {
+							assert.isUndefined( evt.data.link, 'link data type' );
+						} );
+					} );
+
+					widget.setData( 'test', '' );
+					wait();
+				}
+			} );
+		},
+
 		'test link option in context menu': function( editor, bot ) {
 			testLinkOptionInContextMenu( editor, bot, '<figure><a href="http://foo"><img src="%BASE_PATH%_assets/logo.png"></a></figure>', function( editor, index ) {
 				return editor.contextMenu.items[ index ].command == 'link';

--- a/tests/plugins/imagebase/features/link.js
+++ b/tests/plugins/imagebase/features/link.js
@@ -420,11 +420,6 @@
 				html: '<figure><a href="http://foo"><img src="%BASE_PATH%_assets/logo.png"></a></figure>',
 
 				callback: function( evt, widget ) {
-					assertUnlinkWidget( {
-						widget: widget,
-						editor: editor
-					} );
-
 					widget.once( 'data', function( evt ) {
 						resume( function() {
 							assert.isUndefined( evt.data.link, 'link data type' );

--- a/tests/plugins/imagebase/features/link.js
+++ b/tests/plugins/imagebase/features/link.js
@@ -412,7 +412,7 @@
 		},
 
 		// #tp3298
-		'test unlink with data callback after it': function( editor, bot ) {
+		'test calling setData after unlink keeps correct data.link': function( editor, bot ) {
 			addTestWidget( editor );
 
 			testUnlinkCommand( {


### PR DESCRIPTION
## What is the purpose of this pull request?

Bug fix

## Does your PR contain necessary tests?

All patches which change the editor code must include tests. You can always read more
on [PR testing](https://docs.ckeditor.com/ckeditor4/docs/#!/guide/dev_contributing_code-section-tests),
[how to set the testing environment](https://docs.ckeditor.com/ckeditor4/docs/#!/guide/dev_tests) and
[how to create tests](https://docs.ckeditor.com/ckeditor4/docs/#!/guide/dev_tests-section-creating-your-own-test)
in the official CKEditor documentation.

### This PR contains

- [x] Unit tests
- [ ] Manual tests

## What changes did you make?

I forced reset of link state from `null` to `undefined`.
