### PR TITLE
Fixed: Upload tests for Easy Image are unstable on Firefox

### DIFF
--- a/tests/plugins/imagebase/features/_helpers/tools.js
+++ b/tests/plugins/imagebase/features/_helpers/tools.js
@@ -52,7 +52,14 @@
 						}
 
 						resume( function() {
-							callback( objToArray( editor.widgets.instances ), evt, uploadEvt );
+							// Some tests occasionally fail in Firefox. After making them asynchronous tests passes.
+							if ( CKEDITOR.env.gecko ) {
+								wait( function() {
+									callback( objToArray( editor.widgets.instances ), evt, uploadEvt );
+								}, 0 );
+							} else {
+								callback( objToArray( editor.widgets.instances ), evt, uploadEvt );
+							}
 						} );
 					}
 

--- a/tests/plugins/imagebase/features/_helpers/tools.js
+++ b/tests/plugins/imagebase/features/_helpers/tools.js
@@ -51,16 +51,13 @@
 							} );
 						}
 
-						resume( function() {
-							// Some tests occasionally fail in Firefox. After making them asynchronous tests passes.
-							if ( CKEDITOR.env.gecko ) {
-								wait( function() {
-									callback( objToArray( editor.widgets.instances ), evt, uploadEvt );
-								}, 0 );
-							} else {
+						// Some tests occasionally fail in Firefox. After making them asynchronous tests passes (#1571).
+						// Unfortunately we weren't able to figure out a better way than adding a timeout.
+						setTimeout( function() {
+							resume( function() {
 								callback( objToArray( editor.widgets.instances ), evt, uploadEvt );
-							}
-						} );
+							} );
+						}, 0 );
 					}
 
 					if ( options.fullLoad && widgets.length ) {


### PR DESCRIPTION
## What is the purpose of this pull request?

Bug fix

## Does your PR contain necessary tests?

All patches which change the editor code must include tests. You can always read more
on [PR testing](https://docs.ckeditor.com/ckeditor4/docs/#!/guide/dev_contributing_code-section-tests),
[how to set the testing environment](https://docs.ckeditor.com/ckeditor4/docs/#!/guide/dev_tests) and
[how to create tests](https://docs.ckeditor.com/ckeditor4/docs/#!/guide/dev_tests-section-creating-your-own-test)
in the official CKEditor documentation.

### This PR contains

- [ ] Unit tests
- [ ] Manual tests
This is fix to test itself.

## What changes did you make?

When tests are running in Firefox they are fired asynchronously.

Closes #1571 