### PR TITLE
Fix unnecessary undo steps

### DIFF
--- a/plugins/easyimage/plugin.js
+++ b/plugins/easyimage/plugin.js
@@ -360,7 +360,10 @@
 
 						if ( progressBar && loader.uploadTotal ) {
 							percentage = ( loader.uploaded / loader.uploadTotal ) * 100;
+
+							editor.fire( 'lockSnapshot' );
 							progressBar.setStyle( 'width', percentage + '%' );
+							editor.fire( 'unlockSnapshot' );
 						}
 					}, this );
 

--- a/plugins/easyimage/plugin.js
+++ b/plugins/easyimage/plugin.js
@@ -248,11 +248,15 @@
 					widget = this;
 
 				getNaturalWidth( widget.parts.img, function( width ) {
+					editor.fire( 'lockSnapshot' );
+
 					widget.replaceWith( '<figure class="' + ( editor.config.easyimage_class || '' ) + '">' +
 							'<img src="' + upload.responseData.response[ 'default' ] + '" srcset="' + srcset +
 								'" sizes="100vw" width="' + width + '">' +
 							'<figcaption></figcaption>' +
 						'</figure>' );
+
+					editor.fire( 'unlockSnapshot' );
 				} );
 			}
 		};

--- a/tests/plugins/easyimage/manual/undo.html
+++ b/tests/plugins/easyimage/manual/undo.html
@@ -1,0 +1,42 @@
+<p>Note, this test uses a real Cloud Service connection, so you might want to be on-line 😉.</p>
+
+<h2>Classic editor</h2>
+
+<div id="classic">
+	<h1>Sample editor</h1>
+	<p>Go on, put some content here.</p>
+</div>
+
+<h2>Divarea editor</h2>
+
+<div id="divarea">
+	<h1>Sample editor</h1>
+	<p>Go on, put some content here.</p>
+</div>
+
+<h2>Inline editor</h2>
+
+<div id="inline" contenteditable="true">
+	<h1>Sample editor</h1>
+	<p>Go on, put some content here.</p>
+</div>
+
+<script src="_helpers/tools.js"></script>
+<script>
+	if ( CKEDITOR.env.ie && CKEDITOR.env.version < 11 ) {
+		bender.ignore();
+	}
+
+	getToken( function( token ) {
+		var commonConfig = {
+				cloudServices_url: 'https://files.cke-cs.com/upload/',
+				cloudServices_token: token
+			};
+
+		CKEDITOR.replace( 'classic', commonConfig );
+		CKEDITOR.replace( 'divarea', CKEDITOR.tools.extend( {
+			extraPlugins: 'divarea'
+		}, commonConfig ) );
+		CKEDITOR.inline( 'inline', commonConfig );
+	} );
+</script>

--- a/tests/plugins/easyimage/manual/undo.md
+++ b/tests/plugins/easyimage/manual/undo.md
@@ -7,7 +7,7 @@
 Upload some images:
 
 1. Execute one of the following steps:
-	1. Make a screenshot, copy a graphic to the clipboard and paste using `ctrl/cmd+v`.
+	1. Make a screenshot, copy a graphic to the clipboard and paste using `ctrl/cmd+v`. This method does not work in Safari at the moment.
 	1. Drag and drop an jpg/png/bmp/gif image from your OS explorer to the editable.
 	1. Firefox only: Copy an image file (from your OS explorer) into the clipboard, and paste into the editable.
 2. Click "Undo" button

--- a/tests/plugins/easyimage/manual/undo.md
+++ b/tests/plugins/easyimage/manual/undo.md
@@ -20,4 +20,4 @@ Upload some images:
 ### Unexpected
 
 * Widget still exists after pressing "Undo".
-* There are more than one undo steps.
+* There are more than one undo step.

--- a/tests/plugins/easyimage/manual/undo.md
+++ b/tests/plugins/easyimage/manual/undo.md
@@ -1,0 +1,23 @@
+@bender-tags: 4.9.0, feature, 932, tp3183
+@bender-ui: collapsed
+@bender-ckeditor-plugins: sourcearea, wysiwygarea, floatingspace, toolbar, easyimage, undo
+
+## Easy Image Upload
+
+Upload some images:
+
+1. Execute one of the following steps:
+	1. Make a screenshot, copy a graphic to the clipboard and paste using `ctrl/cmd+v`.
+	1. Drag and drop an jpg/png/bmp/gif image from your OS explorer to the editable.
+	1. Firefox only: Copy an image file (from your OS explorer) into the clipboard, and paste into the editable.
+2. Click "Undo" button
+
+### Expected
+
+* Widget is removed from the editor.
+* There is only one undo step.
+
+### Unexpected
+
+* Widget still exists after pressing "Undo".
+* There are more than one undo steps.

--- a/tests/plugins/easyimage/uploadwidget.js
+++ b/tests/plugins/easyimage/uploadwidget.js
@@ -1,5 +1,5 @@
 /* bender-tags: editor,clipboard,widget */
-/* bender-ckeditor-plugins: easyimage,toolbar, */
+/* bender-ckeditor-plugins: easyimage,toolbar,undo */
 /* bender-include: %BASE_PATH%/plugins/clipboard/_helpers/pasting.js */
 /* bender-include: %BASE_PATH%/plugins/uploadfile/_helpers/waitForImage.js */
 /* global pasteFiles, waitForImage */
@@ -154,6 +154,35 @@
 
 				assert.areSame( 0, loadAndUploadCount );
 				assert.areSame( 1, uploadCount );
+			} );
+		},
+
+		// #tp3183
+		'test undo steps (integration test)': function( editor ) {
+			var file = bender.tools.srcToFile( DATA_IMG );
+			file.name = 'foo.gif';
+			pasteFiles( editor, [ file ] );
+
+			var loader = editor.uploadRepository.loaders[ 0 ];
+
+			loader.data = DATA_IMG;
+			loader.uploadTotal = 10;
+			loader.changeStatus( 'uploading' );
+
+			var image = editor.editable().find( 'img[data-widget="uploadeasyimage"]' ).getItem( 0 );
+
+			loader.url = IMG_URL;
+			loader.changeStatus( 'uploaded' );
+
+			waitForImage( image, function() {
+				setTimeout( function() {
+					resume( function() {
+						assert.isFalse( editor.undoManager.undoable(), 'undo state' );
+					} );
+				}, 0 );
+
+				editor.execCommand( 'undo' );
+				wait();
 			} );
 		},
 


### PR DESCRIPTION
## What is the purpose of this pull request?

Bug fix

## Does your PR contain necessary tests?

All patches which change the editor code must include tests. You can always read more
on [PR testing](https://docs.ckeditor.com/ckeditor4/docs/#!/guide/dev_contributing_code-section-tests),
[how to set the testing environment](https://docs.ckeditor.com/ckeditor4/docs/#!/guide/dev_tests) and
[how to create tests](https://docs.ckeditor.com/ckeditor4/docs/#!/guide/dev_tests-section-creating-your-own-test)
in the official CKEditor documentation.

### This PR contains

- [x] Unit tests
- [x] Manual tests

## What changes did you make?

I've locked snapshots before modifying HTML (in `onUploaded` and in `update` handler of progressbar) and immediately unlocked them after modifying.
