### PR TITLE
Balloon toolbar on destroy doesn't destroy its content

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -12,7 +12,7 @@ New Features:
 * [#706](https://github.com/ckeditor/ckeditor-dev/issues/706): Added different cursor style when selecting cells for [Table Selection](https://ckeditor.com/cke4/addon/tableselection) plugin.
 * [#651](https://github.com/ckeditor/ckeditor-dev/issues/651): Text pasted using [Paste from Word](https://ckeditor.com/cke4/addon/pastefromword) preservers indentation in paragraphs.
 * [#1176](https://github.com/ckeditor/ckeditor-dev/pull/1176): The [Balloon Panel](https://ckeditor.com/cke4/addon/balloonpanel) can be attached to selection instead of element.
-* [#1477](https://github.com/ckeditor/ckeditor-dev/issues/1477): Fixed: Balloon toolbar on destroy doesn't destroy its content.
+* [#1477](https://github.com/ckeditor/ckeditor-dev/issues/1477): Fixed: [Balloon toolbar](https://ckeditor.com/cke4/addon/balloontoolbar) on destroy doesn't destroy its content.
 
 API Changes:
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -12,6 +12,7 @@ New Features:
 * [#706](https://github.com/ckeditor/ckeditor-dev/issues/706): Added different cursor style when selecting cells for [Table Selection](https://ckeditor.com/cke4/addon/tableselection) plugin.
 * [#651](https://github.com/ckeditor/ckeditor-dev/issues/651): Text pasted using [Paste from Word](https://ckeditor.com/cke4/addon/pastefromword) preservers indentation in paragraphs.
 * [#1176](https://github.com/ckeditor/ckeditor-dev/pull/1176): The [Balloon Panel](https://ckeditor.com/cke4/addon/balloonpanel) can be attached to selection instead of element.
+* [#1477](https://github.com/ckeditor/ckeditor-dev/issues/1477): Fixed: Balloon toolbar on destroy doesn't destroy its content.
 
 API Changes:
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -12,7 +12,7 @@ New Features:
 * [#706](https://github.com/ckeditor/ckeditor-dev/issues/706): Added different cursor style when selecting cells for [Table Selection](https://ckeditor.com/cke4/addon/tableselection) plugin.
 * [#651](https://github.com/ckeditor/ckeditor-dev/issues/651): Text pasted using [Paste from Word](https://ckeditor.com/cke4/addon/pastefromword) preservers indentation in paragraphs.
 * [#1176](https://github.com/ckeditor/ckeditor-dev/pull/1176): The [Balloon Panel](https://ckeditor.com/cke4/addon/balloonpanel) can be attached to selection instead of element.
-* [#1477](https://github.com/ckeditor/ckeditor-dev/issues/1477): Fixed: [Balloon toolbar](https://ckeditor.com/cke4/addon/balloontoolbar) on destroy doesn't destroy its content.
+* [#1477](https://github.com/ckeditor/ckeditor-dev/issues/1477): Fixed: [Balloon Toolbar](https://ckeditor.com/cke4/addon/balloontoolbar) on destroy doesn't destroy its content.
 
 API Changes:
 

--- a/plugins/balloontoolbar/plugin.js
+++ b/plugins/balloontoolbar/plugin.js
@@ -170,24 +170,16 @@
 	};
 
 	/**
-	 * Cleares Balloon Toolbar from each menu items.
-	 *
-	 * @since 4.9.0
+	 * Hides the toolbar, removes it from the DOM, and clears all its items.
 	 */
-	CKEDITOR.ui.balloonToolbar.prototype.clearItems = function() {
+	CKEDITOR.ui.balloonToolbar.prototype.destroy = function() {
 		for ( var key in this._items ) {
 			if ( this._items[ key ].destroy ) {
 				this._items[ key ].destroy();
 			}
 			this.deleteItem( key );
 		}
-	};
 
-	/**
-	 * Hides the toolbar, removes it from the DOM, and clears all its items.
-	 */
-	CKEDITOR.ui.balloonToolbar.prototype.destroy = function() {
-		this.clearItems();
 		this._pointedElement = null;
 		this._view.destroy();
 	};

--- a/plugins/balloontoolbar/plugin.js
+++ b/plugins/balloontoolbar/plugin.js
@@ -131,6 +131,7 @@
 	 * @param {CKEDITOR.ui.button/CKEDITOR.ui.richCombo} element An instance of the UI element.
 	 */
 	CKEDITOR.ui.balloonToolbar.prototype.addItem = function( name, element ) {
+		// console.log( this._items[ name ] );
 		this._items[ name ] = element;
 	};
 
@@ -170,9 +171,24 @@
 	};
 
 	/**
-	 * Hides the toolbar and removes it from the DOM.
+	 * Cleares Balloon Toolbar from each menu items.
+	 *
+	 * @since 4.9.0
+	 */
+	CKEDITOR.ui.balloonToolbar.prototype.clearItems = function() {
+		for ( var key in this._items ) {
+			if ( this._items[ key ].destroy ) {
+				this._items[ key ].destroy();
+			}
+			this.deleteItem( key );
+		}
+	};
+
+	/**
+	 * Hides the toolbar, removes it from the DOM, and clears all its items.
 	 */
 	CKEDITOR.ui.balloonToolbar.prototype.destroy = function() {
+		this.clearItems();
 		this._pointedElement = null;
 		this._view.destroy();
 	};

--- a/plugins/balloontoolbar/plugin.js
+++ b/plugins/balloontoolbar/plugin.js
@@ -131,7 +131,6 @@
 	 * @param {CKEDITOR.ui.button/CKEDITOR.ui.richCombo} element An instance of the UI element.
 	 */
 	CKEDITOR.ui.balloonToolbar.prototype.addItem = function( name, element ) {
-		// console.log( this._items[ name ] );
 		this._items[ name ] = element;
 	};
 

--- a/plugins/richcombo/plugin.js
+++ b/plugins/richcombo/plugin.js
@@ -96,6 +96,8 @@ CKEDITOR.plugins.add( 'richcombo', {
 				panelDefinition: panelDefinition,
 				items: {}
 			};
+
+			this._listeners = [];
 		},
 
 		proto: {
@@ -178,11 +180,11 @@ CKEDITOR.plugins.add( 'richcombo', {
 				}
 
 				// Update status when activeFilter, mode, selection or readOnly changes.
-				editor.on( 'activeFilterChange', updateState, this );
-				editor.on( 'mode', updateState, this );
-				editor.on( 'selectionChange', updateState, this );
+				this._listeners.push( editor.on( 'activeFilterChange', updateState, this ) );
+				this._listeners.push( editor.on( 'mode', updateState, this ) );
+				this._listeners.push( editor.on( 'selectionChange', updateState, this ) );
 				// If this combo is sensitive to readOnly state, update it accordingly.
-				!this.readOnly && editor.on( 'readOnly', updateState, this );
+				!this.readOnly && this._listeners.push( editor.on( 'readOnly', updateState, this ) );
 
 				var keyDownFn = CKEDITOR.tools.addFunction( function( ev, element ) {
 					ev = new CKEDITOR.dom.event( ev );
@@ -380,6 +382,15 @@ CKEDITOR.plugins.add( 'richcombo', {
 				if ( this._.state != CKEDITOR.TRISTATE_DISABLED ) {
 					this._.lastState = this._.state;
 					this.setState( CKEDITOR.TRISTATE_DISABLED );
+				}
+			},
+
+			destroy: function() {
+				if ( this._listeners.length ) {
+					CKEDITOR.tools.array.forEach( this._listeners, function( listener ) {
+						listener.removeListener();
+					} );
+					this._listeners = [];
 				}
 			}
 		},

--- a/plugins/richcombo/plugin.js
+++ b/plugins/richcombo/plugin.js
@@ -390,12 +390,10 @@ CKEDITOR.plugins.add( 'richcombo', {
 			 * @since 4.11.0
 			 */
 			destroy: function() {
-				if ( this._listeners.length ) {
-					CKEDITOR.tools.array.forEach( this._listeners, function( listener ) {
-						listener.removeListener();
-					} );
-					this._listeners = [];
-				}
+				CKEDITOR.tools.array.forEach( this._listeners, function( listener ) {
+					listener.removeListener();
+				} );
+				this._listeners = [];
 			}
 		},
 

--- a/plugins/richcombo/plugin.js
+++ b/plugins/richcombo/plugin.js
@@ -387,7 +387,7 @@ CKEDITOR.plugins.add( 'richcombo', {
 			/**
 			 * Removes all listeners from richCombo element.
 			 *
-			 * @since 4.9.0
+			 * @since 4.11.0
 			 */
 			destroy: function() {
 				if ( this._listeners.length ) {

--- a/plugins/richcombo/plugin.js
+++ b/plugins/richcombo/plugin.js
@@ -384,7 +384,11 @@ CKEDITOR.plugins.add( 'richcombo', {
 					this.setState( CKEDITOR.TRISTATE_DISABLED );
 				}
 			},
-
+			/**
+			 * Removes all listeners from richCombo element.
+			 *
+			 * @since 4.9.0
+			 */
 			destroy: function() {
 				if ( this._listeners.length ) {
 					CKEDITOR.tools.array.forEach( this._listeners, function( listener ) {

--- a/plugins/richcombo/plugin.js
+++ b/plugins/richcombo/plugin.js
@@ -100,6 +100,7 @@ CKEDITOR.plugins.add( 'richcombo', {
 			/**
 			 * Array containing richCombos registered listeners.
 			 *
+			 * @type {Array}
 			 * @private
 			 */
 			this._listeners = [];

--- a/plugins/richcombo/plugin.js
+++ b/plugins/richcombo/plugin.js
@@ -97,6 +97,11 @@ CKEDITOR.plugins.add( 'richcombo', {
 				items: {}
 			};
 
+			/**
+			 * Array containing richCombos registered listeners.
+			 *
+			 * @private
+			 */
 			this._listeners = [];
 		},
 

--- a/plugins/richcombo/plugin.js
+++ b/plugins/richcombo/plugin.js
@@ -383,6 +383,7 @@ CKEDITOR.plugins.add( 'richcombo', {
 					this.setState( CKEDITOR.TRISTATE_DISABLED );
 				}
 			},
+
 			/**
 			 * Removes all listeners from richCombo element.
 			 *

--- a/plugins/richcombo/plugin.js
+++ b/plugins/richcombo/plugin.js
@@ -103,7 +103,7 @@ CKEDITOR.plugins.add( 'richcombo', {
 			 * @type {Array}
 			 * @private
 			 */
-			this._listeners = [];
+			this._.listeners = [];
 		},
 
 		proto: {
@@ -186,11 +186,11 @@ CKEDITOR.plugins.add( 'richcombo', {
 				}
 
 				// Update status when activeFilter, mode, selection or readOnly changes.
-				this._listeners.push( editor.on( 'activeFilterChange', updateState, this ) );
-				this._listeners.push( editor.on( 'mode', updateState, this ) );
-				this._listeners.push( editor.on( 'selectionChange', updateState, this ) );
+				this._.listeners.push( editor.on( 'activeFilterChange', updateState, this ) );
+				this._.listeners.push( editor.on( 'mode', updateState, this ) );
+				this._.listeners.push( editor.on( 'selectionChange', updateState, this ) );
 				// If this combo is sensitive to readOnly state, update it accordingly.
-				!this.readOnly && this._listeners.push( editor.on( 'readOnly', updateState, this ) );
+				!this.readOnly && this._.listeners.push( editor.on( 'readOnly', updateState, this ) );
 
 				var keyDownFn = CKEDITOR.tools.addFunction( function( ev, element ) {
 					ev = new CKEDITOR.dom.event( ev );
@@ -396,10 +396,10 @@ CKEDITOR.plugins.add( 'richcombo', {
 			 * @since 4.11.0
 			 */
 			destroy: function() {
-				CKEDITOR.tools.array.forEach( this._listeners, function( listener ) {
+				CKEDITOR.tools.array.forEach( this._.listeners, function( listener ) {
 					listener.removeListener();
 				} );
-				this._listeners = [];
+				this._.listeners = [];
 			}
 		},
 

--- a/plugins/richcombo/plugin.js
+++ b/plugins/richcombo/plugin.js
@@ -94,16 +94,9 @@ CKEDITOR.plugins.add( 'richcombo', {
 
 			this._ = {
 				panelDefinition: panelDefinition,
-				items: {}
+				items: {},
+				listeners: []
 			};
-
-			/**
-			 * Array containing richCombos registered listeners.
-			 *
-			 * @type {Array}
-			 * @private
-			 */
-			this._.listeners = [];
 		},
 
 		proto: {

--- a/tests/plugins/balloontoolbar/destroy.js
+++ b/tests/plugins/balloontoolbar/destroy.js
@@ -1,0 +1,49 @@
+/* bender-tags: balloontoolbar, 1477, 4.9.0 */
+/* bender-ckeditor-plugins: balloontoolbar,button,basicstyles,list,richcombo,stylescombo,wysiwygarea,toolbar */
+
+( function() {
+	'use strict';
+
+	bender.editor = {
+	};
+
+	var tests = {
+		'test destroy toolbar with richcombo': function() {
+			var bot = this.editorBot,
+				editor = this.editor,
+				panel = new CKEDITOR.ui.balloonToolbar( this.editor, {
+					width: 'auto',
+					height: 40
+				} );
+
+			// Creating some editor content and attaching balloonToolbar to it in order to create some event listeners related to richCombo
+			bot.setHtmlWithSelection( '<div><p>[Text]</p></div>' );
+			var p = editor.editable().findOne( 'p' ) ;
+
+			panel.addItems( {
+				bold: new CKEDITOR.ui.button( {
+					label: 'test',
+					command: 'bold'
+				} ),
+				Styles: editor.ui.create( 'Styles' )
+			} );
+			panel.attach( p );
+
+			// Pushing items from panel to another variable, because calling destroy() on panel will remove all item references.
+			var items = [];
+			for ( var key in panel._items ) {
+				items.push( panel._items[ key ] );
+			}
+			panel.destroy();
+
+			items.forEach( function( item ) {
+				if ( item instanceof CKEDITOR.ui.richCombo ) {
+					assert.isTrue( item._listeners.length === 0 );
+				}
+			} );
+			assert.isTrue( CKEDITOR.tools.isEmpty( panel._items ) );
+		}
+	};
+
+	bender.test( tests );
+} )();

--- a/tests/plugins/balloontoolbar/destroy.js
+++ b/tests/plugins/balloontoolbar/destroy.js
@@ -1,4 +1,4 @@
-/* bender-tags: balloontoolbar, 1477, 4.9.0 */
+/* bender-tags: balloontoolbar, 1477 */
 /* bender-ckeditor-plugins: balloontoolbar,button,basicstyles,list,richcombo,stylescombo,wysiwygarea,toolbar */
 
 ( function() {

--- a/tests/plugins/balloontoolbar/destroy.js
+++ b/tests/plugins/balloontoolbar/destroy.js
@@ -14,11 +14,13 @@
 				panel = new CKEDITOR.ui.balloonToolbar( this.editor, {
 					width: 'auto',
 					height: 40
-				} );
+				} ),
+				items = [],
+				p;
 
 			// Creating some editor content and attaching balloonToolbar to it in order to create some event listeners related to richCombo
 			bot.setHtmlWithSelection( '<div><p>[Text]</p></div>' );
-			var p = editor.editable().findOne( 'p' ) ;
+			p = editor.editable().findOne( 'p' ) ;
 
 			panel.addItems( {
 				bold: new CKEDITOR.ui.button( {
@@ -30,7 +32,6 @@
 			panel.attach( p );
 
 			// Pushing items from panel to another variable, because calling destroy() on panel will remove all item references.
-			var items = [];
 			for ( var key in panel._items ) {
 				items.push( panel._items[ key ] );
 			}

--- a/tests/plugins/balloontoolbar/destroy.js
+++ b/tests/plugins/balloontoolbar/destroy.js
@@ -37,12 +37,11 @@
 			}
 			panel.destroy();
 
-			items.forEach( function( item ) {
-				if ( item instanceof CKEDITOR.ui.richCombo ) {
-					assert.isTrue( item._listeners.length === 0 );
-				}
+			var listenersDeleted = CKEDITOR.tools.array.every( items, function( item ) {
+				return !( item instanceof CKEDITOR.ui.richCombo ) || item._listeners.length === 0;
 			} );
-			assert.isTrue( CKEDITOR.tools.isEmpty( panel._items ) );
+			assert.isTrue( listenersDeleted, 'All listeners are deleted' );
+
 		}
 	};
 

--- a/tests/plugins/balloontoolbar/destroy.js
+++ b/tests/plugins/balloontoolbar/destroy.js
@@ -15,7 +15,7 @@
 					width: 'auto',
 					height: 40
 				} ),
-				items = [],
+				items,
 				p;
 
 			// Creating some editor content and attaching balloonToolbar to it in order to create some event listeners related to richCombo
@@ -31,17 +31,18 @@
 			} );
 			panel.attach( p );
 
-			// Pushing items from panel to another variable, because calling destroy() on panel will remove all item references.
-			for ( var key in panel._items ) {
-				items.push( panel._items[ key ] );
-			}
+
+			// Storing items from panel in another variable, because calling destroy() on panel will remove all item references.
+			items = CKEDITOR.tools.array.map( CKEDITOR.tools.objectKeys( this._items ), function( key ) {
+				return panel._items[ key ];
+			} );
+
 			panel.destroy();
 
 			var listenersDeleted = CKEDITOR.tools.array.every( items, function( item ) {
 				return !( item instanceof CKEDITOR.ui.richCombo ) || item._listeners.length === 0;
 			} );
 			assert.isTrue( listenersDeleted, 'All listeners are deleted' );
-
 		}
 	};
 

--- a/tests/plugins/balloontoolbar/destroy.js
+++ b/tests/plugins/balloontoolbar/destroy.js
@@ -33,14 +33,14 @@
 
 
 			// Storing items from panel in another variable, because calling destroy() on panel will remove all item references.
-			items = CKEDITOR.tools.array.map( CKEDITOR.tools.objectKeys( this._items ), function( key ) {
+			items = CKEDITOR.tools.array.map( CKEDITOR.tools.objectKeys( panel._items ), function( key ) {
 				return panel._items[ key ];
 			} );
 
 			panel.destroy();
 
 			var listenersDeleted = CKEDITOR.tools.array.every( items, function( item ) {
-				return !( item instanceof CKEDITOR.ui.richCombo ) || item._listeners.length === 0;
+				return !( item instanceof CKEDITOR.ui.richCombo ) || item._.listeners.length === 0;
 			} );
 			assert.isTrue( listenersDeleted, 'All listeners are deleted' );
 		}

--- a/tests/plugins/balloontoolbar/manual/destroy.html
+++ b/tests/plugins/balloontoolbar/manual/destroy.html
@@ -13,25 +13,27 @@
 		bender.ignore();
 	}
 
-	CKEDITOR.disableAutoInline = true;
+	CKEDITOR.replace( 'editor1', {
+		on: {
+			instanceReady: instanceReadyListener
+		}
+	} );
 
 	function instanceReadyListener( evt ) {
-		var lis = this.editable().find( 'li' ),
-			panel = {},
-			i = 0,
-			li,
-			_this = this;
+		var listItems = this.editable().find( 'li' ).toArray(),
+			panel;
 
-
-		while ( ( li = lis.getItem( i++ ) ) ) {
-			li.on( 'click', function() {
+		CKEDITOR.tools.array.forEach( listItems, function( item ) {
+			item.on( 'click', function() {
 				if ( !CKEDITOR.tools.isEmpty( panel ) ) {
 					panel.destroy()
 				}
-				panel = new CKEDITOR.ui.balloonToolbar( _this, {
+
+				panel = new CKEDITOR.ui.balloonToolbar( evt.editor, {
 					width: 'auto',
 					height: 40
 				} );
+
 				panel.addItems( {
 					bold: new CKEDITOR.ui.button( {
 						label: 'test',
@@ -40,17 +42,9 @@
 					language: evt.editor.ui.create('Language'),
 					Styles: evt.editor.ui.create( 'Styles' )
 				} );
+
 				panel.attach( this );
 			} );
-		}
+		} );
 	}
-
-	CKEDITOR.replace( 'editor1', {
-		extraPlugins: 'balloonpanel,language,stylescombo',
-		height: 300,
-		width: 600,
-		on: {
-			instanceReady: instanceReadyListener
-		}
-	} );
 </script>

--- a/tests/plugins/balloontoolbar/manual/destroy.html
+++ b/tests/plugins/balloontoolbar/manual/destroy.html
@@ -1,0 +1,56 @@
+<textarea id="editor1" cols="10" rows="10">
+	<ul>
+		<li>List item 1</li>
+		<li>List item 2</li>
+		<li>List item 3</li>
+		<li>List item 4</li>
+		<li>List item 5</li>
+	</ul>
+</textarea>
+<script>
+	// Currently balloon toolbar is not integrated with old IE browsers.
+	if ( CKEDITOR.env.ie && CKEDITOR.env.version < 9 ) {
+		bender.ignore();
+	}
+
+	CKEDITOR.disableAutoInline = true;
+
+	function instanceReadyListener( evt ) {
+		var lis = this.editable().find( 'li' ),
+			panel = {},
+			i = 0,
+			li,
+			_this = this;
+
+
+		while ( ( li = lis.getItem( i++ ) ) ) {
+			li.on( 'click', function() {
+				if ( !CKEDITOR.tools.isEmpty( panel ) ) {
+					panel.destroy()
+				}
+				panel = new CKEDITOR.ui.balloonToolbar( _this, {
+					width: 'auto',
+					height: 40
+				} );
+				panel.addItems( {
+					bold: new CKEDITOR.ui.button( {
+						label: 'test',
+						command: 'bold'
+					} ),
+					language: evt.editor.ui.create('Language'),
+					Styles: evt.editor.ui.create( 'Styles' )
+				} );
+				panel.attach( this );
+			} );
+		}
+	}
+
+	CKEDITOR.replace( 'editor1', {
+		extraPlugins: 'balloonpanel,language,stylescombo',
+		height: 300,
+		width: 600,
+		on: {
+			instanceReady: instanceReadyListener
+		}
+	} );
+</script>

--- a/tests/plugins/balloontoolbar/manual/destroy.html
+++ b/tests/plugins/balloontoolbar/manual/destroy.html
@@ -9,7 +9,8 @@
 </textarea>
 <script>
 	// Currently balloon toolbar is not integrated with old IE browsers.
-	if ( CKEDITOR.env.ie && CKEDITOR.env.version < 9 ) {
+	// Ignore mobiles, as test requires using console.
+	if ( CKEDITOR.env.ie && CKEDITOR.env.version < 9 || bender.tools.env.mobile ) {
 		bender.ignore();
 	}
 

--- a/tests/plugins/balloontoolbar/manual/destroy.md
+++ b/tests/plugins/balloontoolbar/manual/destroy.md
@@ -1,0 +1,15 @@
+@bender-ui: collapsed
+@bender-tags: 4.9.0 bug, 1477, balloontoolbar
+@bender-ckeditor-plugins: wysiwygarea,toolbar,undo,basicstyles,balloontoolbar,sourcearea,list
+
+1. Click on list item.
+1. Click on another list item.
+
+## Expected:
+
+Balloon toolbar should appear next to last clicked list item.
+
+## Unexpected:
+
+1. Console throws an error.
+1. Two or more balloon toolbar appears at once.

--- a/tests/plugins/balloontoolbar/manual/destroy.md
+++ b/tests/plugins/balloontoolbar/manual/destroy.md
@@ -1,6 +1,6 @@
 @bender-ui: collapsed
 @bender-tags: 4.11.0 bug, 1477, balloontoolbar
-@bender-ckeditor-plugins: wysiwygarea,toolbar,undo,basicstyles,balloontoolbar,sourcearea,list
+@bender-ckeditor-plugins: wysiwygarea,toolbar,basicstyles,balloontoolbar,sourcearea,list,language,stylescombo
 
 1. Click on list item.
 1. Click on another list item.

--- a/tests/plugins/balloontoolbar/manual/destroy.md
+++ b/tests/plugins/balloontoolbar/manual/destroy.md
@@ -2,6 +2,7 @@
 @bender-tags: 4.11.0 bug, 1477, balloontoolbar
 @bender-ckeditor-plugins: wysiwygarea,toolbar,basicstyles,balloontoolbar,sourcearea,list,language,stylescombo
 
+1. Open console.
 1. Click on list item.
 1. Click on another list item.
 

--- a/tests/plugins/balloontoolbar/manual/destroy.md
+++ b/tests/plugins/balloontoolbar/manual/destroy.md
@@ -1,5 +1,5 @@
 @bender-ui: collapsed
-@bender-tags: 4.9.0 bug, 1477, balloontoolbar
+@bender-tags: 4.11.0 bug, 1477, balloontoolbar
 @bender-ckeditor-plugins: wysiwygarea,toolbar,undo,basicstyles,balloontoolbar,sourcearea,list
 
 1. Click on list item.

--- a/tests/plugins/balloontoolbar/manual/destroy.md
+++ b/tests/plugins/balloontoolbar/manual/destroy.md
@@ -1,5 +1,5 @@
 @bender-ui: collapsed
-@bender-tags: 4.11.0 bug, 1477, balloontoolbar
+@bender-tags: 4.11.0, bug, 1477, balloontoolbar
 @bender-ckeditor-plugins: wysiwygarea,toolbar,basicstyles,balloontoolbar,sourcearea,list,language,stylescombo
 
 1. Open console.

--- a/tests/plugins/richcombo/richcombo.js
+++ b/tests/plugins/richcombo/richcombo.js
@@ -38,5 +38,21 @@ bender.test( {
 			anchorEl = CKEDITOR.document.getById( 'cke_' + combo.id ).findOne( 'a' );
 
 		assert.areEqual( anchorEl.getAttribute( 'aria-haspopup' ), 'listbox' );
+	},
+	'test destroy removes combo listeners': function() {
+		var combo = this.editor.ui.get( 'custom_combo' ),
+			spies = CKEDITOR.tools.array.map( combo._listeners, function( listener ) {
+				return sinon.spy( listener, 'removeListener' );
+			} ),
+			listenersRemoved;
+
+		combo.destroy();
+
+		listenersRemoved = CKEDITOR.tools.array.every( spies, function( spy ) {
+			return spy.called;
+		} );
+
+		assert.areEqual( 0, combo._listeners.length, 'Listeners array is empty.' );
+		assert.isTrue( listenersRemoved, 'All listeners are removed.' );
 	}
 } );

--- a/tests/plugins/richcombo/richcombo.js
+++ b/tests/plugins/richcombo/richcombo.js
@@ -41,7 +41,7 @@ bender.test( {
 	},
 	'test destroy removes combo listeners': function() {
 		var combo = this.editor.ui.get( 'custom_combo' ),
-			spies = CKEDITOR.tools.array.map( combo._listeners, function( listener ) {
+			spies = CKEDITOR.tools.array.map( combo._.listeners, function( listener ) {
 				return sinon.spy( listener, 'removeListener' );
 			} ),
 			listenersRemoved;
@@ -52,7 +52,7 @@ bender.test( {
 			return spy.called;
 		} );
 
-		assert.areEqual( 0, combo._listeners.length, 'Listeners array is empty.' );
+		assert.areEqual( 0, combo._.listeners.length, 'Listeners array is empty.' );
 		assert.isTrue( listenersRemoved, 'All listeners are removed.' );
 	}
 } );

--- a/tests/plugins/richcombo/richcombo.js
+++ b/tests/plugins/richcombo/richcombo.js
@@ -39,6 +39,7 @@ bender.test( {
 
 		assert.areEqual( anchorEl.getAttribute( 'aria-haspopup' ), 'listbox' );
 	},
+	// #1477
 	'test destroy removes combo listeners': function() {
 		var combo = this.editor.ui.get( 'custom_combo' ),
 			spies = CKEDITOR.tools.array.map( combo._.listeners, function( listener ) {

--- a/tests/plugins/richcombo/richcombo.js
+++ b/tests/plugins/richcombo/richcombo.js
@@ -39,7 +39,8 @@ bender.test( {
 
 		assert.areEqual( anchorEl.getAttribute( 'aria-haspopup' ), 'listbox' );
 	},
-	// #1477
+
+	// (#1477)
 	'test destroy removes combo listeners': function() {
 		var combo = this.editor.ui.get( 'custom_combo' ),
 			spies = CKEDITOR.tools.array.map( combo._.listeners, function( listener ) {


### PR DESCRIPTION
## What is the purpose of this pull request?

Bugfix

## Does your PR contain necessary tests?

All patches which change the editor code must include tests. You can always read more
on [PR testing](https://docs.ckeditor.com/ckeditor4/docs/#!/guide/dev_contributing_code-section-tests),
[how to set the testing environment](https://docs.ckeditor.com/ckeditor4/docs/#!/guide/dev_tests) and
[how to create tests](https://docs.ckeditor.com/ckeditor4/docs/#!/guide/dev_tests-section-creating-your-own-test)
in the official CKEditor documentation.

### This PR contains

- [x] Unit tests
- [x] Manual tests

## What changes did you make?

I've made balloonToolbar `destroy` to call also `destroy` on each of its `_items`. And added `destroy` method to richCombo, which removes all listeners from it.

Closes #1477