### PR TITLE
[Firefox] Fixed "selection change" on focus with nested contentEditable

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -24,6 +24,7 @@ Fixed Issues:
 * [#1356](https://github.com/ckeditor/ckeditor-dev/issues/1356): Fixed: [Border parse function](https://docs.ckeditor.com/ckeditor4/docs/#!/api/CKEDITOR.tools.style.parse-method-border) should allow spaces in the color value.
 * [#1426](https://github.com/ckeditor/ckeditor-dev/issues/1426): [IE8-9] Fixed: Missing balloon toolbar background in Kama skin. Thanks to [Christian Elmer](https://github.com/keinkurt)!
 * [#1010](https://github.com/ckeditor/ckeditor-dev/issues/1010): Fixed: CSS `border` shorthand property was incorrectly expanded ignoring `border-color` style.
+* [#1113](https://github.com/ckeditor/ckeditor-dev/issues/1113): [Firefox] Fixed: Nested contenteditable elements path not updated on focus with divarea plugin.
 
 API Changes:
 

--- a/core/selection.js
+++ b/core/selection.js
@@ -926,11 +926,16 @@
 					evt.data.preventDefault();
 				}
 			}, editor );
+
 			// Always fire the selection change on focus gain.
 			// On Webkit do this on DOMFocusIn, because the selection is unlocked on it too and
 			// we need synchronization between those listeners to not lost cached editor._.previousActive property
 			// (which is updated on selectionCheck).
-			editable.attachListener( editable, CKEDITOR.env.webkit ? 'DOMFocusIn' : 'focus', function() {
+			// On Gecko with inline editor use focusin insted focus because the last one is not bubbling and
+			// event will not be fired with nested contenteditable (https://github.com/ckeditor/ckeditor-dev/issues/1113).
+			// For IE we already are replacing focus with focusin.
+			var focusEvent = ( CKEDITOR.env.webkit && 'DOMFocusIn' ) || ( isInline && CKEDITOR.env.gecko && 'focusin' ) || 'focus';
+			editable.attachListener( editable, focusEvent, function() {
 				editor.forceNextSelectionCheck();
 				editor.selectionChange( 1 );
 			} );

--- a/tests/core/selection/editor.js
+++ b/tests/core/selection/editor.js
@@ -149,6 +149,17 @@ bender.test( {
 		}, 200 );
 	},
 
+	'test "selectionChange" fires properly with nested contentEditable': function() {
+		var editor = this.editors.editorInline, editable = editor.editable(), stub = sinon.stub( editor, 'selectionChange' );
+
+		bender.tools.setHtmlWithSelection( editor, '<div contenteditable=true><div contenteditable=false><div contenteditable=true id="nested">xxx</div></div></div>' );
+
+		var event = CKEDITOR.env.webkit && 'DOMFocusIn' || CKEDITOR.env.gecko && 'focusin' || 'focus';
+		editable.fire( event, new CKEDITOR.dom.event( { target: editable.findOne( '#nested' ) } ) );
+
+		assert.isTrue( stub.called );
+	},
+
 	'test "selectionChange" not fired when editor selection is locked': function() {
 		var ed = this.editors.editor, editable = ed.editable();
 

--- a/tests/core/selection/manual/geckoselectionchange.html
+++ b/tests/core/selection/manual/geckoselectionchange.html
@@ -1,0 +1,24 @@
+<div id="square" style="width: 50px; height: 50px; background-color: yellow; margin: 10px 50% 10px 50%;"></div>
+
+<div id="editor2" contenteditable="true">
+	<p>You can type here <strong contenteditable="false">This is uneditable part <em contenteditable="true">and you can type again inside this editable part<u> and some underline inside</u></em></strong>.</p>
+</div>
+
+<script>
+	var square = document.getElementById( 'square' );
+	CKEDITOR.replace( 'editor2', {
+		extraPlugins: 'divarea',
+		allowedContent: true,
+		on: {
+			selectionChange: function () {
+				var backgroundColor = square.style.backgroundColor;
+				square.style.backgroundColor = backgroundColor === 'blue' ? 'red' : 'blue';
+			}
+		}
+	} );
+
+	if( !CKEDITOR.env.gecko ) {
+		bender.ignore();
+	}
+
+</script>

--- a/tests/core/selection/manual/geckoselectionchange.md
+++ b/tests/core/selection/manual/geckoselectionchange.md
@@ -1,0 +1,16 @@
+@bender-ui: collapsed
+@bender-tags: 4.9.0, 1113, bug
+@bender-ckeditor-plugins: wysiwygarea, toolbar, undo, basicstyles, elementspath
+
+----
+
+1. Put selection inside text with normal font style e.g. `You can ^type here`
+2. Put selection inside text text with italic font style e.g. *`and you can type again inside this editable ^part and some underline inside`*
+
+## Expected
+
+Upper square toggles color blue/red (default is yellow).
+
+## Unexpected
+
+Upper square is not changing when moving selection between text nodes.


### PR DESCRIPTION
## What is the purpose of this pull request?

Bug fix

## Does your PR contain necessary tests?

All patches which change the editor code must include tests. You can always read more
on [PR testing](https://docs.ckeditor.com/ckeditor4/docs/#!/guide/dev_contributing_code-section-tests),
[how to set the testing environment](https://docs.ckeditor.com/ckeditor4/docs/#!/guide/dev_tests) and
[how to create tests](https://docs.ckeditor.com/ckeditor4/docs/#!/guide/dev_tests-section-creating-your-own-test)
in the official CKEditor documentation.

### This PR contains

- [x] Unit tests
- [x] Manual tests

## What changes did you make?

Changed `focus` to `focusin` for selection update listener when using Firefox browser. The reason for this change was missing event bubbling with `focus` event. It caused problems with nested content editable elements where selection wasn't changed when focusing inner `contenteditable` element. We are already using `DOMFocusIn` for Chrome and converting `focus` to `focusin` for IE. We could change `focus` to `focusin` globally for Gecko [here](https://github.com/ckeditor/ckeditor-dev/blob/major/core/editable.js#L123) but I wasn't sure about so massive change for the editor.

Closes #1113
