### PR TITLE
Fixed: Exception after double-click on the text node

### DIFF
--- a/tests/plugins/balloontoolbar/manual/balloontoolbar.html
+++ b/tests/plugins/balloontoolbar/manual/balloontoolbar.html
@@ -26,19 +26,19 @@
 			i = 0,
 			strong;
 
+			panel.addItems( {
+				bold: new CKEDITOR.ui.button( {
+					label: 'test',
+					command: 'bold'
+				} ),
+				language: evt.editor.ui.create('Language'),
+				Styles: evt.editor.ui.create( 'Styles' )
+			} );
 
 		while ( ( strong = strongs.getItem( i++ ) ) ) {
 			strong.setStyle( 'background', 'pink' );
 			strong.setStyle( 'outline', '4px solid red' );
 			strong.on( 'click', function() {
-				panel.addItems( {
-					bold: new CKEDITOR.ui.button( {
-						label: 'test',
-						command: 'bold'
-					} ),
-					language: evt.editor.ui.create('Language'),
-					Styles: evt.editor.ui.create( 'Styles' )
-				} );
 				panel.attach( this );
 			} );
 		}


### PR DESCRIPTION
## What is the purpose of this pull request?

Bug fix

## Does your PR contain necessary tests?

All patches which change the editor code must include tests. You can always read more
on [PR testing](https://docs.ckeditor.com/ckeditor4/docs/#!/guide/dev_contributing_code-section-tests),
[how to set the testing environment](https://docs.ckeditor.com/ckeditor4/docs/#!/guide/dev_tests) and
[how to create tests](https://docs.ckeditor.com/ckeditor4/docs/#!/guide/dev_tests-section-creating-your-own-test)
in the official CKEditor documentation.

### This PR contains

- [X] Manual tests
This is fix to test itself.

## What changes did you make?

In test `/tests/plugins/balloontoolbar/manual/balloontoolbar.html` items were added to panel on every click event. Now they are initially added which solves the problem.

Closes #1318 