### PR TITLE
Added identifying attribute to the Magic Line plugin

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -6,9 +6,14 @@
 New Features:
 
 * [#1338](https://github.com/ckeditor/ckeditor-dev/issues/1338): Keystroke labels are displayed for function keys (like F7, F8).
+* [#1441](https://github.com/ckeditor/ckeditor-dev/issues/1441): [Magic Line](https://ckeditor.com/cke4/addon/magicline) line element can now be identifiable using `data-cke-magic-line="1"` attribute.
+
+## CKEditor 4.8.1
+
+New Features:
+
 * [#933](https://github.com/ckeditor/ckeditor-dev/issues/933): [File Browser](https://ckeditor.com/cke4/addon/filetools) plugin can now upload files using XHR requests. This allows for setting custom HTTP headers using [`config.fileTools_requestHeaders`](http://docs.ckeditor.test/#!/api/CKEDITOR.config-cfg-fileTools_requestHeaders) configuration option.
 * [#1399](https://github.com/ckeditor/ckeditor-dev/issues/1399): Added possibility to set [`CKEDITOR.config.startupFocus`](https://docs.ckeditor.com/ckeditor4/docs/#!/api/CKEDITOR.config-cfg-startupFocus) as `start` or `end` to specify where editor focus should be after initialization.
-* [#1441](https://github.com/ckeditor/ckeditor-dev/issues/1441): [Magic Line](https://ckeditor.com/cke4/addon/magicline) line element can now be identifiable using `data-cke-magicline-line="1"` attribute.
 
 Fixed Issues:
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -8,6 +8,7 @@ New Features:
 * [#1338](https://github.com/ckeditor/ckeditor-dev/issues/1338): Keystroke labels are displayed for function keys (like F7, F8).
 * [#933](https://github.com/ckeditor/ckeditor-dev/issues/933): [File Browser](https://ckeditor.com/cke4/addon/filetools) plugin can now upload files using XHR requests. This allows for setting custom HTTP headers using [`config.fileTools_requestHeaders`](http://docs.ckeditor.test/#!/api/CKEDITOR.config-cfg-fileTools_requestHeaders) configuration option.
 * [#1399](https://github.com/ckeditor/ckeditor-dev/issues/1399): Added possibility to set [`CKEDITOR.config.startupFocus`](https://docs.ckeditor.com/ckeditor4/docs/#!/api/CKEDITOR.config-cfg-startupFocus) as `start` or `end` to specify where editor focus should be after initialization.
+* [#1441](https://github.com/ckeditor/ckeditor-dev/issues/1441): [Magic Line](https://ckeditor.com/cke4/addon/magicline) line element can now be identifiable using `data-cke-magicline-line="1"` attribute.
 
 Fixed Issues:
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -6,14 +6,9 @@
 New Features:
 
 * [#1338](https://github.com/ckeditor/ckeditor-dev/issues/1338): Keystroke labels are displayed for function keys (like F7, F8).
-* [#1441](https://github.com/ckeditor/ckeditor-dev/issues/1441): [Magic Line](https://ckeditor.com/cke4/addon/magicline) line element can now be identifiable using `data-cke-magic-line="1"` attribute.
-
-## CKEditor 4.8.1
-
-New Features:
-
 * [#933](https://github.com/ckeditor/ckeditor-dev/issues/933): [File Browser](https://ckeditor.com/cke4/addon/filetools) plugin can now upload files using XHR requests. This allows for setting custom HTTP headers using [`config.fileTools_requestHeaders`](http://docs.ckeditor.test/#!/api/CKEDITOR.config-cfg-fileTools_requestHeaders) configuration option.
 * [#1399](https://github.com/ckeditor/ckeditor-dev/issues/1399): Added possibility to set [`CKEDITOR.config.startupFocus`](https://docs.ckeditor.com/ckeditor4/docs/#!/api/CKEDITOR.config-cfg-startupFocus) as `start` or `end` to specify where editor focus should be after initialization.
+* [#1441](https://github.com/ckeditor/ckeditor-dev/issues/1441): [Magic Line](https://ckeditor.com/cke4/addon/magicline) line element can now be identified by `data-cke-magic-line="1"` attribute.
 
 Fixed Issues:
 

--- a/plugins/magicline/plugin.js
+++ b/plugins/magicline/plugin.js
@@ -570,7 +570,7 @@
 	function initLine( that ) {
 		var doc = that.doc,
 			// This the main box element that holds triangles and the insertion button
-			line = newElementFromHtml( '<span contenteditable="false" data-cke-magicline-line="1" style="' + CSS_COMMON + 'position:absolute;border-top:1px dashed ' + that.boxColor + '"></span>', doc ),
+			line = newElementFromHtml( '<span contenteditable="false" data-cke-magic-line="1" style="' + CSS_COMMON + 'position:absolute;border-top:1px dashed ' + that.boxColor + '"></span>', doc ),
 			iconPath = CKEDITOR.getUrl( this.path + 'images/' + ( env.hidpi ? 'hidpi/' : '' ) + 'icon' + ( that.rtl ? '-rtl' : '' ) + '.png' );
 
 		extend( line, {

--- a/plugins/magicline/plugin.js
+++ b/plugins/magicline/plugin.js
@@ -570,7 +570,7 @@
 	function initLine( that ) {
 		var doc = that.doc,
 			// This the main box element that holds triangles and the insertion button
-			line = newElementFromHtml( '<span contenteditable="false" style="' + CSS_COMMON + 'position:absolute;border-top:1px dashed ' + that.boxColor + '"></span>', doc ),
+			line = newElementFromHtml( '<span contenteditable="false" data-cke-magicline-line="1" style="' + CSS_COMMON + 'position:absolute;border-top:1px dashed ' + that.boxColor + '"></span>', doc ),
 			iconPath = CKEDITOR.getUrl( this.path + 'images/' + ( env.hidpi ? 'hidpi/' : '' ) + 'icon' + ( that.rtl ? '-rtl' : '' ) + '.png' );
 
 		extend( line, {

--- a/tests/plugins/magicline/magicline.js
+++ b/tests/plugins/magicline/magicline.js
@@ -475,7 +475,7 @@
 				} );
 		},
 
-		'line has data-cke-magicline-line attribute': function() {
+		'line has data-cke-magic-line attribute': function() {
 				testEditor( this, {},
 					'',
 					function( editor, editable, backdoor ) {
@@ -490,7 +490,7 @@
 						backdoor.that.line.attach().place();
 
 						var line = editable.getChild( [ 0, 0 ] );
-						assert.areEqual( '1', line.getAttribute( 'data-cke-magicline-line' ) );
+						assert.areEqual( '1', line.getAttribute( 'data-cke-magic-line' ) );
 					} );
 			},
 

--- a/tests/plugins/magicline/magicline.js
+++ b/tests/plugins/magicline/magicline.js
@@ -475,6 +475,25 @@
 				} );
 		},
 
+		'line has data-cke-magicline-line attribute': function() {
+				testEditor( this, {},
+					'',
+					function( editor, editable, backdoor ) {
+						var dummy1 = CKEDITOR.dom.element.createFromHtml( '<div>CK</div>', editor.document ),
+							dummy2 = CKEDITOR.dom.element.createFromHtml( '<div>Editor</div>', editor.document );
+
+						editable.setHtml( '' );
+						dummy1.appendTo( editable );
+						dummy2.appendTo( editable );
+
+						backdoor.that.trigger = new backdoor.boxTrigger( [ dummy1, dummy2, EDGE_MIDDLE, TYPE_EXPAND, LOOK_NORMAL ] );
+						backdoor.that.line.attach().place();
+
+						var line = editable.getChild( [ 0, 0 ] );
+						assert.areEqual( '1', line.getAttribute( 'data-cke-magicline-line' ) );
+					} );
+			},
+
 		// Checks line (+ line children) recognition function
 		'is line': function() {
 			testEditor( this, {},

--- a/tests/plugins/magicline/manual/lineattribute.html
+++ b/tests/plugins/magicline/manual/lineattribute.html
@@ -1,0 +1,67 @@
+<textarea cols="80" id="editor1" name="editor1" rows="10">
+  &lt;table border=&quot;1&quot; cellpadding=&quot;1&quot; cellspacing=&quot;1&quot; style=&quot;width: 100%; &quot;&gt;
+    &lt;tbody&gt;
+      &lt;tr&gt;
+        &lt;td&gt;This table&lt;/td&gt;
+        &lt;td&gt;is the&lt;/td&gt;
+        &lt;td&gt;very first&lt;/td&gt;
+        &lt;td&gt;element of the document.&lt;/td&gt;
+      &lt;/tr&gt;
+      &lt;tr&gt;
+        &lt;td&gt;We are still&lt;/td&gt;
+        &lt;td&gt;able to acces&lt;/td&gt;
+        &lt;td&gt;the space before it.&lt;/td&gt;
+        &lt;td&gt;
+        &lt;table border=&quot;1&quot; cellpadding=&quot;1&quot; cellspacing=&quot;1&quot; style=&quot;width: 100%; &quot;&gt;
+          &lt;tbody&gt;
+            &lt;tr&gt;
+              &lt;td&gt;This table is inside of a cell of another table.&lt;/td&gt;
+            &lt;/tr&gt;
+            &lt;tr&gt;
+              &lt;td&gt;We can type&amp;nbsp;either before or after it though.&lt;/td&gt;
+            &lt;/tr&gt;
+          &lt;/tbody&gt;
+        &lt;/table&gt;
+        &lt;/td&gt;
+      &lt;/tr&gt;
+    &lt;/tbody&gt;
+  &lt;/table&gt;
+
+  &lt;p&gt;Two succesive horizontal lines (&lt;tt&gt;HR&lt;/tt&gt; tags). We can access the space in between:&lt;/p&gt;
+
+  &lt;hr /&gt;
+  &lt;hr /&gt;
+  &lt;ol&gt;
+    &lt;li&gt;This numbered list...&lt;/li&gt;
+    &lt;li&gt;...is a neighbour of a horizontal line...&lt;/li&gt;
+    &lt;li&gt;...and another list.&lt;/li&gt;
+  &lt;/ol&gt;
+
+  &lt;ul&gt;
+    &lt;li&gt;We can type between the lists...&lt;/li&gt;
+    &lt;li&gt;...thanks to &lt;strong&gt;Magicline&lt;/strong&gt;.&lt;/li&gt;
+  &lt;/ul&gt;
+
+  &lt;p&gt;Lorem ipsum dolor sit amet dui. Morbi vel turpis. Nullam et leo. Etiam rutrum, urna tellus dui vel tincidunt mattis egestas, justo fringilla vel, massa. Phasellus.&lt;/p&gt;
+
+  &lt;p&gt;Quisque iaculis, dui lectus varius vitae, tortor. Proin lacus. Pellentesque ac lacus. Aenean nonummy commodo nec, pede. Etiam blandit risus elit.&lt;/p&gt;
+
+  &lt;p&gt;Ut pretium. Vestibulum rutrum in, adipiscing elit. Sed in quam in purus sem vitae pede. Pellentesque bibendum, urna sem vel risus. Vivamus posuere metus. Aliquam gravida iaculis nisl. Nam enim. Aliquam erat ac lacus tellus ac felis.&lt;/p&gt;
+
+  &lt;div style=&quot;border: 2px dashed green; background: #ddd; text-align: center;&quot;&gt;
+  &lt;p&gt;This text is wrapped in a&amp;nbsp;&lt;tt&gt;DIV&lt;/tt&gt;&amp;nbsp;element. We can type after this element though.&lt;/p&gt;
+  &lt;/div&gt;
+</textarea>
+
+<script>
+  CKEDITOR.replace( 'editor1', {
+  extraPlugins: 'magicline',
+  magicline_color: 'blue',
+  allowedContent: true
+});
+
+CKEDITOR.addCss( 'span[data-cke-magicline-line="1"] { border-top: solid 1px red !important; } ' +
+                  'span[data-cke-magicline-line="1"] span:nth-child(1) { border-right-color: red !important; } ' +
+                  'span[data-cke-magicline-line="1"] span:nth-child(2) { border-left-color: red !important; } ' +
+                  'span[data-cke-magicline-line="1"] span:nth-child(3) { background-color: red !important; }' );
+</script>

--- a/tests/plugins/magicline/manual/lineattribute.html
+++ b/tests/plugins/magicline/manual/lineattribute.html
@@ -60,7 +60,7 @@
 	} );
 
 	CKEDITOR.addCss( 'span[data-cke-magic-line="1"] { border-top: solid 1px red !important; } ' +
-		'span[data-cke-magic-line="1"] span:nth-child(1) { border-right-color: red !important; } ' +
-		'span[data-cke-magic-line="1"] span:nth-child(2) { border-left-color: red !important; } ' +
-		'span[data-cke-magic-line="1"] span:nth-child(3) { background-color: red !important; }' );
+		'span[data-cke-magic-line="1"] span:first-child { border-right-color: red !important; } ' +
+		'span[data-cke-magic-line="1"] span:first-child + span { border-left-color: red !important; } ' +
+		'span[data-cke-magic-line="1"] span:first-child + span + span { background-color: red !important; }' );
 </script>

--- a/tests/plugins/magicline/manual/lineattribute.html
+++ b/tests/plugins/magicline/manual/lineattribute.html
@@ -60,8 +60,8 @@
   allowedContent: true
 });
 
-CKEDITOR.addCss( 'span[data-cke-magicline-line="1"] { border-top: solid 1px red !important; } ' +
-                  'span[data-cke-magicline-line="1"] span:nth-child(1) { border-right-color: red !important; } ' +
-                  'span[data-cke-magicline-line="1"] span:nth-child(2) { border-left-color: red !important; } ' +
-                  'span[data-cke-magicline-line="1"] span:nth-child(3) { background-color: red !important; }' );
+CKEDITOR.addCss( 'span[data-cke-magic-line="1"] { border-top: solid 1px red !important; } ' +
+                  'span[data-cke-magic-line="1"] span:nth-child(1) { border-right-color: red !important; } ' +
+                  'span[data-cke-magic-line="1"] span:nth-child(2) { border-left-color: red !important; } ' +
+                  'span[data-cke-magic-line="1"] span:nth-child(3) { background-color: red !important; }' );
 </script>

--- a/tests/plugins/magicline/manual/lineattribute.html
+++ b/tests/plugins/magicline/manual/lineattribute.html
@@ -1,67 +1,66 @@
 <textarea cols="80" id="editor1" name="editor1" rows="10">
-  &lt;table border=&quot;1&quot; cellpadding=&quot;1&quot; cellspacing=&quot;1&quot; style=&quot;width: 100%; &quot;&gt;
-    &lt;tbody&gt;
-      &lt;tr&gt;
-        &lt;td&gt;This table&lt;/td&gt;
-        &lt;td&gt;is the&lt;/td&gt;
-        &lt;td&gt;very first&lt;/td&gt;
-        &lt;td&gt;element of the document.&lt;/td&gt;
-      &lt;/tr&gt;
-      &lt;tr&gt;
-        &lt;td&gt;We are still&lt;/td&gt;
-        &lt;td&gt;able to acces&lt;/td&gt;
-        &lt;td&gt;the space before it.&lt;/td&gt;
-        &lt;td&gt;
-        &lt;table border=&quot;1&quot; cellpadding=&quot;1&quot; cellspacing=&quot;1&quot; style=&quot;width: 100%; &quot;&gt;
-          &lt;tbody&gt;
-            &lt;tr&gt;
-              &lt;td&gt;This table is inside of a cell of another table.&lt;/td&gt;
-            &lt;/tr&gt;
-            &lt;tr&gt;
-              &lt;td&gt;We can type&amp;nbsp;either before or after it though.&lt;/td&gt;
-            &lt;/tr&gt;
-          &lt;/tbody&gt;
-        &lt;/table&gt;
-        &lt;/td&gt;
-      &lt;/tr&gt;
-    &lt;/tbody&gt;
-  &lt;/table&gt;
+	&lt;table border=&quot;1&quot; cellpadding=&quot;1&quot; cellspacing=&quot;1&quot; style=&quot;width: 100%; &quot;&gt;
+		&lt;tbody&gt;
+			&lt;tr&gt;
+				&lt;td&gt;This table&lt;/td&gt;
+				&lt;td&gt;is the&lt;/td&gt;
+				&lt;td&gt;very first&lt;/td&gt;
+				&lt;td&gt;element of the document.&lt;/td&gt;
+			&lt;/tr&gt;
+			&lt;tr&gt;
+				&lt;td&gt;We are still&lt;/td&gt;
+				&lt;td&gt;able to acces&lt;/td&gt;
+				&lt;td&gt;the space before it.&lt;/td&gt;
+				&lt;td&gt;
+				&lt;table border=&quot;1&quot; cellpadding=&quot;1&quot; cellspacing=&quot;1&quot; style=&quot;width: 100%; &quot;&gt;
+					&lt;tbody&gt;
+						&lt;tr&gt;
+							&lt;td&gt;This table is inside of a cell of another table.&lt;/td&gt;
+						&lt;/tr&gt;
+						&lt;tr&gt;
+							&lt;td&gt;We can type&amp;nbsp;either before or after it though.&lt;/td&gt;
+						&lt;/tr&gt;
+					&lt;/tbody&gt;
+				&lt;/table&gt;
+				&lt;/td&gt;
+			&lt;/tr&gt;
+		&lt;/tbody&gt;
+	&lt;/table&gt;
 
-  &lt;p&gt;Two succesive horizontal lines (&lt;tt&gt;HR&lt;/tt&gt; tags). We can access the space in between:&lt;/p&gt;
+	&lt;p&gt;Two succesive horizontal lines (&lt;tt&gt;HR&lt;/tt&gt; tags). We can access the space in between:&lt;/p&gt;
 
-  &lt;hr /&gt;
-  &lt;hr /&gt;
-  &lt;ol&gt;
-    &lt;li&gt;This numbered list...&lt;/li&gt;
-    &lt;li&gt;...is a neighbour of a horizontal line...&lt;/li&gt;
-    &lt;li&gt;...and another list.&lt;/li&gt;
-  &lt;/ol&gt;
+	&lt;hr /&gt;
+	&lt;hr /&gt;
+	&lt;ol&gt;
+		&lt;li&gt;This numbered list...&lt;/li&gt;
+		&lt;li&gt;...is a neighbour of a horizontal line...&lt;/li&gt;
+		&lt;li&gt;...and another list.&lt;/li&gt;
+	&lt;/ol&gt;
 
-  &lt;ul&gt;
-    &lt;li&gt;We can type between the lists...&lt;/li&gt;
-    &lt;li&gt;...thanks to &lt;strong&gt;Magicline&lt;/strong&gt;.&lt;/li&gt;
-  &lt;/ul&gt;
+	&lt;ul&gt;
+		&lt;li&gt;We can type between the lists...&lt;/li&gt;
+		&lt;li&gt;...thanks to &lt;strong&gt;Magicline&lt;/strong&gt;.&lt;/li&gt;
+	&lt;/ul&gt;
 
-  &lt;p&gt;Lorem ipsum dolor sit amet dui. Morbi vel turpis. Nullam et leo. Etiam rutrum, urna tellus dui vel tincidunt mattis egestas, justo fringilla vel, massa. Phasellus.&lt;/p&gt;
+	&lt;p&gt;Lorem ipsum dolor sit amet dui. Morbi vel turpis. Nullam et leo. Etiam rutrum, urna tellus dui vel tincidunt mattis egestas, justo fringilla vel, massa. Phasellus.&lt;/p&gt;
 
-  &lt;p&gt;Quisque iaculis, dui lectus varius vitae, tortor. Proin lacus. Pellentesque ac lacus. Aenean nonummy commodo nec, pede. Etiam blandit risus elit.&lt;/p&gt;
+	&lt;p&gt;Quisque iaculis, dui lectus varius vitae, tortor. Proin lacus. Pellentesque ac lacus. Aenean nonummy commodo nec, pede. Etiam blandit risus elit.&lt;/p&gt;
 
-  &lt;p&gt;Ut pretium. Vestibulum rutrum in, adipiscing elit. Sed in quam in purus sem vitae pede. Pellentesque bibendum, urna sem vel risus. Vivamus posuere metus. Aliquam gravida iaculis nisl. Nam enim. Aliquam erat ac lacus tellus ac felis.&lt;/p&gt;
+	&lt;p&gt;Ut pretium. Vestibulum rutrum in, adipiscing elit. Sed in quam in purus sem vitae pede. Pellentesque bibendum, urna sem vel risus. Vivamus posuere metus. Aliquam gravida iaculis nisl. Nam enim. Aliquam erat ac lacus tellus ac felis.&lt;/p&gt;
 
-  &lt;div style=&quot;border: 2px dashed green; background: #ddd; text-align: center;&quot;&gt;
-  &lt;p&gt;This text is wrapped in a&amp;nbsp;&lt;tt&gt;DIV&lt;/tt&gt;&amp;nbsp;element. We can type after this element though.&lt;/p&gt;
-  &lt;/div&gt;
+	&lt;div style=&quot;border: 2px dashed green; background: #ddd; text-align: center;&quot;&gt;
+	&lt;p&gt;This text is wrapped in a&amp;nbsp;&lt;tt&gt;DIV&lt;/tt&gt;&amp;nbsp;element. We can type after this element though.&lt;/p&gt;
+	&lt;/div&gt;
 </textarea>
 
 <script>
-  CKEDITOR.replace( 'editor1', {
-  extraPlugins: 'magicline',
-  magicline_color: 'blue',
-  allowedContent: true
-});
+	CKEDITOR.replace( 'editor1', {
+		magicline_color: 'blue',
+		height: '30em'
+	} );
 
-CKEDITOR.addCss( 'span[data-cke-magic-line="1"] { border-top: solid 1px red !important; } ' +
-                  'span[data-cke-magic-line="1"] span:nth-child(1) { border-right-color: red !important; } ' +
-                  'span[data-cke-magic-line="1"] span:nth-child(2) { border-left-color: red !important; } ' +
-                  'span[data-cke-magic-line="1"] span:nth-child(3) { background-color: red !important; }' );
+	CKEDITOR.addCss( 'span[data-cke-magic-line="1"] { border-top: solid 1px red !important; } ' +
+		'span[data-cke-magic-line="1"] span:nth-child(1) { border-right-color: red !important; } ' +
+		'span[data-cke-magic-line="1"] span:nth-child(2) { border-left-color: red !important; } ' +
+		'span[data-cke-magic-line="1"] span:nth-child(3) { background-color: red !important; }' );
 </script>

--- a/tests/plugins/magicline/manual/lineattribute.md
+++ b/tests/plugins/magicline/manual/lineattribute.md
@@ -1,0 +1,14 @@
+@bender-tags: 1441, feature, 4.9.0, magicline
+@bender-ui: collapsed
+@bender-ckeditor-plugins: wysiwygarea, basicstyles, elementspath, magicline
+
+1. Hover the cursor over the editor and find a magic line pop-up.
+2. Check magic line pop-up color.
+
+## Expected
+
+Magic line pop-up is red.
+
+## Unexpected
+
+Magic line pop-up is blue.

--- a/tests/plugins/magicline/manual/lineattribute.md
+++ b/tests/plugins/magicline/manual/lineattribute.md
@@ -1,14 +1,13 @@
 @bender-tags: 1441, feature, 4.9.0, magicline
 @bender-ui: collapsed
-@bender-ckeditor-plugins: wysiwygarea, basicstyles, elementspath, magicline
+@bender-ckeditor-plugins: wysiwygarea, basicstyles, elementspath, magicline,toolbar, table, list, magicline, div, horizontalrule
 
-1. Hover the cursor over the editor and find a magic line pop-up.
-2. Check magic line pop-up color.
+Hover over different editor elements in a way that magic line is visible.
 
 ## Expected
 
-Magic line pop-up is red.
+Whole magic line element is red.
 
 ## Unexpected
 
-Magic line pop-up is blue.
+Whole magic line element is blue.


### PR DESCRIPTION
## What is the purpose of this pull request?

New feature

## Does your PR contain necessary tests?

All patches which change the editor code must include tests. You can always read more
on [PR testing](https://docs.ckeditor.com/ckeditor4/docs/#!/guide/dev_contributing_code-section-tests),
[how to set the testing environment](https://docs.ckeditor.com/ckeditor4/docs/#!/guide/dev_tests) and
[how to create tests](https://docs.ckeditor.com/ckeditor4/docs/#!/guide/dev_tests-section-creating-your-own-test)
in the official CKEditor documentation.

### This PR contains

- [x] Unit tests
- [x] Manual tests

## What changes did you make?

Added `data-cke-magic-line="1"` attribute to the [Magic Line](https://ckeditor.com/cke4/addon/magicline) line element. 

Closes #1441
