### PR TITLE
Corrections to Easy Image styles system

### DIFF
--- a/plugins/easyimage/plugin.js
+++ b/plugins/easyimage/plugin.js
@@ -137,6 +137,8 @@
 				// Style commands should not be toggled.
 				if ( getStyleNameFromCommand( evt.data.name, styles ) && evt.data.command.style.checkActive( evt.editor.elementPath(), editor ) ) {
 					evt.cancel();
+					// Editor needs to be focused, otherwise balloon toolbar will hide.
+					editor.focus();
 				}
 			} );
 

--- a/plugins/easyimage/plugin.js
+++ b/plugins/easyimage/plugin.js
@@ -561,14 +561,40 @@
 	 * and `easyimage<name>` command, where `<name>` is name of style in pascal case, e.g. `left`
 	 * style would produce `EasyimageLeft` button and `easyimageLeft` command.
 	 *
+	 *		// Adds a custom alignment style.
 	 *		config.easyimage_styles = {
 	 *			left: {
 	 *				attributes: {
 	 *					'class': 'left'
 	 *				},
 	 *				label: 'Align left',
-	 *				icon: '/foo/bar/icons/baz.png',
-	 *				iconHiDpi: '/foo/bar/icons/hidpi/baz.png'
+	 *				icon: '/my/example/icons/left.png',
+	 *				iconHiDpi: '/my/example/icons/hidpi/left.png'
+	 *			}
+	 *		};
+	 *
+	 * Following example changes the class added by full style and adds another border styles:
+	 *
+	 *		config.easyimage_styles = {
+	 *			full: {
+	 *				// Changes just the class name, label icon remains unchanged.
+	 *				attributes: {
+	 *					'class': 'my-custom-full-class'
+	 *				}
+	 *			},
+	 *			skipBorder: {
+	 *				attributes: {
+	 *					'class': 'skip-border'
+	 *				},
+	 *				group: 'borders',
+	 *				label: 'Skip border'
+	 *			},
+	 *			thickBorder: {
+	 *				attributes: {
+	 *					'class': 'thick-border'
+	 *				},
+	 *				group: 'borders',
+	 *				label: 'Thick border'
 	 *			}
 	 *		};
 	 *

--- a/plugins/easyimage/plugin.js
+++ b/plugins/easyimage/plugin.js
@@ -114,11 +114,11 @@
 				return this.style.checkActive( path, editor );
 			} );
 
-			// Enable is called at multiple occasions, especially in ediotr#mode event listeners.
+			// Enable is called at multiple occasions, especially in editor#mode event listeners.
 			// Unfortunately it's even called with a timeout there.
 			cmd.enable = function() {};
 
-			// Without this the command is inited in a wrong state.
+			// Without this the command is inited with a wrong state.
 			cmd.refresh( editor, editor.elementPath() );
 
 			return cmd;
@@ -145,20 +145,11 @@
 	}
 
 	function addButtons( editor, styles ) {
-		function createButton( button ) {
-			editor.ui.addButton( button.name, {
-				label: button.label,
-				command: button.command,
-				toolbar: 'easyimage,' + ( button.order || 99 )
-			} );
-		}
-
 		function addDefaultButtons() {
-			createButton( {
-				name: 'EasyimageAlt',
+			editor.ui.addButton( 'EasyimageAlt', {
 				label: editor.lang.easyimage.commands.altText,
 				command: 'easyimageAlt',
-				order: 3
+				toolbar: 'easyimage,3'
 			} );
 		}
 
@@ -166,11 +157,10 @@
 			var style;
 
 			for ( style in styles ) {
-				createButton( {
-					name: 'Easyimage' + capitalize( style ),
+				editor.ui.addButton( 'Easyimage' + capitalize( style ), {
 					label: styles[ style ].label,
 					command: 'easyimage' + capitalize( style ),
-					order: 99
+					toolbar: 'easyimage,99'
 				} );
 			}
 		}

--- a/plugins/easyimage/plugin.js
+++ b/plugins/easyimage/plugin.js
@@ -551,11 +551,11 @@
 	 *
 	 * There are few styles available by default:
 	 *
-	 * * `full` - adding a `easyimage-full` class to the `figure` element.
-	 * * `side` - adding a `easyimage-side` class to the `figure` element.
-	 * * `alignLeft` - adding a `easyimage-align-left` class to the `figure` element.
-	 * * `alignCenter` - adding a `easyimage-align-center` class to the `figure` element.
-	 * * `alignRight` - adding a `easyimage-align-right` class to the `figure` element.
+	 * * `full` - adding an `easyimage-full` class to the `figure` element.
+	 * * `side` - adding an `easyimage-side` class to the `figure` element.
+	 * * `alignLeft` - adding an `easyimage-align-left` class to the `figure` element.
+	 * * `alignCenter` - adding an `easyimage-align-center` class to the `figure` element.
+	 * * `alignRight` - adding an `easyimage-align-right` class to the `figure` element.
 	 *
 	 * Every style added by this config variable will result in adding `Easyimage<name>` button
 	 * and `easyimage<name>` command, where `<name>` is name of style in pascal case, e.g. `left`
@@ -580,7 +580,7 @@
 
 
 	/**
-	 * the default style to be applied to Easy Image widgets, based on keys in {@link #easyimage_styles}.
+	 * The default style to be applied to Easy Image widgets, based on keys in {@link #easyimage_styles}.
 	 *
 	 * If set to `null` no default style is applied.
 	 *

--- a/plugins/easyimage/plugin.js
+++ b/plugins/easyimage/plugin.js
@@ -549,6 +549,14 @@
 	 * * `icon` - path to the icon used in the balloon toolbar,
 	 * * `iconHiDpi` - path to the high DPI version of the icon.
 	 *
+	 * There are few styles available by default:
+	 *
+	 * * `full` - adding a `easyimage-full` class to the `figure` element.
+	 * * `side` - adding a `easyimage-side` class to the `figure` element.
+	 * * `alignLeft` - adding a `easyimage-align-left` class to the `figure` element.
+	 * * `alignCenter` - adding a `easyimage-align-center` class to the `figure` element.
+	 * * `alignRight` - adding a `easyimage-align-right` class to the `figure` element.
+	 *
 	 * Every style added by this config variable will result in adding `Easyimage<name>` button
 	 * and `easyimage<name>` command, where `<name>` is name of style in pascal case, e.g. `left`
 	 * style would produce `EasyimageLeft` button and `easyimageLeft` command.
@@ -587,8 +595,11 @@
 
 	/**
 	 * List of buttons to be displayed in a balloon toolbar for Easy Image widget.
+	 *
 	 * If Context Menu plugin is enabled, this config variable will be used also to add
 	 * items to the context menu for Easy Image widget.
+	 *
+	 * You can find list of available styles in {@link #easyimage_styles}.
 	 *
 	 *		// Change toolbar to alignment commands.
 	 *		config.easyimage_toolbar = [ 'EasyimageAlignLeft', 'EasyimageAlignCenter', 'EasyimageAlignRight' ];

--- a/plugins/easyimage/plugin.js
+++ b/plugins/easyimage/plugin.js
@@ -230,7 +230,7 @@
 		} );
 	}
 
-	function registerWidget( editor ) {
+	function registerWidget( editor, styles ) {
 		var config = editor.config,
 			figureClass = config.easyimage_class,
 			widgetDefinition = {
@@ -247,6 +247,7 @@
 				},
 
 				requiredContent: 'figure; img[!src]',
+
 				styleableElements: 'figure',
 
 				supportedTypes: /image\/(jpeg|png|gif|bmp)/,
@@ -345,6 +346,26 @@
 					this.on( 'uploadFailed', function() {
 						alert( this.editor.lang.easyimage.uploadFailed ); // jshint ignore:line
 					} );
+
+					this._loadDefaultStyle();
+				},
+
+				_loadDefaultStyle: function() {
+					// Ensures that Easy Image widget uses a default Easy Image style if none other is applied.
+					var styleMatched = false,
+						defaultStyleName = editor.config.easyimage_defaultStyle;
+
+					for ( var styleName in styles ) {
+						var cmd = editor.getCommand( 'easyimage' + capitalize( styleName ) );
+
+						if ( !styleMatched && cmd && cmd.style && cmd.style.group === 'easyimage' && this.checkStyleActive( cmd.style ) ) {
+							styleMatched = true;
+						}
+					}
+
+					if ( !styleMatched && defaultStyleName && editor.getCommand( 'easyimage' + capitalize( defaultStyleName ) ) ) {
+						this.applyStyle( editor.getCommand( 'easyimage' + capitalize( defaultStyleName ) ).style );
+					}
 				}
 			};
 
@@ -501,7 +522,7 @@
 		afterInit: function( editor ) {
 			var styles = getStylesForEditor( editor );
 
-			registerWidget( editor );
+			registerWidget( editor, styles );
 			addPasteListener( editor );
 			addCommands( editor, styles );
 			addButtons( editor, styles );
@@ -528,7 +549,7 @@
 	/**
 	 * Custom styles that could be applied to Easy Image widget.
 	 * All styles must be [valid style definitions](#!/guide/dev_howtos_styles-section-how-do-i-customize-the-styles-drop-down-list%3F).
-	 * There are three additional properties for every style definition:
+	 * There are three additional properties for each style definition:
 	 *
 	 * * `label` - string used as a button label in a balloon toolbar for the widget,
 	 * * `icon` - path to the icon used in the balloon toolbar,
@@ -554,6 +575,21 @@
 	 * @member CKEDITOR.config
 	 */
 	CKEDITOR.config.easyimage_styles = {};
+
+
+	/**
+	 * the default style to be applied to Easy Image widgets, based on keys in {@link #easyimage_styles}.
+	 *
+	 * If set to `null` no default style is applied.
+	 *
+	 *		// Make side image a default style.
+	 *		config.easyimage_defaultStyle = 'side';
+	 *
+	 * @since 4.9.0
+	 * @cfg {String/null} easyimage_defaultStyle
+	 * @member CKEDITOR.config
+	 */
+	CKEDITOR.config.easyimage_defaultStyle = 'full';
 
 	/**
 	 * List of buttons to be displayed in a balloon toolbar for Easy Image widget.

--- a/plugins/easyimage/plugin.js
+++ b/plugins/easyimage/plugin.js
@@ -31,21 +31,21 @@
 
 			alignLeft: {
 				attributes: {
-					'class': 'easyimage-alignLeft'
+					'class': 'easyimage-align-left'
 				},
 				label: editor.lang.easyimage.commands.alignLeft
 			},
 
 			alignCenter: {
 				attributes: {
-					'class': 'easyimage-alignCenter'
+					'class': 'easyimage-align-center'
 				},
 				label: editor.lang.easyimage.commands.alignCenter
 			},
 
 			alignRight: {
 				attributes: {
-					'class': 'easyimage-alignRight'
+					'class': 'easyimage-align-right'
 				},
 				label: editor.lang.easyimage.commands.alignRight
 			}
@@ -79,16 +79,17 @@
 
 			editor.filter.allow( style );
 
-			editor.addCommand( commandName, new CKEDITOR.styleCommand( style, {
-				contextSensitive: true
-			} ) );
-
-			// Command needs to be refetched. Calling addCommand will… create a new command.
-			var cmd = editor.getCommand( commandName );
-
+			// At this point cmd should be treated more as a definition due to #1582.
+			var cmd = new CKEDITOR.styleCommand( style );
+			cmd.contextSensitive = true;
 			cmd.refresh = createCommandRefresh( function( widget, editor, path ) {
 				return this.style.checkActive( path, editor );
 			} );
+
+			editor.addCommand( commandName, cmd );
+
+			// Command needs to be refetched. Calling addCommand will… create a new command.
+			cmd = editor.getCommand( commandName );
 
 			// Enable is called at multiple occasions, especially in editor#mode event listeners.
 			// Unfortunately it's even called with a timeout there.

--- a/plugins/easyimage/plugin.js
+++ b/plugins/easyimage/plugin.js
@@ -75,16 +75,12 @@
 		}
 
 		function createStyleCommand( editor, name, styleDefinition, commandName ) {
-			var style;
-
 			styleDefinition.type = 'widget';
 			styleDefinition.widget = 'easyimage';
 			styleDefinition.group = styleDefinition.group || 'easyimage';
 			styleDefinition.element = 'figure';
-			style = new CKEDITOR.style( styleDefinition );
-
+			var style = new CKEDITOR.style( styleDefinition );
 			editor.filter.allow( style );
-			editor.widgets.registered.easyimage._styles[ name ] = style;
 
 			var cmd = new CKEDITOR.styleCommand( style, {
 				contextSensitive: true
@@ -142,10 +138,6 @@
 
 		function addStylesCommands( styles ) {
 			var style;
-
-			if ( !editor.widgets.registered.easyimage._styles ) {
-				editor.widgets.registered.easyimage._styles = {};
-			}
 
 			for ( style in styles ) {
 				createStyleCommand( editor, style, styles[ style ], 'easyimage' + capitalize( style ) );
@@ -236,19 +228,6 @@
 
 			evt.data[ button.name ] = editor.getCommand( button.command ).state;
 		} );
-	}
-
-	function getActiveStyle( widget ) {
-		var styles = widget.definition._styles,
-			style;
-
-		for ( style in styles ) {
-			if ( widget.checkStyleActive( styles[ style ] ) ) {
-				return style;
-			}
-		}
-
-		return 'full';
 	}
 
 	function registerWidget( editor ) {
@@ -366,16 +345,6 @@
 					this.on( 'uploadFailed', function() {
 						alert( this.editor.lang.easyimage.uploadFailed ); // jshint ignore:line
 					} );
-				},
-
-				data: function( evt ) {
-					var data = evt.data;
-
-					if ( !data.style ) {
-						data.style = getActiveStyle( this );
-
-						return this.applyStyle( this._styles[ data.style ] );
-					}
 				}
 			};
 

--- a/plugins/easyimage/plugin.js
+++ b/plugins/easyimage/plugin.js
@@ -57,20 +57,16 @@
 	function addCommands( editor, styles ) {
 		function createCommandRefresh( enableCheck ) {
 			return function( editor, path ) {
-				var widget = editor.widgets.focused;
+				var widget = editor.widgets.focused,
+					newState = CKEDITOR.TRISTATE_DISABLED;
 
 				if ( widget && widget.name === WIDGET_NAME ) {
-					var callbackResolution = enableCheck && enableCheck.call( this, widget, editor, path ),
-						state = enableCheck ? callbackResolution : CKEDITOR.TRISTATE_OFF;
+					var callbackResolution = enableCheck && enableCheck.call( this, widget, editor, path );
 
-					if ( typeof callbackResolution !== 'number' ) {
-						state = callbackResolution ? CKEDITOR.TRISTATE_ON : CKEDITOR.TRISTATE_OFF;
-					}
-
-					this.setState( state );
-				} else {
-					this.setState( CKEDITOR.TRISTATE_DISABLED );
+					newState = callbackResolution ? CKEDITOR.TRISTATE_ON : CKEDITOR.TRISTATE_OFF;
 				}
+
+				this.setState( newState );
 			};
 		}
 
@@ -79,12 +75,12 @@
 			styleDefinition.widget = 'easyimage';
 			styleDefinition.group = styleDefinition.group || 'easyimage';
 			styleDefinition.element = 'figure';
-			var style = new CKEDITOR.style( styleDefinition );
-			editor.filter.allow( style );
+			var style = new CKEDITOR.style( styleDefinition ),
+				cmd = new CKEDITOR.styleCommand( style, {
+					contextSensitive: true
+				} );
 
-			var cmd = new CKEDITOR.styleCommand( style, {
-				contextSensitive: true
-			} );
+			editor.filter.allow( style );
 
 			editor.addCommand( commandName, cmd );
 

--- a/plugins/easyimage/plugin.js
+++ b/plugins/easyimage/plugin.js
@@ -349,7 +349,7 @@
 					for ( var styleName in styles ) {
 						var cmd = editor.getCommand( 'easyimage' + capitalize( styleName ) );
 
-						if ( !styleMatched && cmd && cmd.style && cmd.style.group === 'easyimage' && this.checkStyleActive( cmd.style ) ) {
+						if ( !styleMatched && cmd && cmd.style && CKEDITOR.tools.array.indexOf( cmd.style.group, 'easyimage' ) !== -1 && this.checkStyleActive( cmd.style ) ) {
 							styleMatched = true;
 						}
 					}

--- a/plugins/easyimage/styles/easyimage.css
+++ b/plugins/easyimage/styles/easyimage.css
@@ -35,7 +35,7 @@ The outline is not a part of the element's dimensions, we have to use a border a
 }
 
 .cke_widget_wrapper_easyimage-side, :not(.cke_widget_wrapper_easyimage):not(.cke_widget_wrapper_easyimage-side) > .easyimage-side,
-.cke_widget_wrapper_easyimage-alignRight, :not(.cke_widget_wrapper_easyimage):not(.cke_widget_wrapper_easyimage-alignRight) > .easyimage-alignRight {
+.cke_widget_wrapper_easyimage-align-right, :not(.cke_widget_wrapper_easyimage):not(.cke_widget_wrapper_easyimage-align-right) > .easyimage-align-right {
 	/*
 	:not() selector will be used for Easy Image content ouside of the editor. E.g. when the editor was destoryed.
 	See https://github.com/ckeditor/ckeditor-dev/pull/1150#discussion_r150415261 for more details.
@@ -44,12 +44,12 @@ The outline is not a part of the element's dimensions, we have to use a border a
 	max-width: 25%;
 }
 
-.cke_widget_wrapper_easyimage-alignLeft, :not(.cke_widget_wrapper_easyimage):not(.cke_widget_wrapper_easyimage-alignLeft) > .easyimage-alignLeft {
+.cke_widget_wrapper_easyimage-align-left, :not(.cke_widget_wrapper_easyimage):not(.cke_widget_wrapper_easyimage-align-left) > .easyimage-align-left {
 	float: left;
 	max-width: 25%;
 }
 
-.cke_widget_wrapper_easyimage-alignCenter, :not(.cke_widget_wrapper_easyimage):not(.cke_widget_wrapper_easyimage-alignCenter) > .easyimage-alignCenter {
+.cke_widget_wrapper_easyimage-align-center, :not(.cke_widget_wrapper_easyimage):not(.cke_widget_wrapper_easyimage-align-center) > .easyimage-align-center {
 	margin: 0 auto;
 	max-width: 90%;
 }

--- a/tests/plugins/easyimage/balloontoolbar.js
+++ b/tests/plugins/easyimage/balloontoolbar.js
@@ -68,7 +68,7 @@
 
 					toolbar._view.once( 'show', function() {
 						easyImageTools.assertCommandsState( editor, {
-							easyimageFull: CKEDITOR.TRISTATE_ON,
+							easyimageFull: CKEDITOR.TRISTATE_OFF,
 							easyimageSide: CKEDITOR.TRISTATE_OFF,
 							easyimageAlt: CKEDITOR.TRISTATE_OFF
 						} );

--- a/tests/plugins/easyimage/balloontoolbar.js
+++ b/tests/plugins/easyimage/balloontoolbar.js
@@ -68,7 +68,7 @@
 
 					toolbar._view.once( 'show', function() {
 						easyImageTools.assertCommandsState( editor, {
-							easyimageFull: CKEDITOR.TRISTATE_OFF,
+							easyimageFull: CKEDITOR.TRISTATE_ON,
 							easyimageSide: CKEDITOR.TRISTATE_OFF,
 							easyimageAlt: CKEDITOR.TRISTATE_OFF
 						} );

--- a/tests/plugins/easyimage/commands.js
+++ b/tests/plugins/easyimage/commands.js
@@ -21,7 +21,7 @@
 	};
 
 	var originalGetClientRect = CKEDITOR.dom.element.prototype.getClientRect,
-		widgetHtml = '<figure class="image easyimage"><img src="../image2/_assets/foo.png" alt="foo"><figcaption>Test image</figcaption></figure>',
+		widgetHtml = '<figure class="easyimage easyimage-full"><img src="../image2/_assets/foo.png" alt="foo"><figcaption>Test image</figcaption></figure>',
 		tests = {
 			setUp: function() {
 				if ( CKEDITOR.env.ie ) {

--- a/tests/plugins/easyimage/commands.js
+++ b/tests/plugins/easyimage/commands.js
@@ -103,7 +103,6 @@
 					assert.isTrue( widget.hasClass( 'easyimage' ), 'Widget wrapper has main class' );
 					assert.isFalse( widget.hasClass( 'easyimage-side' ),
 						'Widget wrapper does not have side class' );
-					// assert.areSame( 'full', widget.data.style, 'Widget has correct style data' );
 
 					bot.contextmenu( function( menu ) {
 						easyImageTools.assertMenuItemsState( menu.items, {
@@ -116,7 +115,6 @@
 						assert.isTrue( widget.element.hasClass( 'easyimage-side' ), 'Image has side class' );
 						assert.isTrue( widget.hasClass( 'easyimage' ), 'Widget wrapper has main class' );
 						assert.isTrue( widget.hasClass( 'easyimage-side' ), 'Widget wrapper has side class' );
-						// assert.areSame( 'side', widget.data.style, 'Widget has correct style data' );
 
 						bot.contextmenu( function( menu ) {
 							easyImageTools.assertMenuItemsState( menu.items, {

--- a/tests/plugins/easyimage/commands.js
+++ b/tests/plugins/easyimage/commands.js
@@ -22,7 +22,6 @@
 
 	var originalGetClientRect = CKEDITOR.dom.element.prototype.getClientRect,
 		widgetHtml = '<figure class="image easyimage"><img src="../image2/_assets/foo.png" alt="foo"><figcaption>Test image</figcaption></figure>',
-		sideWidgetHtml = '<figure class="image easyimage easyimage-side"><img src="../image2/_assets/foo.png" alt="foo"><figcaption>Test image</figcaption></figure>',
 		tests = {
 			setUp: function() {
 				if ( CKEDITOR.env.ie ) {
@@ -104,7 +103,7 @@
 					assert.isTrue( widget.hasClass( 'easyimage' ), 'Widget wrapper has main class' );
 					assert.isFalse( widget.hasClass( 'easyimage-side' ),
 						'Widget wrapper does not have side class' );
-					assert.areSame( 'full', widget.data.style, 'Widget has correct style data' );
+					// assert.areSame( 'full', widget.data.style, 'Widget has correct style data' );
 
 					bot.contextmenu( function( menu ) {
 						easyImageTools.assertMenuItemsState( menu.items, {
@@ -117,7 +116,7 @@
 						assert.isTrue( widget.element.hasClass( 'easyimage-side' ), 'Image has side class' );
 						assert.isTrue( widget.hasClass( 'easyimage' ), 'Widget wrapper has main class' );
 						assert.isTrue( widget.hasClass( 'easyimage-side' ), 'Widget wrapper has side class' );
-						assert.areSame( 'side', widget.data.style, 'Widget has correct style data' );
+						// assert.areSame( 'side', widget.data.style, 'Widget has correct style data' );
 
 						bot.contextmenu( function( menu ) {
 							easyImageTools.assertMenuItemsState( menu.items, {
@@ -128,14 +127,6 @@
 							menu.hide();
 						} );
 					} );
-				} );
-			},
-
-			'test initial type data for side image': function( editor, bot ) {
-				bot.setData( sideWidgetHtml, function() {
-					var widget = editor.widgets.getByElement( editor.editable().findOne( 'figure' ) );
-
-					assert.areSame( 'side', widget.data.style, 'Widget has correct style data' );
 				} );
 			},
 

--- a/tests/plugins/easyimage/config.html
+++ b/tests/plugins/easyimage/config.html
@@ -18,7 +18,7 @@
 </div>
 
 <div id="expectedCustomAlignLeftClass">
-	<figure class="customClass easyimage-alignLeft" id="customSideId">
+	<figure class="customClass easyimage-align-left" id="customSideId">
 		<img alt="fig1" src="../image2/_assets/foo.png" />
 		<figcaption>Changed class</figcaption>
 	</figure>
@@ -30,7 +30,7 @@
 </div>
 
 <div id="expectedCustomAlignCenterClass">
-	<figure class="customClass easyimage-alignCenter" id="customSideId">
+	<figure class="customClass easyimage-align-center" id="customSideId">
 		<img alt="fig1" src="../image2/_assets/foo.png" />
 		<figcaption>Changed class</figcaption>
 	</figure>
@@ -42,7 +42,7 @@
 </div>
 
 <div id="expectedCustomAlignRightClass">
-	<figure class="customClass easyimage-alignRight" id="customSideId">
+	<figure class="customClass easyimage-align-right" id="customSideId">
 		<img alt="fig1" src="../image2/_assets/foo.png" />
 		<figcaption>Changed class</figcaption>
 	</figure>

--- a/tests/plugins/easyimage/config.html
+++ b/tests/plugins/easyimage/config.html
@@ -16,3 +16,39 @@
 		<figcaption>Figure without class</figcaption>
 	</figure>
 </div>
+
+<div id="expectedCustomAlignLeftClass">
+	<figure class="customClass easyimage-alignLeft" id="customSideId">
+		<img alt="fig1" src="../image2/_assets/foo.png" />
+		<figcaption>Changed class</figcaption>
+	</figure>
+
+	<figure>
+		<img src="../image2/_assets/foo.png" alt="fig2">
+		<figcaption>Figure without class</figcaption>
+	</figure>
+</div>
+
+<div id="expectedCustomAlignCenterClass">
+	<figure class="customClass easyimage-alignCenter" id="customSideId">
+		<img alt="fig1" src="../image2/_assets/foo.png" />
+		<figcaption>Changed class</figcaption>
+	</figure>
+
+	<figure>
+		<img src="../image2/_assets/foo.png" alt="fig2">
+		<figcaption>Figure without class</figcaption>
+	</figure>
+</div>
+
+<div id="expectedCustomAlignRightClass">
+	<figure class="customClass easyimage-alignRight" id="customSideId">
+		<img alt="fig1" src="../image2/_assets/foo.png" />
+		<figcaption>Changed class</figcaption>
+	</figure>
+
+	<figure>
+		<img src="../image2/_assets/foo.png" alt="fig2">
+		<figcaption>Figure without class</figcaption>
+	</figure>
+</div>

--- a/tests/plugins/easyimage/config.js
+++ b/tests/plugins/easyimage/config.js
@@ -32,6 +32,26 @@
 		}
 	};
 
+	function createCustomClassTest( command ) {
+		return function() {
+			var bot = this.editorBots.classCustomized;
+
+			bot.setData( CKEDITOR.document.getById( 'changedClass' ).getHtml(), function() {
+				var editor = bot.editor,
+					widgetInstance = widgetTestsTools.getWidgetById( editor, 'customSideId', true );
+
+				widgetInstance.focus();
+
+				// IE11 for some reasons needs to have the command state force refreshed, after focusing the widget with API only.
+				editor.commands[ 'easyimage' + command ].refresh( editor, editor.elementPath() );
+
+				editor.execCommand( 'easyimage' + command );
+
+				assert.beautified.html( CKEDITOR.document.getById( 'expectedCustom' + command + 'Class' ).getHtml(), editor.getData() );
+			} );
+		};
+	}
+
 	function createToolbarTest( editorName, expectedItems ) {
 		return function() {
 			var editor = bender.editors[ editorName ],
@@ -85,6 +105,10 @@
 				bot: this.editorBots.classCustomized
 			} );
 		},
+
+		'test default styles for alignLeft': createCustomClassTest( 'AlignLeft' ),
+		'test default styles for alignCenter': createCustomClassTest( 'AlignCenter' ),
+		'test default styles for alignRight': createCustomClassTest( 'AlignRight' ),
 
 		'test balloon toolbar buttons (default settings)': createToolbarTest( 'standard',
 			[ 'EasyimageFull', 'EasyimageSide', 'EasyimageAlt' ] ),

--- a/tests/plugins/easyimage/config.js
+++ b/tests/plugins/easyimage/config.js
@@ -29,6 +29,20 @@
 				extraPlugins: 'basicstyles',
 				easyimage_toolbar: [ 'Bold', 'Italic' ]
 			}
+		},
+
+		customDefaultStyle: {
+			config: {
+				easyimage_class: null,
+				easyimage_defaultStyle: 'side'
+			}
+		},
+
+		unsetDefaultStyle: {
+			config: {
+				easyimage_class: null,
+				easyimage_defaultStyle: null
+			}
 		}
 	};
 
@@ -104,7 +118,34 @@
 				widgetOffset: 0,
 				nameCreated: 'easyimage',
 				html: CKEDITOR.document.getById( 'changedClass' ).getHtml(),
-				bot: this.editorBots.classCustomized
+				bot: this.editorBots.classCustomized,
+				assertNewData: function( widget ) {
+					assert.isTrue( widget.element.hasClass( 'easyimage-full' ), 'Widget has a proper class by default' );
+				}
+			} );
+		},
+
+		'test easyimage_defaultStyle - changed': function() {
+			widgetTestsTools.assertWidget( {
+				widgetOffset: 0,
+				nameCreated: 'easyimage',
+				html: CKEDITOR.document.getById( 'standardWidget' ).getHtml(),
+				bot: this.editorBots.customDefaultStyle,
+				assertNewData: function( widget ) {
+					assert.isTrue( widget.element.hasClass( 'easyimage-side' ), 'Widget element has a proper class' );
+				}
+			} );
+		},
+
+		'test easyimage_defaultStyle - unset': function() {
+			widgetTestsTools.assertWidget( {
+				widgetOffset: 0,
+				nameCreated: 'easyimage',
+				html: CKEDITOR.document.getById( 'standardWidget' ).getHtml(),
+				bot: this.editorBots.unsetDefaultStyle,
+				assertNewData: function( widget ) {
+					assert.areSame( 'cke_widget_element', widget.element.getAttribute( 'class' ), 'Widget element classes' );
+				}
 			} );
 		},
 

--- a/tests/plugins/easyimage/config.js
+++ b/tests/plugins/easyimage/config.js
@@ -42,8 +42,10 @@
 
 				widgetInstance.focus();
 
-				// IE11 for some reasons needs to have the command state force refreshed, after focusing the widget with API only.
-				editor.commands[ 'easyimage' + command ].refresh( editor, editor.elementPath() );
+				if ( CKEDITOR.env.ie && !CKEDITOR.env.edge ) {
+					// IE11 for some reasons needs to have the command state force refreshed, after focusing the widget with API only.
+					editor.commands[ 'easyimage' + command ].refresh( editor, editor.elementPath() );
+				}
 
 				editor.execCommand( 'easyimage' + command );
 

--- a/tests/plugins/easyimage/customstyles.html
+++ b/tests/plugins/easyimage/customstyles.html
@@ -1,5 +1,5 @@
 <div id="standard">
-	<figure class="easyimage">
+	<figure class="easyimage easyimage-full">
 		<img src="../image2/_assets/foo.png" alt="fig1">
 		<figcaption>Standard Easy Image widget</figcaption>
 	</figure>

--- a/tests/plugins/easyimage/customstyles.js
+++ b/tests/plugins/easyimage/customstyles.js
@@ -147,7 +147,7 @@
 			} );
 		},
 
-		'test style command does not change element': function( editor, bot ) {
+		'test style command does not change element tag name': function( editor, bot ) {
 			bot.setData( CKEDITOR.document.getById( 'standard' ).getHtml(), function() {
 				var widget = editor.widgets.getByElement( editor.editable().findOne( 'figure' ) );
 

--- a/tests/plugins/easyimage/customstyles.js
+++ b/tests/plugins/easyimage/customstyles.js
@@ -7,6 +7,7 @@
 	'use strict';
 
 	var commonConfig = {
+		toolbar: [ [ 'Paste', 'EasyimageFull', 'EasyimageSide' ] ],
 		easyimage_styles: {
 			test: {
 				attributes: {
@@ -46,6 +47,7 @@
 		},
 
 		'test default styles are always defined': function( editor ) {
+			editor.focus();
 			easyImageTools.assertCommandsState( editor, {
 				easyimageFull: CKEDITOR.TRISTATE_DISABLED,
 				easyimageSide: CKEDITOR.TRISTATE_DISABLED,
@@ -87,27 +89,20 @@
 			bot.setData( CKEDITOR.document.getById( 'standard' ).getHtml(), function() {
 				var widget = editor.widgets.getByElement( editor.editable().findOne( 'figure' ) );
 
-				editor.once( 'afterCommandExec', function() {
-					editor.once( 'afterCommandExec', function() {
-						resume( function() {
-							easyImageTools.assertCommandsState( editor, {
-								easyimageTest: CKEDITOR.TRISTATE_ON
-							} );
-							assert.areSame( 'test', widget.data.style, 'Widget has correct style data' );
-						} );
-					} );
-
-					easyImageTools.assertCommandsState( editor, {
-						easyimageTest: CKEDITOR.TRISTATE_ON
-					} );
-					assert.areSame( 'test', widget.data.style, 'Widget has correct style data' );
-
-					editor.execCommand( 'easyimageTest' );
-				} );
-
 				widget.focus();
 				editor.execCommand( 'easyimageTest' );
-				wait();
+
+				easyImageTools.assertCommandsState( editor, {
+					easyimageTest: CKEDITOR.TRISTATE_ON
+				} );
+				// assert.areSame( 'test', widget.data.style, 'Widget has correct style data' );
+
+				editor.execCommand( 'easyimageTest' );
+
+				easyImageTools.assertCommandsState( editor, {
+					easyimageTest: CKEDITOR.TRISTATE_ON
+				} );
+				// assert.areSame( 'test', widget.data.style, 'Widget has correct style data' );
 			} );
 		},
 
@@ -119,18 +114,18 @@
 					editor.once( 'afterCommandExec', function() {
 						resume( function() {
 							assert.isFalse( widget.hasClass( 'test' ), 'Style removed' );
-							easyImageTools.assertCommandsState( editor, {
-								easyimageTest: CKEDITOR.TRISTATE_OFF,
-								easyimageAlignLeft: CKEDITOR.TRISTATE_ON
-							} );
+							// easyImageTools.assertCommandsState( editor, {
+							// 	easyimageTest: CKEDITOR.TRISTATE_OFF,
+							// 	easyimageAlignLeft: CKEDITOR.TRISTATE_ON
+							// } );
 						} );
 					} );
 
 					assert.isTrue( widget.hasClass( 'test' ), 'Style applied' );
-					easyImageTools.assertCommandsState( editor, {
-						easyimageFull: CKEDITOR.TRISTATE_OFF,
-						easyimageTest: CKEDITOR.TRISTATE_ON
-					} );
+					// easyImageTools.assertCommandsState( editor, {
+					// 	easyimageFull: CKEDITOR.TRISTATE_OFF,
+					// 	easyimageTest: CKEDITOR.TRISTATE_ON
+					// } );
 
 					editor.execCommand( 'easyimageAlignLeft' );
 				} );
@@ -199,7 +194,7 @@
 						easyImageTools.assertCommandsState( editor, {
 							easyimageAlignLeft: CKEDITOR.TRISTATE_ON
 						} );
-						assert.areSame( 'alignLeft', widget.data.style, 'Widget has correct style data' );
+						// assert.areSame( 'alignLeft', widget.data.style, 'Widget has correct style data' );
 						assert.isTrue( widget.hasClass( 'customClass' ), 'Widget has appropriate class' );
 					} );
 				} );
@@ -210,5 +205,6 @@
 			} );
 		} );
 	};
+
 	bender.test( tests );
 } )();

--- a/tests/plugins/easyimage/customstyles.js
+++ b/tests/plugins/easyimage/customstyles.js
@@ -95,14 +95,12 @@
 				easyImageTools.assertCommandsState( editor, {
 					easyimageTest: CKEDITOR.TRISTATE_ON
 				} );
-				// assert.areSame( 'test', widget.data.style, 'Widget has correct style data' );
 
 				editor.execCommand( 'easyimageTest' );
 
 				easyImageTools.assertCommandsState( editor, {
 					easyimageTest: CKEDITOR.TRISTATE_ON
 				} );
-				// assert.areSame( 'test', widget.data.style, 'Widget has correct style data' );
 			} );
 		},
 
@@ -114,18 +112,18 @@
 					editor.once( 'afterCommandExec', function() {
 						resume( function() {
 							assert.isFalse( widget.hasClass( 'test' ), 'Style removed' );
-							// easyImageTools.assertCommandsState( editor, {
-							// 	easyimageTest: CKEDITOR.TRISTATE_OFF,
-							// 	easyimageAlignLeft: CKEDITOR.TRISTATE_ON
-							// } );
+							easyImageTools.assertCommandsState( editor, {
+								easyimageTest: CKEDITOR.TRISTATE_OFF,
+								easyimageAlignLeft: CKEDITOR.TRISTATE_ON
+							} );
 						} );
 					} );
 
 					assert.isTrue( widget.hasClass( 'test' ), 'Style applied' );
-					// easyImageTools.assertCommandsState( editor, {
-					// 	easyimageFull: CKEDITOR.TRISTATE_OFF,
-					// 	easyimageTest: CKEDITOR.TRISTATE_ON
-					// } );
+					easyImageTools.assertCommandsState( editor, {
+						easyimageFull: CKEDITOR.TRISTATE_OFF,
+						easyimageTest: CKEDITOR.TRISTATE_ON
+					} );
 
 					editor.execCommand( 'easyimageAlignLeft' );
 				} );
@@ -163,7 +161,6 @@
 			bot.setData( CKEDITOR.document.getById( 'standard' ).getHtml(), function() {
 				var widget = editor.widgets.getByElement( editor.editable().findOne( 'figure' ) );
 
-				assert.areSame( 'full', widget.data.style, 'Widget has correct style data' );
 				assert.isTrue( widget.hasClass( 'easyimage-full' ), 'Widget has correct style' );
 			} );
 		}
@@ -194,7 +191,6 @@
 						easyImageTools.assertCommandsState( editor, {
 							easyimageAlignLeft: CKEDITOR.TRISTATE_ON
 						} );
-						// assert.areSame( 'alignLeft', widget.data.style, 'Widget has correct style data' );
 						assert.isTrue( widget.hasClass( 'customClass' ), 'Widget has appropriate class' );
 					} );
 				} );

--- a/tests/plugins/easyimage/customstyles.js
+++ b/tests/plugins/easyimage/customstyles.js
@@ -42,6 +42,12 @@
 	};
 
 	var tests = {
+		setUp: function() {
+			if ( CKEDITOR.env.ie && CKEDITOR.env.version < 11 ) {
+				assert.ignore();
+			}
+		},
+
 		'test style is integrated with ACF': function( editor ) {
 			assert.isTrue( editor.filter.check( 'figure(test)' ) );
 		},

--- a/tests/plugins/easyimage/customstyles.js
+++ b/tests/plugins/easyimage/customstyles.js
@@ -169,6 +169,14 @@
 
 				assert.isTrue( widget.hasClass( 'easyimage-full' ), 'Widget has correct style' );
 			} );
+		},
+
+		'test custom style widget does not get the default style': function( editor, bot ) {
+			bot.setData( CKEDITOR.document.getById( 'predefined' ).getHtml(), function() {
+				var widget = editor.widgets.getByElement( editor.editable().findOne( 'figure' ) );
+
+				assert.isFalse( widget.hasClass( 'easyimage-full' ), 'Default class is not added' );
+			} );
 		}
 	};
 

--- a/tests/plugins/easyimage/manual/customgroups.html
+++ b/tests/plugins/easyimage/manual/customgroups.html
@@ -1,0 +1,55 @@
+<h2>Classic editor</h2>
+<div id="classic">
+	<p>Standard img:</p>
+	<figure class="easyimage">
+		<img src="../../image2/_assets/bar.png" alt="foo">
+		<figcaption>Test image</figcaption>
+	</figure>
+</div>
+
+<h2>Divarea editor</h2>
+<div id="divarea">
+		<p>Standard img:</p>
+		<figure class="easyimage">
+			<img src="../../image2/_assets/bar.png" alt="foo">
+			<figcaption>Test image</figcaption>
+		</figure>
+</div>
+
+<script>
+	( function() {
+		if ( CKEDITOR.env.ie && CKEDITOR.env.version < 11 ) {
+			bender.ignore();
+		}
+
+		var commonConfig = {
+			easyimage_styles: {
+				border1: {
+					attributes: {
+						'class': 'border1'
+					},
+					icon: 'test',
+					label: 'Border1',
+					group: 'easyimageborder'
+				},
+				border2: {
+					attributes: {
+						'class': 'border2'
+					},
+					icon: 'test',
+					label: 'Border2',
+					group: 'easyimageborder'
+				}
+			},
+			easyimage_toolbar: [ 'EasyimageFull', 'EasyimageSide', 'EasyimageBorder1', 'EasyimageBorder2' ]
+		};
+
+		CKEDITOR.addCss( '.border1 { border: 2px solid green }' );
+		CKEDITOR.addCss( '.border2 { border: 2px solid pink }' );
+
+		CKEDITOR.replace( 'classic', commonConfig );
+		CKEDITOR.replace( 'divarea', CKEDITOR.tools.object.merge( {
+			extraPlugins: 'divarea'
+		}, commonConfig ) );
+	}() );
+</script>

--- a/tests/plugins/easyimage/manual/customgroups.md
+++ b/tests/plugins/easyimage/manual/customgroups.md
@@ -4,7 +4,7 @@
 
 ## Styles Group
 
-This manual test shows how one could
+This manual test shows how one could add style groups unrelated to positioning.
 
 1. Click on image widget.
 1. Click "Side Image" button.

--- a/tests/plugins/easyimage/manual/customgroups.md
+++ b/tests/plugins/easyimage/manual/customgroups.md
@@ -7,7 +7,7 @@
 This manual test shows how one could
 
 1. Click on image widget.
-1. Click side image button.
+1. Click "Side Image" button.
 1. Click "Border1" button.
 	## Expected
 

--- a/tests/plugins/easyimage/manual/customgroups.md
+++ b/tests/plugins/easyimage/manual/customgroups.md
@@ -1,0 +1,27 @@
+@bender-tags: 4.9.0, feature, 932
+@bender-ui: collapsed
+@bender-ckeditor-plugins: sourcearea, wysiwygarea, floatingspace, toolbar, easyimage
+
+## Styles Group
+
+This manual test shows how one could
+
+1. Click on image widget.
+1. Click side image button.
+1. Click "Border1" button.
+	## Expected
+
+	* Green outline is applied to the widget.
+	* Border1 button becomes active.
+	* Side image style **remains active** too.
+2. Click "Border2" button.
+	## Expected:
+
+	* "Border1" button gets deactivated.
+	* "Border2" button becomes active.
+	* Green outline is replaced with a pink one.
+	* Side image style **remains active**.
+
+Repeat test for the "Divarea editor".
+
+**Note:** custom styles might not have an icon.

--- a/tests/plugins/easyimage/manual/customstyles.html
+++ b/tests/plugins/easyimage/manual/customstyles.html
@@ -1,7 +1,7 @@
 <h2>Classic editor</h2>
 <div id="classic">
 	<p><strong>Apollo 11</strong> was the spaceflight that landed the first humans on the Moon on July 20, 1969, at 20:18 UTC.</p>
-	<figure class="easyimage easyimage-alignCenter">
+	<figure class="easyimage easyimage-align-center">
 		<img src="../../image2/_assets/foo.png" alt="foo">
 		<figcaption>Test image</figcaption>
 	</figure>
@@ -11,7 +11,7 @@
 <h2>Divarea editor</h2>
 <div id="divarea">
 	<p><strong>Apollo 11</strong> was the spaceflight that landed the first humans on the Moon on July 20, 1969, at 20:18 UTC.</p>
-	<figure class="easyimage easyimage-alignCenter">
+	<figure class="easyimage easyimage-align-center">
 		<img src="../../image2/_assets/foo.png" alt="foo">
 		<figcaption>Test image</figcaption>
 	</figure>

--- a/tests/plugins/easyimage/manual/customstyles.html
+++ b/tests/plugins/easyimage/manual/customstyles.html
@@ -20,6 +20,10 @@
 
 <script>
 	( function() {
+		if ( CKEDITOR.env.ie && CKEDITOR.env.version < 11 ) {
+			bender.ignore();
+		}
+
 		CKEDITOR.addCss( '.test { background: red; }' );
 
 		var commonConfig = {

--- a/tests/plugins/easyimage/manual/customstyles.html
+++ b/tests/plugins/easyimage/manual/customstyles.html
@@ -1,7 +1,7 @@
 <h2>Classic editor</h2>
 <div id="classic">
 	<p><strong>Apollo 11</strong> was the spaceflight that landed the first humans on the Moon on July 20, 1969, at 20:18 UTC.</p>
-	<figure class="image easyimage easyimage">
+	<figure class="easyimage easyimage-alignCenter">
 		<img src="../../image2/_assets/foo.png" alt="foo">
 		<figcaption>Test image</figcaption>
 	</figure>
@@ -11,7 +11,7 @@
 <h2>Divarea editor</h2>
 <div id="divarea">
 	<p><strong>Apollo 11</strong> was the spaceflight that landed the first humans on the Moon on July 20, 1969, at 20:18 UTC.</p>
-	<figure class="image easyimage easyimage">
+	<figure class="easyimage easyimage-alignCenter">
 		<img src="../../image2/_assets/foo.png" alt="foo">
 		<figcaption>Test image</figcaption>
 	</figure>

--- a/tests/plugins/easyimage/manual/customtoolbar.html
+++ b/tests/plugins/easyimage/manual/customtoolbar.html
@@ -20,6 +20,10 @@
 
 <script>
 	( function() {
+		if ( CKEDITOR.env.ie && CKEDITOR.env.version < 11 ) {
+			bender.ignore();
+		}
+
 		var commonConfig = {
 			easyimage_toolbar: [ 'Copy', 'Paste' ]
 		};

--- a/tests/plugins/easyimage/widget.js
+++ b/tests/plugins/easyimage/widget.js
@@ -120,7 +120,7 @@
 
 				// Drag and drop probably destroyed old widget, so we should fetch it once more.
 				widget = editor.widgets.focused;
-				assert.areSame( 'side', widget.data.style, 'Widget has correct data style' );
+				assert.isTrue( widget.element.hasClass( 'easyimage-side' ), 'Widget preserved the class' );
 			} );
 		}
 	};


### PR DESCRIPTION
## What is the purpose of this pull request?

Review corrections

## Does your PR contain necessary tests?

All patches which change the editor code must include tests. You can always read more
on [PR testing](https://docs.ckeditor.com/ckeditor4/docs/#!/guide/dev_contributing_code-section-tests),
[how to set the testing environment](https://docs.ckeditor.com/ckeditor4/docs/#!/guide/dev_tests) and
[how to create tests](https://docs.ckeditor.com/ckeditor4/docs/#!/guide/dev_tests-section-creating-your-own-test)
in the official CKEditor documentation.

### This PR contains

- [x] Unit tests
- [x] Manual tests

## What changes did you make?

PR with corrections to #1518. The most important change is that it reuses `CKEDITOR.styleCommand`, and does not rely on widget data.

Unit tests had a really good coverage, and I didn't have to do much there worked fine with changed solution for the most part.

Below is a more detailed list of changes:

* It reuses `CKEDITOR.styleCommand` for style application.
* It drops [`_styles` member](https://github.com/ckeditor/ckeditor-dev/blob/c6b5a7679b542b68364a816b0cba1859bd08e881/plugins/easyimage/plugin.js#L223) which was causing a redundancy of information whether the style is applied or not.
* Uses dash-separated names for CSS e.g. `easyimage-align-left` to be in line with other CKEditor classes.
* It now allows to specify a `group` for members in `config.easyimage_styles`. That's useful if you want to add styles for something else that the image positioning itself.
* Added `easyimage_defaultStyle` see it's API docs for more.
* Improved API docs (especially config).