### PR TITLE
Prevented EasyImage from initializing on IE10 and lower

### DIFF
--- a/plugins/easyimage/plugin.js
+++ b/plugins/easyimage/plugin.js
@@ -515,7 +515,7 @@
 		},
 
 		init: function( editor ) {
-			if ( isSupportedBrowser() ) {
+			if ( !isSupportedBrowser() ) {
 				return;
 			}
 			loadStyles( editor, this );
@@ -524,7 +524,7 @@
 		// Widget must be registered after init in case that link plugin is dynamically loaded e.g. via
 		// `config.extraPlugins`.
 		afterInit: function( editor ) {
-			if ( isSupportedBrowser() ) {
+			if ( !isSupportedBrowser() ) {
 				return;
 			}
 			var styles = getStylesForEditor( editor );

--- a/plugins/easyimage/plugin.js
+++ b/plugins/easyimage/plugin.js
@@ -500,6 +500,10 @@
 		}
 	};
 
+	function ieCheck() {
+		return !!( CKEDITOR.env.ie && CKEDITOR.env.version < 11 );
+	}
+
 	CKEDITOR.plugins.add( 'easyimage', {
 		requires: 'imagebase,balloontoolbar,button,dialog,cloudservices',
 		lang: 'en',
@@ -511,12 +515,18 @@
 		},
 
 		init: function( editor ) {
+			if ( ieCheck() ) {
+				return false;
+			}
 			loadStyles( editor, this );
 		},
 
 		// Widget must be registered after init in case that link plugin is dynamically loaded e.g. via
 		// `config.extraPlugins`.
 		afterInit: function( editor ) {
+			if ( ieCheck() ) {
+				return false;
+			}
 			var styles = getStylesForEditor( editor );
 
 			registerWidget( editor, styles );

--- a/plugins/easyimage/plugin.js
+++ b/plugins/easyimage/plugin.js
@@ -500,8 +500,8 @@
 		}
 	};
 
-	function ieCheck() {
-		return !!( CKEDITOR.env.ie && CKEDITOR.env.version < 11 );
+	function isSupportedBrowser() {
+		return !CKEDITOR.env.ie || CKEDITOR.env.version >= 11;
 	}
 
 	CKEDITOR.plugins.add( 'easyimage', {
@@ -515,8 +515,8 @@
 		},
 
 		init: function( editor ) {
-			if ( ieCheck() ) {
-				return false;
+			if ( isSupportedBrowser() ) {
+				return;
 			}
 			loadStyles( editor, this );
 		},
@@ -524,8 +524,8 @@
 		// Widget must be registered after init in case that link plugin is dynamically loaded e.g. via
 		// `config.extraPlugins`.
 		afterInit: function( editor ) {
-			if ( ieCheck() ) {
-				return false;
+			if ( isSupportedBrowser() ) {
+				return;
 			}
 			var styles = getStylesForEditor( editor );
 

--- a/tests/plugins/easyimage/manual/browsersupport.html
+++ b/tests/plugins/easyimage/manual/browsersupport.html
@@ -1,0 +1,20 @@
+<textarea id="editor">
+	<figure class="image easyimage">
+		<img alt="CKEditor logo" src="../_assets/logo.png">
+	</figure>
+	<p>A paragraph with some text.</p>
+	<p>Another paragraph with more text.</p>
+	<p>Next paragraph with even more text.</p>
+	<figure class="image easyimage easyimage-side">
+		<img alt="CKEditor logo" src="../../../_assets/lena.jpg">
+		<figcaption>
+			Test caption.
+		</figcaption>
+	</figure>
+</textarea>
+
+<script>
+	CKEDITOR.replace( 'editor', {
+		height: 500
+	} );
+</script>

--- a/tests/plugins/easyimage/manual/browsersupport.html
+++ b/tests/plugins/easyimage/manual/browsersupport.html
@@ -3,18 +3,8 @@
 		<img alt="CKEditor logo" src="../_assets/logo.png">
 	</figure>
 	<p>A paragraph with some text.</p>
-	<p>Another paragraph with more text.</p>
-	<p>Next paragraph with even more text.</p>
-	<figure class="image easyimage easyimage-side">
-		<img alt="CKEditor logo" src="../../../_assets/lena.jpg">
-		<figcaption>
-			Test caption.
-		</figcaption>
-	</figure>
 </textarea>
 
 <script>
-	CKEDITOR.replace( 'editor', {
-		height: 500
-	} );
+	CKEDITOR.replace( 'editor' );
 </script>

--- a/tests/plugins/easyimage/manual/browsersupport.md
+++ b/tests/plugins/easyimage/manual/browsersupport.md
@@ -1,11 +1,13 @@
 @bender-tags: 4.9.0, bug, 1596
 @bender-ui: collapsed
-@bender-ckeditor-plugins: wysiwygarea, floatingspace, toolbar, easyimage
+@bender-ckeditor-plugins: wysiwygarea, toolbar, easyimage
 
-## EasyImage support for different browsers
+## Easy Image browser support
 
-Do this test on Internet Explorer 10 and lower.
+1. Check the editor contents.
 
 ## Expected
 
-There shouldn't be no EasyImage instances visible in editor.
+**IE8-10**: There is no Easy Image instance visible in editor.
+
+**Other browsers**: Easy Image widget is visible.

--- a/tests/plugins/easyimage/manual/browsersupport.md
+++ b/tests/plugins/easyimage/manual/browsersupport.md
@@ -1,0 +1,11 @@
+@bender-tags: 4.9.0, bug, 1596
+@bender-ui: collapsed
+@bender-ckeditor-plugins: wysiwygarea, floatingspace, toolbar, easyimage
+
+## EasyImage support for different browsers
+
+Do this test on Internet Explorer 10 and lower.
+
+## Expected
+
+There shouldn't be no EasyImage instances visible in editor.


### PR DESCRIPTION
## What is the purpose of this pull request?

Bug fix

## Does your PR contain necessary tests?

All patches which change the editor code must include tests. You can always read more
on [PR testing](https://docs.ckeditor.com/ckeditor4/docs/#!/guide/dev_contributing_code-section-tests),
[how to set the testing environment](https://docs.ckeditor.com/ckeditor4/docs/#!/guide/dev_tests) and
[how to create tests](https://docs.ckeditor.com/ckeditor4/docs/#!/guide/dev_tests-section-creating-your-own-test)
in the official CKEditor documentation.

### This PR contains

- [ ] Unit tests
- [x] Manual tests

## What changes did you make?

Added `return false;` when IE<11 is detected inside `init` and `afterInit`, and added manual test.

Closes #1596 