### PR TITLE
Disabled cutting widget in a readonly mode using cmd/ctrl + x keys

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -28,6 +28,7 @@ Fixed Issues:
 * [#1470](https://github.com/ckeditor/ckeditor-dev/issues/1470): Fixed: [Balloon Toolbar](https://ckeditor.com/cke4/addon/balloontoolbar) is not visible after drag and drop of a widget it is attached to.
 * [#1535](https://github.com/ckeditor/ckeditor-dev/issues/1535): Fixed: Improve [Widget](https://ckeditor.com/cke4/addon/widget) mouse over border contrast.
 * [#1516](https://github.com/ckeditor/ckeditor-dev/issues/1516): Fixed: Fake selection allows removing in a readonly mode using `Backspace`/`Delete` keys.
+* [#1570](https://github.com/ckeditor/ckeditor-dev/issues/1570): Fixed: Fake selection allows cutting in a readonly mode using `Ctrl`/`Cmd` + `X` keys.
 
 API Changes:
 

--- a/plugins/widget/plugin.js
+++ b/plugins/widget/plugin.js
@@ -3191,7 +3191,8 @@
 
 			editor.fire( 'unlockSnapshot' );
 
-			if ( isCut ) {
+			// Prevent cutting read only (#1570).
+			if ( isCut && !editor.readOnly ) {
 				widget.repository.del( widget );
 				editor.fire( 'saveSnapshot' );
 			}

--- a/plugins/widget/plugin.js
+++ b/plugins/widget/plugin.js
@@ -3191,7 +3191,7 @@
 
 			editor.fire( 'unlockSnapshot' );
 
-			// Prevent cutting read only (#1570).
+			// Prevent cutting in read-only editor (#1570).
 			if ( isCut && !editor.readOnly ) {
 				widget.repository.del( widget );
 				editor.fire( 'saveSnapshot' );

--- a/tests/plugins/widget/manual/readonly.html
+++ b/tests/plugins/widget/manual/readonly.html
@@ -1,0 +1,5 @@
+<textarea id="editor1" cols="10" rows="10"><p>[[placeholder]] foo bar</p></textarea>
+
+<script>
+	CKEDITOR.replace( 'editor1', { readOnly: true } );
+</script>

--- a/tests/plugins/widget/manual/readonly.html
+++ b/tests/plugins/widget/manual/readonly.html
@@ -2,4 +2,9 @@
 
 <script>
 	CKEDITOR.replace( 'editor1', { readOnly: true } );
+
+	// Test has been ignored for IE due to #1575 issue. Remove this ignore statement after the issue fix.
+	if ( CKEDITOR.env.ie && !CKEDITOR.env.edge ) {
+		bender.ignore();
+	}
 </script>

--- a/tests/plugins/widget/manual/readonly.md
+++ b/tests/plugins/widget/manual/readonly.md
@@ -1,0 +1,16 @@
+@bender-tags: selection, fake, widget, 4.9.0, bug, 1570
+@bender-ui: collapsed
+@bender-ckeditor-plugins: wysiwygarea, placeholder, basicstyles, toolbar, floatingspace
+
+1. Focus the placeholder widget.
+2. Blur the placeholder widget.
+3. Focus placeholder widget again.
+4. Press `ctrl/cmd + x` key.
+
+## Expected
+
+The placeholder widget shouldn't change.
+
+## Unexpected
+
+The placeholder widget has been deleted.

--- a/tests/plugins/widget/widgetsintegration.js
+++ b/tests/plugins/widget/widgetsintegration.js
@@ -53,6 +53,10 @@
 	}
 
 	bender.test( {
+		tearDown: function() {
+			this.editor.setReadOnly( false );
+		},
+
 		'test initializing widgets': function() {
 			var editor = this.editor;
 
@@ -629,6 +633,39 @@
 				wait( function() {
 					assert.isTrue( selectionChanged > 0, 'selection has been changed' );
 					assert.isFalse( !!getWidgetById( editor, 'w1' ), 'widget was deleted' );
+					assert.isFalse( !!editor.getSelection().isFake, 'selection is not faked' );
+					assert.isFalse( !!editor.document.getById( 'cke_copybin' ), 'copybin was removed' );
+				}, 150 );
+			} );
+		},
+
+		// #1570
+		'test cutting single focused widget with readonly mode': function() {
+			var editor = this.editor;
+
+			this.editorBot.setData( '<p>X</p><p id="w1" data-widget="test2">A</p><p>X</p>', function() {
+				var widget = getWidgetById( editor, 'w1' ),
+					selectionChanged = 0;
+
+				widget.focus();
+
+				editor.on( 'selectionChange', function() {
+					selectionChanged += 1;
+				} );
+
+				editor.setReadOnly( true );
+
+				editor.editable().fire( 'keydown', new CKEDITOR.dom.event( { keyCode: CKEDITOR.CTRL + 88 } ) );
+
+				var copybin = editor.document.getById( 'cke_copybin' ),
+					selContainer = editor.getSelection().getCommonAncestor();
+
+				assert.isTrue( !!copybin, 'copybin was created' );
+				assert.isTrue( copybin.contains( selContainer ) || copybin.equals( selContainer ), 'selection was moved to the copybin' );
+
+				wait( function() {
+					assert.isTrue( selectionChanged == 0, 'selection has not been changed' );
+					assert.isTrue( !!getWidgetById( editor, 'w1' ), 'widget has not been deleted' );
 					assert.isFalse( !!editor.getSelection().isFake, 'selection is not faked' );
 					assert.isFalse( !!editor.document.getById( 'cke_copybin' ), 'copybin was removed' );
 				}, 150 );

--- a/tests/plugins/widget/widgetsintegration.js
+++ b/tests/plugins/widget/widgetsintegration.js
@@ -641,6 +641,11 @@
 
 		// #1570
 		'test cutting single focused widget with readonly mode': function() {
+			// Test has been ignored for IE due to #1575 issue. Remove this ignore statement after the issue fix.
+			if ( CKEDITOR.env.ie && !CKEDITOR.env.edge ) {
+				assert.ignore();
+			}
+
 			var editor = this.editor;
 
 			this.editorBot.setData( '<p>X</p><p id="w1" data-widget="test2">A</p><p>X</p>', function() {


### PR DESCRIPTION
## What is the purpose of this pull request?

Bug fix.

## Does your PR contain necessary tests?

All patches which change the editor code must include tests. You can always read more
on [PR testing](https://docs.ckeditor.com/ckeditor4/docs/#!/guide/dev_contributing_code-section-tests),
[how to set the testing environment](https://docs.ckeditor.com/ckeditor4/docs/#!/guide/dev_tests) and
[how to create tests](https://docs.ckeditor.com/ckeditor4/docs/#!/guide/dev_tests-section-creating-your-own-test)
in the official CKEditor documentation.

### This PR contains

- [x] Unit tests
- [x] Manual tests

## What changes did you make?

Added condition to prevent deleting focused widget when cutting using `cmd/ctrl + x` keys in read only mode.

Closes #1570
