### PR TITLE
Improving color contrast on Widget hover border

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -26,6 +26,7 @@ Fixed Issues:
 * [#1426](https://github.com/ckeditor/ckeditor-dev/issues/1426): [IE8-9] Fixed: Missing balloon toolbar background in Kama skin. Thanks to [Christian Elmer](https://github.com/keinkurt)!
 * [#1010](https://github.com/ckeditor/ckeditor-dev/issues/1010): Fixed: CSS `border` shorthand property was incorrectly expanded ignoring `border-color` style.
 * [#1470](https://github.com/ckeditor/ckeditor-dev/issues/1470): Fixed: [Balloon Toolbar](https://ckeditor.com/cke4/addon/balloontoolbar) is not visible after drag and drop of a widget it is attached to.
+* [#1535](https://github.com/ckeditor/ckeditor-dev/issues/1535): Fixed: [Widget](https://ckeditor.com/cke4/addon/widget) border color has low contrast.
 
 API Changes:
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -26,7 +26,7 @@ Fixed Issues:
 * [#1426](https://github.com/ckeditor/ckeditor-dev/issues/1426): [IE8-9] Fixed: Missing balloon toolbar background in Kama skin. Thanks to [Christian Elmer](https://github.com/keinkurt)!
 * [#1010](https://github.com/ckeditor/ckeditor-dev/issues/1010): Fixed: CSS `border` shorthand property was incorrectly expanded ignoring `border-color` style.
 * [#1470](https://github.com/ckeditor/ckeditor-dev/issues/1470): Fixed: [Balloon Toolbar](https://ckeditor.com/cke4/addon/balloontoolbar) is not visible after drag and drop of a widget it is attached to.
-* [#1535](https://github.com/ckeditor/ckeditor-dev/issues/1535): Fixed: [Widget](https://ckeditor.com/cke4/addon/widget) border color has low contrast.
+* [#1535](https://github.com/ckeditor/ckeditor-dev/issues/1535): Fixed: Improve [Widget](https://ckeditor.com/cke4/addon/widget) mouse over border contrast.
 
 API Changes:
 

--- a/contents.css
+++ b/contents.css
@@ -113,8 +113,7 @@ span[lang]
 figure
 {
 	text-align: center;
-	border: solid 1px #ccc;
-	border-radius: 2px;
+	outline: solid 1px #ccc;
 	background: rgba(0,0,0,0.05);
 	padding: 10px;
 	margin: 10px 20px;

--- a/plugins/widget/plugin.js
+++ b/plugins/widget/plugin.js
@@ -31,16 +31,16 @@
 					'display:inline-block' +
 				'}' +
 				'.cke_widget_wrapper:hover>.cke_widget_element{' +
-					'outline:2px solid yellow;' +
+					'outline:2px solid #ffd25c;' +
 					'cursor:default' +
 				'}' +
 				'.cke_widget_wrapper:hover .cke_widget_editable{' +
-					'outline:2px solid yellow' +
+					'outline:2px solid #ffd25c' +
 				'}' +
 				'.cke_widget_wrapper.cke_widget_focused>.cke_widget_element,' +
 				// We need higher specificity than hover style.
 				'.cke_widget_wrapper .cke_widget_editable.cke_widget_editable_focused{' +
-					'outline:2px solid #ace' +
+					'outline:2px solid #47a4f5' +
 				'}' +
 				'.cke_widget_editable{' +
 					'cursor:text' +

--- a/tests/plugins/widget/manual/outline.html
+++ b/tests/plugins/widget/manual/outline.html
@@ -1,0 +1,32 @@
+<head>
+	<link rel="stylesheet" href="/apps/ckeditor/contents.css">
+</head>
+
+<div>
+	<h2>Classic</h2>
+	<hr>
+	<textarea id="classic">
+		<figure class="image" style="float:left"><img alt="Saturn V" src="../../image2/_assets/bar.png" width="200" />
+			<figcaption>Roll out of Saturn V on launch pad</figcaption>
+		</figure>
+		<p>Some text.</p>
+	</textarea>
+</div>
+
+<div>
+	<h2>Inline</h2>
+	<hr>
+	<div id="inline" contenteditable="true">
+		<figure class="image" style="float:left"><img alt="Saturn V" src="../../image2/_assets/bar.png" width="200" />
+			<figcaption>Roll out of Saturn V on launch pad</figcaption>
+		</figure>
+		<p>Some text.</p>
+	</div>
+</div>
+
+
+<script>
+	CKEDITOR.replace( 'classic' );
+
+	CKEDITOR.inline( 'inline' );
+</script>

--- a/tests/plugins/widget/manual/outline.md
+++ b/tests/plugins/widget/manual/outline.md
@@ -1,0 +1,17 @@
+@bender-ui: collapsed
+@bender-tags: 4.9.0, 1535, feature
+@bender-ckeditor-plugins: wysiwygarea,toolbar,elementspath,clipboard,floatingspace,image2
+
+## For each editor instance:
+
+1. Hover on widget.
+1. Focus widget.
+1. Focus widget editable.
+
+### Expected:
+
+Widget outline on hover has orange color and 2px thickness.
+
+### Unexpected:
+
+Widget outline on hover has yellow color.


### PR DESCRIPTION
## What is the purpose of this pull request?

Task

## Does your PR contain necessary tests?

All patches which change the editor code must include tests. You can always read more
on [PR testing](https://docs.ckeditor.com/ckeditor4/docs/#!/guide/dev_contributing_code-section-tests),
[how to set the testing environment](https://docs.ckeditor.com/ckeditor4/docs/#!/guide/dev_tests) and
[how to create tests](https://docs.ckeditor.com/ckeditor4/docs/#!/guide/dev_tests-section-creating-your-own-test)
in the official CKEditor documentation.

### This PR contains

- [ ] Unit tests
- [x] Manual tests

## What changes did you make?

Changed Widget ( figure selector in our css ) border and border radius to none,
added outline with same value as border, but without radius.
Changed Widget and its editable hover and focus outline to 3px and changed colors to more contrasting.

Closes #1535 