### PR TITLE
Fixed required attribute not being correctly recognized by form dialog

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -8,7 +8,7 @@ Fixed Issues:
 * [#1181](https://github.com/ckeditor/ckeditor-dev/issues/1181): [Chrome] Fixed: Opening context menu in readonly editor results in error.
 * [#2276](https://github.com/ckeditor/ckeditor-dev/issues/2276): [iOS] Fixed: [Button](https://ckeditor.com/cke4/addon/button) state doesn't refresh properly.
 * [#1489](https://github.com/ckeditor/ckeditor-dev/issues/1489): Fixed: [Table Selection](https://docs.ckeditor.com/ckeditor4/latest/api/CKEDITOR_plugins_tableselection.html) table contents can be removed in readonly mode.
-* [#586](https://github.com/ckeditor/ckeditor-dev/issues/586) Fixed: required attribute not being correctly recognized by form dialog.
+* [#586](https://github.com/ckeditor/ckeditor-dev/issues/586) Fixed: required attribute not being correctly recognized by form dialog. Thanks to [Roli Züger](https://github.com/rzueger)!
 
 API Changes:
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -8,6 +8,7 @@ Fixed Issues:
 * [#1181](https://github.com/ckeditor/ckeditor-dev/issues/1181): [Chrome] Fixed: Opening context menu in readonly editor results in error.
 * [#2276](https://github.com/ckeditor/ckeditor-dev/issues/2276): [iOS] Fixed: [Button](https://ckeditor.com/cke4/addon/button) state doesn't refresh properly.
 * [#1489](https://github.com/ckeditor/ckeditor-dev/issues/1489): Fixed: [Table Selection](https://docs.ckeditor.com/ckeditor4/latest/api/CKEDITOR_plugins_tableselection.html) table contents can be removed in readonly mode.
+* [#586](https://github.com/ckeditor/ckeditor-dev/issues/586) Fixed: required attribute not being correctly recognized by form dialog.
 
 API Changes:
 

--- a/plugins/forms/dialogs/checkbox.js
+++ b/plugins/forms/dialogs/checkbox.js
@@ -137,7 +137,7 @@ CKEDITOR.dialog.add( 'checkbox', function( editor ) {
 				'default': '',
 				accessKey: 'Q',
 				value: 'required',
-				setup: CKEDITOR.plugins.forms._setupFormDialogRequired,
+				setup: CKEDITOR.plugins.forms._setupRequiredAttribute,
 				commit: function( data ) {
 					var element = data.element;
 					if ( this.getValue() )

--- a/plugins/forms/dialogs/checkbox.js
+++ b/plugins/forms/dialogs/checkbox.js
@@ -137,10 +137,7 @@ CKEDITOR.dialog.add( 'checkbox', function( editor ) {
 				'default': '',
 				accessKey: 'Q',
 				value: 'required',
-				setup: function( element ) {
-					var required = element.getAttribute( 'required' );
-					this.setValue( required === '' || required === 'required' );
-				},
+				setup: CKEDITOR.plugins.forms._setupFormDialogRequired,
 				commit: function( data ) {
 					var element = data.element;
 					if ( this.getValue() )

--- a/plugins/forms/dialogs/checkbox.js
+++ b/plugins/forms/dialogs/checkbox.js
@@ -138,7 +138,8 @@ CKEDITOR.dialog.add( 'checkbox', function( editor ) {
 				accessKey: 'Q',
 				value: 'required',
 				setup: function( element ) {
-					this.setValue( element.getAttribute( 'required' ) );
+					var required = element.getAttribute( 'required' );
+					this.setValue( required === '' || required === 'required' );
 				},
 				commit: function( data ) {
 					var element = data.element;

--- a/plugins/forms/dialogs/radio.js
+++ b/plugins/forms/dialogs/radio.js
@@ -125,7 +125,7 @@ CKEDITOR.dialog.add( 'radio', function( editor ) {
 				'default': '',
 				accessKey: 'Q',
 				value: 'required',
-				setup: CKEDITOR.plugins.forms._setupFormDialogRequired,
+				setup: CKEDITOR.plugins.forms._setupRequiredAttribute,
 				commit: function( data ) {
 					var element = data.element;
 					if ( this.getValue() )

--- a/plugins/forms/dialogs/radio.js
+++ b/plugins/forms/dialogs/radio.js
@@ -126,7 +126,8 @@ CKEDITOR.dialog.add( 'radio', function( editor ) {
 				accessKey: 'Q',
 				value: 'required',
 				setup: function( element ) {
-					this.setValue( element.getAttribute( 'required' ) );
+					var required = element.getAttribute( 'required' );
+					this.setValue( required === '' || required === 'required' );
 				},
 				commit: function( data ) {
 					var element = data.element;

--- a/plugins/forms/dialogs/radio.js
+++ b/plugins/forms/dialogs/radio.js
@@ -125,10 +125,7 @@ CKEDITOR.dialog.add( 'radio', function( editor ) {
 				'default': '',
 				accessKey: 'Q',
 				value: 'required',
-				setup: function( element ) {
-					var required = element.getAttribute( 'required' );
-					this.setValue( required === '' || required === 'required' );
-				},
+				setup: CKEDITOR.plugins.forms._setupFormDialogRequired,
 				commit: function( data ) {
 					var element = data.element;
 					if ( this.getValue() )

--- a/plugins/forms/dialogs/select.js
+++ b/plugins/forms/dialogs/select.js
@@ -490,8 +490,10 @@ CKEDITOR.dialog.add( 'select', function( editor ) {
 						accessKey: 'Q',
 						value: 'checked',
 						setup: function( name, element ) {
-							if ( name == 'select' )
-								this.setValue( element.getAttribute( 'required' ) );
+							if ( name == 'select' ) {
+								var required = element.getAttribute( 'required' );
+								this.setValue( required === '' || required === 'required' );
+							}
 						},
 						commit: function( element ) {
 							if ( this.getValue() )

--- a/plugins/forms/dialogs/select.js
+++ b/plugins/forms/dialogs/select.js
@@ -491,7 +491,7 @@ CKEDITOR.dialog.add( 'select', function( editor ) {
 						value: 'checked',
 						setup: function( name, element ) {
 							if ( name == 'select' ) {
-								CKEDITOR.plugins.forms._setupFormDialogRequired.call( this, element );
+								CKEDITOR.plugins.forms._setupRequiredAttribute.call( this, element );
 							}
 						},
 						commit: function( element ) {

--- a/plugins/forms/dialogs/select.js
+++ b/plugins/forms/dialogs/select.js
@@ -491,8 +491,7 @@ CKEDITOR.dialog.add( 'select', function( editor ) {
 						value: 'checked',
 						setup: function( name, element ) {
 							if ( name == 'select' ) {
-								var required = element.getAttribute( 'required' );
-								this.setValue( required === '' || required === 'required' );
+								CKEDITOR.plugins.forms._setupFormDialogRequired.call( this, element );
 							}
 						},
 						commit: function( element ) {

--- a/plugins/forms/dialogs/textarea.js
+++ b/plugins/forms/dialogs/textarea.js
@@ -113,7 +113,7 @@ CKEDITOR.dialog.add( 'textarea', function( editor ) {
 				'default': '',
 				accessKey: 'Q',
 				value: 'required',
-				setup: CKEDITOR.plugins.forms._setupFormDialogRequired,
+				setup: CKEDITOR.plugins.forms._setupRequiredAttribute,
 				commit: function( element ) {
 					if ( this.getValue() )
 						element.setAttribute( 'required', 'required' );

--- a/plugins/forms/dialogs/textarea.js
+++ b/plugins/forms/dialogs/textarea.js
@@ -113,10 +113,7 @@ CKEDITOR.dialog.add( 'textarea', function( editor ) {
 				'default': '',
 				accessKey: 'Q',
 				value: 'required',
-				setup: function( element ) {
-					var required = element.getAttribute( 'required' );
-					this.setValue( required === '' || required === 'required' );
-				},
+				setup: CKEDITOR.plugins.forms._setupFormDialogRequired,
 				commit: function( element ) {
 					if ( this.getValue() )
 						element.setAttribute( 'required', 'required' );

--- a/plugins/forms/dialogs/textarea.js
+++ b/plugins/forms/dialogs/textarea.js
@@ -114,7 +114,8 @@ CKEDITOR.dialog.add( 'textarea', function( editor ) {
 				accessKey: 'Q',
 				value: 'required',
 				setup: function( element ) {
-					this.setValue( element.getAttribute( 'required' ) );
+					var required = element.getAttribute( 'required' );
+					this.setValue( required === '' || required === 'required' );
 				},
 				commit: function( element ) {
 					if ( this.getValue() )

--- a/plugins/forms/dialogs/textfield.js
+++ b/plugins/forms/dialogs/textfield.js
@@ -178,7 +178,8 @@ CKEDITOR.dialog.add( 'textfield', function( editor ) {
 				accessKey: 'Q',
 				value: 'required',
 				setup: function( element ) {
-					this.setValue( element.getAttribute( 'required' ) );
+					var required = element.getAttribute( 'required' );
+					this.setValue( required === '' || required === 'required' );
 				},
 				commit: function( data ) {
 					var element = data.element;

--- a/plugins/forms/dialogs/textfield.js
+++ b/plugins/forms/dialogs/textfield.js
@@ -177,7 +177,7 @@ CKEDITOR.dialog.add( 'textfield', function( editor ) {
 				'default': '',
 				accessKey: 'Q',
 				value: 'required',
-				setup: CKEDITOR.plugins.forms._setupFormDialogRequired,
+				setup: CKEDITOR.plugins.forms._setupRequiredAttribute,
 				commit: function( data ) {
 					var element = data.element;
 					if ( this.getValue() )

--- a/plugins/forms/dialogs/textfield.js
+++ b/plugins/forms/dialogs/textfield.js
@@ -177,10 +177,7 @@ CKEDITOR.dialog.add( 'textfield', function( editor ) {
 				'default': '',
 				accessKey: 'Q',
 				value: 'required',
-				setup: function( element ) {
-					var required = element.getAttribute( 'required' );
-					this.setValue( required === '' || required === 'required' );
-				},
+				setup: CKEDITOR.plugins.forms._setupFormDialogRequired,
 				commit: function( data ) {
 					var element = data.element;
 					if ( this.getValue() )

--- a/plugins/forms/plugin.js
+++ b/plugins/forms/plugin.js
@@ -288,7 +288,8 @@ CKEDITOR.plugins.add( 'forms', {
  */
 CKEDITOR.plugins.forms = {
 	/**
-	* Sets dialog required value.
+	* Sets dialogs 'required' value to match presence of 'required' attribute on element.
+	* Based on algorithm described in specification.
 	*
 	* @since 4.10.2
 	* @private

--- a/plugins/forms/plugin.js
+++ b/plugins/forms/plugin.js
@@ -286,7 +286,6 @@ CKEDITOR.plugins.forms = {
 	* @param {CKEDITOR.dom.element} element Element which required attribute is checked.
 	* */
 	_setupFormDialogRequired: function( element ) {
-		var required = element.getAttribute( 'required' );
-		this.setValue( required === '' || required === 'required' );
+		this.setValue( element.hasAttribute( 'required' ) );
 	}
 };

--- a/plugins/forms/plugin.js
+++ b/plugins/forms/plugin.js
@@ -278,13 +278,22 @@ CKEDITOR.plugins.add( 'forms', {
 	}
 } );
 
+/**
+ * Namespace containing helper functions for Forms Plugin.
+ *
+ * @since 4.10.2
+ * @private
+ * @singleton
+ * @class CKEDITOR.plugins.forms
+ */
 CKEDITOR.plugins.forms = {
-	/*
-	* Private helper function for setting dialog required value.
+	/**
+	* Sets dialog required value.
 	*
+	* @since 4.10.2
 	* @private
-	* @param {CKEDITOR.dom.element} element Element which required attribute is checked.
-	* */
+	* @param {CKEDITOR.dom.element} element An element which required attribute is checked.
+	*/
 	_setupFormDialogRequired: function( element ) {
 		this.setValue( element.hasAttribute( 'required' ) );
 	}

--- a/plugins/forms/plugin.js
+++ b/plugins/forms/plugin.js
@@ -277,3 +277,16 @@ CKEDITOR.plugins.add( 'forms', {
 		}
 	}
 } );
+
+CKEDITOR.plugins.forms = {
+	/*
+	* Private helper function for setting dialog required value.
+	*
+	* @private
+	* @param {CKEDITOR.dom.element} element Element which required attribute is checked.
+	* */
+	_setupFormDialogRequired: function( element ) {
+		var required = element.getAttribute( 'required' );
+		this.setValue( required === '' || required === 'required' );
+	}
+};

--- a/plugins/forms/plugin.js
+++ b/plugins/forms/plugin.js
@@ -294,7 +294,7 @@ CKEDITOR.plugins.forms = {
 	* @private
 	* @param {CKEDITOR.dom.element} element An element which required attribute is checked.
 	*/
-	_setupFormDialogRequired: function( element ) {
+	_setupRequiredAttribute: function( element ) {
 		this.setValue( element.hasAttribute( 'required' ) );
 	}
 };

--- a/plugins/forms/plugin.js
+++ b/plugins/forms/plugin.js
@@ -282,18 +282,17 @@ CKEDITOR.plugins.add( 'forms', {
  * Namespace containing helper functions for Forms Plugin.
  *
  * @since 4.10.2
- * @private
  * @singleton
  * @class CKEDITOR.plugins.forms
  */
 CKEDITOR.plugins.forms = {
 	/**
-	* Sets dialogs 'required' value to match presence of 'required' attribute on element.
-	* Based on algorithm described in specification.
+	* Sets dialogs `required` value to match presence of `required` attribute on element.
+	* Based on [algorithm described in HTML specification](https://html.spec.whatwg.org/multipage/common-microsyntaxes.html#boolean-attribute).
 	*
 	* @since 4.10.2
 	* @private
-	* @param {CKEDITOR.dom.element} element An element which required attribute is checked.
+	* @param {CKEDITOR.dom.element} element An element which `required` attribute is checked.
 	*/
 	_setupRequiredAttribute: function( element ) {
 		this.setValue( element.hasAttribute( 'required' ) );

--- a/tests/plugins/forms/_helpers/tools.js
+++ b/tests/plugins/forms/_helpers/tools.js
@@ -2,7 +2,7 @@
 	'use strict';
 	window.formsTools = {
 		/**
-		 * Asserts required attribute of an form element.
+		 * Asserts 'required' attribute of a form element.
 		 *
 		 * @param {Object} setup Test setup object
 		 * @param {String} setup.html Html string to be set as editor data

--- a/tests/plugins/forms/_helpers/tools.js
+++ b/tests/plugins/forms/_helpers/tools.js
@@ -1,0 +1,25 @@
+( function() {
+	'use strict';
+	window.formsTools = {
+		/**
+		 * Asserts required attribute of an form element.
+		 *
+		 * @param {Object} setup Test setup object
+		 * @param {String} setup.html Html string to be set as editor data
+		 * @param {String} setup.type Type of tested form element
+		 * @param {Boolean} setup.expected Whenever form dialog should have required field selected
+		 * */
+		assertRequiredAttribute: function( setup ) {
+			return function() {
+				var bot = this.editorBot;
+
+				bot.setHtmlWithSelection( setup.html );
+
+				bot.dialog( setup.type, function( dialog ) {
+					assert[ setup.expected ? 'isTrue' : 'isFalse' ]( dialog.getValueOf( 'info', 'required' ) );
+					dialog.destroy();
+				} );
+			};
+		}
+	};
+} )();

--- a/tests/plugins/forms/_helpers/tools.js
+++ b/tests/plugins/forms/_helpers/tools.js
@@ -4,10 +4,10 @@
 		/**
 		 * Asserts 'required' attribute of a form element.
 		 *
-		 * @param {Object} setup Test setup object
-		 * @param {String} setup.html Html string to be set as editor data
-		 * @param {String} setup.type Type of tested form element
-		 * @param {Boolean} setup.expected Whenever form dialog should have required field selected
+		 * @param {Object} setup Test setup object.
+		 * @param {String} setup.html Html string to be set as editor data.
+		 * @param {String} setup.type Type of tested form element.
+		 * @param {Boolean} setup.expected Whenever form dialog should have required field selected.
 		 * */
 		assertRequiredAttribute: function( setup ) {
 			return function() {

--- a/tests/plugins/forms/_helpers/tools.js
+++ b/tests/plugins/forms/_helpers/tools.js
@@ -4,19 +4,19 @@
 		/**
 		 * Asserts 'required' attribute of a form element.
 		 *
-		 * @param {Object} setup Test setup object.
-		 * @param {String} setup.html Html string to be set as editor data.
-		 * @param {String} setup.type Type of tested form element.
-		 * @param {Boolean} setup.expected Whenever form dialog should have required field selected.
+		 * @param {Object} options
+		 * @param {String} options.html Html string to be set as editor data.
+		 * @param {String} options.type Type of tested form element.
+		 * @param {Boolean} options.expected Whenever form dialog should have required field selected.
 		 * */
-		assertRequiredAttribute: function( setup ) {
+		assertRequiredAttribute: function( options ) {
 			return function() {
 				var bot = this.editorBot;
 
-				bot.setHtmlWithSelection( setup.html );
+				bot.setHtmlWithSelection( options.html );
 
-				bot.dialog( setup.type, function( dialog ) {
-					assert[ setup.expected ? 'isTrue' : 'isFalse' ]( dialog.getValueOf( 'info', 'required' ) );
+				bot.dialog( options.type, function( dialog ) {
+					assert[ options.expected ? 'isTrue' : 'isFalse' ]( dialog.getValueOf( 'info', 'required' ) );
 					dialog.destroy();
 				} );
 			};

--- a/tests/plugins/forms/checkbox.js
+++ b/tests/plugins/forms/checkbox.js
@@ -43,5 +43,55 @@ bender.test( {
 
 			assert.areSame( '<input type="checkbox" />', bot.getData( false, true ) );
 		} );
+	},
+
+	'test read collapsed required attribute': function() {
+		var bot = this.editorBot;
+
+		bot.setHtmlWithSelection( '[<input type="checkbox" required />]' );
+
+		bot.dialog( 'checkbox', function( dialog ) {
+			assert.isTrue( dialog.getValueOf( 'info', 'required' ) );
+		} );
+	},
+
+	'test read empty required attribute': function() {
+		var bot = this.editorBot;
+
+		bot.setHtmlWithSelection( '[<input type="checkbox" required="" />]' );
+
+		bot.dialog( 'checkbox', function( dialog ) {
+			assert.isTrue( dialog.getValueOf( 'info', 'required' ) );
+		} );
+	},
+
+	'test read required attribute with value `required`': function() {
+		var bot = this.editorBot;
+
+		bot.setHtmlWithSelection( '[<input type="checkbox" required="required" />]' );
+
+		bot.dialog( 'checkbox', function( dialog ) {
+			assert.isTrue( dialog.getValueOf( 'info', 'required' ) );
+		} );
+	},
+
+	'test required attribute absent': function() {
+		var bot = this.editorBot;
+
+		bot.setHtmlWithSelection( '[<input type="checkbox" />]' );
+
+		bot.dialog( 'checkbox', function( dialog ) {
+			assert.isFalse( dialog.getValueOf( 'info', 'required' ) );
+		} );
+	},
+
+	'test read required attribute with invalid value': function() {
+		var bot = this.editorBot;
+
+		bot.setHtmlWithSelection( '[<input type="checkbox" required="any value other than empty string or required" />]' );
+
+		bot.dialog( 'checkbox', function( dialog ) {
+			assert.isFalse( dialog.getValueOf( 'info', 'required' ) );
+		} );
 	}
 } );

--- a/tests/plugins/forms/checkbox.js
+++ b/tests/plugins/forms/checkbox.js
@@ -45,15 +45,15 @@ bender.test( {
 		} );
 	},
 
-	'test read collapsed required attribute': assertRequiredAttribute( '[<input type="checkbox" required />]', true ),
+	'test required attribute collapsed': assertRequiredAttribute( '[<input type="checkbox" required />]', true ),
 
-	'test read empty required attribute': assertRequiredAttribute( '[<input type="checkbox" required="" />]', true ),
+	'test required attribute without value': assertRequiredAttribute( '[<input type="checkbox" required="" />]', true ),
 
-	'test read required attribute with value `required`': assertRequiredAttribute( '[<input type="checkbox" required="required" />]', true ),
+	'test required attribute with value `required`': assertRequiredAttribute( '[<input type="checkbox" required="required" />]', true ),
 
 	'test required attribute absent': assertRequiredAttribute( '[<input type="checkbox" />]', false ),
 
-	'test read required attribute with invalid value': assertRequiredAttribute(
+	'test required attribute with invalid value': assertRequiredAttribute(
 		'[<input type="checkbox" required="any value other than empty string or required" />]', true )
 } );
 

--- a/tests/plugins/forms/checkbox.js
+++ b/tests/plugins/forms/checkbox.js
@@ -45,53 +45,26 @@ bender.test( {
 		} );
 	},
 
-	'test read collapsed required attribute': function() {
-		var bot = this.editorBot;
+	'test read collapsed required attribute': assertRequiredAttribute( '[<input type="checkbox" required />]', true ),
 
-		bot.setHtmlWithSelection( '[<input type="checkbox" required />]' );
+	'test read empty required attribute': assertRequiredAttribute( '[<input type="checkbox" required="" />]', true ),
 
-		bot.dialog( 'checkbox', function( dialog ) {
-			assert.isTrue( dialog.getValueOf( 'info', 'required' ) );
-		} );
-	},
+	'test read required attribute with value `required`': assertRequiredAttribute( '[<input type="checkbox" required="required" />]', true ),
 
-	'test read empty required attribute': function() {
-		var bot = this.editorBot;
+	'test required attribute absent': assertRequiredAttribute( '[<input type="checkbox" />]', false ),
 
-		bot.setHtmlWithSelection( '[<input type="checkbox" required="" />]' );
-
-		bot.dialog( 'checkbox', function( dialog ) {
-			assert.isTrue( dialog.getValueOf( 'info', 'required' ) );
-		} );
-	},
-
-	'test read required attribute with value `required`': function() {
-		var bot = this.editorBot;
-
-		bot.setHtmlWithSelection( '[<input type="checkbox" required="required" />]' );
-
-		bot.dialog( 'checkbox', function( dialog ) {
-			assert.isTrue( dialog.getValueOf( 'info', 'required' ) );
-		} );
-	},
-
-	'test required attribute absent': function() {
-		var bot = this.editorBot;
-
-		bot.setHtmlWithSelection( '[<input type="checkbox" />]' );
-
-		bot.dialog( 'checkbox', function( dialog ) {
-			assert.isFalse( dialog.getValueOf( 'info', 'required' ) );
-		} );
-	},
-
-	'test read required attribute with invalid value': function() {
-		var bot = this.editorBot;
-
-		bot.setHtmlWithSelection( '[<input type="checkbox" required="any value other than empty string or required" />]' );
-
-		bot.dialog( 'checkbox', function( dialog ) {
-			assert.isFalse( dialog.getValueOf( 'info', 'required' ) );
-		} );
-	}
+	'test read required attribute with invalid value': assertRequiredAttribute(
+		'[<input type="checkbox" required="any value other than empty string or required" />]', true )
 } );
+
+function assertRequiredAttribute( html, expected ) {
+	return function() {
+		var bot = this.editorBot;
+
+		bot.setHtmlWithSelection( html );
+
+		bot.dialog( 'checkbox', function( dialog ) {
+			assert[ expected ? 'isTrue' : 'isFalse' ]( dialog.getValueOf( 'info', 'required' ) );
+		} );
+	};
+}

--- a/tests/plugins/forms/checkbox.js
+++ b/tests/plugins/forms/checkbox.js
@@ -1,5 +1,9 @@
 /* bender-tags: editor */
 /* bender-ckeditor-plugins: dialog,button,forms,htmlwriter,toolbar */
+/* bender-include: _helpers/tools.js */
+/* global formsTools */
+
+var assertRequiredAttribute = formsTools.assertRequiredAttribute;
 
 bender.editor = {
 	config: {
@@ -45,26 +49,33 @@ bender.test( {
 		} );
 	},
 
-	'test required attribute collapsed': assertRequiredAttribute( '[<input type="checkbox" required />]', true ),
+	'test required attribute collapsed': assertRequiredAttribute( {
+		html: '[<input type="checkbox" required />]',
+		type: 'checkbox',
+		expected: true
+	} ),
 
-	'test required attribute without value': assertRequiredAttribute( '[<input type="checkbox" required="" />]', true ),
+	'test required attribute without value': assertRequiredAttribute( {
+		html: '[<input type="checkbox" required="" />]',
+		type: 'checkbox',
+		expected: true
+	} ),
 
-	'test required attribute with value `required`': assertRequiredAttribute( '[<input type="checkbox" required="required" />]', true ),
+	'test required attribute with value `required`': assertRequiredAttribute( {
+		html: '[<input type="checkbox" required="required" />]',
+		type: 'checkbox',
+		expected: true
+	} ),
 
-	'test required attribute absent': assertRequiredAttribute( '[<input type="checkbox" />]', false ),
+	'test required attribute absent': assertRequiredAttribute( {
+		html: '[<input type="checkbox" />]',
+		type: 'checkbox',
+		expected: false
+	} ),
 
-	'test required attribute with invalid value': assertRequiredAttribute(
-		'[<input type="checkbox" required="any value other than empty string or required" />]', true )
+	'test required attribute with invalid value': assertRequiredAttribute( {
+		html: '[<input type="checkbox" required="any value other than empty string or required" />]',
+		type: 'checkbox',
+		expected: true
+	} )
 } );
-
-function assertRequiredAttribute( html, expected ) {
-	return function() {
-		var bot = this.editorBot;
-
-		bot.setHtmlWithSelection( html );
-
-		bot.dialog( 'checkbox', function( dialog ) {
-			assert[ expected ? 'isTrue' : 'isFalse' ]( dialog.getValueOf( 'info', 'required' ) );
-		} );
-	};
-}

--- a/tests/plugins/forms/manual/required.html
+++ b/tests/plugins/forms/manual/required.html
@@ -1,0 +1,15 @@
+<body>
+<div id="editor">
+	<p>
+		<input required type="checkbox">
+		<input required type="radio">
+		<input required type="text">
+		<textarea required></textarea>
+		<select required></select>
+	</p>
+</div>
+
+<script>
+	CKEDITOR.replace( 'editor' );
+</script>
+</body>

--- a/tests/plugins/forms/manual/required.html
+++ b/tests/plugins/forms/manual/required.html
@@ -2,10 +2,10 @@
 <div id="editor">
 	<p>
 		<input required type="checkbox">
-		<input required type="radio">
-		<input required type="text">
-		<textarea required></textarea>
-		<select required></select>
+		<input required="" type="radio">
+		<input required="true" type="text">
+		<textarea required="false"></textarea>
+		<select required="test"></select>
 	</p>
 </div>
 

--- a/tests/plugins/forms/manual/required.md
+++ b/tests/plugins/forms/manual/required.md
@@ -1,0 +1,12 @@
+@bender-tags: editor, bug, 4.10.0, forms, 586
+@bender-ui: collapsed
+@bender-ckeditor-plugins: forms, wysiwygarea, toolbar, sourcearea, contextmenu
+
+----
+
+# Required attribute in dialog
+
+For each element in editor open dialog by double clicking it or using context menu.
+
+## Expected:
+* Once dialog is open 'required' field should be checked.

--- a/tests/plugins/forms/manual/required.md
+++ b/tests/plugins/forms/manual/required.md
@@ -1,4 +1,4 @@
-@bender-tags: editor, bug, 4.10.0, 586
+@bender-tags: editor, bug, 4.10.2, 586
 @bender-ui: collapsed
 @bender-ckeditor-plugins: forms, wysiwygarea, toolbar, sourcearea, contextmenu
 

--- a/tests/plugins/forms/manual/required.md
+++ b/tests/plugins/forms/manual/required.md
@@ -1,4 +1,4 @@
-@bender-tags: editor, bug, 4.10.0, forms, 586
+@bender-tags: editor, bug, 4.10.0, 586
 @bender-ui: collapsed
 @bender-ckeditor-plugins: forms, wysiwygarea, toolbar, sourcearea, contextmenu
 

--- a/tests/plugins/forms/radio.js
+++ b/tests/plugins/forms/radio.js
@@ -55,5 +55,55 @@ bender.test( {
 				assert.areSame( '<input type="radio" />', bot.getData( false, true ) );
 			}
 		} );
+	},
+
+	'test read collapsed required attribute': function() {
+		var bot = this.editorBot;
+
+		bot.setHtmlWithSelection( '[<input type="radio" required />]' );
+
+		bot.dialog( 'radio', function( dialog ) {
+			assert.isTrue( dialog.getValueOf( 'info', 'required' ) );
+		} );
+	},
+
+	'test read empty required attribute': function() {
+		var bot = this.editorBot;
+
+		bot.setHtmlWithSelection( '[<input type="radio" required="" />]' );
+
+		bot.dialog( 'radio', function( dialog ) {
+			assert.isTrue( dialog.getValueOf( 'info', 'required' ) );
+		} );
+	},
+
+	'test read required attribute with value `required`': function() {
+		var bot = this.editorBot;
+
+		bot.setHtmlWithSelection( '[<input type="radio" required="required" />]' );
+
+		bot.dialog( 'radio', function( dialog ) {
+			assert.isTrue( dialog.getValueOf( 'info', 'required' ) );
+		} );
+	},
+
+	'test required attribute absent': function() {
+		var bot = this.editorBot;
+
+		bot.setHtmlWithSelection( '[<input type="radio" />]' );
+
+		bot.dialog( 'radio', function( dialog ) {
+			assert.isFalse( dialog.getValueOf( 'info', 'required' ) );
+		} );
+	},
+
+	'test read required attribute with invalid value': function() {
+		var bot = this.editorBot;
+
+		bot.setHtmlWithSelection( '[<input type="radio" required="any value other than empty string or required" />]' );
+
+		bot.dialog( 'radio', function( dialog ) {
+			assert.isFalse( dialog.getValueOf( 'info', 'required' ) );
+		} );
 	}
 } );

--- a/tests/plugins/forms/radio.js
+++ b/tests/plugins/forms/radio.js
@@ -1,5 +1,9 @@
 /* bender-tags: editor */
 /* bender-ckeditor-plugins: dialog,button,forms,htmlwriter,toolbar */
+/* bender-include: _helpers/tools.js */
+/* global formsTools */
+
+var assertRequiredAttribute = formsTools.assertRequiredAttribute;
 
 bender.editor = {
 	config: {
@@ -57,53 +61,33 @@ bender.test( {
 		} );
 	},
 
-	'test read collapsed required attribute': function() {
-		var bot = this.editorBot;
+	'test required attribute collapsed': assertRequiredAttribute( {
+		html: '[<input type="checkbox" required />]',
+		type: 'checkbox',
+		expected: true
+	} ),
 
-		bot.setHtmlWithSelection( '[<input type="radio" required />]' );
+	'test required attribute without value': assertRequiredAttribute( {
+		html: '[<input type="checkbox" required="" />]',
+		type: 'checkbox',
+		expected: true
+	} ),
 
-		bot.dialog( 'radio', function( dialog ) {
-			assert.isTrue( dialog.getValueOf( 'info', 'required' ) );
-		} );
-	},
+	'test required attribute with value `required`': assertRequiredAttribute( {
+		html: '[<input type="checkbox" required="required" />]',
+		type: 'checkbox',
+		expected: true
+	} ),
 
-	'test read empty required attribute': function() {
-		var bot = this.editorBot;
+	'test required attribute absent': assertRequiredAttribute( {
+		html: '[<input type="checkbox" />]',
+		type: 'checkbox',
+		expected: false
+	} ),
 
-		bot.setHtmlWithSelection( '[<input type="radio" required="" />]' );
-
-		bot.dialog( 'radio', function( dialog ) {
-			assert.isTrue( dialog.getValueOf( 'info', 'required' ) );
-		} );
-	},
-
-	'test read required attribute with value `required`': function() {
-		var bot = this.editorBot;
-
-		bot.setHtmlWithSelection( '[<input type="radio" required="required" />]' );
-
-		bot.dialog( 'radio', function( dialog ) {
-			assert.isTrue( dialog.getValueOf( 'info', 'required' ) );
-		} );
-	},
-
-	'test required attribute absent': function() {
-		var bot = this.editorBot;
-
-		bot.setHtmlWithSelection( '[<input type="radio" />]' );
-
-		bot.dialog( 'radio', function( dialog ) {
-			assert.isFalse( dialog.getValueOf( 'info', 'required' ) );
-		} );
-	},
-
-	'test read required attribute with invalid value': function() {
-		var bot = this.editorBot;
-
-		bot.setHtmlWithSelection( '[<input type="radio" required="any value other than empty string or required" />]' );
-
-		bot.dialog( 'radio', function( dialog ) {
-			assert.isFalse( dialog.getValueOf( 'info', 'required' ) );
-		} );
-	}
+	'test required attribute with invalid value': assertRequiredAttribute( {
+		html: '[<input type="checkbox" required="any value other than empty string or required" />]',
+		type: 'checkbox',
+		expected: true
+	} )
 } );

--- a/tests/plugins/forms/select.js
+++ b/tests/plugins/forms/select.js
@@ -49,5 +49,55 @@ bender.test( {
 
 			assert.areSame( '<select></select>', bot.getData( false, true ) );
 		} );
+	},
+
+	'test read collapsed required attribute': function() {
+		var bot = this.editorBot;
+
+		bot.setHtmlWithSelection( '[<select required></select>]' );
+
+		bot.dialog( 'select', function( dialog ) {
+			assert.isTrue( dialog.getValueOf( 'info', 'required' ) );
+		} );
+	},
+
+	'test read empty required attribute': function() {
+		var bot = this.editorBot;
+
+		bot.setHtmlWithSelection( '[<select required=""></select>]' );
+
+		bot.dialog( 'select', function( dialog ) {
+			assert.isTrue( dialog.getValueOf( 'info', 'required' ) );
+		} );
+	},
+
+	'test read required attribute with value `required`': function() {
+		var bot = this.editorBot;
+
+		bot.setHtmlWithSelection( '[<select required="required"></select>]' );
+
+		bot.dialog( 'select', function( dialog ) {
+			assert.isTrue( dialog.getValueOf( 'info', 'required' ) );
+		} );
+	},
+
+	'test required attribute absent': function() {
+		var bot = this.editorBot;
+
+		bot.setHtmlWithSelection( '[<select></select>]' );
+
+		bot.dialog( 'select', function( dialog ) {
+			assert.isFalse( dialog.getValueOf( 'info', 'required' ) );
+		} );
+	},
+
+	'test read required attribute with invalid value': function() {
+		var bot = this.editorBot;
+
+		bot.setHtmlWithSelection( '[<select required="any value other than empty string or required"></select>]' );
+
+		bot.dialog( 'select', function( dialog ) {
+			assert.isFalse( dialog.getValueOf( 'info', 'required' ) );
+		} );
 	}
 } );

--- a/tests/plugins/forms/select.js
+++ b/tests/plugins/forms/select.js
@@ -1,5 +1,9 @@
 /* bender-tags: editor */
 /* bender-ckeditor-plugins: dialog,button,forms,htmlwriter,toolbar */
+/* bender-include: _helpers/tools.js */
+/* global formsTools */
+
+var assertRequiredAttribute = formsTools.assertRequiredAttribute;
 
 bender.editor = {
 	config: {
@@ -51,53 +55,33 @@ bender.test( {
 		} );
 	},
 
-	'test read collapsed required attribute': function() {
-		var bot = this.editorBot;
+	'test required attribute collapsed': assertRequiredAttribute( {
+		html: '[<select required></select>]',
+		type: 'select',
+		expected: true
+	} ),
 
-		bot.setHtmlWithSelection( '[<select required></select>]' );
+	'test required attribute without value': assertRequiredAttribute( {
+		html: '[<select required=""></select>]',
+		type: 'select',
+		expected: true
+	} ),
 
-		bot.dialog( 'select', function( dialog ) {
-			assert.isTrue( dialog.getValueOf( 'info', 'required' ) );
-		} );
-	},
+	'test required attribute with value `required`': assertRequiredAttribute( {
+		html: '[<select required="required"></select>]',
+		type: 'select',
+		expected: true
+	} ),
 
-	'test read empty required attribute': function() {
-		var bot = this.editorBot;
+	'test required attribute absent': assertRequiredAttribute( {
+		html: '[<select></select>]',
+		type: 'select',
+		expected: false
+	} ),
 
-		bot.setHtmlWithSelection( '[<select required=""></select>]' );
-
-		bot.dialog( 'select', function( dialog ) {
-			assert.isTrue( dialog.getValueOf( 'info', 'required' ) );
-		} );
-	},
-
-	'test read required attribute with value `required`': function() {
-		var bot = this.editorBot;
-
-		bot.setHtmlWithSelection( '[<select required="required"></select>]' );
-
-		bot.dialog( 'select', function( dialog ) {
-			assert.isTrue( dialog.getValueOf( 'info', 'required' ) );
-		} );
-	},
-
-	'test required attribute absent': function() {
-		var bot = this.editorBot;
-
-		bot.setHtmlWithSelection( '[<select></select>]' );
-
-		bot.dialog( 'select', function( dialog ) {
-			assert.isFalse( dialog.getValueOf( 'info', 'required' ) );
-		} );
-	},
-
-	'test read required attribute with invalid value': function() {
-		var bot = this.editorBot;
-
-		bot.setHtmlWithSelection( '[<select required="any value other than empty string or required"></select>]' );
-
-		bot.dialog( 'select', function( dialog ) {
-			assert.isFalse( dialog.getValueOf( 'info', 'required' ) );
-		} );
-	}
+	'test required attribute with invalid value': assertRequiredAttribute( {
+		html: '[<select required="any value other than empty string or required"></select>]',
+		type: 'select',
+		expected: true
+	} )
 } );

--- a/tests/plugins/forms/textarea.js
+++ b/tests/plugins/forms/textarea.js
@@ -88,5 +88,55 @@ bender.test( {
 
 		// Start testing.
 		testValue.call( this, 0 );
+	},
+
+	'test read collapsed required attribute': function() {
+		var bot = this.editorBot;
+
+		bot.setHtmlWithSelection( '[<textarea required></textarea>]' );
+
+		bot.dialog( 'textarea', function( dialog ) {
+			assert.isTrue( dialog.getValueOf( 'info', 'required' ) );
+		} );
+	},
+
+	'test read empty required attribute': function() {
+		var bot = this.editorBot;
+
+		bot.setHtmlWithSelection( '[<textarea required=""></textarea>]' );
+
+		bot.dialog( 'textarea', function( dialog ) {
+			assert.isTrue( dialog.getValueOf( 'info', 'required' ) );
+		} );
+	},
+
+	'test read required attribute with value `required`': function() {
+		var bot = this.editorBot;
+
+		bot.setHtmlWithSelection( '[<textarea required="required"></textarea>]' );
+
+		bot.dialog( 'textarea', function( dialog ) {
+			assert.isTrue( dialog.getValueOf( 'info', 'required' ) );
+		} );
+	},
+
+	'test required attribute absent': function() {
+		var bot = this.editorBot;
+
+		bot.setHtmlWithSelection( '[<textarea></textarea>]' );
+
+		bot.dialog( 'textarea', function( dialog ) {
+			assert.isFalse( dialog.getValueOf( 'info', 'required' ) );
+		} );
+	},
+
+	'test read required attribute with invalid value': function() {
+		var bot = this.editorBot;
+
+		bot.setHtmlWithSelection( '[<textarea required="any value other than empty string or required"></textarea>]' );
+
+		bot.dialog( 'textarea', function( dialog ) {
+			assert.isFalse( dialog.getValueOf( 'info', 'required' ) );
+		} );
 	}
 } );

--- a/tests/plugins/forms/textarea.js
+++ b/tests/plugins/forms/textarea.js
@@ -1,5 +1,9 @@
 /* bender-tags: editor */
 /* bender-ckeditor-plugins: forms,toolbar */
+/* bender-include: _helpers/tools.js */
+/* global formsTools */
+
+var assertRequiredAttribute = formsTools.assertRequiredAttribute;
 
 bender.editor = {
 	config: {
@@ -90,53 +94,33 @@ bender.test( {
 		testValue.call( this, 0 );
 	},
 
-	'test read collapsed required attribute': function() {
-		var bot = this.editorBot;
+	'test required attribute collapsed': assertRequiredAttribute( {
+		html: '[<textarea required></textarea>]',
+		type: 'textarea',
+		expected: true
+	} ),
 
-		bot.setHtmlWithSelection( '[<textarea required></textarea>]' );
+	'test required attribute without value': assertRequiredAttribute( {
+		html: '[<textarea required=""></textarea>]',
+		type: 'textarea',
+		expected: true
+	} ),
 
-		bot.dialog( 'textarea', function( dialog ) {
-			assert.isTrue( dialog.getValueOf( 'info', 'required' ) );
-		} );
-	},
+	'test required attribute with value `required`': assertRequiredAttribute( {
+		html: '[<textarea required="required"></textarea>]',
+		type: 'textarea',
+		expected: true
+	} ),
 
-	'test read empty required attribute': function() {
-		var bot = this.editorBot;
+	'test required attribute absent': assertRequiredAttribute( {
+		html: '[<textarea></textarea>]',
+		type: 'textarea',
+		expected: false
+	} ),
 
-		bot.setHtmlWithSelection( '[<textarea required=""></textarea>]' );
-
-		bot.dialog( 'textarea', function( dialog ) {
-			assert.isTrue( dialog.getValueOf( 'info', 'required' ) );
-		} );
-	},
-
-	'test read required attribute with value `required`': function() {
-		var bot = this.editorBot;
-
-		bot.setHtmlWithSelection( '[<textarea required="required"></textarea>]' );
-
-		bot.dialog( 'textarea', function( dialog ) {
-			assert.isTrue( dialog.getValueOf( 'info', 'required' ) );
-		} );
-	},
-
-	'test required attribute absent': function() {
-		var bot = this.editorBot;
-
-		bot.setHtmlWithSelection( '[<textarea></textarea>]' );
-
-		bot.dialog( 'textarea', function( dialog ) {
-			assert.isFalse( dialog.getValueOf( 'info', 'required' ) );
-		} );
-	},
-
-	'test read required attribute with invalid value': function() {
-		var bot = this.editorBot;
-
-		bot.setHtmlWithSelection( '[<textarea required="any value other than empty string or required"></textarea>]' );
-
-		bot.dialog( 'textarea', function( dialog ) {
-			assert.isFalse( dialog.getValueOf( 'info', 'required' ) );
-		} );
-	}
+	'test required attribute with invalid value': assertRequiredAttribute( {
+		html: '[<textarea required="any value other than empty string or required"></textarea>]',
+		type: 'textarea',
+		expected: true
+	} )
 } );

--- a/tests/plugins/forms/textfield.js
+++ b/tests/plugins/forms/textfield.js
@@ -77,5 +77,55 @@ bender.test( {
 
 			assert.areSame( '<input name="name" type="text" value="test@host.com" />', bot.getData( true ) );
 		} );
+	},
+
+	'test read collapsed required attribute': function() {
+		var bot = this.editorBot;
+
+		bot.setHtmlWithSelection( '[<input type="text" required />]' );
+
+		bot.dialog( 'textfield', function( dialog ) {
+			assert.isTrue( dialog.getValueOf( 'info', 'required' ) );
+		} );
+	},
+
+	'test read empty required attribute': function() {
+		var bot = this.editorBot;
+
+		bot.setHtmlWithSelection( '[<input type="text" required="" />]' );
+
+		bot.dialog( 'textfield', function( dialog ) {
+			assert.isTrue( dialog.getValueOf( 'info', 'required' ) );
+		} );
+	},
+
+	'test read required attribute with value `required`': function() {
+		var bot = this.editorBot;
+
+		bot.setHtmlWithSelection( '[<input type="text" required="required" />]' );
+
+		bot.dialog( 'textfield', function( dialog ) {
+			assert.isTrue( dialog.getValueOf( 'info', 'required' ) );
+		} );
+	},
+
+	'test required attribute absent': function() {
+		var bot = this.editorBot;
+
+		bot.setHtmlWithSelection( '[<input type="text" />]' );
+
+		bot.dialog( 'textfield', function( dialog ) {
+			assert.isFalse( dialog.getValueOf( 'info', 'required' ) );
+		} );
+	},
+
+	'test read required attribute with invalid value': function() {
+		var bot = this.editorBot;
+
+		bot.setHtmlWithSelection( '[<input type="text" required="any value other than empty string or required" />]' );
+
+		bot.dialog( 'textfield', function( dialog ) {
+			assert.isFalse( dialog.getValueOf( 'info', 'required' ) );
+		} );
 	}
 } );

--- a/tests/plugins/forms/textfield.js
+++ b/tests/plugins/forms/textfield.js
@@ -1,5 +1,9 @@
 /* bender-tags: editor */
 /* bender-ckeditor-plugins: dialog,button,forms,toolbar */
+/* bender-include: _helpers/tools.js */
+/* global formsTools */
+
+var assertRequiredAttribute = formsTools.assertRequiredAttribute;
 
 bender.editor = {
 	config: {
@@ -79,53 +83,33 @@ bender.test( {
 		} );
 	},
 
-	'test read collapsed required attribute': function() {
-		var bot = this.editorBot;
+	'test required attribute collapsed': assertRequiredAttribute( {
+		html: '[<input type="text" required />]',
+		type: 'textfield',
+		expected: true
+	} ),
 
-		bot.setHtmlWithSelection( '[<input type="text" required />]' );
+	'test required attribute without value': assertRequiredAttribute( {
+		html: '[<input type="text" required="" />]',
+		type: 'textfield',
+		expected: true
+	} ),
 
-		bot.dialog( 'textfield', function( dialog ) {
-			assert.isTrue( dialog.getValueOf( 'info', 'required' ) );
-		} );
-	},
+	'test required attribute with value `required`': assertRequiredAttribute( {
+		html: '[<input type="text" required="required" />]',
+		type: 'textfield',
+		expected: true
+	} ),
 
-	'test read empty required attribute': function() {
-		var bot = this.editorBot;
+	'test required attribute absent': assertRequiredAttribute( {
+		html: '[<input type="text" />]',
+		type: 'textfield',
+		expected: false
+	} ),
 
-		bot.setHtmlWithSelection( '[<input type="text" required="" />]' );
-
-		bot.dialog( 'textfield', function( dialog ) {
-			assert.isTrue( dialog.getValueOf( 'info', 'required' ) );
-		} );
-	},
-
-	'test read required attribute with value `required`': function() {
-		var bot = this.editorBot;
-
-		bot.setHtmlWithSelection( '[<input type="text" required="required" />]' );
-
-		bot.dialog( 'textfield', function( dialog ) {
-			assert.isTrue( dialog.getValueOf( 'info', 'required' ) );
-		} );
-	},
-
-	'test required attribute absent': function() {
-		var bot = this.editorBot;
-
-		bot.setHtmlWithSelection( '[<input type="text" />]' );
-
-		bot.dialog( 'textfield', function( dialog ) {
-			assert.isFalse( dialog.getValueOf( 'info', 'required' ) );
-		} );
-	},
-
-	'test read required attribute with invalid value': function() {
-		var bot = this.editorBot;
-
-		bot.setHtmlWithSelection( '[<input type="text" required="any value other than empty string or required" />]' );
-
-		bot.dialog( 'textfield', function( dialog ) {
-			assert.isFalse( dialog.getValueOf( 'info', 'required' ) );
-		} );
-	}
+	'test required attribute with invalid value': assertRequiredAttribute( {
+		html: '[<input type="text" required="any value other than empty string or required" />]',
+		type: 'textfield',
+		expected: true
+	} )
 } );


### PR DESCRIPTION
## What is the purpose of this pull request?

Bug fix

## Does your PR contain necessary tests?

All patches which change the editor code must include tests. You can always read more
on [PR testing](https://docs.ckeditor.com/ckeditor4/docs/#!/guide/dev_contributing_code-section-tests),
[how to set the testing environment](https://docs.ckeditor.com/ckeditor4/docs/#!/guide/dev_tests) and
[how to create tests](https://docs.ckeditor.com/ckeditor4/docs/#!/guide/dev_tests-section-creating-your-own-test)
in the official CKEditor documentation.

### This PR contains

- [x] Unit tests
- [x] Manual tests

## What changes did you make?

I've changed form dialog to set its property `required = true` whenever matching attribute exists on form element.

Closes #586 
  