### PR TITLE
Fixed executing editor.destroy() during image upload

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -19,6 +19,7 @@ Fixed Issues:
 * [#1592](https://github.com/ckeditor/ckeditor-dev/issues/1592): [Image Base](https://ckeditor.com/cke4/addon/imagebase) caption is not visible after paste.
 * [#620](https://github.com/ckeditor/ckeditor-dev/issues/620): Fixed: [`forcePasteAsPlainText`](https://docs.ckeditor.com/ckeditor4/latest/api/CKEDITOR_config.html#cfg-forcePasteAsPlainText) will be respected when internal and cross-editor pasting happen.
 * [#1467](https://github.com/ckeditor/ckeditor-dev/issues/1467): Fixed: [Table Resize](https://ckeditor.com/cke4/addon/tableresize) resizing coursor appearing in middle of merged cell.
+* [#966](https://github.com/ckeditor/ckeditor-dev/issues/966): Fixed: Executing [`editor.destroy()`](https://docs.ckeditor.com/ckeditor4/latest/api/CKEDITOR_editor.html#destroy) during [file upload](https://docs.ckeditor.com/ckeditor4/latest/api/CKEDITOR_fileTools_uploadWidgetDefinition.html#onUploading) throws error.
 
 API Changes:
 
@@ -100,7 +101,6 @@ Fixed Issues:
 * [#1516](https://github.com/ckeditor/ckeditor-dev/issues/1516): Fixed: Fake selection allows removing content in read-only mode using the <kbd>Backspace</kbd> and <kbd>Delete</kbd> keys.
 * [#1570](https://github.com/ckeditor/ckeditor-dev/issues/1570): Fixed: Fake selection allows cutting content in read-only mode using the <kbd>Ctrl</kbd>/<kbd>Cmd</kbd> + <kbd>X</kbd> keys.
 * [#1363](https://github.com/ckeditor/ckeditor-dev/issues/1363): Fixed: Paste notification is unclear and it might confuse users.
-* [#966](https://github.com/ckeditor/ckeditor-dev/issues/966): Fixed: Executing [`editor.destroy()`](https://docs.ckeditor.com/ckeditor4/latest/api/CKEDITOR_editor.html#destroy) during [file upload](https://docs.ckeditor.com/ckeditor4/latest/api/CKEDITOR_fileTools_uploadWidgetDefinition.html#onUploading) throws error.
 
 API Changes:
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -100,6 +100,7 @@ Fixed Issues:
 * [#1516](https://github.com/ckeditor/ckeditor-dev/issues/1516): Fixed: Fake selection allows removing content in read-only mode using the <kbd>Backspace</kbd> and <kbd>Delete</kbd> keys.
 * [#1570](https://github.com/ckeditor/ckeditor-dev/issues/1570): Fixed: Fake selection allows cutting content in read-only mode using the <kbd>Ctrl</kbd>/<kbd>Cmd</kbd> + <kbd>X</kbd> keys.
 * [#1363](https://github.com/ckeditor/ckeditor-dev/issues/1363): Fixed: Paste notification is unclear and it might confuse users.
+* [#966](https://github.com/ckeditor/ckeditor-dev/issues/966): Fixed: Executing [`editor.destroy()`](https://docs.ckeditor.com/ckeditor4/latest/api/CKEDITOR_editor.html#destroy) during [file upload](https://docs.ckeditor.com/ckeditor4/latest/api/CKEDITOR_fileTools_uploadWidgetDefinition.html#onUploading) throws error.
 
 API Changes:
 

--- a/plugins/uploadwidget/plugin.js
+++ b/plugins/uploadwidget/plugin.js
@@ -1,4 +1,4 @@
-﻿/**
+/**
  * @license Copyright (c) 2003-2018, CKSource - Frederico Knabben. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-oss-license
  */
@@ -252,6 +252,11 @@
 					oldStyle, newStyle;
 
 				loader.on( 'update', function( evt ) {
+					// Abort if the editor has been destroyed.
+					if ( widget.editor.status === 'destroyed' ) {
+						return;
+					}
+
 					// Abort if widget was removed.
 					if ( !widget.wrapper || !widget.wrapper.getParent() ) {
 						if ( !editor.editable().find( '[data-cke-upload-id="' + id + '"]' ).count() ) {

--- a/plugins/uploadwidget/plugin.js
+++ b/plugins/uploadwidget/plugin.js
@@ -252,14 +252,10 @@
 					oldStyle, newStyle;
 
 				loader.on( 'update', function( evt ) {
-					// Abort if the editor has been destroyed.
-					if ( widget.editor.status === 'destroyed' ) {
-						return;
-					}
-
 					// Abort if widget was removed.
 					if ( !widget.wrapper || !widget.wrapper.getParent() ) {
-						if ( !editor.editable().find( '[data-cke-upload-id="' + id + '"]' ).count() ) {
+						// Don't continue if the editor has been destroyed (#966).
+						if ( !editor.editable() || !editor.editable().find( '[data-cke-upload-id="' + id + '"]' ).count() ) {
 							loader.abort();
 						}
 						evt.removeListener();
@@ -527,7 +523,9 @@
 
 		loader.on( 'abort', function() {
 			task && task.cancel();
-			editor.showNotification( editor.lang.uploadwidget.abort, 'info' );
+			if ( editor.editable() ) {
+				editor.showNotification( editor.lang.uploadwidget.abort, 'info' );
+			}
 		} );
 
 		function createAggregator() {

--- a/tests/plugins/uploadwidget/manual/destroyeditor.html
+++ b/tests/plugins/uploadwidget/manual/destroyeditor.html
@@ -1,0 +1,21 @@
+<div id="editor"></div>
+<button id="destroyer">Destroy</button>
+
+<script>
+	CKEDITOR.replace( 'editor', {
+		imageUploadUrl: 'http://sub.ckeditor.dev/',
+		on: {
+				instanceReady: function( evt ) {
+					var editor = evt.editor;
+
+					document.getElementById( 'destroyer' ).addEventListener( 'click', function() {
+						editor.destroy();
+					} );
+
+					if ( !CKEDITOR.fileTools.isFileUploadSupported ) {
+						bender.ignore();
+					}
+				}
+			}
+	} );
+</script>

--- a/tests/plugins/uploadwidget/manual/destroyeditor.html
+++ b/tests/plugins/uploadwidget/manual/destroyeditor.html
@@ -12,7 +12,7 @@
 						editor.destroy();
 					} );
 
-					if ( !CKEDITOR.fileTools.isFileUploadSupported ) {
+					if ( !CKEDITOR.fileTools.isFileUploadSupported || bender.tools.env.mobile ) {
 						bender.ignore();
 					}
 				}

--- a/tests/plugins/uploadwidget/manual/destroyeditor.html
+++ b/tests/plugins/uploadwidget/manual/destroyeditor.html
@@ -2,19 +2,18 @@
 <button id="destroyer">Destroy</button>
 
 <script>
+
 	CKEDITOR.replace( 'editor', {
 		imageUploadUrl: 'http://sub.ckeditor.dev/',
 		on: {
 				instanceReady: function( evt ) {
-					var editor = evt.editor;
-
-					document.getElementById( 'destroyer' ).addEventListener( 'click', function() {
-						editor.destroy();
-					} );
-
 					if ( !CKEDITOR.fileTools.isFileUploadSupported || bender.tools.env.mobile ) {
 						bender.ignore();
 					}
+
+					CKEDITOR.document.getById( 'destroyer' ).on( 'click', function() {
+						evt.editor.destroy();
+					} );
 				}
 			}
 	} );

--- a/tests/plugins/uploadwidget/manual/destroyeditor.md
+++ b/tests/plugins/uploadwidget/manual/destroyeditor.md
@@ -1,4 +1,4 @@
-@bender-tags: 4.9.0, 966, bug
+@bender-tags: 4.9.1, 966, bug
 @bender-ui: collapsed
 @bender-ckeditor-plugins: wysiwygarea, image2, uploadimage, toolbar
 @bender-include: _helpers/xhr.js

--- a/tests/plugins/uploadwidget/manual/destroyeditor.md
+++ b/tests/plugins/uploadwidget/manual/destroyeditor.md
@@ -1,0 +1,16 @@
+@bender-tags: 4.9.0, 966, bug
+@bender-ui: collapsed
+@bender-ckeditor-plugins: wysiwygarea, image2, uploadimage, toolbar
+@bender-include: _helpers/xhr.js
+
+1. Open browser console.
+2. Drag and drop some image into editable.
+3. Click `Destroy` button during image upload.
+
+## Expected
+
+Editor has been destroyed. No errors showed up in a console.
+
+## Unexpected
+
+Editor has not been destroyed and/or any error showed up in a console.

--- a/tests/plugins/uploadwidget/manual/destroyeditor.md
+++ b/tests/plugins/uploadwidget/manual/destroyeditor.md
@@ -1,4 +1,4 @@
-@bender-tags: 4.9.1, 966, bug
+@bender-tags: 4.10.0, 966, bug
 @bender-ui: collapsed
 @bender-ckeditor-plugins: wysiwygarea, image2, uploadimage, toolbar
 @bender-include: _helpers/xhr.js

--- a/tests/plugins/uploadwidget/uploadwidget.js
+++ b/tests/plugins/uploadwidget/uploadwidget.js
@@ -156,6 +156,26 @@
 			} );
 		},
 
+		'test destroy editor during upload': function() {
+
+			bender.editorBot.create( { name: 'destroy_test', config: { extraPlugins: 'uploadwidget' } }, function( bot ) {
+				var editor = bot.editor;
+
+				addTestUploadWidget( editor, 'testuploadwidget' );
+				pasteFiles( editor, [ bender.tools.getTestPngFile() ] );
+
+				var loader = editor.uploadRepository.loaders[ 0 ];
+
+				try {
+					editor.destroy();
+					loader.changeStatus( 'uploading' );
+					assert.pass();
+				} catch ( err ) {
+					assert.fail( 'Exception thrown during file upload.' );
+				}
+			} );
+		},
+
 		'test markElement': function() {
 			var element = new CKEDITOR.dom.element( 'p' );
 			CKEDITOR.fileTools.markElement( element, 'widgetName', 1 );

--- a/tests/plugins/uploadwidget/uploadwidget.js
+++ b/tests/plugins/uploadwidget/uploadwidget.js
@@ -156,7 +156,8 @@
 			} );
 		},
 
-		'test destroy editor during upload': function() {
+		// (#966)
+		'test uploading with destroyed editor': function() {
 
 			bender.editorBot.create( { name: 'destroy_test', config: { extraPlugins: 'uploadwidget' } }, function( bot ) {
 				var editor = bot.editor;


### PR DESCRIPTION
## What is the purpose of this pull request?

Bug fix.

## Does your PR contain necessary tests?

All patches which change the editor code must include tests. You can always read more
on [PR testing](https://docs.ckeditor.com/ckeditor4/docs/#!/guide/dev_contributing_code-section-tests),
[how to set the testing environment](https://docs.ckeditor.com/ckeditor4/docs/#!/guide/dev_tests) and
[how to create tests](https://docs.ckeditor.com/ckeditor4/docs/#!/guide/dev_tests-section-creating-your-own-test)
in the official CKEditor documentation.

### This PR contains

- [x] Unit tests
- [x] Manual tests

## What changes did you make?

Handled [`destroyed`](https://docs.ckeditor.com/ckeditor4/latest/api/CKEDITOR_editor.html#destroy) editor status during [file upload](https://docs.ckeditor.com/ckeditor4/latest/api/CKEDITOR_fileTools_uploadWidgetDefinition.html#onUploading).

Closes #966
