### PR TITLE
Bug's workaround for flickering scrollbar in chrome

### DIFF
--- a/plugins/easyimage/styles/easyimage.css
+++ b/plugins/easyimage/styles/easyimage.css
@@ -49,7 +49,8 @@ The outline is not a part of the element's dimensions, we have to use a border a
 }
 
 /*
-Overwrite 25% in classic editor to prevent existing this bug https://bugs.chromium.org/p/chromium/issues/detail?id=803045
+Overwrite max-width: 25% with max-width: 25vw to prevent native Chrome bug
+https://bugs.chromium.org/p/chromium/issues/detail?id=803045 (#1550).
 */
 body.cke_editable > .cke_widget_wrapper_easyimage-side {
 	max-width: 25vw;

--- a/plugins/easyimage/styles/easyimage.css
+++ b/plugins/easyimage/styles/easyimage.css
@@ -51,7 +51,7 @@ The outline is not a part of the element's dimensions, we have to use a border a
 /*
 Overwrite 25% in classic editor to prevent existing this bug https://bugs.chromium.org/p/chromium/issues/detail?id=803045
 */
-body.cke_editable .cke_widget_wrapper_easyimage-side {
+body.cke_editable > .cke_widget_wrapper_easyimage-side {
 	max-width: 25vw;
 }
 

--- a/plugins/easyimage/styles/easyimage.css
+++ b/plugins/easyimage/styles/easyimage.css
@@ -48,6 +48,13 @@ The outline is not a part of the element's dimensions, we have to use a border a
 	min-width: 10em;
 }
 
+/*
+Overwrite 25% in classic editor to prevent existing this bug https://bugs.chromium.org/p/chromium/issues/detail?id=803045
+*/
+body.cke_editable .cke_widget_wrapper_easyimage-side {
+	max-width: 25vw;
+}
+
 .easyimage .cke_widget_editable {
 	background-color: #f7f7f7;
 	/* Add border so when caption is focused, blue border does not cause flickering. */

--- a/plugins/easyimage/styles/easyimage.css
+++ b/plugins/easyimage/styles/easyimage.css
@@ -49,7 +49,7 @@ The outline is not a part of the element's dimensions, we have to use a border a
 }
 
 /*
-Overwrite max-width: 25% with max-width: 25vw to prevent native Chrome bug
+Overwrite 'max-width: 25%' with 'max-width: 25vw' to prevent native Chrome bug
 https://bugs.chromium.org/p/chromium/issues/detail?id=803045 (#1550).
 */
 body.cke_editable > .cke_widget_wrapper_easyimage-side {

--- a/tests/plugins/easyimage/manual/scrollbarchromebug.html
+++ b/tests/plugins/easyimage/manual/scrollbarchromebug.html
@@ -1,0 +1,30 @@
+<textarea id="classic">
+	<h1>Apollo 11</h1>
+	<figure class="easyimage">
+		<img alt="CKEditor Sample" src="%BASE_PATH%_assets/logo.png" />
+	</figure>
+	<p><strong>Apollo 11</strong> was the spaceflight that landed the first humans, Americans <a href="http://en.wikipedia.org/wiki/Neil_Armstrong">Neil Armstrong</a> and <a href="http://en.wikipedia.org/wiki/Buzz_Aldrin">Buzz Aldrin</a>, on the Moon on July 20, 1969, at 20:18 UTC. Armstrong became the first to step onto the lunar surface 6 hours later on July 21 at 02:56 UTC.</p>
+	<figure class="easyimage easyimage-side">
+		<img alt="Saturn V carrying Apollo 11" src="%BASE_PATH%_assets/lena.jpg">
+		<figcaption>Saturn V carrying Apollo 11</figcaption>
+	</figure>
+	<p>Armstrong spent about <s>three and a half</s> two and a half hours outside the spacecraft, Aldrin slightly less; and together they collected 47.5 pounds (21.5&nbsp;kg) of lunar material for return to Earth. A third member of the mission, <a href="http://en.wikipedia.org/wiki/Michael_Collins_(astronaut)">Michael Collins</a>, piloted the <a href="http://en.wikipedia.org/wiki/Apollo_Command/Service_Module">command</a> spacecraft alone in lunar orbit until Armstrong and Aldrin returned to it for the trip back to Earth.</p>
+</textarea>
+
+<script>
+	if ( CKEDITOR.env.ie && CKEDITOR.env.version < 11 ) {
+		bender.ignore();
+	}
+
+	getToken( function( token ) {
+		CKEDITOR.replace( 'classic', {
+			cloudServices_url: 'https://files.cke-cs.com/upload/',
+			cloudServices_token: token,
+			width: 600,
+			height: 400,
+			toolbar: [
+				[ 'Source', '-', 'Link' ]
+			]
+		} );
+	} );
+</script>

--- a/tests/plugins/easyimage/manual/scrollbarchromebug.html
+++ b/tests/plugins/easyimage/manual/scrollbarchromebug.html
@@ -11,20 +11,37 @@
 	<p>Armstrong spent about <s>three and a half</s> two and a half hours outside the spacecraft, Aldrin slightly less; and together they collected 47.5 pounds (21.5&nbsp;kg) of lunar material for return to Earth. A third member of the mission, <a href="http://en.wikipedia.org/wiki/Michael_Collins_(astronaut)">Michael Collins</a>, piloted the <a href="http://en.wikipedia.org/wiki/Apollo_Command/Service_Module">command</a> spacecraft alone in lunar orbit until Armstrong and Aldrin returned to it for the trip back to Earth.</p>
 </textarea>
 
+<div id="divarea">
+	<h1>Apollo 11</h1>
+	<figure class="easyimage">
+		<img alt="CKEditor Sample" src="%BASE_PATH%_assets/logo.png" />
+	</figure>
+	<p><strong>Apollo 11</strong> was the spaceflight that landed the first humans, Americans <a href="http://en.wikipedia.org/wiki/Neil_Armstrong">Neil Armstrong</a> and <a href="http://en.wikipedia.org/wiki/Buzz_Aldrin">Buzz Aldrin</a>, on the Moon on July 20, 1969, at 20:18 UTC. Armstrong became the first to step onto the lunar surface 6 hours later on July 21 at 02:56 UTC.</p>
+	<figure class="easyimage easyimage-side">
+		<img alt="Saturn V carrying Apollo 11" src="%BASE_PATH%_assets/lena.jpg">
+		<figcaption>Saturn V carrying Apollo 11</figcaption>
+	</figure>
+	<p>Armstrong spent about <s>three and a half</s> two and a half hours outside the spacecraft, Aldrin slightly less; and together they collected 47.5 pounds (21.5&nbsp;kg) of lunar material for return to Earth. A third member of the mission, <a href="http://en.wikipedia.org/wiki/Michael_Collins_(astronaut)">Michael Collins</a>, piloted the <a href="http://en.wikipedia.org/wiki/Apollo_Command/Service_Module">command</a> spacecraft alone in lunar orbit until Armstrong and Aldrin returned to it for the trip back to Earth.</p>
+</div>
+
 <script>
 	if ( CKEDITOR.env.ie && CKEDITOR.env.version < 11 ) {
 		bender.ignore();
 	}
 
-	getToken( function( token ) {
-		CKEDITOR.replace( 'classic', {
-			cloudServices_url: 'https://files.cke-cs.com/upload/',
-			cloudServices_token: token,
-			width: 600,
-			height: 400,
-			toolbar: [
-				[ 'Source', '-', 'Link' ]
-			]
-		} );
+	CKEDITOR.replace( 'classic', {
+		width: 600,
+		height: 412,
+		toolbar: [
+			[ 'Source', '-', 'Link' ]
+		]
+	} );
+	CKEDITOR.replace( 'divarea', {
+		width: 600,
+		height: 412,
+		extraPlugins: 'divarea',
+		toolbar: [
+			[ 'Source', '-', 'Link' ]
+		]
 	} );
 </script>

--- a/tests/plugins/easyimage/manual/scrollbarchromebug.html
+++ b/tests/plugins/easyimage/manual/scrollbarchromebug.html
@@ -1,3 +1,10 @@
+<style>
+	/* Make sure flickering is visible in 'divarea' editor. */
+	.cke_widget_wrapper_easyimage-side, :not(.cke_widget_wrapper_easyimage):not(.cke_widget_wrapper_easyimage-side) > .easyimage-side {
+		min-width: 5em;
+	}
+</style>
+
 <textarea id="classic">
 	<h1>Apollo 11</h1>
 	<figure class="easyimage">

--- a/tests/plugins/easyimage/manual/scrollbarchromebug.md
+++ b/tests/plugins/easyimage/manual/scrollbarchromebug.md
@@ -1,0 +1,13 @@
+@bender-tags: 4.9.0, bug, 932
+@bender-ui: collapsed
+@bender-ckeditor-plugins: sourcearea, wysiwygarea, toolbar, easyimage, link
+@bender-include: ./_helpers/tools.js
+
+----
+1. Move cursor over image.
+
+**Expected:** Nothing unusal happen.
+
+**Unexpected:**
+  * Empty scrollbar shows up.
+  * Scrollbar flicker when cursor is over image.

--- a/tests/plugins/easyimage/manual/scrollbarchromebug.md
+++ b/tests/plugins/easyimage/manual/scrollbarchromebug.md
@@ -1,13 +1,14 @@
 @bender-tags: 4.9.0, bug, 932
 @bender-ui: collapsed
 @bender-ckeditor-plugins: sourcearea, wysiwygarea, toolbar, easyimage, link
-@bender-include: ./_helpers/tools.js
 
 ----
-1. Move cursor over image.
+Note: Problem exists only in **Chrome** browsers. All other browsers should work fine and flickering scrollbar shouldn't be present.
 
-**Expected:** Nothing unusal happen.
+1. Move cursor over image in both editors.
+
+**Expected:** Nothing unusal happen in 1st editor. Unfortunatelly bug is not fixed in divarea editor, so flickering should be observable in bottom editor, what is expected behaviour here.
 
 **Unexpected:**
   * Empty scrollbar shows up.
-  * Scrollbar flicker when cursor is over image.
+  * Scrollbar flicker when cursor is moved over the images.

--- a/tests/plugins/easyimage/manual/scrollbarchromebug.md
+++ b/tests/plugins/easyimage/manual/scrollbarchromebug.md
@@ -1,14 +1,15 @@
-@bender-tags: 4.9.0, bug, 932
+@bender-tags: 4.9.0, bug, 1550, easyimage
 @bender-ui: collapsed
 @bender-ckeditor-plugins: sourcearea, wysiwygarea, toolbar, easyimage, link
 
 ----
-Note: Problem exists only in **Chrome** browsers. All other browsers should work fine and flickering scrollbar shouldn't be present.
 
 1. Move cursor over image in both editors.
 
-**Expected:** Nothing unusal happen in 1st editor. Unfortunatelly bug is not fixed in divarea editor, so flickering should be observable in bottom editor, what is expected behaviour here.
+**Expected:** Nothing unusual happens, scrollbar is not flickering.
 
 **Unexpected:**
-  * Empty scrollbar shows up.
-  * Scrollbar flicker when cursor is moved over the images.
+* Empty scrollbar shows up.
+* Scrollbar flicker when cursor is moved over the images.
+
+_**Note:** In **Chrome** browser in second editor, scrollbars flickers as the issue is not fixed for `divarea editor` (https://bugs.chromium.org/p/chromium/issues/detail?id=803045)._

--- a/tests/plugins/easyimage/manual/scrollbarchromebug.md
+++ b/tests/plugins/easyimage/manual/scrollbarchromebug.md
@@ -10,6 +10,7 @@
 
 **Unexpected:**
 * Empty scrollbar shows up.
-* Scrollbar flicker when cursor is moved over the images.
+* Scrollbar flickers when cursor is moved over the images.
 
-_**Note:** In **Chrome** browser in second editor, scrollbars flickers as the issue is not fixed for `divarea editor` (https://bugs.chromium.org/p/chromium/issues/detail?id=803045)._
+_**Note:** In **Chrome** browser scrollbars flicker in second editor as the issue is not fixed
+for `divarea editor` (https://bugs.chromium.org/p/chromium/issues/detail?id=803045)._


### PR DESCRIPTION
## What is the purpose of this pull request?

Bug fix

## Does your PR contain necessary tests?

All patches which change the editor code must include tests. You can always read more
on [PR testing](https://docs.ckeditor.com/ckeditor4/docs/#!/guide/dev_contributing_code-section-tests),
[how to set the testing environment](https://docs.ckeditor.com/ckeditor4/docs/#!/guide/dev_tests) and
[how to create tests](https://docs.ckeditor.com/ckeditor4/docs/#!/guide/dev_tests-section-creating-your-own-test)
in the official CKEditor documentation.

### This PR contains

- [ ] Unit tests
- [x] Manual tests

## What changes did you make?

- correct styles which might generate [flickering error](https://bugs.chromium.org/p/chromium/issues/detail?id=803045) in Chrome
- bug fix only for classic editor to not break divarea and inline cases when `vw` will be calculated for entire page not for editor

close: #1550 