### PR TITLE
Ignore widgetselection tests on non-webkit browsers.

### DIFF
--- a/tests/plugins/widgetselection/keys.js
+++ b/tests/plugins/widgetselection/keys.js
@@ -23,6 +23,12 @@
 	}
 
 	bender.test( {
+		setUp: function() {
+			if ( !CKEDITOR.env.webkit ) {
+				assert.ignore();
+			}
+		},
+
 		'test `ctrl + a` key combination': function() {
 			var editor = this.editor;
 			this.editorBot.setHtmlWithSelection( '<p contenteditable="false">Non-editable</p><p>This ^is text</p>' );

--- a/tests/plugins/widgetselection/manual/specialcharacters.html
+++ b/tests/plugins/widgetselection/manual/specialcharacters.html
@@ -5,6 +5,9 @@
 </div>
 
 <script>
+	if ( !CKEDITOR.env.webkit ) {
+		bender.ignore();
+	}
 	CKEDITOR.replace( 'editor1', {
 		extraAllowedContent: 'p[contenteditable]'
 	} );


### PR DESCRIPTION
## What is the purpose of this pull request?

Bug (testcase) fix 

### This PR contains

- [ ] Unit tests
- [ ] Manual tests

## What changes did you make?

- ignore tests on non-webkit browsers, as widgetselection only affects webkit browsers.
https://github.com/ckeditor/ckeditor-dev/blob/1e4ca706d26294e969e5048231f18bc5d39b7ff3/plugins/widgetselection/plugin.js#L16-L19

close: #1593 
task which introduced this test suit and issue: #1423