### PR TITLE
JSCS now requires line feed at file end

### DIFF
--- a/.jscsrc
+++ b/.jscsrc
@@ -54,5 +54,6 @@
 	"validateIndentation": {
 		"value": "\t",
 		"allExcept": [ "comments", "emptyLines" ]
-	}
+	},
+	"requireLineFeedAtFileEnd": true
 }


### PR DESCRIPTION
## What is the purpose of this pull request?

Task

## Does your PR contain necessary tests?

All patches which change the editor code must include tests. You can always read more
on [PR testing](https://docs.ckeditor.com/ckeditor4/docs/#!/guide/dev_contributing_code-section-tests),
[how to set the testing environment](https://docs.ckeditor.com/ckeditor4/docs/#!/guide/dev_tests) and
[how to create tests](https://docs.ckeditor.com/ckeditor4/docs/#!/guide/dev_tests-section-creating-your-own-test)
in the official CKEditor documentation.

### This PR contains

- [ ] Unit tests
- [ ] Manual tests

## What changes did you make?

Appened to our `.jscsrc` following line:
`"requireLineFeedAtFileEnd": true`
Which does exactly what is says.

Closes #1461 
