### PR TITLE
Fix for: Using dialog to remove table header when tbody is empty throws an error

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -3,6 +3,10 @@
 
 ## CKEditor 4.11.4
 
+Fixed Issues:
+
+* [#1397](https://github.com/ckeditor/ckeditor-dev/issues/1397): Fixed: Using dialog to remove headers from [table](https://ckeditor.com/cke4/addon/table) with one row causes JavaScript Error.
+
 ## CKEditor 4.11.3
 
 Fixed Issues:

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -5,7 +5,7 @@
 
 Fixed Issues:
 
-* [#1397](https://github.com/ckeditor/ckeditor-dev/issues/1397): Fixed: Using dialog to remove headers from [table](https://ckeditor.com/cke4/addon/table) with one row causes JavaScript Error.
+* [#1397](https://github.com/ckeditor/ckeditor-dev/issues/1397): Fixed: Using dialog to remove headers from the [table](https://ckeditor.com/cke4/addon/table) with one headers row only throws an error.
 
 ## CKEditor 4.11.3
 

--- a/plugins/table/dialogs/table.js
+++ b/plugins/table/dialogs/table.js
@@ -193,7 +193,11 @@
 									newCell.removeAttribute( 'scope' );
 								}
 							}
-							theRow.insertBefore( previousFirstRow );
+							if ( previousFirstRow ) {
+								theRow.insertBefore( previousFirstRow );
+							} else {
+								tbody.append( theRow );
+							}
 						}
 						thead.remove();
 					}

--- a/plugins/table/dialogs/table.js
+++ b/plugins/table/dialogs/table.js
@@ -183,7 +183,6 @@
 						thead = new CKEDITOR.dom.element( table.$.tHead );
 						tbody = table.getElementsByTag( 'tbody' ).getItem( 0 );
 
-						var previousFirstRow = tbody.getFirst();
 						while ( thead.getChildCount() > 0 ) {
 							theRow = thead.getFirst();
 							for ( i = 0; i < theRow.getChildCount(); i++ ) {
@@ -193,11 +192,9 @@
 									newCell.removeAttribute( 'scope' );
 								}
 							}
-							if ( previousFirstRow ) {
-								theRow.insertBefore( previousFirstRow );
-							} else {
-								tbody.append( theRow );
-							}
+
+							// Append the row to the start (#1397).
+							tbody.append( theRow, true );
 						}
 						thead.remove();
 					}

--- a/tests/plugins/table/manual/onlyrowheader.html
+++ b/tests/plugins/table/manual/onlyrowheader.html
@@ -13,5 +13,8 @@
 </textarea>
 
 <script>
+	if ( bender.env.mobile ) {
+		bender.ignore();
+	}
 	CKEDITOR.replace( 'editor1' );
 </script>

--- a/tests/plugins/table/manual/onlyrowheader.html
+++ b/tests/plugins/table/manual/onlyrowheader.html
@@ -1,0 +1,17 @@
+<textarea id="editor1">
+	<table border="1" cellspacing="1" cellpadding="1" style="width:500px;">
+		<thead>
+			<tr>
+				<th scope="row"><br></th>
+				<th scope="col"><br></th>
+			</tr>
+		</thead>
+		<tbody>
+
+		</tbody>
+	</table>
+</textarea>
+
+<script>
+	CKEDITOR.replace( 'editor1' );
+</script>

--- a/tests/plugins/table/manual/onlyrowheader.md
+++ b/tests/plugins/table/manual/onlyrowheader.md
@@ -1,4 +1,4 @@
-@bender-tags: 4.8.1, bug, table, 1397
+@bender-tags: 4.11.4, bug, table, 1397
 @bender-ui: collapsed
 @bender-ckeditor-plugins: wysiwygarea,toolbar,table,sourcearea,dialogadvtab,contextmenu
 

--- a/tests/plugins/table/manual/onlyrowheader.md
+++ b/tests/plugins/table/manual/onlyrowheader.md
@@ -3,7 +3,7 @@
 @bender-ckeditor-plugins: wysiwygarea,toolbar,table,sourcearea,dialogadvtab,contextmenu
 
 # Test steps
-1. Rightclick on table, open table properties from context menu.
+1. Open context menu on table and choose table properties.
 1. Change headers to none and press ok.
 
 ## Expected

--- a/tests/plugins/table/manual/onlyrowheader.md
+++ b/tests/plugins/table/manual/onlyrowheader.md
@@ -2,9 +2,13 @@
 @bender-ui: collapsed
 @bender-ckeditor-plugins: wysiwygarea,toolbar,table,sourcearea,dialogadvtab,contextmenu
 
-# Test steps
+1. Open developer console.
 1. Open context menu on table and choose table properties.
 1. Change headers to none and press ok.
 
 ## Expected
-Table headers should become regular cells.
+Table headers transforms into regular cells.
+
+## Unexpected
+- Table headers doesn't change into cells.
+- Type Error is thrown in console.

--- a/tests/plugins/table/manual/onlyrowheader.md
+++ b/tests/plugins/table/manual/onlyrowheader.md
@@ -1,0 +1,10 @@
+@bender-tags: 4.8.1, bug, table, 1397
+@bender-ui: collapsed
+@bender-ckeditor-plugins: wysiwygarea,toolbar,table,sourcearea,dialogadvtab,contextmenu
+
+# Test steps
+1. Rightclick on table, open table properties from context menu.
+1. Change headers to none and press ok.
+
+## Expected
+Table headers should become regular cells.

--- a/tests/plugins/table/table.js
+++ b/tests/plugins/table/table.js
@@ -172,8 +172,6 @@
 				'</table>'
 			);
 
-
-
 			bot.dialog( 'tableProperties', function( dialog, editor ) {
 				dialog.setValueOf( 'info', 'selHeaders', 'none' );
 

--- a/tests/plugins/table/table.js
+++ b/tests/plugins/table/table.js
@@ -163,8 +163,8 @@
 				'<table border="1" cellspacing="1" cellpadding="1" style="width:500px;">' +
 					'<thead>' +
 						'<tr>' +
-							'<th scope="row">^<br></th>' +
-							'<th scope="col"><br></th>' +
+							'<th>^<br></th>' +
+							'<th><br></th>' +
 						'</tr>' +
 					'</thead>' +
 					'<tbody>' +
@@ -191,12 +191,12 @@
 				'<table border="1" cellspacing="1" cellpadding="1" style="width:500px;">' +
 					'<thead>' +
 						'<tr>' +
-							'<th scope="row">^Foo</th>' +
+							'<th>^Foo</th>' +
 						'</tr>' +
 					'</thead>' +
 					'<tbody>' +
 						'<tr>' +
-							'<td scope="row">Bar</td>' +
+							'<td>Bar</td>' +
 						'</tr>' +
 					'</tbody>' +
 				'</table>'
@@ -215,7 +215,7 @@
 								'<td>Foo</td>' +
 							'</tr>' +
 							'<tr>' +
-								'<td scope="row">Bar</td>' +
+								'<td>Bar</td>' +
 							'</tr>' +
 						'</tbody>' +
 					'</table>',

--- a/tests/plugins/table/table.js
+++ b/tests/plugins/table/table.js
@@ -181,6 +181,46 @@
 				assert.isNull( dialog.parts.dialog.findOne( 'th' ) );
 				assert.isTrue( !!dialog.parts.dialog.findOne( 'td' ) );
 			} );
+		},
+
+		// (#1397)
+		'test table remove headers': function() {
+			var bot = this.editorBots.editor;
+
+			bot.setHtmlWithSelection(
+				'<table border="1" cellspacing="1" cellpadding="1" style="width:500px;">' +
+					'<thead>' +
+						'<tr>' +
+							'<th scope="row">^Foo</th>' +
+						'</tr>' +
+					'</thead>' +
+					'<tbody>' +
+						'<tr>' +
+							'<td scope="row">Bar</td>' +
+						'</tr>' +
+					'</tbody>' +
+				'</table>'
+			);
+
+			bot.dialog( 'tableProperties', function( dialog ) {
+				dialog.setValueOf( 'info', 'selHeaders', 'none' );
+
+				dialog.fire( 'ok' );
+				dialog.hide();
+
+				assert.beautified.html(
+					'<table border="1" cellspacing="1" cellpadding="1" style="width:500px">' +
+						'<tbody>' +
+							'<tr>' +
+								'<td>Foo</td>' +
+							'</tr>' +
+							'<tr>' +
+								'<td scope="row">Bar</td>' +
+							'</tr>' +
+						'</tbody>' +
+					'</table>',
+					dialog.getParentEditor().getData() );
+			} );
 		}
 	} );
 } )();

--- a/tests/plugins/table/table.js
+++ b/tests/plugins/table/table.js
@@ -155,6 +155,7 @@
 			assert.isTrue( /border="1"/.test( bot.editor.getData() ), 'Border attribute should be one' );
 		},
 
+		// (#1397)
 		'test table dialog error when only row is header': function() {
 			var bot = this.editorBots.editor;
 

--- a/tests/plugins/table/table.js
+++ b/tests/plugins/table/table.js
@@ -153,7 +153,36 @@
 				'</table>' );
 
 			assert.isTrue( /border="1"/.test( bot.editor.getData() ), 'Border attribute should be one' );
+		},
+
+		'test table dialog error when only row is header': function() {
+			var bot = this.editorBots.editor;
+			var editor = bot.editor;
+
+			bot.setHtmlWithSelection(
+				'<table border="1" cellspacing="1" cellpadding="1" style="width:500px;">' +
+					'<thead>' +
+						'<tr>' +
+							'<th scope="row">^<br></th>' +
+							'<th scope="col"><br></th>' +
+						'</tr>' +
+					'</thead>' +
+					'<tbody>' +
+					'</tbody>' +
+				'</table>'
+			);
+
+
+
+			bot.dialog( 'tableProperties', function( dialog, editor ) {
+				dialog.setValueOf( 'info', 'selHeaders', 'none' );
+
+				dialog.fire( 'ok' );
+				dialog.hide();
+
+				assert.isNull( dialog.parts.dialog.findOne( 'th' ) );
+				assert.isTrue( !!dialog.parts.dialog.findOne( 'td' ) );
+			} );
 		}
 	} );
-
 } )();

--- a/tests/plugins/table/table.js
+++ b/tests/plugins/table/table.js
@@ -157,7 +157,6 @@
 
 		'test table dialog error when only row is header': function() {
 			var bot = this.editorBots.editor;
-			var editor = bot.editor;
 
 			bot.setHtmlWithSelection(
 				'<table border="1" cellspacing="1" cellpadding="1" style="width:500px;">' +
@@ -172,7 +171,7 @@
 				'</table>'
 			);
 
-			bot.dialog( 'tableProperties', function( dialog, editor ) {
+			bot.dialog( 'tableProperties', function( dialog ) {
 				dialog.setValueOf( 'info', 'selHeaders', 'none' );
 
 				dialog.fire( 'ok' );


### PR DESCRIPTION
## What is the purpose of this pull request?

Bug fix

## Does your PR contain necessary tests?

All patches which change the editor code must include tests. You can always read more
on [PR testing](https://docs.ckeditor.com/ckeditor4/docs/#!/guide/dev_contributing_code-section-tests),
[how to set the testing environment](https://docs.ckeditor.com/ckeditor4/docs/#!/guide/dev_tests) and
[how to create tests](https://docs.ckeditor.com/ckeditor4/docs/#!/guide/dev_tests-section-creating-your-own-test)
in the official CKEditor documentation.

### This PR contains

- [x] Unit tests
- [x] Manual tests

## What changes did you make?

If tbodies is empty it is impossible to `instertBefore` its first child. I've changed it to use method `append` instead.

Closes #1397 