### PR TITLE
Fixed: [tableselection] table contents can be removed in a readonly mode

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -141,7 +141,7 @@ Fixed Issues:
 * [#1516](https://github.com/ckeditor/ckeditor-dev/issues/1516): Fixed: Fake selection allows removing content in read-only mode using the <kbd>Backspace</kbd> and <kbd>Delete</kbd> keys.
 * [#1570](https://github.com/ckeditor/ckeditor-dev/issues/1570): Fixed: Fake selection allows cutting content in read-only mode using the <kbd>Ctrl</kbd>/<kbd>Cmd</kbd> + <kbd>X</kbd> keys.
 * [#1363](https://github.com/ckeditor/ckeditor-dev/issues/1363): Fixed: Paste notification is unclear and it might confuse users.
-* [#1489](https://github.com/ckeditor/ckeditor-dev/issues/1489): Fixed: [tableselection](https://docs.ckeditor.com/ckeditor4/latest/api/CKEDITOR_plugins_tableselection.html) table contents can be removed in readonly mode.
+* [#1489](https://github.com/ckeditor/ckeditor-dev/issues/1489): Fixed: [Table Selection](https://docs.ckeditor.com/ckeditor4/latest/api/CKEDITOR_plugins_tableselection.html) table contents can be removed in readonly mode.
 
 API Changes:
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -141,6 +141,7 @@ Fixed Issues:
 * [#1516](https://github.com/ckeditor/ckeditor-dev/issues/1516): Fixed: Fake selection allows removing content in read-only mode using the <kbd>Backspace</kbd> and <kbd>Delete</kbd> keys.
 * [#1570](https://github.com/ckeditor/ckeditor-dev/issues/1570): Fixed: Fake selection allows cutting content in read-only mode using the <kbd>Ctrl</kbd>/<kbd>Cmd</kbd> + <kbd>X</kbd> keys.
 * [#1363](https://github.com/ckeditor/ckeditor-dev/issues/1363): Fixed: Paste notification is unclear and it might confuse users.
+* [#1489](https://github.com/ckeditor/ckeditor-dev/issues/1489): Fixed: [tableselection](https://docs.ckeditor.com/ckeditor4/latest/api/CKEDITOR_plugins_tableselection.html) table contents can be removed in readonly mode.
 
 API Changes:
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -7,6 +7,7 @@ Fixed Issues:
 
 * [#1181](https://github.com/ckeditor/ckeditor-dev/issues/1181): [Chrome] Fixed: Opening context menu in readonly editor results in error.
 * [#2276](https://github.com/ckeditor/ckeditor-dev/issues/2276): [iOS] Fixed: [Button](https://ckeditor.com/cke4/addon/button) state doesn't refresh properly.
+* [#1489](https://github.com/ckeditor/ckeditor-dev/issues/1489): Fixed: [Table Selection](https://docs.ckeditor.com/ckeditor4/latest/api/CKEDITOR_plugins_tableselection.html) table contents can be removed in readonly mode.
 
 ## CKEditor 4.10.1
 
@@ -141,7 +142,6 @@ Fixed Issues:
 * [#1516](https://github.com/ckeditor/ckeditor-dev/issues/1516): Fixed: Fake selection allows removing content in read-only mode using the <kbd>Backspace</kbd> and <kbd>Delete</kbd> keys.
 * [#1570](https://github.com/ckeditor/ckeditor-dev/issues/1570): Fixed: Fake selection allows cutting content in read-only mode using the <kbd>Ctrl</kbd>/<kbd>Cmd</kbd> + <kbd>X</kbd> keys.
 * [#1363](https://github.com/ckeditor/ckeditor-dev/issues/1363): Fixed: Paste notification is unclear and it might confuse users.
-* [#1489](https://github.com/ckeditor/ckeditor-dev/issues/1489): Fixed: [Table Selection](https://docs.ckeditor.com/ckeditor4/latest/api/CKEDITOR_plugins_tableselection.html) table contents can be removed in readonly mode.
 
 API Changes:
 

--- a/plugins/tableselection/plugin.js
+++ b/plugins/tableselection/plugin.js
@@ -974,7 +974,7 @@
 						i;
 
 					// Handle only left/right/del/bspace keys.
-					if ( !keystrokes[ key ] ) {
+					if ( !keystrokes[ key ] || editor.readOnly ) {
 						return;
 					}
 
@@ -1042,6 +1042,10 @@
 					ranges,
 					firstCell,
 					i;
+
+				if ( editor.readOnly ) {
+					return;
+				}
 
 				// We must check if the event really did not produce any character as it's fired for all keys in Gecko.
 				if ( !selection || !selection.isInTable() || !selection.isFake || !isCharKey ||

--- a/plugins/tableselection/plugin.js
+++ b/plugins/tableselection/plugin.js
@@ -974,6 +974,7 @@
 						i;
 
 					// Handle only left/right/del/bspace keys.
+					// Disable editing cells in readonly mode (#1489).
 					if ( !keystrokes[ key ] || editor.readOnly ) {
 						return;
 					}
@@ -1043,6 +1044,7 @@
 					firstCell,
 					i;
 
+				// Disable editing cells in readonly mode (#1489).
 				if ( editor.readOnly ) {
 					return;
 				}

--- a/tests/plugins/tableselection/manual/readonly.html
+++ b/tests/plugins/tableselection/manual/readonly.html
@@ -1,0 +1,30 @@
+<div id="editor1">
+	<table border="1">
+		<tr>
+			<td>Cell 1.1.1</td>
+			<td>Cell 1.1.2</td>
+			<td>Cell 1.1.3</td>
+			<td>Cell 1.1.4</td>
+		</tr>
+		<tr>
+			<td>Cell 1.2.1</td>
+			<td>Cell 1.2.2</td>
+			<td>Cell 1.2.3</td>
+			<td>Cell 1.2.4</td>
+		</tr>
+		<tr>
+			<td>Cell 1.3.1</td>
+			<td>Cell 1.3.2</td>
+			<td>Cell 1.3.3</td>
+			<td>Cell 1.3.4</td>
+		</tr>
+	</table>
+</div>
+
+<script>
+	if ( ( CKEDITOR.env.ie && CKEDITOR.env.version < 11 ) || bender.tools.env.mobile ) {
+		bender.ignore();
+	}
+
+	CKEDITOR.replace( 'editor1', { readOnly : true } );
+</script>

--- a/tests/plugins/tableselection/manual/readonly.html
+++ b/tests/plugins/tableselection/manual/readonly.html
@@ -22,9 +22,11 @@
 </div>
 
 <script>
-	if ( ( CKEDITOR.env.ie && CKEDITOR.env.version < 11 ) || bender.tools.env.mobile ) {
+	if ( bender.tools.env.mobile || CKEDITOR.env.ie && CKEDITOR.env.version < 11 ) {
 		bender.ignore();
 	}
 
-	CKEDITOR.replace( 'editor1', { readOnly : true } );
+	CKEDITOR.replace( 'editor1', {
+		readOnly : true
+	} );
 </script>

--- a/tests/plugins/tableselection/manual/readonly.md
+++ b/tests/plugins/tableselection/manual/readonly.md
@@ -1,0 +1,16 @@
+@bender-ui: collapsed
+@bender-tags: 1489, 4.9.0, bug
+@bender-ckeditor-plugins: wysiwygarea, toolbar, tableselection, sourcearea, undo, elementspath
+
+1. Focus the editor.
+1. Select the first row in table.
+3. Press `backspace` key.
+4. Repeat 1-3 with `delete` key.
+
+## Expected
+
+Selected row didn't change.
+
+## Unexpected
+
+Selected row has been deleted.

--- a/tests/plugins/tableselection/manual/readonly.md
+++ b/tests/plugins/tableselection/manual/readonly.md
@@ -1,11 +1,12 @@
 @bender-ui: collapsed
-@bender-tags: 1489, 4.9.0, bug
-@bender-ckeditor-plugins: wysiwygarea, toolbar, tableselection, sourcearea, undo, elementspath
+@bender-tags: 1489, 4.10.0, bug
+@bender-ckeditor-plugins: wysiwygarea, toolbar, tableselection
 
 1. Focus the editor.
 1. Select the first row in table.
-3. Press `backspace` key.
-4. Repeat 1-3 with `delete` key.
+1. Press `backspace` key.
+1. Repeat 1-3 with `delete` key.
+1. Repeat 1-3 with `a`, `k` keys (random key validation).
 
 ## Expected
 

--- a/tests/plugins/tableselection/manual/readonly.md
+++ b/tests/plugins/tableselection/manual/readonly.md
@@ -1,9 +1,9 @@
 @bender-ui: collapsed
-@bender-tags: 1489, 4.10.0, bug
+@bender-tags: 1489, 4.10.2, bug
 @bender-ckeditor-plugins: wysiwygarea, toolbar, tableselection
 
 1. Focus the editor.
-1. Select the first row in table.
+1. Select the first row in a table.
 1. Press `backspace` key.
 1. Repeat 1-3 with `delete` key.
 1. Repeat 1-3 with `a`, `k` keys (random key validation).

--- a/tests/plugins/tableselection/tableselection.js
+++ b/tests/plugins/tableselection/tableselection.js
@@ -147,7 +147,6 @@
 			} );
 		},
 
-<<<<<<< HEAD
 		// (#2003)
 		'test right-click in cell with empty paragraph': function( editor, bot ) {
 			if ( !CKEDITOR.env.gecko ) {
@@ -176,21 +175,17 @@
 		},
 
 		// (#1489)
-		'test delete/backspace keys are not removing readonly selection': function( editor ) {
-=======
-		// (#1489)
-		'test random keys are not removing readonly selection': function( editor ) {
->>>>>>> Refactoring.
+		'test random keys are not removing readonly selection': function( editor  ) {
 			var selection = editor.getSelection(),
 				editable = editor.editable(),
-				table = CKEDITOR.document.getById( 'simpleTable' ).getHtml();
+				table = CKEDITOR.document.getById( 'simpleTable'  ).getHtml();
 
-			editor.setReadOnly( true );
+			editor.setReadOnly( true  );
 
-			bender.tools.setHtmlWithSelection( editor, table );
+			bender.tools.setHtmlWithSelection( editor, table  );
 
-			var row = editor.editable().findOne( 'tr' );
-			selection.selectElement( row );
+			var row = editor.editable().findOne( 'tr'  );
+			selection.selectElement( row  );
 
 			editable.fire( 'keydown', new CKEDITOR.dom.event( { keyCode: 8 } ) ); // backspace
 			editable.fire( 'keydown', new CKEDITOR.dom.event( { keyCode: 46 } ) ); // delete
@@ -198,9 +193,9 @@
 			editable.fire( 'keypress', new CKEDITOR.dom.event( { keyCode: 65, charCode: 65 } ) ); // `a`
 			editable.fire( 'keypress', new CKEDITOR.dom.event( { keyCode: 93, charCode: 93 } ) ); // `t`
 
-			editor.setReadOnly( false );
+			editor.setReadOnly( false  );
 
-			assert.areSame( bender.tools.compatHtml( table ), editor.getData(), 'Editor data' );
+			assert.areSame( bender.tools.compatHtml( table  ), editor.getData(), 'Editor data'  );
 		}
 	};
 

--- a/tests/plugins/tableselection/tableselection.js
+++ b/tests/plugins/tableselection/tableselection.js
@@ -175,17 +175,17 @@
 		},
 
 		// (#1489)
-		'test random keys are not removing readonly selection': function( editor  ) {
+		'test random keys are not removing readonly selection': function( editor ) {
 			var selection = editor.getSelection(),
 				editable = editor.editable(),
-				table = CKEDITOR.document.getById( 'simpleTable'  ).getHtml();
+				table = CKEDITOR.document.getById( 'simpleTable' ).getHtml();
 
-			editor.setReadOnly( true  );
+			editor.setReadOnly( true );
 
-			bender.tools.setHtmlWithSelection( editor, table  );
+			bender.tools.setHtmlWithSelection( editor, table );
 
-			var row = editor.editable().findOne( 'tr'  );
-			selection.selectElement( row  );
+			var row = editor.editable().findOne( 'tr' );
+			selection.selectElement( row );
 
 			editable.fire( 'keydown', new CKEDITOR.dom.event( { keyCode: 8 } ) ); // backspace
 			editable.fire( 'keydown', new CKEDITOR.dom.event( { keyCode: 46 } ) ); // delete
@@ -193,9 +193,9 @@
 			editable.fire( 'keypress', new CKEDITOR.dom.event( { keyCode: 65, charCode: 65 } ) ); // `a`
 			editable.fire( 'keypress', new CKEDITOR.dom.event( { keyCode: 93, charCode: 93 } ) ); // `t`
 
-			editor.setReadOnly( false  );
+			editor.setReadOnly( false );
 
-			assert.areSame( bender.tools.compatHtml( table  ), editor.getData(), 'Editor data'  );
+			assert.areSame( bender.tools.compatHtml( table ), editor.getData(), 'Editor data' );
 		}
 	};
 

--- a/tests/plugins/tableselection/tableselection.js
+++ b/tests/plugins/tableselection/tableselection.js
@@ -190,6 +190,9 @@
 			editable.fire( 'keydown', new CKEDITOR.dom.event( { keyCode: 8 } ) ); // backspace
 			editable.fire( 'keydown', new CKEDITOR.dom.event( { keyCode: 46 } ) ); // delete
 
+			editable.fire( 'keypress', new CKEDITOR.dom.event( { keyCode: 65, charCode: 65 } ) ); // `a`
+			editable.fire( 'keypress', new CKEDITOR.dom.event( { keyCode: 93, charCode: 93 } ) ); // `t`
+
 			assert.areSame( bender.tools.compatHtml( table ), editor.getData(), 'Editor data' );
 		}
 	};

--- a/tests/plugins/tableselection/tableselection.js
+++ b/tests/plugins/tableselection/tableselection.js
@@ -147,6 +147,7 @@
 			} );
 		},
 
+<<<<<<< HEAD
 		// (#2003)
 		'test right-click in cell with empty paragraph': function( editor, bot ) {
 			if ( !CKEDITOR.env.gecko ) {
@@ -176,6 +177,10 @@
 
 		// (#1489)
 		'test delete/backspace keys are not removing readonly selection': function( editor ) {
+=======
+		// (#1489)
+		'test random keys are not removing readonly selection': function( editor ) {
+>>>>>>> Refactoring.
 			var selection = editor.getSelection(),
 				editable = editor.editable(),
 				table = CKEDITOR.document.getById( 'simpleTable' ).getHtml();
@@ -192,6 +197,8 @@
 
 			editable.fire( 'keypress', new CKEDITOR.dom.event( { keyCode: 65, charCode: 65 } ) ); // `a`
 			editable.fire( 'keypress', new CKEDITOR.dom.event( { keyCode: 93, charCode: 93 } ) ); // `t`
+
+			editor.setReadOnly( false );
 
 			assert.areSame( bender.tools.compatHtml( table ), editor.getData(), 'Editor data' );
 		}

--- a/tests/plugins/tableselection/tableselection.js
+++ b/tests/plugins/tableselection/tableselection.js
@@ -172,6 +172,25 @@
 
 				assert.areSame( ranges, editor.getSelection().getRanges(), 'Selected ranges should be unchanged' );
 			} );
+		},
+
+		// (#1489)
+		'test delete/backspace keys are not removing readonly selection': function( editor ) {
+			var selection = editor.getSelection(),
+				editable = editor.editable(),
+				table = CKEDITOR.document.getById( 'simpleTable' ).getHtml();
+
+			editor.setReadOnly( true );
+
+			bender.tools.setHtmlWithSelection( editor, table );
+
+			var row = editor.editable().findOne( 'tr' );
+			selection.selectElement( row );
+
+			editable.fire( 'keydown', new CKEDITOR.dom.event( { keyCode: 8 } ) ); // backspace
+			editable.fire( 'keydown', new CKEDITOR.dom.event( { keyCode: 46 } ) ); // delete
+
+			assert.areSame( bender.tools.compatHtml( table ), editor.getData(), 'Editor data' );
 		}
 	};
 


### PR DESCRIPTION
## What is the purpose of this pull request?

Bug fix.

## Does your PR contain necessary tests?

All patches which change the editor code must include tests. You can always read more
on [PR testing](https://docs.ckeditor.com/ckeditor4/docs/#!/guide/dev_contributing_code-section-tests),
[how to set the testing environment](https://docs.ckeditor.com/ckeditor4/docs/#!/guide/dev_tests) and
[how to create tests](https://docs.ckeditor.com/ckeditor4/docs/#!/guide/dev_tests-section-creating-your-own-test)
in the official CKEditor documentation.

### This PR contains

- [x] Unit tests
- [x] Manual tests

## What changes did you make?

Disabled table selection delete on `keypress` and `keydown` events in a readonly mode.

~**NOTE:** This pull request depends on #1525 fix. It was created from `t/1525` branch.~

Based on #1692

Closes #1489
