### PR TITLE
Fixed: fake selection allows for removing in a readonly mode

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -27,7 +27,7 @@ Fixed Issues:
 * [#1010](https://github.com/ckeditor/ckeditor-dev/issues/1010): Fixed: CSS `border` shorthand property was incorrectly expanded ignoring `border-color` style.
 * [#1470](https://github.com/ckeditor/ckeditor-dev/issues/1470): Fixed: [Balloon Toolbar](https://ckeditor.com/cke4/addon/balloontoolbar) is not visible after drag and drop of a widget it is attached to.
 * [#1535](https://github.com/ckeditor/ckeditor-dev/issues/1535): Fixed: Improve [Widget](https://ckeditor.com/cke4/addon/widget) mouse over border contrast.
-* [#1516](https://github.com/ckeditor/ckeditor-dev/issues/1516): Fixed: Selection allows removing in a readonly mode using `Backspace`/`Delete` keys.
+* [#1516](https://github.com/ckeditor/ckeditor-dev/issues/1516): Fixed: Fake selection allows removing in a readonly mode using `Backspace`/`Delete` keys.
 
 API Changes:
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -27,6 +27,7 @@ Fixed Issues:
 * [#1010](https://github.com/ckeditor/ckeditor-dev/issues/1010): Fixed: CSS `border` shorthand property was incorrectly expanded ignoring `border-color` style.
 * [#1470](https://github.com/ckeditor/ckeditor-dev/issues/1470): Fixed: [Balloon Toolbar](https://ckeditor.com/cke4/addon/balloontoolbar) is not visible after drag and drop of a widget it is attached to.
 * [#1535](https://github.com/ckeditor/ckeditor-dev/issues/1535): Fixed: Improve [Widget](https://ckeditor.com/cke4/addon/widget) mouse over border contrast.
+* [#1516](https://github.com/ckeditor/ckeditor-dev/issues/1516): Fixed: Selection allows removing in a readonly mode using `Backspace`/`Delete` keys.
 
 API Changes:
 

--- a/core/selection.js
+++ b/core/selection.js
@@ -526,6 +526,10 @@
 					range = editor.createRange(),
 					found;
 
+				if ( editor.readOnly ) {
+					return;
+				}
+
 				// If haven't found place for caret on the default side,
 				// try to find it on the other side.
 				if ( !( found = range.moveToClosestEditablePosition( evt.selected, right ) ) )
@@ -1085,8 +1089,9 @@
 		}, null, null, 100 );
 
 		editor.on( 'key', function( evt ) {
-			if ( editor.mode != 'wysiwyg' )
+			if ( editor.mode != 'wysiwyg' ) {
 				return;
+			}
 
 			var sel = editor.getSelection();
 			if ( !sel.isFake )

--- a/core/selection.js
+++ b/core/selection.js
@@ -526,6 +526,7 @@
 					range = editor.createRange(),
 					found;
 
+				// We have to skip deletion for read only editor (#1516).
 				if ( editor.readOnly ) {
 					return;
 				}

--- a/tests/core/selection/fake.js
+++ b/tests/core/selection/fake.js
@@ -5,7 +5,8 @@ bender.editor = {
 	config: {
 		extraAllowedContent: 'p span em ul li[id,contenteditable]',
 		// They make HTML comparison different in build and dev modes.
-		removePlugins: 'htmlwriter,entities'
+		removePlugins: 'htmlwriter,entities',
+		extraPlugins: 'placeholder'
 	}
 };
 
@@ -74,6 +75,10 @@ function getKeyEvent( keyCode, preventDefaultCallback ) {
 }
 
 bender.test( {
+	tearDown: function() {
+		this.editor.setReadOnly( false );
+	},
+
 	'Make fake-selection': function() {
 		var editor = this.editor;
 
@@ -1053,6 +1058,30 @@ bender.test( {
 
 			// Be sure the selection is really there - regexp doesn't check it.
 			assert.isTrue( !!html.match( /\[/ ) && !!html.match( /\]/ ), 'Selection exists' );
+		} );
+	},
+
+	// #1516
+	'Test delete/backspace keys are not removing readonly selection': function() {
+
+		// Test has been ignored for IE due to #1575 issue. Remove this ignore statement after the issue fix.
+		if ( CKEDITOR.env.ie && !CKEDITOR.env.edge ) {
+			assert.ignore();
+		}
+
+		var editor = this.editor, bot = this.editorBot;
+
+		editor.setReadOnly( true );
+
+		bot.setData( '<p>[[placeholder]]</p>', function() {
+			var widget = editor.widgets.instances[ 0 ];
+
+			widget.focus();
+
+			editor.fire( 'key', { keyCode: 8 } ); // backspace
+			editor.fire( 'key', { keyCode: 46 } ); // delete
+
+			assert.areEqual( '<p>[[placeholder]]</p>', editor.getData() );
 		} );
 	}
 } );

--- a/tests/core/selection/manual/readonly.html
+++ b/tests/core/selection/manual/readonly.html
@@ -1,0 +1,5 @@
+<textarea id="editor1" cols="10" rows="10"><p>[[placeholder]] foo bar</p></textarea>
+
+<script>
+	CKEDITOR.replace( 'editor1', { readOnly: true } );
+</script>

--- a/tests/core/selection/manual/readonly.html
+++ b/tests/core/selection/manual/readonly.html
@@ -2,4 +2,9 @@
 
 <script>
 	CKEDITOR.replace( 'editor1', { readOnly: true } );
+
+	// Test has been ignored for IE due to #1575 issue. Remove this ignore statement after the issue fix.
+	if ( CKEDITOR.env.ie && !CKEDITOR.env.edge ) {
+		bender.ignore();
+	}
 </script>

--- a/tests/core/selection/manual/readonly.md
+++ b/tests/core/selection/manual/readonly.md
@@ -1,0 +1,16 @@
+@bender-tags: selection, fake, widget, 4.9.0, bug, 1516
+@bender-ui: collapsed
+@bender-ckeditor-plugins: wysiwygarea, placeholder, basicstyles, toolbar, floatingspace
+
+1. Focus the placeholder widget.
+2. Blur the placeholder widget.
+3. Focus placeholder widget again.
+4. Press `delete/backspace` key.
+
+## Expected
+
+The placeholder widget shouldn't change.
+
+## Unexpected
+
+The placeholder widget has been deleted.

--- a/tests/core/selection/selection.js
+++ b/tests/core/selection/selection.js
@@ -4,7 +4,8 @@
 
 bender.editor = {
 	config: {
-		allowedContent: true
+		allowedContent: true,
+		extraPlugins: 'placeholder'
 	}
 };
 
@@ -785,5 +786,22 @@ bender.test( {
 		bender.tools.setHtmlWithSelection( editor, '<p>T^es^t</p>' );
 
 		assert.isFalse( editor.getSelection().isCollapsed() );
+	},
+
+	'test delete/backspace keys are not removing readonly widgets': function() {
+		var editor = this.editor, bot = this.editorBot;
+
+		editor.setReadOnly( true );
+
+		bot.setData( '<p>[[placeholder]]</p>', function() {
+			var widget = editor.widgets.instances[ 0 ];
+
+			widget.focus();
+
+			editor.fire( 'key', { keyCode: 8 } ); // backspace
+			editor.fire( 'keydown', { keyCode: 46 } ); // delete
+
+			assert.areEqual( '<p>[[placeholder]]</p>', editor.getData() );
+		} );
 	}
 } );

--- a/tests/core/selection/selection.js
+++ b/tests/core/selection/selection.js
@@ -788,7 +788,7 @@ bender.test( {
 		assert.isFalse( editor.getSelection().isCollapsed() );
 	},
 
-	'test delete/backspace keys are not removing readonly widgets': function() {
+	'test delete/backspace keys are not removing readonly selection': function() {
 		var editor = this.editor, bot = this.editorBot;
 
 		editor.setReadOnly( true );
@@ -799,7 +799,7 @@ bender.test( {
 			widget.focus();
 
 			editor.fire( 'key', { keyCode: 8 } ); // backspace
-			editor.fire( 'keydown', { keyCode: 46 } ); // delete
+			editor.fire( 'key', { keyCode: 46 } ); // delete
 
 			assert.areEqual( '<p>[[placeholder]]</p>', editor.getData() );
 		} );

--- a/tests/core/selection/selection.js
+++ b/tests/core/selection/selection.js
@@ -4,8 +4,7 @@
 
 bender.editor = {
 	config: {
-		allowedContent: true,
-		extraPlugins: 'placeholder'
+		allowedContent: true
 	}
 };
 
@@ -786,25 +785,5 @@ bender.test( {
 		bender.tools.setHtmlWithSelection( editor, '<p>T^es^t</p>' );
 
 		assert.isFalse( editor.getSelection().isCollapsed() );
-	},
-
-	'test delete/backspace keys are not removing readonly selection': function() {
-		var editor = this.editor, bot = this.editorBot;
-
-		editor.setReadOnly( true );
-
-		bot.setData( '<p>[[placeholder]]</p>', function() {
-			var widget = editor.widgets.instances[ 0 ];
-
-			widget.focus();
-
-			editor.fire( 'key', { keyCode: 8 } ); // backspace
-			editor.fire( 'key', { keyCode: 46 } ); // delete
-
-			assert.areEqual( '<p>[[placeholder]]</p>', editor.getData() );
-		} );
-
-		// Teardown
-		editor.setReadOnly( false );
 	}
 } );

--- a/tests/core/selection/selection.js
+++ b/tests/core/selection/selection.js
@@ -803,5 +803,8 @@ bender.test( {
 
 			assert.areEqual( '<p>[[placeholder]]</p>', editor.getData() );
 		} );
+
+		// Teardown
+		editor.setReadOnly( false );
 	}
 } );


### PR DESCRIPTION
## What is the purpose of this pull request?

Bug fix.

## Does your PR contain necessary tests?

All patches which change the editor code must include tests. You can always read more
on [PR testing](https://docs.ckeditor.com/ckeditor4/docs/#!/guide/dev_contributing_code-section-tests),
[how to set the testing environment](https://docs.ckeditor.com/ckeditor4/docs/#!/guide/dev_tests) and
[how to create tests](https://docs.ckeditor.com/ckeditor4/docs/#!/guide/dev_tests-section-creating-your-own-test)
in the official CKEditor documentation.

### This PR contains

- [x] Unit tests
- [x] Manual tests

## What changes did you make?

Disabled deleting selection in a readonly mode for fake selection.

Closes #1516
