### PR TITLE
Fixed `alt + a` key combination for editor content selection on Windows

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -9,6 +9,7 @@ New Features:
 
 Fixed Issues:
 
+* [#1419](https://github.com/ckeditor/ckeditor-dev/issues/1419): Fixed: [Widged Selection](https://docs.ckeditor.com/ckeditor4/docs/#!/api/CKEDITOR.plugins.widgetselection) selects editor content with `alt + a` key combination on Windows.
 * [#1274](https://github.com/ckeditor/ckeditor-dev/issues/1274): Fixed: [Balloon Toolbar](https://ckeditor.com/cke4/addon/balloontoolbar) does not match a single selected image using [`contextDefinition.cssSelector`](https://docs.ckeditor.com/ckeditor4/docs/#!/api/CKEDITOR.plugins.balloontoolbar.contextDefinition-property-cssSelector) matcher.
 * [#1232](https://github.com/ckeditor/ckeditor-dev/issues/1232): Fixed: [Balloon Toolbar](https://ckeditor.com/cke4/addon/balloontoolbar) buttons should be registered as focusable elements.
 * [#1342](https://github.com/ckeditor/ckeditor-dev/issues/1342): Fixed: [Balloon Toolbar](https://ckeditor.com/cke4/addon/balloontoolbar) should be re-positioned after a [change](https://docs.ckeditor.com/ckeditor4/docs/#!/api/CKEDITOR.editor-event-change) event.

--- a/plugins/widgetselection/plugin.js
+++ b/plugins/widgetselection/plugin.js
@@ -26,14 +26,10 @@
 						editable = editor.editable();
 
 					editable.attachListener( doc, 'keydown', function( evt ) {
-						var data = evt.data.$;
-
 						// Ctrl/Cmd + A
-						if ( evt.data.getKey() == 65 && ( CKEDITOR.env.mac && data.metaKey || !CKEDITOR.env.mac && data.ctrlKey ) ) {
-
+						if ( evt.data.getKeystroke() == CKEDITOR.CTRL + 65 ) {
 							// Defer the call so the selection is already changed by the pressed keys.
 							CKEDITOR.tools.setTimeout( function() {
-
 								// Manage filler elements on keydown. If there is no need
 								// to add fillers, we need to check and clean previously used once.
 								if ( !widgetselection.addFillers( editable ) ) {

--- a/tests/plugins/widgetselection/keys.js
+++ b/tests/plugins/widgetselection/keys.js
@@ -1,0 +1,41 @@
+/* bender-tags: editor */
+/* bender-ckeditor-plugins: widgetselection */
+
+( function() {
+	'use strict';
+
+	bender.editor = true;
+
+	function testKeyCombination( editor, eventData, callCount ) {
+		var addFillersStub = sinon.stub( CKEDITOR.plugins.widgetselection, 'addFillers' );
+
+		editor.document.fire( 'keydown', new CKEDITOR.dom.event( eventData ) );
+
+		// Test has to be async because widgetSelection.addFillers is called inside setTimeout.
+		setTimeout( function() {
+			resume( function() {
+				addFillersStub.restore();
+				assert.areSame( callCount, addFillersStub.callCount, 'addFillers call count' );
+			} );
+		}, 50 );
+
+		wait();
+	}
+
+	bender.test( {
+		'test `ctrl + a` key combination': function() {
+			var editor = this.editor;
+			this.editorBot.setHtmlWithSelection( '<p contenteditable="false">Non-editable</p><p>This ^is text</p>' );
+
+			testKeyCombination( editor, { keyCode: 65, ctrlKey: true }, 1 );
+		},
+
+		'test ctrl + alt + a key combination': function() {
+			var editor = this.editor;
+			this.editorBot.setHtmlWithSelection( '<p contenteditable="false">Non-editable</p><p>This ^is text</p>' );
+
+			testKeyCombination( editor, { keyCode: 65, ctrlKey: true, altKey: true }, 0 );
+		}
+	} );
+
+} )();

--- a/tests/plugins/widgetselection/manual/specialcharacters.html
+++ b/tests/plugins/widgetselection/manual/specialcharacters.html
@@ -1,4 +1,4 @@
-<div id="editor01">
+<div id="editor1">
 	<p contenteditable="false">NonEditable</p>
 	<h1>Hello world!</h1>
 	<p>I&#39;m an instance of <a href="http://ckeditor.com">CKEditor</a>.</p>

--- a/tests/plugins/widgetselection/manual/specialcharacters.html
+++ b/tests/plugins/widgetselection/manual/specialcharacters.html
@@ -5,9 +5,5 @@
 </div>
 
 <script>
-	var config = {
-		height: 200,
-		allowedContent: true
-	};
-    var editor = CKEDITOR.replace( 'editor01', config );
+	CKEDITOR.replace( 'editor1' );
 </script>

--- a/tests/plugins/widgetselection/manual/specialcharacters.html
+++ b/tests/plugins/widgetselection/manual/specialcharacters.html
@@ -5,5 +5,7 @@
 </div>
 
 <script>
-	CKEDITOR.replace( 'editor1' );
+	CKEDITOR.replace( 'editor1', {
+		extraAllowedContent: 'p[contenteditable]'
+	} );
 </script>

--- a/tests/plugins/widgetselection/manual/specialcharacters.html
+++ b/tests/plugins/widgetselection/manual/specialcharacters.html
@@ -1,0 +1,13 @@
+<div id="editor01">
+	<p contenteditable="false">NonEditable</p>
+	<h1>Hello world!</h1>
+	<p>I&#39;m an instance of <a href="http://ckeditor.com">CKEditor</a>.</p>
+</div>
+
+<script>
+	var config = {
+		height: 200,
+		allowedContent: true
+	};
+    var editor = CKEDITOR.replace( 'editor01', config );
+</script>

--- a/tests/plugins/widgetselection/manual/specialcharacters.md
+++ b/tests/plugins/widgetselection/manual/specialcharacters.md
@@ -1,0 +1,17 @@
+@bender-tags: 4.8.1, bug, 1419, widgetselection
+@bender-ui: collapsed
+@bender-ckeditor-plugins: wysiwygarea,toolbar,basicstyles,link,format,sourcearea,widgetselection,elementspath
+
+----
+
+Test should be performed on a Windows operating system with polish keyboard layout. You can't validate this test case on UNIX based systems. 
+
+1. Set system settings to use polish keyboard layout.
+2. Focus editor instance.
+3. Press `Alt + a` to insert `ą` letter.
+
+**Expected:**
+`ą` letter has been inserted at the caret position. Editor content has not been selected.
+
+**Unexpected:** 
+`ą` letter has not been inserted and/or editor content has been selected.

--- a/tests/plugins/widgetselection/manual/specialcharacters.md
+++ b/tests/plugins/widgetselection/manual/specialcharacters.md
@@ -1,14 +1,12 @@
 @bender-tags: 4.8.1, bug, 1419, widgetselection
 @bender-ui: collapsed
-@bender-ckeditor-plugins: wysiwygarea,toolbar,basicstyles,link,format,sourcearea,widgetselection,elementspath
+@bender-ckeditor-plugins: wysiwygarea,toolbar,link,format,sourcearea,widgetselection,elementspath
 
 ----
 
-Test should be performed on a Windows operating system with Polish keyboard layout. You can't validate this test case on UNIX based systems. 
-
 1. Set system settings to use Polish keyboard layout.
 2. Focus editor instance.
-3. Press `Alt + a` to insert `ą` letter.
+3. Press `AltGr (right alt) + a` (or `option + a` on Mac) to insert `ą` letter.
 
 ## Expected
 `ą` letter has been inserted at the caret position. Editor content has not been selected.

--- a/tests/plugins/widgetselection/manual/specialcharacters.md
+++ b/tests/plugins/widgetselection/manual/specialcharacters.md
@@ -11,5 +11,5 @@
 ## Expected
 `ą` letter has been inserted at the caret position. Editor content has not been selected.
 
-## Expected
+## Unexpected
 `ą` letter has not been inserted and/or editor content has been selected.

--- a/tests/plugins/widgetselection/manual/specialcharacters.md
+++ b/tests/plugins/widgetselection/manual/specialcharacters.md
@@ -4,14 +4,14 @@
 
 ----
 
-Test should be performed on a Windows operating system with polish keyboard layout. You can't validate this test case on UNIX based systems. 
+Test should be performed on a Windows operating system with Polish keyboard layout. You can't validate this test case on UNIX based systems. 
 
-1. Set system settings to use polish keyboard layout.
+1. Set system settings to use Polish keyboard layout.
 2. Focus editor instance.
 3. Press `Alt + a` to insert `ą` letter.
 
-**Expected:**
+## Expected
 `ą` letter has been inserted at the caret position. Editor content has not been selected.
 
-**Unexpected:** 
+## Expected
 `ą` letter has not been inserted and/or editor content has been selected.


### PR DESCRIPTION
## What is the purpose of this pull request?

Bug fix

## Does your PR contain necessary tests?

All patches which change the editor code must include tests. You can always read more
on [PR testing](https://docs.ckeditor.com/ckeditor4/docs/#!/guide/dev_contributing_code-section-tests),
[how to set the testing environment](https://docs.ckeditor.com/ckeditor4/docs/#!/guide/dev_tests) and
[how to create tests](https://docs.ckeditor.com/ckeditor4/docs/#!/guide/dev_tests-section-creating-your-own-test)
in the official CKEditor documentation.

### This PR contains

- [x] Unit tests
- [x] Manual tests

## What changes did you make?
Used [CKEDITOR.dom.event.getKeystroke](https://docs.ckeditor.com/ckeditor4/docs/#!/api/CKEDITOR.dom.event-method-getKeystroke) function to define content selection by `cmd/ctrl+a` key combination.  

Closes #1419
#1419: Fixed: [Widged Selection](https://docs.ckeditor.com/ckeditor4/docs/#!/api/CKEDITOR.plugins.widgetselection) selects editor content with `alt + a` key combination on Windows.