### PR TITLE
Check if nested editable has upcasted widget parent

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -12,6 +12,7 @@ Fixed Issues:
 
 * [#2672](https://github.com/ckeditor/ckeditor-dev/issues/2672): Fixed: When resizing [Enhanced Image](https://ckeditor.com/cke4/addon/image2) to minimum size with a resizer the image dialog doesn't show actual values.
 * [#1478](https://github.com/ckeditor/ckeditor-dev/issues/1478): Fixed: Custom colors added to [Color Button](https://ckeditor.com/cke4/addon/colorbutton) via [`config.colorButton_colors`](https://ckeditor.com/docs/ckeditor4/latest/api/CKEDITOR_config.html#cfg-colorButton_colors) in form label/code don't work correctly.
+[#1469](https://github.com/ckeditor/ckeditor-dev/issues/1469): Fixed: Trying to get data from nested editable inside freshly pasted widget throws an error.
 
 API Changes:
 
@@ -297,6 +298,7 @@ Fixed Issues:
 * [#1516](https://github.com/ckeditor/ckeditor-dev/issues/1516): Fixed: Fake selection allows removing content in read-only mode using the <kbd>Backspace</kbd> and <kbd>Delete</kbd> keys.
 * [#1570](https://github.com/ckeditor/ckeditor-dev/issues/1570): Fixed: Fake selection allows cutting content in read-only mode using the <kbd>Ctrl</kbd>/<kbd>Cmd</kbd> + <kbd>X</kbd> keys.
 * [#1363](https://github.com/ckeditor/ckeditor-dev/issues/1363): Fixed: Paste notification is unclear and it might confuse users.
+
 
 API Changes:
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -12,7 +12,7 @@ Fixed Issues:
 
 * [#2672](https://github.com/ckeditor/ckeditor-dev/issues/2672): Fixed: When resizing [Enhanced Image](https://ckeditor.com/cke4/addon/image2) to minimum size with a resizer the image dialog doesn't show actual values.
 * [#1478](https://github.com/ckeditor/ckeditor-dev/issues/1478): Fixed: Custom colors added to [Color Button](https://ckeditor.com/cke4/addon/colorbutton) via [`config.colorButton_colors`](https://ckeditor.com/docs/ckeditor4/latest/api/CKEDITOR_config.html#cfg-colorButton_colors) in form label/code don't work correctly.
-[#1469](https://github.com/ckeditor/ckeditor-dev/issues/1469): Fixed: Trying to get data from nested editable inside freshly pasted widget throws an error.
+* [#1469](https://github.com/ckeditor/ckeditor-dev/issues/1469): Fixed: Trying to get data from nested editable inside freshly pasted widget throws an error.
 
 API Changes:
 

--- a/plugins/widget/plugin.js
+++ b/plugins/widget/plugin.js
@@ -2888,7 +2888,11 @@
 					// Nested editables are downcasted in the successive toDataFormat to create an opportunity
 					// for dataFilter's "excludeNestedEditable" option to do its job (that option relies on
 					// contenteditable="true" attribute) (https://dev.ckeditor.com/ticket/11372).
-					toBeDowncasted[ toBeDowncasted.length - 1 ].editables[ attrs[ 'data-cke-widget-editable' ] ] = element;
+					// There is possibility that nested editable is detected during pasting, when widget
+					// containing it is not yet upcasted (#1469).
+					if ( toBeDowncasted.length > 0 ) {
+						toBeDowncasted[ toBeDowncasted.length - 1 ].editables[ attrs[ 'data-cke-widget-editable' ] ] = element;
+					}
 
 					// Don't check children - there won't be next wrapper or nested editable which we
 					// should process in this session.

--- a/tests/plugins/widget/manual/pastewidget.html
+++ b/tests/plugins/widget/manual/pastewidget.html
@@ -1,0 +1,16 @@
+<div id="editor">
+	<figure class="image">
+		<img src="%BASE_PATH%_assets/logo.png" alt="CKSource">
+		<figcaption>Paste here</figcaption>
+	</figure>
+</div>
+
+<script>
+	CKEDITOR.replace( 'editor', {
+		on: {
+			selectionChange: function( evt ) {
+				evt.editor.widgets.instances[ 0 ].editables.caption.getData();
+			}
+		}
+	} );
+</script>

--- a/tests/plugins/widget/manual/pastewidget.html
+++ b/tests/plugins/widget/manual/pastewidget.html
@@ -6,6 +6,10 @@
 </div>
 
 <script>
+	if ( bender.tools.env.mobile ) {
+		bender.ignore();
+	}
+
 	CKEDITOR.replace( 'editor', {
 		on: {
 			selectionChange: function() {

--- a/tests/plugins/widget/manual/pastewidget.html
+++ b/tests/plugins/widget/manual/pastewidget.html
@@ -8,8 +8,10 @@
 <script>
 	CKEDITOR.replace( 'editor', {
 		on: {
-			selectionChange: function( evt ) {
-				evt.editor.widgets.instances[ 0 ].editables.caption.getData();
+			selectionChange: function() {
+				for ( var key in this.widgets.instances ) {
+					this.widgets.instances[ key ].editables.caption.getData();
+				}
 			}
 		}
 	} );

--- a/tests/plugins/widget/manual/pastewidget.md
+++ b/tests/plugins/widget/manual/pastewidget.md
@@ -1,0 +1,17 @@
+@bender-tags: 4.9.0, bug, 1469, widget
+@bender-ui: collapsed
+@bender-ckeditor-plugins: image2, wysiwygarea, toolbar, sourcearea, floatingspace, elementspath
+
+## Procedure
+
+1. Open console.
+2. Select and copy widget.
+3. Paste into widget's caption.
+
+### Expected result
+
+There is no error in the console.
+
+### Unexpected result
+
+There is error thrown.

--- a/tests/plugins/widget/manual/pastewidget.md
+++ b/tests/plugins/widget/manual/pastewidget.md
@@ -1,4 +1,4 @@
-@bender-tags: 4.9.0, bug, 1469, widget
+@bender-tags: 4.12.0, bug, 1469, widget
 @bender-ui: collapsed
 @bender-ckeditor-plugins: image2, wysiwygarea, toolbar, sourcearea, floatingspace, elementspath
 

--- a/tests/plugins/widget/nestededitables.js
+++ b/tests/plugins/widget/nestededitables.js
@@ -1421,6 +1421,52 @@
 			} );
 		},
 
+		// #1469
+		'test pasting widget into widget nested editable with selectionChange callback': function() {
+			var editor = this.editor,
+				bot = this.editorBot;
+
+			editor.widgets.add( 'widget-pastenested', {
+				parts: {
+					label: 'p'
+				},
+
+				editables: {
+					nested: {
+						selector: '.widget-nested'
+					}
+				}
+			} );
+
+			bot.setData( '<div id="w1" data-widget="widget-pastenested"><p>Widget</p><div class="widget-nested">xx</div></div>', function() {
+				var widget = getWidgetById( editor, 'w1' ),
+					nested = widget.editables.nested,
+					range = editor.createRange();
+
+				range.setStart( nested.getFirst(), 1 );
+				range.collapse( 1 );
+				range.select();
+				nested.focus();
+
+				editor.once( 'selectionChange', function() {
+					resume( function() {
+						try {
+							nested.getData();
+						} catch ( e ) {
+							assert.fail( 'Error was thrown' );
+						}
+
+						assert.pass( 'Everything worked' );
+					} );
+				} );
+
+				// Simulate pasted copied, upcasted widget
+				bender.tools.emulatePaste( editor, '<div data-cke-widget-wrapper="1"><div data-widget="widget-pastenested"><div data-cke-widget-editable="nested"></div></div></div>' );
+
+				wait();
+			} );
+		},
+
 		// Behaviour has been changed in 4.5 (https://dev.ckeditor.com/ticket/12112), so we're leaving this
 		// test as a validation of this change.
 		'test widgets\' commands are enabled in nested editable': function() {

--- a/tests/plugins/widget/nestededitables.js
+++ b/tests/plugins/widget/nestededitables.js
@@ -1460,7 +1460,7 @@
 					} );
 				} );
 
-				// Simulate pasted copied, upcasted widget
+				// Simulate pasting copied, upcasted widget.
 				bender.tools.emulatePaste( editor, '<div data-cke-widget-wrapper="1"><div data-cke-widget-upcasted="1" data-widget="pastenested"><div data-cke-widget-editable="nested">Test</div></div></div>' );
 
 				wait();

--- a/tests/plugins/widget/nestededitables.js
+++ b/tests/plugins/widget/nestededitables.js
@@ -1448,12 +1448,12 @@
 				range.select();
 				nested.focus();
 
-				editor.once( 'selectionChange', function() {
+				editor.once( 'afterPaste', function() {
 					resume( function() {
 						try {
 							nested.getData();
 						} catch ( e ) {
-							assert.fail( 'Error was thrown' );
+							assert.fail( 'Error was thrown: ' + e );
 						}
 
 						assert.pass( 'Everything worked' );
@@ -1461,7 +1461,7 @@
 				} );
 
 				// Simulate pasted copied, upcasted widget
-				bender.tools.emulatePaste( editor, '<div data-cke-widget-wrapper="1"><div data-widget="widget-pastenested"><div data-cke-widget-editable="nested"></div></div></div>' );
+				bender.tools.emulatePaste( editor, '<div data-cke-widget-wrapper="1"><div data-cke-widget-upcasted="1" data-widget="pastenested"><div data-cke-widget-editable="nested">Test</div></div></div>' );
 
 				wait();
 			} );


### PR DESCRIPTION
## What is the purpose of this pull request?

Bug fix

## Does your PR contain necessary tests?

All patches which change the editor code must include tests. You can always read more
on [PR testing](https://docs.ckeditor.com/ckeditor4/docs/#!/guide/dev_contributing_code-section-tests),
[how to set the testing environment](https://docs.ckeditor.com/ckeditor4/docs/#!/guide/dev_tests) and
[how to create tests](https://docs.ckeditor.com/ckeditor4/docs/#!/guide/dev_tests-section-creating-your-own-test)
in the official CKEditor documentation.

### This PR contains

- [x] Unit tests
- [x] Manual tests

## What changes did you make?

I've added check to `toData` callback to ensure that only nested editables, that are inside upcasted widgets, will be downcasted.

Closes #1469.
