### PR TITLE
Prevent loss of user-entered spaces in `getData`

### DIFF
--- a/core/selection.js
+++ b/core/selection.js
@@ -1132,7 +1132,7 @@
 			// Note: Used low priority to filter when dataProcessor works on strings,
 			// not pseudo–DOM.
 			editor.on( 'toDataFormat', function( evt ) {
-				evt.data.dataValue = removeFillingCharSequenceString( evt.data.dataValue );
+				evt.data.dataValue = removeFillingCharSequenceString( evt.data.dataValue, 1 );
 			}, null, null, 0 );
 		} );
 	}

--- a/tests/core/editable/setgetdata.js
+++ b/tests/core/editable/setgetdata.js
@@ -66,5 +66,27 @@ bender.test( {
 				assert.areSame( 1, toDataFormat, 'toDataFormat was fired once' );
 			} );
 		} );
+	},
+
+	'test toDataFormat - preserves space after br': function() {
+		bender.editorBot.create( {
+			name: 'test_data_space_after_newline',
+			creator: 'inline',
+			config: {
+				enterMode: CKEDITOR.ENTER_BR
+			}
+		}, function( bot ) {
+			var editor = bot.editor;
+
+			// Insert text in multiple steps so that selectionchange is triggered in between,
+			// which causes CKEDITOR to insert fillingCharSequence.
+			bot.htmlWithSelection( 'first line<br />^' );
+			editor.insertText( ' ' );
+			editor.insertText( 'second line' );
+
+			// Removal of fillingCharSequence during `toDataFormat` may be performed incorrectly,
+			// causing the space to be removed.
+			assert.areSame( 'first line<br />&nbsp;second line', editor.getData(), 'getData preserved space' );
+		} );
 	}
 } );


### PR DESCRIPTION
## What is the purpose of this pull request?

Bug fix for #1416.

## Does your PR contain necessary tests?

Yes, a test is added to `tests/core/editable/setgetdata.js`.

### This PR contains

- [x] Unit tests
- [ ] Manual tests

## What changes did you make?

In `toDataFormat` handler inside `selection.js` `removeFillingCharSequenceString` is now called with `nbspAware=1`.
