### PR TITLE
Updated caching width and height for image2 on src change

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -26,6 +26,7 @@ Fixed Issues:
 * [#1426](https://github.com/ckeditor/ckeditor-dev/issues/1426): [IE8-9] Fixed: Missing balloon toolbar background in Kama skin. Thanks to [Christian Elmer](https://github.com/keinkurt)!
 * [#1010](https://github.com/ckeditor/ckeditor-dev/issues/1010): Fixed: CSS `border` shorthand property was incorrectly expanded ignoring `border-color` style.
 * [#1470](https://github.com/ckeditor/ckeditor-dev/issues/1470): Fixed: [Balloon Toolbar](https://ckeditor.com/cke4/addon/balloontoolbar) is not visible after drag and drop of a widget it is attached to.
+* [#1348](https://github.com/ckeditor/ckeditor-dev/issues/1348): Fixed: [Enhanced Image](https://ckeditor.com/cke4/addon/image2) aspect ratio locking uses old width and height on `src` change.
 
 API Changes:
 

--- a/plugins/image2/dialogs/image2.js
+++ b/plugins/image2/dialogs/image2.js
@@ -152,10 +152,10 @@ CKEDITOR.dialog.add( 'image2', function( editor ) {
 				// Fill height field with the height of the new image.
 				heightField.setValue( editor.config.image2_prefillDimensions === false ? 0 : height );
 
-				// Cache the new width.
+				// Cache the new width and update initial cache (#1348).
 				preLoadedWidth = domWidth = width;
 
-				// Cache the new height.
+				// Cache the new height and update initial cache (#1348).
 				preLoadedHeight = domHeight = height;
 
 				// Check for new lock value if image exist.

--- a/plugins/image2/dialogs/image2.js
+++ b/plugins/image2/dialogs/image2.js
@@ -153,10 +153,10 @@ CKEDITOR.dialog.add( 'image2', function( editor ) {
 				heightField.setValue( editor.config.image2_prefillDimensions === false ? 0 : height );
 
 				// Cache the new width.
-				preLoadedWidth = width;
+				preLoadedWidth = domWidth = width;
 
 				// Cache the new height.
-				preLoadedHeight = height;
+				preLoadedHeight = domHeight = height;
 
 				// Check for new lock value if image exist.
 				toggleLockRatio( helpers.checkHasNaturalRatio( image ) );

--- a/tests/plugins/image2/editing.js
+++ b/tests/plugins/image2/editing.js
@@ -74,6 +74,37 @@
 			wait();
 		},
 
+		// #1348
+		'test image dialog has correct aspect ratio after src change': function() {
+			var bot = this.editorBot,
+				editor = bot.editor;
+
+			editor.once( 'dialogShow', function( evt ) {
+				var dialog = evt.data,
+					widthInput = CKEDITOR.document.findOne( '#' + dialog.getContentElement( 'info', 'width' )._.inputId );
+
+				dialog.setValueOf( 'info', 'src', '_assets/foo.png' );
+				downloadImage( '_assets/foo.png', assertImage );
+
+				function assertImage() {
+					widthInput.fire( 'keyup', new CKEDITOR.dom.event( {} ) ); // It will force image dialog to recalculate width and height.
+
+					assert.areEqual( 50, dialog.getContentElement( 'info', 'width' ).getValue(), 'invalid width' );
+					assert.areEqual( 120, dialog.getContentElement( 'info', 'height' ).getValue(), 'invalid height' );
+
+					dialog.hide();
+
+					resume();
+				}
+			} );
+
+			bot.setData( widgetsHtml, function() {
+				getWidgetById( editor, 'y' ).focus();
+				editor.execCommand( 'image' );
+				wait();
+			} );
+		},
+
 		'test create inline widget with a global command': function() {
 			var editorBot = this.editorBot,
 				onResume = function( dialog ) {

--- a/tests/plugins/image2/manual/aspectratio.html
+++ b/tests/plugins/image2/manual/aspectratio.html
@@ -1,0 +1,7 @@
+<div id="editor1" contenteditable="true">
+	<img alt="alt" src="%BASE_PATH%/_assets/logo.png" />
+</div>
+
+<script>
+	CKEDITOR.replace( 'editor1' );
+</script>

--- a/tests/plugins/image2/manual/aspectratio.md
+++ b/tests/plugins/image2/manual/aspectratio.md
@@ -1,0 +1,17 @@
+@bender-tags: 4.9.0, bug, 1348
+@bender-ui: collapsed
+@bender-ckeditor-plugins: wysiwygarea, sourcearea, toolbar, image2, link, undo
+
+1. Double click on the image to popup dialog.
+2. Change url of the image to `/tests//_assets/lena.jpg`.
+3. Ensure that the image is locked.
+4. Change `width` to `400`.
+5. Click `OK` button.
+
+## Expected
+
+The image has preserved aspect ratio.
+
+## Unexpected
+
+The image is streched, aspect ratio is not preserved.


### PR DESCRIPTION
## What is the purpose of this pull request?

Bug fix.

## Does your PR contain necessary tests?

All patches which change the editor code must include tests. You can always read more
on [PR testing](https://docs.ckeditor.com/ckeditor4/docs/#!/guide/dev_contributing_code-section-tests),
[how to set the testing environment](https://docs.ckeditor.com/ckeditor4/docs/#!/guide/dev_tests) and
[how to create tests](https://docs.ckeditor.com/ckeditor4/docs/#!/guide/dev_tests-section-creating-your-own-test)
in the official CKEditor documentation.

### This PR contains

- [x] Unit tests
- [x] Manual tests

## What changes did you make?

Updated caching width and height for image2 on src change. Without this change aspect ratio calculation was based on old image width/height.
