### PR TITLE
Improved uploading progress visual feedback

### DIFF
--- a/plugins/easyimage/styles/easyimage.css
+++ b/plugins/easyimage/styles/easyimage.css
@@ -110,3 +110,14 @@ body.cke_editable > .cke_widget_wrapper_easyimage-side {
 	left: 40px;
 	right: 40px;
 }
+
+/* Fancy opacity effect discussed in #1533. Transition assigned in this awkward way so that it **does not** happen for
+the initial render, otherwise it would start transitioning from opacity 1 to 0.x upon first render. */
+
+.cke_widget_wrapper_easyimage:not(.cke_widget_wrapper_uploading) figure img {
+	transition: opacity 0.3s ease-in-out;
+}
+
+.cke_widget_wrapper_easyimage.cke_widget_wrapper_uploading figure img {
+	opacity: 0.75;
+}

--- a/plugins/imagebase/plugin.js
+++ b/plugins/imagebase/plugin.js
@@ -351,7 +351,7 @@
 					if ( widget.isInited() ) {
 						widget.setData( 'uploadId', undefined );
 					}
-					// widget.wrapper.removeClass( 'cke_widget_wrapper_uploading' );
+					widget.wrapper.removeClass( 'cke_widget_wrapper_uploading' );
 				}
 
 				function failHandling() {
@@ -366,7 +366,6 @@
 
 				function uploadComplete() {
 					widgetCleanup();
-					widget.wrapper.removeClass( 'cke_widget_wrapper_uploading' );
 
 					widget.fire( 'uploadDone', {
 						loader: loader

--- a/plugins/imagebase/plugin.js
+++ b/plugins/imagebase/plugin.js
@@ -351,7 +351,7 @@
 					if ( widget.isInited() ) {
 						widget.setData( 'uploadId', undefined );
 					}
-					widget.removeClass( 'uploading' );
+					// widget.wrapper.removeClass( 'cke_widget_wrapper_uploading' );
 				}
 
 				function failHandling() {
@@ -366,6 +366,7 @@
 
 				function uploadComplete() {
 					widgetCleanup();
+					widget.wrapper.removeClass( 'cke_widget_wrapper_uploading' );
 
 					widget.fire( 'uploadDone', {
 						loader: loader
@@ -394,11 +395,12 @@
 
 				if ( widget.fire( 'uploadStarted', loader ) !== false && widget.progressReporterType ) {
 					if ( !widget._isLoaderDone( loader ) ) {
+						// Deliberately add class to wrapper, it does not make sense for widget element.
+						widget.wrapper.addClass( 'cke_widget_wrapper_uploading' );
 						// Progress reporter has only sense if widget is in progress.
 						var progress = new widget.progressReporterType();
 						widget.wrapper.append( progress.wrapper );
 						progress.bindLoader( loader );
-						widget.addClass( 'uploading' );
 					} else {
 						if ( loaderEventMapping[ loader.status ] ) {
 							loaderEventMapping[ loader.status ]();
@@ -454,7 +456,7 @@
 			 *		} );
 			 *
 			 * This event is cancelable, if canceled, the default progress bar will not be created
-			 * and widget element and wrapper won't be marked with `cke_widget_(wrapper_)uploading` class.
+			 * and the widget wrapper won't be marked with `cke_widget_wrapper_uploading` class.
 			 *
 			 * Note that the event will be fired even if the widget was created for a loader that
 			 * is already resolved.

--- a/plugins/imagebase/plugin.js
+++ b/plugins/imagebase/plugin.js
@@ -351,6 +351,7 @@
 					if ( widget.isInited() ) {
 						widget.setData( 'uploadId', undefined );
 					}
+					widget.removeClass( 'uploading' );
 				}
 
 				function failHandling() {
@@ -397,6 +398,7 @@
 						var progress = new widget.progressReporterType();
 						widget.wrapper.append( progress.wrapper );
 						progress.bindLoader( loader );
+						widget.addClass( 'uploading' );
 					} else {
 						if ( loaderEventMapping[ loader.status ] ) {
 							loaderEventMapping[ loader.status ]();
@@ -451,7 +453,8 @@
 			 *			// Implement a custom progress bar.
 			 *		} );
 			 *
-			 * This event is cancelable, if canceled, the default progress bar will not be created.
+			 * This event is cancelable, if canceled, the default progress bar will not be created
+			 * and widget element and wrapper won't be marked with `cke_widget_(wrapper_)uploading` class.
 			 *
 			 * Note that the event will be fired even if the widget was created for a loader that
 			 * is already resolved.

--- a/tests/plugins/easyimage/manual/progressbar.md
+++ b/tests/plugins/easyimage/manual/progressbar.md
@@ -1,4 +1,4 @@
-@bender-tags: 4.9.0, feature, 932
+@bender-tags: 4.9.0, feature, 932, 1533
 @bender-ui: collapsed
 @bender-ckeditor-plugins: sourcearea, wysiwygarea, floatingspace, toolbar, easyimage
 @bender-include: ../../uploadwidget/manual/_helpers/xhr.js
@@ -14,6 +14,14 @@ Remarks:
 
 1. Drop an image into the editor.
 
-### Expected
+	### Expected
 
-* Upload progress is shown.
+	* Upload progress is shown.
+	* The image is a little opaque.
+
+1. Wait till the image load completes.
+
+	### Expected
+
+	* Progress indicator disappear.
+	* Image is no longer opaque.

--- a/tests/plugins/easyimage/manual/progressbar.md
+++ b/tests/plugins/easyimage/manual/progressbar.md
@@ -17,11 +17,11 @@ Remarks:
 	### Expected
 
 	* Upload progress is shown.
-	* The image is a little opaque.
+	* The image is a little transparent.
 
 1. Wait till the image load completes.
 
 	### Expected
 
 	* Progress indicator disappear.
-	* Image is no longer opaque.
+	* Image has its regular color.

--- a/tests/plugins/imagebase/features/upload.js
+++ b/tests/plugins/imagebase/features/upload.js
@@ -393,11 +393,11 @@
 					files: [ getTestRtfFile() ],
 					callback: function( widgets ) {
 						var widget = widgets[ 0 ];
-						assert.isTrue( widget.hasClass( 'uploading' ), 'Class is present during the upload' );
+						assert.isTrue( widget.wrapper.hasClass( 'cke_widget_wrapper_uploading' ), 'Class is present during the upload' );
 
 						widget.once( 'uploadDone', function() {
 							resume( function() {
-								assert.isFalse( widget.hasClass( 'uploading' ), 'Class is removed after upload' );
+								assert.isFalse( widget.wrapper.hasClass( 'cke_widget_wrapper_uploading' ), 'Class is removed after upload' );
 							} );
 						} );
 
@@ -428,7 +428,7 @@
 						editor.widgets.registered.testImageWidget.loaderType = originalLoader;
 
 						var widget = widgets[ 0 ];
-						assert.isTrue( widget.hasClass( 'uploading' ), 'Class is present during the upload' );
+						assert.isTrue( widget.wrapper.hasClass( 'cke_widget_wrapper_uploading' ), 'Class is present during the upload' );
 					}
 				} );
 			},

--- a/tests/plugins/imagebase/features/upload.js
+++ b/tests/plugins/imagebase/features/upload.js
@@ -385,6 +385,54 @@
 				} );
 			},
 
+			// (#1533)
+			'test widget gets class during the upload': function() {
+				var editor = this.editor;
+
+				assertPasteFiles( editor, {
+					files: [ getTestRtfFile() ],
+					callback: function( widgets ) {
+						var widget = widgets[ 0 ];
+						assert.isTrue( widget.hasClass( 'uploading' ), 'Class is present during the upload' );
+
+						widget.once( 'uploadDone', function() {
+							resume( function() {
+								assert.isFalse( widget.hasClass( 'uploading' ), 'Class is removed after upload' );
+							} );
+						} );
+
+						wait();
+					}
+				} );
+			},
+
+			'test widget upload class is removed after fail': function() {
+				var editor = this.editor,
+					listeners = this.listeners,
+					originalLoader = editor.widgets.registered.testImageWidget.loaderType;
+
+				// Force a loader that will fail.
+				editor.widgets.registered.testImageWidget.loaderType = FailFileLoader;
+
+				// Make sure to prevent default handling, otherwise widget is removed.
+				this.listeners.push( editor.widgets.on( 'instanceCreated', function( evt ) {
+					listeners.push( evt.data.on( 'uploadFailed', function( evt ) {
+						evt.cancel();
+					} ) );
+				} ) );
+
+				assertPasteFiles( editor, {
+					files: [ bender.tools.getTestPngFile() ],
+					callback: function( widgets ) {
+						// Note FailFileLoader is synchronous, so there's no need to wait for uploadFailed.
+						editor.widgets.registered.testImageWidget.loaderType = originalLoader;
+
+						var widget = widgets[ 0 ];
+						assert.isTrue( widget.hasClass( 'uploading' ), 'Class is present during the upload' );
+					}
+				} );
+			},
+
 			'test data.uploadId behavior': function() {
 				var editor = this.editor;
 


### PR DESCRIPTION
## What is the purpose of this pull request?

New feature

## Does your PR contain necessary tests?

All patches which change the editor code must include tests. You can always read more
on [PR testing](https://docs.ckeditor.com/ckeditor4/docs/#!/guide/dev_contributing_code-section-tests),
[how to set the testing environment](https://docs.ckeditor.com/ckeditor4/docs/#!/guide/dev_tests) and
[how to create tests](https://docs.ckeditor.com/ckeditor4/docs/#!/guide/dev_tests-section-creating-your-own-test)
in the official CKEditor documentation.

### This PR contains

- [x] Unit tests
- [x] Manual tests

## What changes did you make?

This PR allows for improvement in uploading feedback by adding a class to a widget that is uploaded. As soon as uploading is done, the class is removed.

For the time being it adds only a slight opacity to the Easy Image during the upload, then once it's done transitions back into regular image colors.

Closes #1533.