### PR TITLE
Use HTTPS for CKBuilder and langtool jar download

### DIFF
--- a/dev/builder/build.sh
+++ b/dev/builder/build.sh
@@ -10,7 +10,7 @@ echo "CKBuilder - Builds a release version of ckeditor-dev."
 echo ""
 
 CKBUILDER_VERSION="2.3.2"
-CKBUILDER_URL="http://download.cksource.com/CKBuilder/$CKBUILDER_VERSION/ckbuilder.jar"
+CKBUILDER_URL="https://download.cksource.com/CKBuilder/$CKBUILDER_VERSION/ckbuilder.jar"
 
 PROGNAME=$(basename $0)
 MSG_UPDATE_FAILED="Warning: The attempt to update ckbuilder.jar failed. The existing file will be used."

--- a/dev/langtool/_common.sh
+++ b/dev/langtool/_common.sh
@@ -5,7 +5,7 @@
 # Updates cklangtool. This script should not be executed separately, it is included in other scripts.
 
 CKLANGTOOL_VERSION="1.2.2"
-CKLANGTOOL_URL="http://download.cksource.com/CKLangTool/$CKLANGTOOL_VERSION/langtool.jar"
+CKLANGTOOL_URL="https://download.cksource.com/CKLangTool/$CKLANGTOOL_VERSION/langtool.jar"
 
 PROGNAME=$(basename $0)
 MSG_UPDATE_FAILED="Warning: The attempt to update cklangtooljar failed. The existing file will be used."


### PR DESCRIPTION
ckbuilder.jar and langtool.jar should be downloaded via HTTPS

## What is the purpose of this pull request?

Bug fix - Security

## Does your PR contain necessary tests?

URL change only - no tests needed. 

### This PR contains

- [ ] Unit tests
- [ ] Manual tests

## What changes did you make?

Changed the default URLs for downloading ckbuilder.jar and langtool.jar to HTTPS to prevent tampering. This is important because build.sh and _common.sh download and execute those files with no verification. 

Closes #1591.