### PR TITLE
Ignore failing imagebase link tests on IE11

### DIFF
--- a/tests/plugins/imagebase/features/link.js
+++ b/tests/plugins/imagebase/features/link.js
@@ -167,6 +167,13 @@
 	}
 
 	var tests = {
+		setUp: function() {
+			if ( CKEDITOR.env.ie && CKEDITOR.env.version <= 11 ) {
+				// Tests fails quite randomly on IE11. Ignore for now (#1552).
+				assert.ignore();
+			}
+		},
+
 		'test adding image widget with link feature': function( editor ) {
 			var expectedParts = {
 				caption: 'figcaption',


### PR DESCRIPTION
## What is the purpose of this pull request?

Task

## Does your PR contain necessary tests?

All patches which change the editor code must include tests. You can always read more
on [PR testing](https://docs.ckeditor.com/ckeditor4/docs/#!/guide/dev_contributing_code-section-tests),
[how to set the testing environment](https://docs.ckeditor.com/ckeditor4/docs/#!/guide/dev_tests) and
[how to create tests](https://docs.ckeditor.com/ckeditor4/docs/#!/guide/dev_tests-section-creating-your-own-test)
in the official CKEditor documentation.

### This PR contains

- [ ] Unit tests
- [ ] Manual tests

## What changes did you make?

We decided to ignore those tests for now and take care of it as a follow up in 4.9.1.
Related to #1552.
