### PR TITLE
Fixed 'uploadWidgetDefinition.onAbort' method is not called when loader is aborted

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -173,6 +173,7 @@ Fixed Issues:
 * [#1516](https://github.com/ckeditor/ckeditor-dev/issues/1516): Fixed: Fake selection allows removing content in read-only mode using the <kbd>Backspace</kbd> and <kbd>Delete</kbd> keys.
 * [#1570](https://github.com/ckeditor/ckeditor-dev/issues/1570): Fixed: Fake selection allows cutting content in read-only mode using the <kbd>Ctrl</kbd>/<kbd>Cmd</kbd> + <kbd>X</kbd> keys.
 * [#1363](https://github.com/ckeditor/ckeditor-dev/issues/1363): Fixed: Paste notification is unclear and it might confuse users.
+* [#1454](https://github.com/ckeditor/ckeditor-dev/issues/1454): Fixed: [Upload Widget](https://ckeditor.com/cke4/addon/uploadwidget) [`onAbort`](https://docs.ckeditor.com/ckeditor4/docs/#!/api/CKEDITOR.fileTools.uploadWidgetDefinition-property-onAbort) method is not called when loader is aborted.
 
 API Changes:
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -39,6 +39,7 @@ API Changes:
 	* [`tools.eventsBuffer`](https://docs.ckeditor.com/ckeditor4/latest/api/CKEDITOR_tools.html#method-eventsBuffer) has been extracted into [`tools.buffers.event`](https://docs.ckeditor.com/ckeditor4/latest/api/CKEDITOR_tools_buffers_event.html)
 	* [`tools.throttle`](https://docs.ckeditor.com/ckeditor4/latest/api/CKEDITOR_tools.html#method-throttle) has been extracted into [`tools.buffers.throttle`](https://docs.ckeditor.com/ckeditor4/latest/api/CKEDITOR_tools_buffers_throttle.html)
 * [#1451](https://github.com/ckeditor/ckeditor-dev/issues/1451): Fixed: Context menu is incorrectly positioned when opened with `Shift-F10`.
+* [#1454](https://github.com/ckeditor/ckeditor-dev/issues/1454): Fixed: [Upload Widget](https://ckeditor.com/cke4/addon/uploadwidget) [`onAbort`](https://docs.ckeditor.com/ckeditor4/docs/#!/api/CKEDITOR.fileTools.uploadWidgetDefinition-property-onAbort) method is not called when loader is aborted.
 
 ## CKEditor 4.10.1
 
@@ -173,7 +174,6 @@ Fixed Issues:
 * [#1516](https://github.com/ckeditor/ckeditor-dev/issues/1516): Fixed: Fake selection allows removing content in read-only mode using the <kbd>Backspace</kbd> and <kbd>Delete</kbd> keys.
 * [#1570](https://github.com/ckeditor/ckeditor-dev/issues/1570): Fixed: Fake selection allows cutting content in read-only mode using the <kbd>Ctrl</kbd>/<kbd>Cmd</kbd> + <kbd>X</kbd> keys.
 * [#1363](https://github.com/ckeditor/ckeditor-dev/issues/1363): Fixed: Paste notification is unclear and it might confuse users.
-* [#1454](https://github.com/ckeditor/ckeditor-dev/issues/1454): Fixed: [Upload Widget](https://ckeditor.com/cke4/addon/uploadwidget) [`onAbort`](https://docs.ckeditor.com/ckeditor4/docs/#!/api/CKEDITOR.fileTools.uploadWidgetDefinition-property-onAbort) method is not called when loader is aborted.
 
 API Changes:
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -30,6 +30,7 @@ Fixed Issues:
 * [#1113](https://github.com/ckeditor/ckeditor-dev/issues/1113): [Firefox] Fixed: Nested contenteditable elements path not updated on focus with [Div Editing Area](https://ckeditor.com/cke4/addon/divarea) plugin.
 * [#1682](https://github.com/ckeditor/ckeditor-dev/issues/1682) Fixed: Hovering [Balloon Toolbar](https://ckeditor.com/cke4/addon/balloontoolbar) panel changes its size causing flickering.
 * [#421](https://github.com/ckeditor/ckeditor-dev/issues/421) Fixed: Expandable [Button](https://ckeditor.com/cke4/addon/button) puts `(Selected)` text at the end of the label when clicked.
+* [#1454](https://github.com/ckeditor/ckeditor-dev/issues/1454): Fixed: [Upload Widget](https://ckeditor.com/cke4/addon/uploadwidget) [`onAbort`](https://docs.ckeditor.com/ckeditor4/docs/#!/api/CKEDITOR.fileTools.uploadWidgetDefinition-property-onAbort) method is not called when loader is aborted.
 
 API Changes:
 
@@ -39,7 +40,6 @@ API Changes:
 	* [`tools.eventsBuffer`](https://docs.ckeditor.com/ckeditor4/latest/api/CKEDITOR_tools.html#method-eventsBuffer) has been extracted into [`tools.buffers.event`](https://docs.ckeditor.com/ckeditor4/latest/api/CKEDITOR_tools_buffers_event.html)
 	* [`tools.throttle`](https://docs.ckeditor.com/ckeditor4/latest/api/CKEDITOR_tools.html#method-throttle) has been extracted into [`tools.buffers.throttle`](https://docs.ckeditor.com/ckeditor4/latest/api/CKEDITOR_tools_buffers_throttle.html)
 * [#1451](https://github.com/ckeditor/ckeditor-dev/issues/1451): Fixed: Context menu is incorrectly positioned when opened with `Shift-F10`.
-* [#1454](https://github.com/ckeditor/ckeditor-dev/issues/1454): Fixed: [Upload Widget](https://ckeditor.com/cke4/addon/uploadwidget) [`onAbort`](https://docs.ckeditor.com/ckeditor4/docs/#!/api/CKEDITOR.fileTools.uploadWidgetDefinition-property-onAbort) method is not called when loader is aborted.
 
 ## CKEditor 4.10.1
 

--- a/plugins/uploadwidget/plugin.js
+++ b/plugins/uploadwidget/plugin.js
@@ -257,7 +257,6 @@
 						if ( typeof widget.onAbort === 'function' ) {
 							widget.onAbort( loader );
 						}
-						return;
 					}
 
 					// Abort if widget was removed.

--- a/plugins/uploadwidget/plugin.js
+++ b/plugins/uploadwidget/plugin.js
@@ -251,14 +251,15 @@
 					capitalize = CKEDITOR.tools.capitalize,
 					oldStyle, newStyle;
 
-				// (#1454)
-				loader.once( 'abort', function() {
-					if ( typeof widget.onAbort === 'function' ) {
-						widget.onAbort( loader );
-					}
-				} );
-
 				loader.on( 'update', function( evt ) {
+					// (#1454)
+					if ( loader.status === 'abort' ) {
+						if ( typeof widget.onAbort === 'function' ) {
+							widget.onAbort( loader );
+						}
+						return;
+					}
+
 					// Abort if widget was removed.
 					if ( !widget.wrapper || !widget.wrapper.getParent() ) {
 						// Uploading should be aborted if the editor is already destroyed (#966) or the upload widget was removed.
@@ -275,7 +276,7 @@
 					// `onUploaded` method will be called, if exists.
 					var methodName = 'on' + capitalize( loader.status );
 
-					if ( loader.status !== 'abort' && typeof widget[ methodName ] === 'function' ) {
+					if ( typeof widget[ methodName ] === 'function' ) {
 						if ( widget[ methodName ]( loader ) === false ) {
 							editor.fire( 'unlockSnapshot' );
 							return;

--- a/plugins/uploadwidget/plugin.js
+++ b/plugins/uploadwidget/plugin.js
@@ -275,7 +275,7 @@
 					// `onUploaded` method will be called, if exists.
 					var methodName = 'on' + capitalize( loader.status );
 
-					if ( typeof widget[ methodName ] === 'function' ) {
+					if ( loader.status !== 'abort' && typeof widget[ methodName ] === 'function' ) {
 						if ( widget[ methodName ]( loader ) === false ) {
 							editor.fire( 'unlockSnapshot' );
 							return;

--- a/tests/plugins/uploadwidget/manual/abortupload.html
+++ b/tests/plugins/uploadwidget/manual/abortupload.html
@@ -1,0 +1,19 @@
+<div id="editor1"></div>
+<script>
+	CKEDITOR.replace( 'editor1', {
+		height: 400,
+		uploadUrl: '%BASE_PATH%',
+		on: {
+			instanceReady: function(evt) {
+				var editor = evt.editor;
+				editor.widgets.registered.uploadimage.onAbort = function() {
+					editor.showNotification('You are awesome!');
+					return true;
+				}
+				if ( !CKEDITOR.fileTools.isFileUploadSupported ) {
+					bender.ignore();
+				}
+			}
+		}
+	} );
+</script>

--- a/tests/plugins/uploadwidget/manual/abortupload.html
+++ b/tests/plugins/uploadwidget/manual/abortupload.html
@@ -10,7 +10,7 @@
 					editor.showNotification( 'You are awesome!' );
 					return true;
 				};
-				if ( !CKEDITOR.fileTools.isFileUploadSupported ) {
+				if ( !CKEDITOR.fileTools.isFileUploadSupported || bender.tools.env.mobile ) {
 					bender.ignore();
 				}
 			}

--- a/tests/plugins/uploadwidget/manual/abortupload.html
+++ b/tests/plugins/uploadwidget/manual/abortupload.html
@@ -5,14 +5,15 @@
 		uploadUrl: '%BASE_PATH%',
 		on: {
 			instanceReady: function( evt ) {
+				if ( !CKEDITOR.fileTools.isFileUploadSupported || bender.tools.env.mobile ) {
+					bender.ignore();
+				}
+
 				var editor = evt.editor;
 				editor.widgets.registered.uploadimage.onAbort = function() {
 					editor.showNotification( 'You are awesome!' );
 					return true;
 				};
-				if ( !CKEDITOR.fileTools.isFileUploadSupported || bender.tools.env.mobile ) {
-					bender.ignore();
-				}
 			}
 		}
 	} );

--- a/tests/plugins/uploadwidget/manual/abortupload.html
+++ b/tests/plugins/uploadwidget/manual/abortupload.html
@@ -4,12 +4,12 @@
 		height: 400,
 		uploadUrl: '%BASE_PATH%',
 		on: {
-			instanceReady: function(evt) {
+			instanceReady: function( evt ) {
 				var editor = evt.editor;
 				editor.widgets.registered.uploadimage.onAbort = function() {
-					editor.showNotification('You are awesome!');
+					editor.showNotification( 'You are awesome!' );
 					return true;
-				}
+				};
 				if ( !CKEDITOR.fileTools.isFileUploadSupported ) {
 					bender.ignore();
 				}

--- a/tests/plugins/uploadwidget/manual/abortupload.html
+++ b/tests/plugins/uploadwidget/manual/abortupload.html
@@ -6,7 +6,7 @@
 		on: {
 			instanceReady: function( evt ) {
 				if ( !CKEDITOR.fileTools.isFileUploadSupported || bender.tools.env.mobile ) {
-					bender.ignore();
+					return bender.ignore();
 				}
 
 				var editor = evt.editor;

--- a/tests/plugins/uploadwidget/manual/abortupload.md
+++ b/tests/plugins/uploadwidget/manual/abortupload.md
@@ -1,4 +1,4 @@
-@bender-tags: clipboard, widget, filetools, 4.10.2, 1454, bug
+@bender-tags: clipboard, widget, filetools, 4.11.0, 1454, bug
 @bender-ui: collapsed
 @bender-ckeditor-plugins: wysiwygarea, image2, uploadimage, toolbar
 @bender-include: ../../uploadwidget/manual/_helpers/xhr.js

--- a/tests/plugins/uploadwidget/manual/abortupload.md
+++ b/tests/plugins/uploadwidget/manual/abortupload.md
@@ -1,4 +1,4 @@
-@bender-tags: clipboard, widget, filetools, 4.9.1, 1454, bug
+@bender-tags: clipboard, widget, filetools, 4.10.2, 1454, bug
 @bender-ui: collapsed
 @bender-ckeditor-plugins: wysiwygarea, image2, uploadimage, toolbar
 @bender-include: ../../uploadwidget/manual/_helpers/xhr.js

--- a/tests/plugins/uploadwidget/manual/abortupload.md
+++ b/tests/plugins/uploadwidget/manual/abortupload.md
@@ -1,0 +1,17 @@
+@bender-tags: clipboard, widget, filetools, 4.8.1, 1454, bug
+@bender-ui: collapsed
+@bender-ckeditor-plugins: wysiwygarea, image2, uploadimage, toolbar
+@bender-include: ../../uploadwidget/manual/_helpers/xhr.js
+
+1. Drag and drop some image into editable.
+2. Click on the image and press `delete` key to remove image before upload progress bar finished.
+
+## Expected
+
+The editor shows notification `You are awesome!` exactly once.
+
+## Unexpected
+
+No notification or many notifications with `You are awesome!` message emerged.
+
+**Note:** This test use upload mock which will show you *Lena* instead of the real uploaded image.

--- a/tests/plugins/uploadwidget/manual/abortupload.md
+++ b/tests/plugins/uploadwidget/manual/abortupload.md
@@ -1,4 +1,4 @@
-@bender-tags: clipboard, widget, filetools, 4.8.1, 1454, bug
+@bender-tags: clipboard, widget, filetools, 4.9.1, 1454, bug
 @bender-ui: collapsed
 @bender-ckeditor-plugins: wysiwygarea, image2, uploadimage, toolbar
 @bender-include: ../../uploadwidget/manual/_helpers/xhr.js

--- a/tests/plugins/uploadwidget/uploadwidget.js
+++ b/tests/plugins/uploadwidget/uploadwidget.js
@@ -156,6 +156,48 @@
 			} );
 		},
 
+		'test abort': function() {
+			var bot = this.editorBot,
+				editor = bot.editor;
+
+			var stub = sinon.stub().returns( true );
+
+			addTestUploadWidget( editor, 'testuploadwidget', {
+				onAbort: stub
+			} );
+
+			bot.setData( '', function() {
+				pasteFiles( editor, [ bender.tools.getTestPngFile() ] );
+
+				var loader = editor.uploadRepository.loaders[ 0 ];
+				loader.changeStatus( 'abort' );
+
+				assert.isTrue( stub.calledOnce );
+			} );
+		},
+
+		'test abort can be called only once': function() {
+			var bot = this.editorBot,
+				editor = bot.editor;
+
+			var stub = sinon.stub().returns( true );
+
+			addTestUploadWidget( editor, 'testuploadwidget', {
+				onAbort: stub
+			} );
+
+			bot.setData( '', function() {
+				pasteFiles( editor, [ bender.tools.getTestPngFile() ] );
+
+				var loader = editor.uploadRepository.loaders[ 0 ];
+
+				loader.changeStatus( 'abort' );
+				loader.changeStatus( 'abort' );
+
+				assert.isTrue( stub.calledOnce );
+			} );
+		},
+
 		'test markElement': function() {
 			var element = new CKEDITOR.dom.element( 'p' );
 			CKEDITOR.fileTools.markElement( element, 'widgetName', 1 );

--- a/tests/plugins/uploadwidget/uploadwidget.js
+++ b/tests/plugins/uploadwidget/uploadwidget.js
@@ -171,7 +171,7 @@
 
 				var loader = editor.uploadRepository.loaders[ 0 ];
 
-				editor.widgets.destroyAll();
+				bender.tools.objToArray( editor.widgets.instances )[ 0 ].wrapper = null;
 				editor.editable().findOne( '[data-cke-upload-id="' + loader.id + '"]' ).remove();
 
 				loader.fire( 'update' );

--- a/tests/plugins/uploadwidget/uploadwidget.js
+++ b/tests/plugins/uploadwidget/uploadwidget.js
@@ -157,7 +157,7 @@
 		},
 
 		// (#1454)
-		'test onAbort': function() {
+		'test calling widget onAbort function when widget is destroyed': function() {
 			var bot = this.editorBot,
 				editor = bot.editor,
 				stub = sinon.stub().returns( true );
@@ -173,30 +173,6 @@
 
 				editor.widgets.destroyAll();
 
-				loader.abort();
-
-				assert.isTrue( stub.calledOnce );
-			} );
-		},
-
-		// (#1454)
-		'test onAbort can be called only once': function() {
-			var bot = this.editorBot,
-				editor = bot.editor,
-				stub = sinon.stub().returns( true );
-
-			addTestUploadWidget( editor, 'testuploadwidget', {
-				onAbort: stub
-			} );
-
-			bot.setData( '', function() {
-				pasteFiles( editor, [ bender.tools.getTestPngFile() ] );
-
-				var loader = editor.uploadRepository.loaders[ 0 ];
-
-				editor.widgets.destroyAll();
-
-				loader.abort();
 				loader.abort();
 
 				assert.isTrue( stub.calledOnce );

--- a/tests/plugins/uploadwidget/uploadwidget.js
+++ b/tests/plugins/uploadwidget/uploadwidget.js
@@ -180,6 +180,28 @@
 			} );
 		},
 
+		// (#1454)
+		'test onAbort can be called only once': function() {
+			var bot = this.editorBot,
+				editor = bot.editor,
+				stub = sinon.stub().returns( true );
+
+			addTestUploadWidget( editor, 'testuploadwidget', {
+				onAbort: stub
+			} );
+
+			bot.setData( '', function() {
+				pasteFiles( editor, [ bender.tools.getTestPngFile() ] );
+
+				var loader = editor.uploadRepository.loaders[ 0 ];
+
+				loader.abort();
+				loader.abort();
+
+				assert.isTrue( stub.calledOnce );
+			} );
+		},
+
 		'test markElement': function() {
 			var element = new CKEDITOR.dom.element( 'p' );
 			CKEDITOR.fileTools.markElement( element, 'widgetName', 1 );

--- a/tests/plugins/uploadwidget/uploadwidget.js
+++ b/tests/plugins/uploadwidget/uploadwidget.js
@@ -157,7 +157,7 @@
 		},
 
 		// (#1454)
-		'test abort': function() {
+		'test onAbort': function() {
 			var bot = this.editorBot,
 				editor = bot.editor;
 
@@ -183,7 +183,7 @@
 		},
 
 		// (#1454)
-		'test abort can be called only once': function() {
+		'test onAbort can be called only once': function() {
 			var bot = this.editorBot,
 				editor = bot.editor;
 

--- a/tests/plugins/uploadwidget/uploadwidget.js
+++ b/tests/plugins/uploadwidget/uploadwidget.js
@@ -172,11 +172,7 @@
 
 				var loader = editor.uploadRepository.loaders[ 0 ];
 
-				// Remove widget from the DOM.
-				editor.widgets.destroyAll();
-				editor.editable().findOne( '[data-cke-upload-id="' + loader.id + '"]' ).remove();
-
-				loader.changeStatus( 'abort' );
+				loader.abort();
 
 				assert.isTrue( stub.calledOnce );
 			} );
@@ -198,12 +194,8 @@
 
 				var loader = editor.uploadRepository.loaders[ 0 ];
 
-				// Remove widget from the DOM.
-				editor.widgets.destroyAll();
-				editor.editable().findOne( '[data-cke-upload-id="' + loader.id + '"]' ).remove();
-
-				loader.changeStatus( 'abort' );
-				loader.changeStatus( 'abort' );
+				loader.abort();
+				loader.abort();
 
 				assert.isTrue( stub.calledOnce );
 			} );

--- a/tests/plugins/uploadwidget/uploadwidget.js
+++ b/tests/plugins/uploadwidget/uploadwidget.js
@@ -159,9 +159,8 @@
 		// (#1454)
 		'test onAbort': function() {
 			var bot = this.editorBot,
-				editor = bot.editor;
-
-			var stub = sinon.stub().returns( true );
+				editor = bot.editor,
+				stub = sinon.stub().returns( true );
 
 			addTestUploadWidget( editor, 'testuploadwidget', {
 				onAbort: stub
@@ -181,9 +180,8 @@
 		// (#1454)
 		'test onAbort can be called only once': function() {
 			var bot = this.editorBot,
-				editor = bot.editor;
-
-			var stub = sinon.stub().returns( true );
+				editor = bot.editor,
+				stub = sinon.stub().returns( true );
 
 			addTestUploadWidget( editor, 'testuploadwidget', {
 				onAbort: stub

--- a/tests/plugins/uploadwidget/uploadwidget.js
+++ b/tests/plugins/uploadwidget/uploadwidget.js
@@ -171,6 +171,8 @@
 
 				var loader = editor.uploadRepository.loaders[ 0 ];
 
+				editor.widgets.destroyAll();
+
 				loader.abort();
 
 				assert.isTrue( stub.calledOnce );
@@ -191,6 +193,8 @@
 				pasteFiles( editor, [ bender.tools.getTestPngFile() ] );
 
 				var loader = editor.uploadRepository.loaders[ 0 ];
+
+				editor.widgets.destroyAll();
 
 				loader.abort();
 				loader.abort();

--- a/tests/plugins/uploadwidget/uploadwidget.js
+++ b/tests/plugins/uploadwidget/uploadwidget.js
@@ -172,8 +172,9 @@
 				var loader = editor.uploadRepository.loaders[ 0 ];
 
 				editor.widgets.destroyAll();
+				editor.editable().findOne( '[data-cke-upload-id="' + loader.id + '"]' ).remove();
 
-				loader.abort();
+				loader.fire( 'update' );
 
 				assert.isTrue( stub.calledOnce );
 			} );

--- a/tests/plugins/uploadwidget/uploadwidget.js
+++ b/tests/plugins/uploadwidget/uploadwidget.js
@@ -156,6 +156,7 @@
 			} );
 		},
 
+		// (#1454)
 		'test abort': function() {
 			var bot = this.editorBot,
 				editor = bot.editor;
@@ -170,12 +171,18 @@
 				pasteFiles( editor, [ bender.tools.getTestPngFile() ] );
 
 				var loader = editor.uploadRepository.loaders[ 0 ];
+
+				// Remove widget from the DOM.
+				editor.widgets.destroyAll();
+				editor.editable().findOne( '[data-cke-upload-id="' + loader.id + '"]' ).remove();
+
 				loader.changeStatus( 'abort' );
 
 				assert.isTrue( stub.calledOnce );
 			} );
 		},
 
+		// (#1454)
 		'test abort can be called only once': function() {
 			var bot = this.editorBot,
 				editor = bot.editor;
@@ -190,6 +197,10 @@
 				pasteFiles( editor, [ bender.tools.getTestPngFile() ] );
 
 				var loader = editor.uploadRepository.loaders[ 0 ];
+
+				// Remove widget from the DOM.
+				editor.widgets.destroyAll();
+				editor.editable().findOne( '[data-cke-upload-id="' + loader.id + '"]' ).remove();
 
 				loader.changeStatus( 'abort' );
 				loader.changeStatus( 'abort' );


### PR DESCRIPTION
## What is the purpose of this pull request?

Bug fix.

## Does your PR contain necessary tests?

All patches which change the editor code must include tests. You can always read more
on [PR testing](https://docs.ckeditor.com/ckeditor4/docs/#!/guide/dev_contributing_code-section-tests),
[how to set the testing environment](https://docs.ckeditor.com/ckeditor4/docs/#!/guide/dev_tests) and
[how to create tests](https://docs.ckeditor.com/ckeditor4/docs/#!/guide/dev_tests-section-creating-your-own-test)
in the official CKEditor documentation.

### This PR contains

- [x] Unit tests
- [x] Manual tests

## What changes did you make?

Changed initialisation of the [upload Widget Definition](https://docs.ckeditor.com/ckeditor4/docs/#!/api/CKEDITOR.fileTools.uploadWidgetDefinition) to include [`onAbort`](https://docs.ckeditor.com/ckeditor4/docs/#!/api/CKEDITOR.fileTools.uploadWidgetDefinition-property-onAbort) method when upload status changes to `abort`.

Closes #1454
