### PR TITLE
Fixed: Paste notification isn't very straightforward and it might confuse users

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -30,6 +30,7 @@ Fixed Issues:
 * [#1535](https://github.com/ckeditor/ckeditor-dev/issues/1535): Fixed: Improve [Widget](https://ckeditor.com/cke4/addon/widget) mouse over border contrast.
 * [#1516](https://github.com/ckeditor/ckeditor-dev/issues/1516): Fixed: Fake selection allows removing in a readonly mode using `Backspace`/`Delete` keys.
 * [#1570](https://github.com/ckeditor/ckeditor-dev/issues/1570): Fixed: Fake selection allows cutting in a readonly mode using `Ctrl`/`Cmd` + `X` keys.
+* [#1363](https://github.com/ckeditor/ckeditor-dev/issues/1363): Fixed: Paste notification isn't very straightforward and it might confuse users.
 
 API Changes:
 

--- a/plugins/clipboard/lang/af.js
+++ b/plugins/clipboard/lang/af.js
@@ -8,7 +8,7 @@ CKEDITOR.plugins.setLang( 'clipboard', 'af', {
 	cut: 'Knip',
 	cutError: 'U blaaier se sekuriteitsinstelling belet die outomatiese knip-aksie. Gebruik die sleutelbordkombinasie (Ctrl/Cmd+X).',
 	paste: 'Plak',
-	pasteNotification: 'Your browser doesn\'t allow you to paste this way. Press %1 to paste.', // MISSING
+	pasteNotification: 'Press %1 to paste. Your browser doesn‘t support pasting with the toolbar button or context menu option.', // MISSING
 	pasteArea: 'Plak-area',
 	pasteMsg: 'Plak die teks in die volgende teks-area met die sleutelbordkombinasie (<STRONG>Ctrl/Cmd+V</STRONG>) en druk <STRONG>OK</STRONG>.',
 	title: 'Byvoeg'

--- a/plugins/clipboard/lang/ar.js
+++ b/plugins/clipboard/lang/ar.js
@@ -8,7 +8,7 @@ CKEDITOR.plugins.setLang( 'clipboard', 'ar', {
 	cut: 'قص',
 	cutError: 'الإعدادات الأمنية للمتصفح الذي تستخدمه تمنع القص التلقائي. فضلاً إستخدم لوحة المفاتيح لفعل ذلك (Ctrl/Cmd+X).',
 	paste: 'لصق',
-	pasteNotification: 'Your browser doesn\'t allow you to paste this way. Press %1 to paste.', // MISSING
+	pasteNotification: 'Press %1 to paste. Your browser doesn‘t support pasting with the toolbar button or context menu option.', // MISSING
 	pasteArea: 'منطقة اللصق',
 	pasteMsg: 'الصق داخل الصندوق بإستخدام زرائر (<STRONG>Ctrl/Cmd+V</STRONG>) في لوحة المفاتيح، ثم اضغط زر  <STRONG>موافق</STRONG>.',
 	title: 'لصق'

--- a/plugins/clipboard/lang/az.js
+++ b/plugins/clipboard/lang/az.js
@@ -8,7 +8,7 @@ CKEDITOR.plugins.setLang( 'clipboard', 'az', {
 	cut: 'Kəs',
 	cutError: 'Avtomatik kəsmə mümkün deyil. Ctrl+X basın.',
 	paste: 'Əlavə et',
-	pasteNotification: 'Sizin İnternet bələdçisi bu cür mətnin köçürməsi dəstəklənmir. Əlavə etmək üçün %1 basın.',
+	pasteNotification: 'Press %1 to paste. Your browser doesn‘t support pasting with the toolbar button or context menu option.', // MISSING
 	pasteArea: 'Paste Area', // MISSING
 	pasteMsg: 'Please paste inside the following box using the keyboard (<strong>Ctrl/Cmd+V</strong>) and hit OK', // MISSING
 	title: 'Paste' // MISSING

--- a/plugins/clipboard/lang/bg.js
+++ b/plugins/clipboard/lang/bg.js
@@ -8,7 +8,7 @@ CKEDITOR.plugins.setLang( 'clipboard', 'bg', {
 	cut: 'Отрежи',
 	cutError: 'Настройките за сигурност на Вашия браузър не позволяват на редактора автоматично да изъплни действията за отрязване. Моля ползвайте клавиатурните команди за целта (ctrl+x).',
 	paste: 'Вмъкни',
-	pasteNotification: 'Your browser doesn\'t allow you to paste this way. Press %1 to paste.', // MISSING
+	pasteNotification: 'Press %1 to paste. Your browser doesn‘t support pasting with the toolbar button or context menu option.', // MISSING
 	pasteArea: 'Зона за вмъкване',
 	pasteMsg: 'Вмъкнете тук съдъжанието с клавиатуарата (<STRONG>Ctrl/Cmd+V</STRONG>) и натиснете <STRONG>OK</STRONG>.',
 	title: 'Вмъкни'

--- a/plugins/clipboard/lang/bn.js
+++ b/plugins/clipboard/lang/bn.js
@@ -8,7 +8,7 @@ CKEDITOR.plugins.setLang( 'clipboard', 'bn', {
 	cut: 'কাট',
 	cutError: 'আপনার ব্রাউজারের সুরক্ষা সেটিংস এডিটরকে অটোমেটিক কাট করার অনুমতি দেয়নি। দয়া করে এই কাজের জন্য কিবোর্ড ব্যবহার করুন (Ctrl/Cmd+X)।',
 	paste: 'পেস্ট',
-	pasteNotification: 'Your browser doesn\'t allow you to paste this way. Press %1 to paste.', // MISSING
+	pasteNotification: 'Press %1 to paste. Your browser doesn‘t support pasting with the toolbar button or context menu option.', // MISSING
 	pasteArea: 'Paste Area', // MISSING
 	pasteMsg: 'অনুগ্রহ করে নীচের বাক্সে কিবোর্ড ব্যবহার করে (<STRONG>Ctrl/Cmd+V</STRONG>) পেস্ট করুন এবং <STRONG>OK</STRONG> চাপ দিন',
 	title: 'পেস্ট'

--- a/plugins/clipboard/lang/bs.js
+++ b/plugins/clipboard/lang/bs.js
@@ -8,7 +8,7 @@ CKEDITOR.plugins.setLang( 'clipboard', 'bs', {
 	cut: 'Izreži',
 	cutError: 'Sigurnosne postavke vašeg pretraživaèa ne dozvoljavaju operacije automatskog rezanja. Molimo koristite kraticu na tastaturi (Ctrl/Cmd+X).',
 	paste: 'Zalijepi',
-	pasteNotification: 'Your browser doesn\'t allow you to paste this way. Press %1 to paste.', // MISSING
+	pasteNotification: 'Press %1 to paste. Your browser doesn‘t support pasting with the toolbar button or context menu option.', // MISSING
 	pasteArea: 'Paste Area', // MISSING
 	pasteMsg: 'Please paste inside the following box using the keyboard (<strong>Ctrl/Cmd+V</strong>) and hit OK', // MISSING
 	title: 'Zalijepi'

--- a/plugins/clipboard/lang/ca.js
+++ b/plugins/clipboard/lang/ca.js
@@ -8,7 +8,7 @@ CKEDITOR.plugins.setLang( 'clipboard', 'ca', {
 	cut: 'Retallar',
 	cutError: 'La configuració de seguretat del vostre navegador no permet executar automàticament les operacions de retallar. Si us plau, utilitzeu el teclat (Ctrl/Cmd+X).',
 	paste: 'Enganxar',
-	pasteNotification: 'Your browser doesn\'t allow you to paste this way. Press %1 to paste.', // MISSING
+	pasteNotification: 'Press %1 to paste. Your browser doesn‘t support pasting with the toolbar button or context menu option.', // MISSING
 	pasteArea: 'Àrea d\'enganxat',
 	pasteMsg: 'Si us plau, enganxi dins del següent camp utilitzant el teclat (<strong>Ctrl/Cmd+V</strong>) i premi OK.',
 	title: 'Enganxar'

--- a/plugins/clipboard/lang/cs.js
+++ b/plugins/clipboard/lang/cs.js
@@ -8,7 +8,7 @@ CKEDITOR.plugins.setLang( 'clipboard', 'cs', {
 	cut: 'Vyjmout',
 	cutError: 'Bezpečnostní nastavení vašeho prohlížeče nedovolují editoru spustit funkci pro vyjmutí zvoleného textu do schránky. Prosím vyjměte zvolený text do schránky pomocí klávesnice (Ctrl/Cmd+X).',
 	paste: 'Vložit',
-	pasteNotification: 'Your browser doesn\'t allow you to paste this way. Press %1 to paste.', // MISSING
+	pasteNotification: 'Press %1 to paste. Your browser doesn‘t support pasting with the toolbar button or context menu option.', // MISSING
 	pasteArea: 'Oblast vkládání',
 	pasteMsg: 'Do následujícího pole vložte požadovaný obsah pomocí klávesnice (<STRONG>Ctrl/Cmd+V</STRONG>) a stiskněte <STRONG>OK</STRONG>.',
 	title: 'Vložit'

--- a/plugins/clipboard/lang/cy.js
+++ b/plugins/clipboard/lang/cy.js
@@ -8,7 +8,7 @@ CKEDITOR.plugins.setLang( 'clipboard', 'cy', {
 	cut: 'Torri',
 	cutError: 'Nid yw gosodiadau diogelwch eich porwr yn caniatàu\'r golygydd i gynnal \'gweithredoedd torri\' yn awtomatig. Defnyddiwch y bysellfwrdd (Ctrl/Cmd+X).',
 	paste: 'Gludo',
-	pasteNotification: 'Your browser doesn\'t allow you to paste this way. Press %1 to paste.', // MISSING
+	pasteNotification: 'Press %1 to paste. Your browser doesn‘t support pasting with the toolbar button or context menu option.', // MISSING
 	pasteArea: 'Ardal Gludo',
 	pasteMsg: 'Gludwch i mewn i\'r blwch canlynol gan ddefnyddio\'r bysellfwrdd (<strong>Ctrl/Cmd+V</strong>) a phwyso <strong>Iawn</strong>.',
 	title: 'Gludo'

--- a/plugins/clipboard/lang/da.js
+++ b/plugins/clipboard/lang/da.js
@@ -8,7 +8,7 @@ CKEDITOR.plugins.setLang( 'clipboard', 'da', {
 	cut: 'Klip',
 	cutError: 'Din browsers sikkerhedsindstillinger tillader ikke editoren at få automatisk adgang til udklipsholderen.<br><br>Brug i stedet tastaturet til at klippe teksten (Ctrl/Cmd+X).',
 	paste: 'Indsæt',
-	pasteNotification: 'Your browser doesn\'t allow you to paste this way. Press %1 to paste.', // MISSING
+	pasteNotification: 'Press %1 to paste. Your browser doesn‘t support pasting with the toolbar button or context menu option.', // MISSING
 	pasteArea: 'Indsæt område',
 	pasteMsg: 'Indsæt i feltet herunder (<STRONG>Ctrl/Cmd+V</STRONG>) og klik på <STRONG>OK</STRONG>.',
 	title: 'Indsæt'

--- a/plugins/clipboard/lang/de-ch.js
+++ b/plugins/clipboard/lang/de-ch.js
@@ -8,7 +8,7 @@ CKEDITOR.plugins.setLang( 'clipboard', 'de-ch', {
 	cut: 'Ausschneiden',
 	cutError: 'Die Sicherheitseinstellungen Ihres Browsers lassen es nicht zu, den Text automatisch auszuschneiden. Bitte benutzen Sie die System-Zwischenablage über STRG-X (ausschneiden) und STRG-V (einfügen).',
 	paste: 'Einfügen',
-	pasteNotification: 'Your browser doesn\'t allow you to paste this way. Press %1 to paste.', // MISSING
+	pasteNotification: 'Press %1 to paste. Your browser doesn‘t support pasting with the toolbar button or context menu option.', // MISSING
 	pasteArea: 'Einfügebereich',
 	pasteMsg: 'Bitte fügen Sie den Text in der folgenden Box über die Tastatur (mit <STRONG>Strg+V</STRONG>) ein und bestätigen Sie mit <STRONG>OK</STRONG>.',
 	title: 'Einfügen'

--- a/plugins/clipboard/lang/de.js
+++ b/plugins/clipboard/lang/de.js
@@ -8,7 +8,7 @@ CKEDITOR.plugins.setLang( 'clipboard', 'de', {
 	cut: 'Ausschneiden',
 	cutError: 'Die Sicherheitseinstellungen Ihres Browsers lassen es nicht zu, den Text automatisch auszuschneiden. Bitte benutzen Sie die System-Zwischenablage über STRG-X (ausschneiden) und STRG-V (einfügen).',
 	paste: 'Einfügen',
-	pasteNotification: 'Ihr Browser verhindert das Einfügen über diesen Weg. Zum einfügen drücken Sie %1.',
+	pasteNotification: 'Press %1 to paste. Your browser doesn‘t support pasting with the toolbar button or context menu option.', // MISSING
 	pasteArea: 'Einfügebereich',
 	pasteMsg: 'Bitte fügen Sie den Text in der folgenden Box über die Tastatur (mit <STRONG>Strg+V</STRONG>) ein und bestätigen Sie mit <STRONG>OK</STRONG>.',
 	title: 'Einfügen'

--- a/plugins/clipboard/lang/el.js
+++ b/plugins/clipboard/lang/el.js
@@ -8,7 +8,7 @@ CKEDITOR.plugins.setLang( 'clipboard', 'el', {
 	cut: 'Αποκοπή',
 	cutError: 'Οι ρυθμίσεις ασφαλείας του περιηγητή σας δεν επιτρέπουν την επιλεγμένη εργασία αποκοπής. Παρακαλώ χρησιμοποιείστε το πληκτρολόγιο (Ctrl/Cmd+X).',
 	paste: 'Επικόλληση',
-	pasteNotification: 'Ο περιηγητής σας δεν σας επιτρέπει να επικολλήσετε με αυτόν τον τρόπο. Πατήστε %1 για επικόλληση.',
+	pasteNotification: 'Press %1 to paste. Your browser doesn‘t support pasting with the toolbar button or context menu option.', // MISSING
 	pasteArea: 'Περιοχή Επικόλλησης',
 	pasteMsg: 'Παρακαλώ επικολλήστε στο ακόλουθο κουτί χρησιμοποιώντας το πληκτρολόγιο (<strong>Ctrl/Cmd+V</strong>) και πατήστε OK.',
 	title: 'Επικόλληση'

--- a/plugins/clipboard/lang/en-au.js
+++ b/plugins/clipboard/lang/en-au.js
@@ -8,7 +8,7 @@ CKEDITOR.plugins.setLang( 'clipboard', 'en-au', {
 	cut: 'Cut',
 	cutError: 'Your browser security settings don\'t permit the editor to automatically execute cutting operations. Please use the keyboard for that (Ctrl/Cmd+X).',
 	paste: 'Paste',
-	pasteNotification: 'Your browser doesn\'t allow you to paste this way. Press %1 to paste.',
+	pasteNotification: 'Press %1 to paste. Your browser doesn‘t support pasting with the toolbar button or context menu option.', // MISSING
 	pasteArea: 'Paste Area', // MISSING
 	pasteMsg: 'Please paste inside the following box using the keyboard (<strong>Ctrl/Cmd+V</strong>) and hit OK',
 	title: 'Paste'

--- a/plugins/clipboard/lang/en-ca.js
+++ b/plugins/clipboard/lang/en-ca.js
@@ -8,7 +8,7 @@ CKEDITOR.plugins.setLang( 'clipboard', 'en-ca', {
 	cut: 'Cut',
 	cutError: 'Your browser security settings don\'t permit the editor to automatically execute cutting operations. Please use the keyboard for that (Ctrl/Cmd+X).',
 	paste: 'Paste',
-	pasteNotification: 'Your browser doesn\'t allow you to paste this way. Press %1 to paste.', // MISSING
+	pasteNotification: 'Press %1 to paste. Your browser doesn‘t support pasting with the toolbar button or context menu option.', // MISSING
 	pasteArea: 'Paste Area', // MISSING
 	pasteMsg: 'Please paste inside the following box using the keyboard (<strong>Ctrl/Cmd+V</strong>) and hit OK',
 	title: 'Paste'

--- a/plugins/clipboard/lang/en-gb.js
+++ b/plugins/clipboard/lang/en-gb.js
@@ -8,7 +8,7 @@ CKEDITOR.plugins.setLang( 'clipboard', 'en-gb', {
 	cut: 'Cut',
 	cutError: 'Your browser security settings don\'t permit the editor to automatically execute cutting operations. Please use the keyboard for that (Ctrl/Cmd+X).',
 	paste: 'Paste',
-	pasteNotification: 'Your browser doesn\'t allow you to paste this way. Press %1 to paste.', // MISSING
+	pasteNotification: 'Press %1 to paste. Your browser doesn‘t support pasting with the toolbar button or context menu option.', // MISSING
 	pasteArea: 'Paste Area',
 	pasteMsg: 'Please paste inside the following box using the keyboard (<strong>Ctrl/Cmd+V</strong>) and hit OK',
 	title: 'Paste'

--- a/plugins/clipboard/lang/en.js
+++ b/plugins/clipboard/lang/en.js
@@ -8,7 +8,7 @@ CKEDITOR.plugins.setLang( 'clipboard', 'en', {
 	cut: 'Cut',
 	cutError: 'Your browser security settings don\'t permit the editor to automatically execute cutting operations. Please use the keyboard for that (Ctrl/Cmd+X).',
 	paste: 'Paste',
-	pasteNotification: 'Your browser doesn\'t allow you to paste this way. Press %1 to paste.',
+	pasteNotification: 'Press %1 to paste. Your browser doesn‘t support pasting with the toolbar button or context menu option.',
 	pasteArea: 'Paste Area',
 	pasteMsg: 'Please paste inside the following box and hit OK',
 	title: 'Paste'

--- a/plugins/clipboard/lang/eo.js
+++ b/plugins/clipboard/lang/eo.js
@@ -8,7 +8,7 @@ CKEDITOR.plugins.setLang( 'clipboard', 'eo', {
 	cut: 'Eltondi',
 	cutError: 'La sekurecagordo de via TTT-legilo ne permesas, ke la redaktilo faras eltondajn operaciojn. Bonvolu uzi la klavaron por tio (Ctrl/Cmd-X).',
 	paste: 'Interglui',
-	pasteNotification: 'Your browser doesn\'t allow you to paste this way. Press %1 to paste.', // MISSING
+	pasteNotification: 'Press %1 to paste. Your browser doesn‘t support pasting with the toolbar button or context menu option.', // MISSING
 	pasteArea: 'Intergluoareo',
 	pasteMsg: 'Bonvolu glui la tekston en la jenan areon per uzado de la klavaro (<strong>Ctrl/Cmd+V</strong>) kaj premu OK',
 	title: 'Interglui'

--- a/plugins/clipboard/lang/es-mx.js
+++ b/plugins/clipboard/lang/es-mx.js
@@ -8,7 +8,7 @@ CKEDITOR.plugins.setLang( 'clipboard', 'es-mx', {
 	cut: 'Cortar',
 	cutError: 'La configuración de seguridad de su navegador no permite al editor ejecutar automáticamente operaciones de corte. Por favor, utilice el teclado para (Ctrl/Cmd+X).',
 	paste: 'Pegar',
-	pasteNotification: 'Tu navegador no permite pegar de esta manera. Presiona %1 para pegar.',
+	pasteNotification: 'Press %1 to paste. Your browser doesn‘t support pasting with the toolbar button or context menu option.', // MISSING
 	pasteArea: 'Paste Area', // MISSING
 	pasteMsg: 'Please paste inside the following box using the keyboard (<strong>Ctrl/Cmd+V</strong>) and hit OK', // MISSING
 	title: 'Paste' // MISSING

--- a/plugins/clipboard/lang/es.js
+++ b/plugins/clipboard/lang/es.js
@@ -8,7 +8,7 @@ CKEDITOR.plugins.setLang( 'clipboard', 'es', {
 	cut: 'Cortar',
 	cutError: 'La configuración de seguridad de este navegador no permite la ejecución automática de operaciones de cortado.\r\nPor favor use el teclado (Ctrl/Cmd+X).',
 	paste: 'Pegar',
-	pasteNotification: 'Your browser doesn\'t allow you to paste this way. Press %1 to paste.', // MISSING
+	pasteNotification: 'Press %1 to paste. Your browser doesn‘t support pasting with the toolbar button or context menu option.', // MISSING
 	pasteArea: 'Zona de pegado',
 	pasteMsg: 'Por favor pegue dentro del cuadro utilizando el teclado (<STRONG>Ctrl/Cmd+V</STRONG>);\r\nluego presione <STRONG>Aceptar</STRONG>.',
 	title: 'Pegar'

--- a/plugins/clipboard/lang/et.js
+++ b/plugins/clipboard/lang/et.js
@@ -8,7 +8,7 @@ CKEDITOR.plugins.setLang( 'clipboard', 'et', {
 	cut: 'Lõika',
 	cutError: 'Sinu veebisirvija turvaseaded ei luba redaktoril automaatselt lõigata. Palun kasutage selleks klaviatuuri klahvikombinatsiooni (Ctrl/Cmd+X).',
 	paste: 'Aseta',
-	pasteNotification: 'Your browser doesn\'t allow you to paste this way. Press %1 to paste.', // MISSING
+	pasteNotification: 'Press %1 to paste. Your browser doesn‘t support pasting with the toolbar button or context menu option.', // MISSING
 	pasteArea: 'Asetamise ala',
 	pasteMsg: 'Palun aseta tekst järgnevasse kasti kasutades klaviatuuri klahvikombinatsiooni (<STRONG>Ctrl/Cmd+V</STRONG>) ja vajuta seejärel <STRONG>OK</STRONG>.',
 	title: 'Asetamine'

--- a/plugins/clipboard/lang/eu.js
+++ b/plugins/clipboard/lang/eu.js
@@ -8,7 +8,7 @@ CKEDITOR.plugins.setLang( 'clipboard', 'eu', {
 	cut: 'Ebaki',
 	cutError: 'Zure web nabigatzailearen segurtasun ezarpenek ez dute baimentzen testuak automatikoki moztea. Mesedez teklatua erabil ezazu (Ctrl/Cmd+X).',
 	paste: 'Itsatsi',
-	pasteNotification: 'Your browser doesn\'t allow you to paste this way. Press %1 to paste.', // MISSING
+	pasteNotification: 'Press %1 to paste. Your browser doesn‘t support pasting with the toolbar button or context menu option.', // MISSING
 	pasteArea: 'Itsasteko area',
 	pasteMsg: 'Mesedez teklatua erabiliz (<strong>Ctrl/Cmd+V</strong>) ondorengo eremuan testua itsatsi eta sakatu <strong>Ados</strong>.',
 	title: 'Itsatsi'

--- a/plugins/clipboard/lang/fa.js
+++ b/plugins/clipboard/lang/fa.js
@@ -8,7 +8,7 @@ CKEDITOR.plugins.setLang( 'clipboard', 'fa', {
 	cut: 'برش',
 	cutError: 'تنظیمات امنیتی مرورگر شما اجازه نمیدهد که ویرایشگر به طور خودکار عملکردهای برش را انجام دهد. لطفا با دکمههای صفحه کلید این کار را انجام دهید (Ctrl/Cmd+X).',
 	paste: 'چسباندن',
-	pasteNotification: 'Your browser doesn\'t allow you to paste this way. Press %1 to paste.', // MISSING
+	pasteNotification: 'Press %1 to paste. Your browser doesn‘t support pasting with the toolbar button or context menu option.', // MISSING
 	pasteArea: 'محل چسباندن',
 	pasteMsg: 'لطفا متن را با کلیدهای (<STRONG>Ctrl/Cmd+V</STRONG>) در این جعبهٴ متنی بچسبانید و <STRONG>پذیرش</STRONG> را بزنید.',
 	title: 'چسباندن'

--- a/plugins/clipboard/lang/fi.js
+++ b/plugins/clipboard/lang/fi.js
@@ -8,7 +8,7 @@ CKEDITOR.plugins.setLang( 'clipboard', 'fi', {
 	cut: 'Leikkaa',
 	cutError: 'Selaimesi turva-asetukset eivät salli editorin toteuttaa leikkaamista. Käytä näppäimistöä leikkaamiseen (Ctrl+X).',
 	paste: 'Liitä',
-	pasteNotification: 'Your browser doesn\'t allow you to paste this way. Press %1 to paste.', // MISSING
+	pasteNotification: 'Press %1 to paste. Your browser doesn‘t support pasting with the toolbar button or context menu option.', // MISSING
 	pasteArea: 'Leikealue',
 	pasteMsg: 'Liitä painamalla (<STRONG>Ctrl+V</STRONG>) ja painamalla <STRONG>OK</STRONG>.',
 	title: 'Liitä'

--- a/plugins/clipboard/lang/fo.js
+++ b/plugins/clipboard/lang/fo.js
@@ -8,7 +8,7 @@ CKEDITOR.plugins.setLang( 'clipboard', 'fo', {
 	cut: 'Kvett',
 	cutError: 'Trygdaruppseting alnótskagans forðar tekstviðgeranum í at kvetta tekstin. Vinarliga nýt knappaborðið til at kvetta tekstin (Ctrl/Cmd+X).',
 	paste: 'Innrita',
-	pasteNotification: 'Your browser doesn\'t allow you to paste this way. Press %1 to paste.', // MISSING
+	pasteNotification: 'Press %1 to paste. Your browser doesn‘t support pasting with the toolbar button or context menu option.', // MISSING
 	pasteArea: 'Avritingarumráði',
 	pasteMsg: 'Vinarliga koyr tekstin í hendan rútin við knappaborðinum (<strong>Ctrl/Cmd+V</strong>) og klikk á <strong>Góðtak</strong>.',
 	title: 'Innrita'

--- a/plugins/clipboard/lang/fr-ca.js
+++ b/plugins/clipboard/lang/fr-ca.js
@@ -8,7 +8,7 @@ CKEDITOR.plugins.setLang( 'clipboard', 'fr-ca', {
 	cut: 'Couper',
 	cutError: 'Les paramètres de sécurité de votre navigateur empêchent l\'éditeur de couper automatiquement vos données. Veuillez utiliser les équivalents claviers (Ctrl/Cmd+X).',
 	paste: 'Coller',
-	pasteNotification: 'Your browser doesn\'t allow you to paste this way. Press %1 to paste.', // MISSING
+	pasteNotification: 'Press %1 to paste. Your browser doesn‘t support pasting with the toolbar button or context menu option.', // MISSING
 	pasteArea: 'Coller la zone',
 	pasteMsg: 'Veuillez coller dans la zone ci-dessous en utilisant le clavier (<STRONG>Ctrl/Cmd+V</STRONG>) et appuyer sur <STRONG>OK</STRONG>.',
 	title: 'Coller'

--- a/plugins/clipboard/lang/fr.js
+++ b/plugins/clipboard/lang/fr.js
@@ -8,7 +8,7 @@ CKEDITOR.plugins.setLang( 'clipboard', 'fr', {
 	cut: 'Couper',
 	cutError: 'Les paramètres de sécurité de votre navigateur n\'autorisent pas l\'éditeur à exécuter automatiquement l\'opération « Couper ». Veuillez utiliser le raccourci clavier à cet effet (Ctrl/Cmd+X).',
 	paste: 'Coller',
-	pasteNotification: 'Your browser doesn\'t allow you to paste this way. Press %1 to paste.', // MISSING
+	pasteNotification: 'Press %1 to paste. Your browser doesn‘t support pasting with the toolbar button or context menu option.', // MISSING
 	pasteArea: 'Coller la zone',
 	pasteMsg: 'Veuillez coller le texte dans la zone suivante en utilisant le raccourci clavier (<strong>Ctrl/Cmd+V</strong>) et cliquez sur OK.',
 	title: 'Coller'

--- a/plugins/clipboard/lang/gl.js
+++ b/plugins/clipboard/lang/gl.js
@@ -8,7 +8,7 @@ CKEDITOR.plugins.setLang( 'clipboard', 'gl', {
 	cut: 'Cortar',
 	cutError: 'Os axustes de seguranza do seu navegador non permiten que o editor realice automaticamente as tarefas de corte. Use o teclado para iso (Ctrl/Cmd+X).',
 	paste: 'Pegar',
-	pasteNotification: 'O seu navegador non permite pegar deste xeito. Prema %1 para pegar.',
+	pasteNotification: 'Press %1 to paste. Your browser doesn‘t support pasting with the toolbar button or context menu option.', // MISSING
 	pasteArea: 'Zona de pegado',
 	pasteMsg: 'Pegue dentro do seguinte cadro usando o teclado (<STRONG>Ctrl/Cmd+V</STRONG>) e prema en Aceptar',
 	title: 'Pegar'

--- a/plugins/clipboard/lang/gu.js
+++ b/plugins/clipboard/lang/gu.js
@@ -8,7 +8,7 @@ CKEDITOR.plugins.setLang( 'clipboard', 'gu', {
 	cut: 'કાપવું',
 	cutError: 'તમારા બ્રાઉઝર ની સુરક્ષિત સેટિંગસ કટ કરવાની પરવાનગી નથી આપતી. (Ctrl/Cmd+X) નો ઉપયોગ કરો.',
 	paste: 'પેસ્ટ',
-	pasteNotification: 'Your browser doesn\'t allow you to paste this way. Press %1 to paste.', // MISSING
+	pasteNotification: 'Press %1 to paste. Your browser doesn‘t support pasting with the toolbar button or context menu option.', // MISSING
 	pasteArea: 'પેસ્ટ કરવાની જગ્યા',
 	pasteMsg: 'Ctrl/Cmd+V નો પ્રયોગ કરી પેસ્ટ કરો',
 	title: 'પેસ્ટ'

--- a/plugins/clipboard/lang/he.js
+++ b/plugins/clipboard/lang/he.js
@@ -8,7 +8,7 @@ CKEDITOR.plugins.setLang( 'clipboard', 'he', {
 	cut: 'גזירה',
 	cutError: 'הגדרות האבטחה בדפדפן שלך לא מאפשרות לעורך לבצע פעולות גזירה אוטומטיות. יש להשתמש במקלדת לשם כך (Ctrl/Cmd+X).',
 	paste: 'הדבקה',
-	pasteNotification: 'Your browser doesn\'t allow you to paste this way. Press %1 to paste.', // MISSING
+	pasteNotification: 'Press %1 to paste. Your browser doesn‘t support pasting with the toolbar button or context menu option.', // MISSING
 	pasteArea: 'איזור הדבקה',
 	pasteMsg: 'נא להדביק בתוך הקופסה באמצעות (<b>Ctrl/Cmd+V</b>) וללחוץ על <b>אישור</b>.',
 	title: 'הדבקה'

--- a/plugins/clipboard/lang/hi.js
+++ b/plugins/clipboard/lang/hi.js
@@ -8,7 +8,7 @@ CKEDITOR.plugins.setLang( 'clipboard', 'hi', {
 	cut: 'कट',
 	cutError: 'आपके ब्राउज़र की सुरक्षा सॅटिन्ग्स ने कट करने की अनुमति नहीं प्रदान की है। (Ctrl/Cmd+X) का प्रयोग करें।',
 	paste: 'पेस्ट',
-	pasteNotification: 'Your browser doesn\'t allow you to paste this way. Press %1 to paste.', // MISSING
+	pasteNotification: 'Press %1 to paste. Your browser doesn‘t support pasting with the toolbar button or context menu option.', // MISSING
 	pasteArea: 'Paste Area', // MISSING
 	pasteMsg: 'Ctrl/Cmd+V का प्रयोग करके पेस्ट करें और ठीक है करें.',
 	title: 'पेस्ट'

--- a/plugins/clipboard/lang/hr.js
+++ b/plugins/clipboard/lang/hr.js
@@ -8,7 +8,7 @@ CKEDITOR.plugins.setLang( 'clipboard', 'hr', {
 	cut: 'Izreži',
 	cutError: 'Sigurnosne postavke Vašeg pretraživača ne dozvoljavaju operacije automatskog izrezivanja. Molimo koristite kraticu na tipkovnici (Ctrl/Cmd+X).',
 	paste: 'Zalijepi',
-	pasteNotification: 'Vaš preglednik Vam ne dozvoljava lijepljenje na ovaj način. Za lijepljenje, pritisnite %1.',
+	pasteNotification: 'Press %1 to paste. Your browser doesn‘t support pasting with the toolbar button or context menu option.', // MISSING
 	pasteArea: 'Prostor za ljepljenje',
 	pasteMsg: 'Molimo zaljepite unutar doljnjeg okvira koristeći tipkovnicu (<STRONG>Ctrl/Cmd+V</STRONG>) i kliknite <STRONG>OK</STRONG>.',
 	title: 'Zalijepi'

--- a/plugins/clipboard/lang/hu.js
+++ b/plugins/clipboard/lang/hu.js
@@ -8,7 +8,7 @@ CKEDITOR.plugins.setLang( 'clipboard', 'hu', {
 	cut: 'Kivágás',
 	cutError: 'A böngésző biztonsági beállításai nem engedélyezik a szerkesztőnek, hogy végrehajtsa a kivágás műveletet. Használja az alábbi billentyűkombinációt (Ctrl/Cmd+X).',
 	paste: 'Beillesztés',
-	pasteNotification: 'Your browser doesn\'t allow you to paste this way. Press %1 to paste.', // MISSING
+	pasteNotification: 'Press %1 to paste. Your browser doesn‘t support pasting with the toolbar button or context menu option.', // MISSING
 	pasteArea: 'Beszúrás mező',
 	pasteMsg: 'Másolja be az alábbi mezőbe a <STRONG>Ctrl/Cmd+V</STRONG> billentyűk lenyomásával, majd nyomjon <STRONG>Rendben</STRONG>-t.',
 	title: 'Beillesztés'

--- a/plugins/clipboard/lang/id.js
+++ b/plugins/clipboard/lang/id.js
@@ -8,7 +8,7 @@ CKEDITOR.plugins.setLang( 'clipboard', 'id', {
 	cut: 'Potong',
 	cutError: 'Your browser security settings don\'t permit the editor to automatically execute cutting operations. Please use the keyboard for that (Ctrl/Cmd+X).', // MISSING
 	paste: 'Tempel',
-	pasteNotification: 'Your browser doesn\'t allow you to paste this way. Press %1 to paste.', // MISSING
+	pasteNotification: 'Press %1 to paste. Your browser doesn‘t support pasting with the toolbar button or context menu option.', // MISSING
 	pasteArea: 'Area Tempel',
 	pasteMsg: 'Please paste inside the following box using the keyboard (<strong>Ctrl/Cmd+V</strong>) and hit OK', // MISSING
 	title: 'Tempel'

--- a/plugins/clipboard/lang/is.js
+++ b/plugins/clipboard/lang/is.js
@@ -8,7 +8,7 @@ CKEDITOR.plugins.setLang( 'clipboard', 'is', {
 	cut: 'Klippa',
 	cutError: 'Öryggisstillingar vafrans þíns leyfa ekki klippingu texta með músaraðgerð. Notaðu lyklaborðið í klippa (Ctrl/Cmd+X).',
 	paste: 'Líma',
-	pasteNotification: 'Your browser doesn\'t allow you to paste this way. Press %1 to paste.', // MISSING
+	pasteNotification: 'Press %1 to paste. Your browser doesn‘t support pasting with the toolbar button or context menu option.', // MISSING
 	pasteArea: 'Paste Area', // MISSING
 	pasteMsg: 'Límdu í svæðið hér að neðan og (<STRONG>Ctrl/Cmd+V</STRONG>) og smelltu á <STRONG>OK</STRONG>.',
 	title: 'Líma'

--- a/plugins/clipboard/lang/it.js
+++ b/plugins/clipboard/lang/it.js
@@ -8,7 +8,7 @@ CKEDITOR.plugins.setLang( 'clipboard', 'it', {
 	cut: 'Taglia',
 	cutError: 'Le impostazioni di sicurezza del browser non permettono di tagliare automaticamente il testo. Usa la tastiera (Ctrl/Cmd+X).',
 	paste: 'Incolla',
-	pasteNotification: 'Il browser non permette di incollare in questo modo. Premere %1 per incollare.',
+	pasteNotification: 'Press %1 to paste. Your browser doesn‘t support pasting with the toolbar button or context menu option.', // MISSING
 	pasteArea: 'Incolla',
 	pasteMsg: 'Incolla il testo all\'interno dell\'area sottostante usando la scorciatoia di tastiere (<STRONG>Ctrl/Cmd+V</STRONG>) e premi <STRONG>OK</STRONG>.',
 	title: 'Incolla'

--- a/plugins/clipboard/lang/ja.js
+++ b/plugins/clipboard/lang/ja.js
@@ -8,7 +8,7 @@ CKEDITOR.plugins.setLang( 'clipboard', 'ja', {
 	cut: '切り取り',
 	cutError: 'ブラウザーのセキュリティ設定によりエディタの切り取り操作を自動で実行することができません。実行するには手動でキーボードの(Ctrl/Cmd+X)を使用してください。',
 	paste: '貼り付け',
-	pasteNotification: 'ブラウザの設定によりこの方法で貼り付けることはできません。手動で実行するにはキーボードの「%1」を押してください。',
+	pasteNotification: 'Press %1 to paste. Your browser doesn‘t support pasting with the toolbar button or context menu option.', // MISSING
 	pasteArea: '貼り付け場所',
 	pasteMsg: 'キーボード(<STRONG>Ctrl/Cmd+V</STRONG>)を使用して、次の入力エリア内で貼り付けて、<STRONG>OK</STRONG>を押してください。',
 	title: '貼り付け'

--- a/plugins/clipboard/lang/ka.js
+++ b/plugins/clipboard/lang/ka.js
@@ -8,7 +8,7 @@ CKEDITOR.plugins.setLang( 'clipboard', 'ka', {
 	cut: 'ამოჭრა',
 	cutError: 'თქვენი ბროუზერის უსაფრთხოების პარამეტრები არ იძლევა ამოჭრის ოპერაციის ავტომატურად განხორციელების საშუალებას. გამოიყენეთ კლავიატურა ამისთვის (Ctrl/Cmd+X).',
 	paste: 'ჩასმა',
-	pasteNotification: 'Your browser doesn\'t allow you to paste this way. Press %1 to paste.', // MISSING
+	pasteNotification: 'Press %1 to paste. Your browser doesn‘t support pasting with the toolbar button or context menu option.', // MISSING
 	pasteArea: 'ჩასმის არე',
 	pasteMsg: 'ჩასვით ამ არის შიგნით კლავიატურის გამოყენებით (<strong>Ctrl/Cmd+V</strong>) და დააჭირეთ OK-ს',
 	title: 'ჩასმა'

--- a/plugins/clipboard/lang/km.js
+++ b/plugins/clipboard/lang/km.js
@@ -8,7 +8,7 @@ CKEDITOR.plugins.setLang( 'clipboard', 'km', {
 	cut: 'កាត់យក',
 	cutError: 'ការកំណត់សុវត្ថភាពរបស់កម្មវិធីរុករករបស់លោកអ្នក នេះ​មិនអាចធ្វើកម្មវិធីតាក់តែងអត្ថបទ កាត់អត្ថបទយកដោយស្វ័យប្រវត្តបានឡើយ ។ សូមប្រើប្រាស់បន្សំ ឃីដូចនេះ  (Ctrl/Cmd+X) ។',
 	paste: 'បិទ​ភ្ជាប់',
-	pasteNotification: 'Your browser doesn\'t allow you to paste this way. Press %1 to paste.', // MISSING
+	pasteNotification: 'Press %1 to paste. Your browser doesn‘t support pasting with the toolbar button or context menu option.', // MISSING
 	pasteArea: 'តំបន់​បិទ​ភ្ជាប់',
 	pasteMsg: 'សូមចំលងអត្ថបទទៅដាក់ក្នុងប្រអប់ដូចខាងក្រោមដោយប្រើប្រាស់ ឃី ​(<STRONG>Ctrl/Cmd+V</STRONG>) ហើយចុច <STRONG>OK</STRONG> ។',
 	title: 'បិទ​ភ្ជាប់'

--- a/plugins/clipboard/lang/ko.js
+++ b/plugins/clipboard/lang/ko.js
@@ -8,7 +8,7 @@ CKEDITOR.plugins.setLang( 'clipboard', 'ko', {
 	cut: '잘라내기',
 	cutError: '브라우저의 보안설정 때문에 잘라내기 기능을 실행할 수 없습니다. 키보드(Ctrl/Cmd+X)를 이용해서 잘라내기 하십시오',
 	paste: '붙여넣기',
-	pasteNotification: 'Your browser doesn\'t allow you to paste this way. Press %1 to paste.', // MISSING
+	pasteNotification: 'Press %1 to paste. Your browser doesn‘t support pasting with the toolbar button or context menu option.', // MISSING
 	pasteArea: '붙여넣기 범위',
 	pasteMsg: '키보드(<strong>Ctrl/Cmd+V</strong>)를 이용해서 상자안에 붙여넣고 <strong>확인</strong> 를 누르세요.',
 	title: '붙여넣기'

--- a/plugins/clipboard/lang/ku.js
+++ b/plugins/clipboard/lang/ku.js
@@ -8,7 +8,7 @@ CKEDITOR.plugins.setLang( 'clipboard', 'ku', {
 	cut: 'بڕین',
 	cutError: 'پارێزی وێبگەڕەکەت ڕێگەنادات بە سەرنووسەکە لەبڕینی خۆکارانە. تکایە لەبری ئەمە ئەم فەرمانە بەکاربهێنە بەداگرتنی کلیلی (Ctrl/Cmd+X).',
 	paste: 'لکاندن',
-	pasteNotification: 'وێبگەڕەکەت ڕێگەت پێنادات بۆ لکاندنی تێکست بە ڕێگایە. کلیکی %1 بۆ لکاندن.',
+	pasteNotification: 'Press %1 to paste. Your browser doesn‘t support pasting with the toolbar button or context menu option.', // MISSING
 	pasteArea: 'ناوچەی لکاندن',
 	pasteMsg: 'تکایە بیلکێنە لەناوەوەی ئەم سنوقە لەڕێی تەختەکلیلەکەت بە بەکارهێنانی کلیلی (<STRONG>Ctrl/Cmd+V</STRONG>) دووای کلیکی باشە بکە.',
 	title: 'لکاندن'

--- a/plugins/clipboard/lang/lt.js
+++ b/plugins/clipboard/lang/lt.js
@@ -8,7 +8,7 @@ CKEDITOR.plugins.setLang( 'clipboard', 'lt', {
 	cut: 'Iškirpti',
 	cutError: 'Jūsų naršyklės saugumo nustatymai neleidžia redaktoriui automatiškai įvykdyti iškirpimo operacijų. Tam prašome naudoti klaviatūrą (Ctrl/Cmd+X).',
 	paste: 'Įdėti',
-	pasteNotification: 'Your browser doesn\'t allow you to paste this way. Press %1 to paste.', // MISSING
+	pasteNotification: 'Press %1 to paste. Your browser doesn‘t support pasting with the toolbar button or context menu option.', // MISSING
 	pasteArea: 'Įkelti dalį',
 	pasteMsg: 'Žemiau esančiame įvedimo lauke įdėkite tekstą, naudodami klaviatūrą (<STRONG>Ctrl/Cmd+V</STRONG>) ir paspauskite mygtuką <STRONG>OK</STRONG>.',
 	title: 'Įdėti'

--- a/plugins/clipboard/lang/lv.js
+++ b/plugins/clipboard/lang/lv.js
@@ -8,7 +8,7 @@ CKEDITOR.plugins.setLang( 'clipboard', 'lv', {
 	cut: 'Izgriezt',
 	cutError: 'Jūsu pārlūkprogrammas drošības iestatījumi nepieļauj redaktoram automātiski veikt izgriezšanas darbību.  Lūdzu, izmantojiet (Ctrl/Cmd+X), lai veiktu šo darbību.',
 	paste: 'Ielīmēt',
-	pasteNotification: 'Your browser doesn\'t allow you to paste this way. Press %1 to paste.', // MISSING
+	pasteNotification: 'Press %1 to paste. Your browser doesn‘t support pasting with the toolbar button or context menu option.', // MISSING
 	pasteArea: 'Ielīmēšanas zona',
 	pasteMsg: 'Lūdzu, ievietojiet tekstu šajā laukumā, izmantojot klaviatūru (<STRONG>Ctrl/Cmd+V</STRONG>) un apstipriniet ar <STRONG>Darīts!</STRONG>.',
 	title: 'Ievietot'

--- a/plugins/clipboard/lang/mk.js
+++ b/plugins/clipboard/lang/mk.js
@@ -8,7 +8,7 @@ CKEDITOR.plugins.setLang( 'clipboard', 'mk', {
 	cut: 'Исечи (Cut)',
 	cutError: 'Опциите за безбедност на вашиот прелистувач не дозволуваат уредувачот автоматски да изврши сечење. Ве молиме употребете ја тастатурата. (Ctrl/Cmd+C)',
 	paste: 'Залепи (Paste)',
-	pasteNotification: 'Your browser doesn\'t allow you to paste this way. Press %1 to paste.', // MISSING
+	pasteNotification: 'Press %1 to paste. Your browser doesn‘t support pasting with the toolbar button or context menu option.', // MISSING
 	pasteArea: 'Простор за залепување',
 	pasteMsg: 'Ве молиме да залепите во следниот квадрат користејќи ја тастатурата (<string>Ctrl/Cmd+V</string>) и да притиснете OK',
 	title: 'Залепи (Paste)'

--- a/plugins/clipboard/lang/mn.js
+++ b/plugins/clipboard/lang/mn.js
@@ -8,7 +8,7 @@ CKEDITOR.plugins.setLang( 'clipboard', 'mn', {
 	cut: 'Хайчлах',
 	cutError: 'Таны browser-ын хамгаалалтын тохиргоо editor-д автоматаар хайчлах үйлдэлийг зөвшөөрөхгүй байна. (Ctrl/Cmd+X) товчны хослолыг ашиглана уу.',
 	paste: 'Буулгах',
-	pasteNotification: 'Your browser doesn\'t allow you to paste this way. Press %1 to paste.', // MISSING
+	pasteNotification: 'Press %1 to paste. Your browser doesn‘t support pasting with the toolbar button or context menu option.', // MISSING
 	pasteArea: 'Paste Area', // MISSING
 	pasteMsg: '(<strong>Ctrl/Cmd+V</strong>) товчийг ашиглан paste хийнэ үү. Мөн <strong>OK</strong> дар.',
 	title: 'Буулгах'

--- a/plugins/clipboard/lang/ms.js
+++ b/plugins/clipboard/lang/ms.js
@@ -8,7 +8,7 @@ CKEDITOR.plugins.setLang( 'clipboard', 'ms', {
 	cut: 'Potong',
 	cutError: 'Keselamatan perisian browser anda tidak membenarkan operasi suntingan text/imej. Sila gunakan papan kekunci (Ctrl/Cmd+X).',
 	paste: 'Tampal',
-	pasteNotification: 'Your browser doesn\'t allow you to paste this way. Press %1 to paste.', // MISSING
+	pasteNotification: 'Press %1 to paste. Your browser doesn‘t support pasting with the toolbar button or context menu option.', // MISSING
 	pasteArea: 'Paste Area', // MISSING
 	pasteMsg: 'Please paste inside the following box using the keyboard (<strong>Ctrl/Cmd+V</strong>) and hit OK', // MISSING
 	title: 'Tampal'

--- a/plugins/clipboard/lang/nb.js
+++ b/plugins/clipboard/lang/nb.js
@@ -8,7 +8,7 @@ CKEDITOR.plugins.setLang( 'clipboard', 'nb', {
 	cut: 'Klipp ut',
 	cutError: 'Din nettlesers sikkerhetsinstillinger tillater ikke automatisk utklipping av tekst. Vennligst bruk tastatursnarveien (Ctrl/Cmd+X).',
 	paste: 'Lim inn',
-	pasteNotification: 'Nettleseren din lar deg ikke lime inn på denne måten. Trykk %1 for å lime inn.',
+	pasteNotification: 'Press %1 to paste. Your browser doesn‘t support pasting with the toolbar button or context menu option.', // MISSING
 	pasteArea: 'Innlimingsområde',
 	pasteMsg: 'Vennligst lim inn i følgende boks med tastaturet (<strong>Ctrl/Cmd+V</strong>) og trykk <strong>OK</strong>.',
 	title: 'Lim inn'

--- a/plugins/clipboard/lang/nl.js
+++ b/plugins/clipboard/lang/nl.js
@@ -8,7 +8,7 @@ CKEDITOR.plugins.setLang( 'clipboard', 'nl', {
 	cut: 'Knippen',
 	cutError: 'De beveiligingsinstelling van de browser verhinderen het automatisch knippen. Gebruik de sneltoets Ctrl/Cmd+X van het toetsenbord.',
 	paste: 'Plakken',
-	pasteNotification: 'Your browser doesn\'t allow you to paste this way. Press %1 to paste.', // MISSING
+	pasteNotification: 'Press %1 to paste. Your browser doesn‘t support pasting with the toolbar button or context menu option.', // MISSING
 	pasteArea: 'Plakgebied',
 	pasteMsg: 'Plak de tekst in het volgende vak gebruikmakend van uw toetsenbord (<strong>Ctrl/Cmd+V</strong>) en klik op OK.',
 	title: 'Plakken'

--- a/plugins/clipboard/lang/no.js
+++ b/plugins/clipboard/lang/no.js
@@ -8,7 +8,7 @@ CKEDITOR.plugins.setLang( 'clipboard', 'no', {
 	cut: 'Klipp ut',
 	cutError: 'Din nettlesers sikkerhetsinstillinger tillater ikke automatisk utklipping av tekst. Vennligst bruk snarveien (Ctrl/Cmd+X).',
 	paste: 'Lim inn',
-	pasteNotification: 'Your browser doesn\'t allow you to paste this way. Press %1 to paste.', // MISSING
+	pasteNotification: 'Press %1 to paste. Your browser doesn‘t support pasting with the toolbar button or context menu option.', // MISSING
 	pasteArea: 'Innlimingsområde',
 	pasteMsg: 'Vennligst lim inn i følgende boks med tastaturet (<STRONG>Ctrl/Cmd+V</STRONG>) og trykk <STRONG>OK</STRONG>.',
 	title: 'Lim inn'

--- a/plugins/clipboard/lang/oc.js
+++ b/plugins/clipboard/lang/oc.js
@@ -8,7 +8,7 @@ CKEDITOR.plugins.setLang( 'clipboard', 'oc', {
 	cut: 'Talhar',
 	cutError: 'Los paramètres de seguretat de vòstre navigador autorizan pas l\'editor a executar automaticament l\'operacion « Talhar ». Utilizatz l\'acorchi de clavièr a aqueste efièit (Ctrl/Cmd+X).',
 	paste: 'Pegar',
-	pasteNotification: 'Your browser doesn\'t allow you to paste this way. Press %1 to paste.', // MISSING
+	pasteNotification: 'Press %1 to paste. Your browser doesn‘t support pasting with the toolbar button or context menu option.', // MISSING
 	pasteArea: 'Paste Area', // MISSING
 	pasteMsg: 'Please paste inside the following box using the keyboard (<strong>Ctrl/Cmd+V</strong>) and hit OK', // MISSING
 	title: 'Paste' // MISSING

--- a/plugins/clipboard/lang/pl.js
+++ b/plugins/clipboard/lang/pl.js
@@ -8,7 +8,7 @@ CKEDITOR.plugins.setLang( 'clipboard', 'pl', {
 	cut: 'Wytnij',
 	cutError: 'Ustawienia bezpieczeństwa Twojej przeglądarki nie pozwalają na automatyczne wycinanie tekstu. Użyj skrótu klawiszowego Ctrl/Cmd+X.',
 	paste: 'Wklej',
-	pasteNotification: 'Twoja przeglądarka nie pozwala na wklejanie treści w ten sposób. Naciśnij %1 by wkleić tekst.',
+	pasteNotification: 'Press %1 to paste. Your browser doesn‘t support pasting with the toolbar button or context menu option.', // MISSING
 	pasteArea: 'Obszar wklejania',
 	pasteMsg: 'Wklej tekst w poniższym polu, używając skrótu klawiaturowego (<STRONG>Ctrl/Cmd+V</STRONG>), i kliknij <STRONG>OK</STRONG>.',
 	title: 'Wklej'

--- a/plugins/clipboard/lang/pt-br.js
+++ b/plugins/clipboard/lang/pt-br.js
@@ -8,7 +8,7 @@ CKEDITOR.plugins.setLang( 'clipboard', 'pt-br', {
 	cut: 'Recortar',
 	cutError: 'As configurações de segurança do seu navegador não permitem que o editor execute operações de recortar automaticamente. Por favor, utilize o teclado para recortar (Ctrl/Cmd+X).',
 	paste: 'Colar',
-	pasteNotification: 'Your browser doesn\'t allow you to paste this way. Press %1 to paste.', // MISSING
+	pasteNotification: 'Press %1 to paste. Your browser doesn‘t support pasting with the toolbar button or context menu option.', // MISSING
 	pasteArea: 'Área para Colar',
 	pasteMsg: 'Transfira o link usado na caixa usando o teclado com (<STRONG>Ctrl/Cmd+V</STRONG>) e <STRONG>OK</STRONG>.',
 	title: 'Colar'

--- a/plugins/clipboard/lang/pt.js
+++ b/plugins/clipboard/lang/pt.js
@@ -8,7 +8,7 @@ CKEDITOR.plugins.setLang( 'clipboard', 'pt', {
 	cut: 'Cortar',
 	cutError: 'A configuração de segurança do navegador não permite a execução automática de operações de cortar. Por favor use o teclado (Ctrl/Cmd+X).',
 	paste: 'Colar',
-	pasteNotification: 'Your browser doesn\'t allow you to paste this way. Press %1 to paste.', // MISSING
+	pasteNotification: 'Press %1 to paste. Your browser doesn‘t support pasting with the toolbar button or context menu option.', // MISSING
 	pasteArea: 'Colar área',
 	pasteMsg: 'Por favor, cole dentro da seguinte caixa usando o teclado (<STRONG>Ctrl/Cmd+V</STRONG>) e carregue em <STRONG>OK</STRONG>.',
 	title: 'Colar'

--- a/plugins/clipboard/lang/ro.js
+++ b/plugins/clipboard/lang/ro.js
@@ -8,7 +8,7 @@ CKEDITOR.plugins.setLang( 'clipboard', 'ro', {
 	cut: 'Decupează',
 	cutError: 'Setările de securitate ale navigatorului (browser) pe care îl folosiţi nu permit editorului să execute automat operaţiunea de tăiere. Vă rugăm folosiţi tastatura (Ctrl/Cmd+X).',
 	paste: 'Adaugă din clipboard',
-	pasteNotification: 'Permiteți accesul la clipboard pentru a adăuga conținut?',
+	pasteNotification: 'Press %1 to paste. Your browser doesn‘t support pasting with the toolbar button or context menu option.', // MISSING
 	pasteArea: 'Suprafața de adăugare',
 	pasteMsg: 'Vă rugăm adăugaţi în căsuţa următoare folosind tastatura (<strong>Ctrl/Cmd+V</strong>) şi apăsaţi OK',
 	title: 'Adaugă'

--- a/plugins/clipboard/lang/ru.js
+++ b/plugins/clipboard/lang/ru.js
@@ -8,7 +8,7 @@ CKEDITOR.plugins.setLang( 'clipboard', 'ru', {
 	cut: 'Вырезать',
 	cutError: 'Настройки безопасности вашего браузера не разрешают редактору выполнять операции по вырезке текста. Пожалуйста, используйте для этого клавиатуру (Ctrl/Cmd+X).',
 	paste: 'Вставить',
-	pasteNotification: 'Ваш браузер не поддерживает данный метод вставки. Для вставки нажмите %1',
+	pasteNotification: 'Press %1 to paste. Your browser doesn‘t support pasting with the toolbar button or context menu option.', // MISSING
 	pasteArea: 'Зона для вставки',
 	pasteMsg: 'Пожалуйста, вставьте текст в зону ниже, используя клавиатуру (<strong>Ctrl/Cmd+V</strong>) и нажмите кнопку "OK".',
 	title: 'Вставить'

--- a/plugins/clipboard/lang/si.js
+++ b/plugins/clipboard/lang/si.js
@@ -8,7 +8,7 @@ CKEDITOR.plugins.setLang( 'clipboard', 'si', {
 	cut: 'කපාගන්න',
 	cutError: 'Your browser security settings don\'t permit the editor to automatically execute cutting operations. Please use the keyboard for that (Ctrl/Cmd+X).', // MISSING
 	paste: 'අලවන්න',
-	pasteNotification: 'Your browser doesn\'t allow you to paste this way. Press %1 to paste.', // MISSING
+	pasteNotification: 'Press %1 to paste. Your browser doesn‘t support pasting with the toolbar button or context menu option.', // MISSING
 	pasteArea: 'අලවන ප්‍රදේශ',
 	pasteMsg: 'Please paste inside the following box using the keyboard (<strong>Ctrl/Cmd+V</strong>) and hit OK', // MISSING
 	title: 'අලවන්න'

--- a/plugins/clipboard/lang/sk.js
+++ b/plugins/clipboard/lang/sk.js
@@ -8,7 +8,7 @@ CKEDITOR.plugins.setLang( 'clipboard', 'sk', {
 	cut: 'Vystrihnúť',
 	cutError: 'Bezpečnostné nastavenia vášho prehliadača nedovoľujú editoru automaticky spustiť operáciu vystrihnutia. Použite na to klávesnicu (Ctrl/Cmd+X).',
 	paste: 'Vložiť',
-	pasteNotification: 'Váš prehliadač nepovoľuje prilepiť text takýmto spôsobom. Pre prilepenie stlačte %1.',
+	pasteNotification: 'Press %1 to paste. Your browser doesn‘t support pasting with the toolbar button or context menu option.', // MISSING
 	pasteArea: 'Miesto na vloženie',
 	pasteMsg: 'Použitím klávesnice (<STRONG>Ctrl/Cmd+V</STRONG>) vložte text do rámčeka a stlačte OK.',
 	title: 'Vložiť'

--- a/plugins/clipboard/lang/sl.js
+++ b/plugins/clipboard/lang/sl.js
@@ -8,7 +8,7 @@ CKEDITOR.plugins.setLang( 'clipboard', 'sl', {
 	cut: 'Izreži',
 	cutError: 'Varnostne nastavitve brskalnika ne dopuščajo samodejnega izrezovanja. Uporabite kombinacijo tipk na tipkovnici (Ctrl/Cmd+X).',
 	paste: 'Prilepi',
-	pasteNotification: 'Your browser doesn\'t allow you to paste this way. Press %1 to paste.', // MISSING
+	pasteNotification: 'Press %1 to paste. Your browser doesn‘t support pasting with the toolbar button or context menu option.', // MISSING
 	pasteArea: 'Prilepi območje',
 	pasteMsg: 'Prosimo, prilepite v sleči okvir s pomočjo tipkovnice (<strong>Ctrl/Cmd+V</strong>) in pritisnite V redu.',
 	title: 'Prilepi'

--- a/plugins/clipboard/lang/sq.js
+++ b/plugins/clipboard/lang/sq.js
@@ -8,7 +8,7 @@ CKEDITOR.plugins.setLang( 'clipboard', 'sq', {
 	cut: 'Preje',
 	cutError: 'Të dhënat e sigurisë së shfletuesit tuaj nuk lejojnë që redaktuesi automatikisht të kryej veprimin e prerjes. Ju lutemi shfrytëzoni tastierën për këtë veprim (Ctrl/Cmd+X).',
 	paste: 'Hidhe',
-	pasteNotification: 'Your browser doesn\'t allow you to paste this way. Press %1 to paste.', // MISSING
+	pasteNotification: 'Press %1 to paste. Your browser doesn‘t support pasting with the toolbar button or context menu option.', // MISSING
 	pasteArea: 'Hapësira Hedhëse',
 	pasteMsg: 'Ju lutemi hidhni brenda kutizës në vijim duke shfrytëzuar tastierën (<strong>Ctrl/Cmd+V</strong>) dhe shtypni Mirë.',
 	title: 'Hidhe'

--- a/plugins/clipboard/lang/sr-latn.js
+++ b/plugins/clipboard/lang/sr-latn.js
@@ -8,7 +8,7 @@ CKEDITOR.plugins.setLang( 'clipboard', 'sr-latn', {
 	cut: 'Iseci',
 	cutError: 'Sigurnosna podešavanja Vašeg pretraživača ne dozvoljavaju operacije automatskog isecanja teksta. Molimo Vas da koristite prečicu sa tastature (Ctrl/Cmd+X).',
 	paste: 'Zalepi',
-	pasteNotification: 'Your browser doesn\'t allow you to paste this way. Press %1 to paste.', // MISSING
+	pasteNotification: 'Press %1 to paste. Your browser doesn‘t support pasting with the toolbar button or context menu option.', // MISSING
 	pasteArea: 'Prostor za lepljenje',
 	pasteMsg: 'Molimo Vas da zalepite unutar donje povrine koristeći tastaturnu prečicu (<STRONG>Ctrl/Cmd+V</STRONG>) i da pritisnete <STRONG>OK</STRONG>.',
 	title: 'Zalepi'

--- a/plugins/clipboard/lang/sr.js
+++ b/plugins/clipboard/lang/sr.js
@@ -8,7 +8,7 @@ CKEDITOR.plugins.setLang( 'clipboard', 'sr', {
 	cut: 'Исеци',
 	cutError: 'Сигурносна подешавања Вашег претраживача не дозвољавају операције аутоматског исецања текста. Молимо Вас да користите пречицу са тастатуре (Ctrl/Cmd+X).',
 	paste: 'Залепи',
-	pasteNotification: 'Your browser doesn\'t allow you to paste this way. Press %1 to paste.', // MISSING
+	pasteNotification: 'Press %1 to paste. Your browser doesn‘t support pasting with the toolbar button or context menu option.', // MISSING
 	pasteArea: 'Залепи зону',
 	pasteMsg: 'Молимо Вас да залепите унутар доње површине користећи тастатурну пречицу (<STRONG>Ctrl/Cmd+V</STRONG>) и да притиснете <STRONG>OK</STRONG>.',
 	title: 'Залепи'

--- a/plugins/clipboard/lang/sv.js
+++ b/plugins/clipboard/lang/sv.js
@@ -8,7 +8,7 @@ CKEDITOR.plugins.setLang( 'clipboard', 'sv', {
 	cut: 'Klipp ut',
 	cutError: 'Säkerhetsinställningar i din webbläsare tillåter inte åtgärden klipp ut. Använd (Ctrl/Cmd+X) istället.',
 	paste: 'Klistra in',
-	pasteNotification: 'Din webbläsare tillåter dig inte att klistra in på detta vis. Tryck på %1 för att klistra in.',
+	pasteNotification: 'Press %1 to paste. Your browser doesn‘t support pasting with the toolbar button or context menu option.', // MISSING
 	pasteArea: 'Paste Area',
 	pasteMsg: 'Var god och klistra in Er text i rutan nedan genom att använda (<strong>Ctrl/Cmd+V</strong>) klicka sen på OK.',
 	title: 'Klistra in'

--- a/plugins/clipboard/lang/th.js
+++ b/plugins/clipboard/lang/th.js
@@ -8,7 +8,7 @@ CKEDITOR.plugins.setLang( 'clipboard', 'th', {
 	cut: 'ตัด',
 	cutError: 'ไม่สามารถตัดข้อความที่เลือกไว้ได้เนื่องจากการกำหนดค่าระดับความปลอดภัย. กรุณาใช้ปุ่มลัดเพื่อวางข้อความแทน (กดปุ่ม Ctrl/Cmd และตัว X พร้อมกัน).',
 	paste: 'วาง',
-	pasteNotification: 'Your browser doesn\'t allow you to paste this way. Press %1 to paste.', // MISSING
+	pasteNotification: 'Press %1 to paste. Your browser doesn‘t support pasting with the toolbar button or context menu option.', // MISSING
 	pasteArea: 'Paste Area', // MISSING
 	pasteMsg: 'กรุณาใช้คีย์บอร์ดเท่านั้น โดยกดปุ๋ม (<strong>Ctrl/Cmd และ V</strong>)พร้อมๆกัน และกด <strong>OK</strong>.',
 	title: 'วาง'

--- a/plugins/clipboard/lang/tr.js
+++ b/plugins/clipboard/lang/tr.js
@@ -8,7 +8,7 @@ CKEDITOR.plugins.setLang( 'clipboard', 'tr', {
 	cut: 'Kes',
 	cutError: 'Gezgin yazılımınızın güvenlik ayarları düzenleyicinin otomatik kesme işlemine izin vermiyor. İşlem için (Ctrl/Cmd+X) tuşlarını kullanın.',
 	paste: 'Yapıştır',
-	pasteNotification: 'Your browser doesn\'t allow you to paste this way. Press %1 to paste.', // MISSING
+	pasteNotification: 'Press %1 to paste. Your browser doesn‘t support pasting with the toolbar button or context menu option.', // MISSING
 	pasteArea: 'Yapıştırma Alanı',
 	pasteMsg: 'Lütfen aşağıdaki kutunun içine yapıştırın. (<STRONG>Ctrl/Cmd+V</STRONG>) ve <STRONG>Tamam</STRONG> butonunu tıklayın.',
 	title: 'Yapıştır'

--- a/plugins/clipboard/lang/tt.js
+++ b/plugins/clipboard/lang/tt.js
@@ -8,7 +8,7 @@ CKEDITOR.plugins.setLang( 'clipboard', 'tt', {
 	cut: 'Кисеп алу',
 	cutError: 'Браузерыгызның иминлек үзлекләре автоматик рәвештә күчермәләү үтәүне тыя. Тиз төймәләрне (Ctrl/Cmd+C) кулланыгыз.',
 	paste: 'Өстәү',
-	pasteNotification: 'Your browser doesn\'t allow you to paste this way. Press %1 to paste.', // MISSING
+	pasteNotification: 'Press %1 to paste. Your browser doesn‘t support pasting with the toolbar button or context menu option.', // MISSING
 	pasteArea: 'Өстәү мәйданы',
 	pasteMsg: 'Please paste inside the following box using the keyboard (<strong>Ctrl/Cmd+V</strong>) and hit OK', // MISSING
 	title: 'Өстәү'

--- a/plugins/clipboard/lang/ug.js
+++ b/plugins/clipboard/lang/ug.js
@@ -8,7 +8,7 @@ CKEDITOR.plugins.setLang( 'clipboard', 'ug', {
 	cut: 'كەس',
 	cutError: 'تور كۆرگۈڭىزنىڭ بىخەتەرلىك تەڭشىكى تەھرىرلىگۈچنىڭ كەس مەشغۇلاتىنى ئۆزلۈكىدىن ئىجرا قىلىشىغا يول قويمايدۇ، ھەرپتاختا تېز كۇنۇپكا (Ctrl/Cmd+X) ئارقىلىق تاماملاڭ',
 	paste: 'چاپلا',
-	pasteNotification: 'Your browser doesn\'t allow you to paste this way. Press %1 to paste.', // MISSING
+	pasteNotification: 'Press %1 to paste. Your browser doesn‘t support pasting with the toolbar button or context menu option.', // MISSING
 	pasteArea: 'چاپلاش دائىرىسى',
 	pasteMsg: 'ھەرپتاختا تېز كۇنۇپكا (<STRONG>Ctrl/Cmd+V</STRONG>) نى ئىشلىتىپ مەزمۇننى تۆۋەندىكى رامكىغا كۆچۈرۈڭ، ئاندىن <STRONG>جەزملە</STRONG>نى بېسىڭ',
 	title: 'چاپلا'

--- a/plugins/clipboard/lang/uk.js
+++ b/plugins/clipboard/lang/uk.js
@@ -8,7 +8,7 @@ CKEDITOR.plugins.setLang( 'clipboard', 'uk', {
 	cut: 'Вирізати',
 	cutError: 'Налаштування безпеки Вашого браузера не дозволяють редактору автоматично виконувати операції вирізування. Будь ласка, використовуйте клавіатуру для цього (Ctrl/Cmd+X)',
 	paste: 'Вставити',
-	pasteNotification: 'Your browser doesn\'t allow you to paste this way. Press %1 to paste.', // MISSING
+	pasteNotification: 'Press %1 to paste. Your browser doesn‘t support pasting with the toolbar button or context menu option.', // MISSING
 	pasteArea: 'Область вставки',
 	pasteMsg: 'Будь ласка, вставте інформацію з буфера обміну в цю область, користуючись комбінацією клавіш (<STRONG>Ctrl/Cmd+V</STRONG>), та натисніть <STRONG>OK</STRONG>.',
 	title: 'Вставити'

--- a/plugins/clipboard/lang/vi.js
+++ b/plugins/clipboard/lang/vi.js
@@ -8,7 +8,7 @@ CKEDITOR.plugins.setLang( 'clipboard', 'vi', {
 	cut: 'Cắt',
 	cutError: 'Các thiết lập bảo mật của trình duyệt không cho phép trình biên tập tự động thực thi lệnh cắt. Hãy sử dụng bàn phím cho lệnh này (Ctrl/Cmd+X).',
 	paste: 'Dán',
-	pasteNotification: 'Trình duyệt của bạn không cho phép bạn dán theo cách này. Nhấn %1 để dán',
+	pasteNotification: 'Press %1 to paste. Your browser doesn‘t support pasting with the toolbar button or context menu option.', // MISSING
 	pasteArea: 'Khu vực dán',
 	pasteMsg: 'Hãy dán nội dung vào trong khung bên dưới, sử dụng tổ hợp phím (<STRONG>Ctrl/Cmd+V</STRONG>) và nhấn vào nút <STRONG>Đồng ý</STRONG>.',
 	title: 'Dán'

--- a/plugins/clipboard/lang/zh-cn.js
+++ b/plugins/clipboard/lang/zh-cn.js
@@ -8,7 +8,7 @@ CKEDITOR.plugins.setLang( 'clipboard', 'zh-cn', {
 	cut: '剪切',
 	cutError: '您的浏览器安全设置不允许编辑器自动执行剪切操作，请使用键盘快捷键(Ctrl/Cmd+X)来完成。',
 	paste: '粘贴',
-	pasteNotification: '您的浏览器不允许用此方式粘贴，要粘贴请按 %1。',
+	pasteNotification: 'Press %1 to paste. Your browser doesn‘t support pasting with the toolbar button or context menu option.', // MISSING
 	pasteArea: '粘贴区域',
 	pasteMsg: '请使用键盘快捷键(<STRONG>Ctrl/Cmd+V</STRONG>)把内容粘贴到下面的方框里，再按 <STRONG>确定</STRONG>',
 	title: '粘贴'

--- a/plugins/clipboard/lang/zh.js
+++ b/plugins/clipboard/lang/zh.js
@@ -8,7 +8,7 @@ CKEDITOR.plugins.setLang( 'clipboard', 'zh', {
 	cut: '剪下',
 	cutError: '瀏覽器的安全性設定不允許編輯器自動執行剪下動作。請使用鏐盤快捷鍵 (Ctrl/Cmd+X) 剪下。',
 	paste: '貼上',
-	pasteNotification: 'Your browser doesn\'t allow you to paste this way. Press %1 to paste.', // MISSING
+	pasteNotification: 'Press %1 to paste. Your browser doesn‘t support pasting with the toolbar button or context menu option.', // MISSING
 	pasteArea: '貼上區',
 	pasteMsg: '請使用鍵盤快捷鍵 (<strong>Ctrl/Cmd+V</strong>) 貼到下方區域中並按下「確定」。',
 	title: '貼上'

--- a/plugins/pastetext/lang/af.js
+++ b/plugins/pastetext/lang/af.js
@@ -4,6 +4,6 @@ For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-oss-license
 */
 CKEDITOR.plugins.setLang( 'pastetext', 'af', {
 	button: 'Plak as eenvoudige teks',
-	pasteNotification: 'Your browser does not allow you to paste plain text this way. Press %1 to paste.', // MISSING
+	pasteNotification: 'Press %1 to paste. Your browser doesn‘t support pasting with the toolbar button or context menu option.', // MISSING
 	title: 'Plak as eenvoudige teks'
 } );

--- a/plugins/pastetext/lang/ar.js
+++ b/plugins/pastetext/lang/ar.js
@@ -4,6 +4,6 @@ For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-oss-license
 */
 CKEDITOR.plugins.setLang( 'pastetext', 'ar', {
 	button: 'لصق كنص بسيط',
-	pasteNotification: 'Your browser does not allow you to paste plain text this way. Press %1 to paste.', // MISSING
+	pasteNotification: 'Press %1 to paste. Your browser doesn‘t support pasting with the toolbar button or context menu option.', // MISSING
 	title: 'لصق كنص بسيط'
 } );

--- a/plugins/pastetext/lang/az.js
+++ b/plugins/pastetext/lang/az.js
@@ -4,6 +4,6 @@ For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-oss-license
 */
 CKEDITOR.plugins.setLang( 'pastetext', 'az', {
 	button: 'Yalnız mətni saxla',
-	pasteNotification: 'Sizin İnternet bələdçiniz bu cür mətnin köçürməsini dəstəklənmir. Əlavə etmək üçün %1 basın.',
+	pasteNotification: 'Press %1 to paste. Your browser doesn‘t support pasting with the toolbar button or context menu option.', // MISSING
 	title: 'Paste as Plain Text' // MISSING
 } );

--- a/plugins/pastetext/lang/bg.js
+++ b/plugins/pastetext/lang/bg.js
@@ -4,6 +4,6 @@ For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-oss-license
 */
 CKEDITOR.plugins.setLang( 'pastetext', 'bg', {
 	button: 'Вмъкни като чист текст',
-	pasteNotification: 'Your browser does not allow you to paste plain text this way. Press %1 to paste.', // MISSING
+	pasteNotification: 'Press %1 to paste. Your browser doesn‘t support pasting with the toolbar button or context menu option.', // MISSING
 	title: 'Вмъкни като чист текст'
 } );

--- a/plugins/pastetext/lang/bn.js
+++ b/plugins/pastetext/lang/bn.js
@@ -4,6 +4,6 @@ For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-oss-license
 */
 CKEDITOR.plugins.setLang( 'pastetext', 'bn', {
 	button: 'সাধারণ টেক্সট হিসেবে পেইস্ট করি',
-	pasteNotification: 'Your browser does not allow you to paste plain text this way. Press %1 to paste.', // MISSING
+	pasteNotification: 'Press %1 to paste. Your browser doesn‘t support pasting with the toolbar button or context menu option.', // MISSING
 	title: 'সাদা টেক্সট হিসেবে পেস্ট কর'
 } );

--- a/plugins/pastetext/lang/bs.js
+++ b/plugins/pastetext/lang/bs.js
@@ -4,6 +4,6 @@ For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-oss-license
 */
 CKEDITOR.plugins.setLang( 'pastetext', 'bs', {
 	button: 'Zalijepi kao obièan tekst',
-	pasteNotification: 'Your browser does not allow you to paste plain text this way. Press %1 to paste.', // MISSING
+	pasteNotification: 'Press %1 to paste. Your browser doesn‘t support pasting with the toolbar button or context menu option.', // MISSING
 	title: 'Zalijepi kao obièan tekst'
 } );

--- a/plugins/pastetext/lang/ca.js
+++ b/plugins/pastetext/lang/ca.js
@@ -4,6 +4,6 @@ For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-oss-license
 */
 CKEDITOR.plugins.setLang( 'pastetext', 'ca', {
 	button: 'Enganxa com a text no formatat',
-	pasteNotification: 'Your browser does not allow you to paste plain text this way. Press %1 to paste.', // MISSING
+	pasteNotification: 'Press %1 to paste. Your browser doesn‘t support pasting with the toolbar button or context menu option.', // MISSING
 	title: 'Enganxa com a text no formatat'
 } );

--- a/plugins/pastetext/lang/cs.js
+++ b/plugins/pastetext/lang/cs.js
@@ -4,6 +4,6 @@ For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-oss-license
 */
 CKEDITOR.plugins.setLang( 'pastetext', 'cs', {
 	button: 'Vložit jako čistý text',
-	pasteNotification: 'Your browser does not allow you to paste plain text this way. Press %1 to paste.', // MISSING
+	pasteNotification: 'Press %1 to paste. Your browser doesn‘t support pasting with the toolbar button or context menu option.', // MISSING
 	title: 'Vložit jako čistý text'
 } );

--- a/plugins/pastetext/lang/cy.js
+++ b/plugins/pastetext/lang/cy.js
@@ -4,6 +4,6 @@ For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-oss-license
 */
 CKEDITOR.plugins.setLang( 'pastetext', 'cy', {
 	button: 'Gludo fel testun plaen',
-	pasteNotification: 'Your browser does not allow you to paste plain text this way. Press %1 to paste.', // MISSING
+	pasteNotification: 'Press %1 to paste. Your browser doesn‘t support pasting with the toolbar button or context menu option.', // MISSING
 	title: 'Gludo fel Testun Plaen'
 } );

--- a/plugins/pastetext/lang/da.js
+++ b/plugins/pastetext/lang/da.js
@@ -4,6 +4,6 @@ For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-oss-license
 */
 CKEDITOR.plugins.setLang( 'pastetext', 'da', {
 	button: 'Indsæt som ikke-formateret tekst',
-	pasteNotification: 'Your browser does not allow you to paste plain text this way. Press %1 to paste.', // MISSING
+	pasteNotification: 'Press %1 to paste. Your browser doesn‘t support pasting with the toolbar button or context menu option.', // MISSING
 	title: 'Indsæt som ikke-formateret tekst'
 } );

--- a/plugins/pastetext/lang/de-ch.js
+++ b/plugins/pastetext/lang/de-ch.js
@@ -4,6 +4,6 @@ For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-oss-license
 */
 CKEDITOR.plugins.setLang( 'pastetext', 'de-ch', {
 	button: 'Als Klartext einfügen',
-	pasteNotification: 'Your browser does not allow you to paste plain text this way. Press %1 to paste.', // MISSING
+	pasteNotification: 'Press %1 to paste. Your browser doesn‘t support pasting with the toolbar button or context menu option.', // MISSING
 	title: 'Als Klartext einfügen'
 } );

--- a/plugins/pastetext/lang/de.js
+++ b/plugins/pastetext/lang/de.js
@@ -4,6 +4,6 @@ For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-oss-license
 */
 CKEDITOR.plugins.setLang( 'pastetext', 'de', {
 	button: 'Als Klartext einfügen',
-	pasteNotification: 'Ihr Browser verhindert das Einfügen von Text über diesen Weg. Zum einfügen drücken Sie %1.',
+	pasteNotification: 'Press %1 to paste. Your browser doesn‘t support pasting with the toolbar button or context menu option.', // MISSING
 	title: 'Als Klartext einfügen'
 } );

--- a/plugins/pastetext/lang/el.js
+++ b/plugins/pastetext/lang/el.js
@@ -4,6 +4,6 @@ For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-oss-license
 */
 CKEDITOR.plugins.setLang( 'pastetext', 'el', {
 	button: 'Επικόλληση ως απλό κείμενο',
-	pasteNotification: 'Ο φυλλομετρητής σας δεν επιτρέπει την επικόλληση απλού κειμένου με αυτόν τον τρόπο. Πατήστε 1% για να επικολλήστε.',
+	pasteNotification: 'Press %1 to paste. Your browser doesn‘t support pasting with the toolbar button or context menu option.', // MISSING
 	title: 'Επικόλληση ως απλό κείμενο'
 } );

--- a/plugins/pastetext/lang/en-au.js
+++ b/plugins/pastetext/lang/en-au.js
@@ -4,6 +4,6 @@ For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-oss-license
 */
 CKEDITOR.plugins.setLang( 'pastetext', 'en-au', {
 	button: 'Paste as plain text',
-	pasteNotification: 'Your browser does not allow you to paste plain text this way. Press %1 to paste.',
+	pasteNotification: 'Press %1 to paste. Your browser doesn‘t support pasting with the toolbar button or context menu option.', // MISSING
 	title: 'Paste as Plain Text'
 } );

--- a/plugins/pastetext/lang/en-ca.js
+++ b/plugins/pastetext/lang/en-ca.js
@@ -4,6 +4,6 @@ For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-oss-license
 */
 CKEDITOR.plugins.setLang( 'pastetext', 'en-ca', {
 	button: 'Paste as plain text',
-	pasteNotification: 'Your browser does not allow you to paste plain text this way. Press %1 to paste.', // MISSING
+	pasteNotification: 'Press %1 to paste. Your browser doesn‘t support pasting with the toolbar button or context menu option.', // MISSING
 	title: 'Paste as Plain Text'
 } );

--- a/plugins/pastetext/lang/en-gb.js
+++ b/plugins/pastetext/lang/en-gb.js
@@ -4,6 +4,6 @@ For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-oss-license
 */
 CKEDITOR.plugins.setLang( 'pastetext', 'en-gb', {
 	button: 'Paste as plain text',
-	pasteNotification: 'Your browser does not allow you to paste plain text this way. Press %1 to paste.', // MISSING
+	pasteNotification: 'Press %1 to paste. Your browser doesn‘t support pasting with the toolbar button or context menu option.', // MISSING
 	title: 'Paste as Plain Text'
 } );

--- a/plugins/pastetext/lang/en.js
+++ b/plugins/pastetext/lang/en.js
@@ -4,6 +4,6 @@ For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-oss-license
 */
 CKEDITOR.plugins.setLang( 'pastetext', 'en', {
 	button: 'Paste as plain text',
-	pasteNotification: 'Your browser does not allow you to paste plain text this way. Press %1 to paste.',
+	pasteNotification: 'Press %1 to paste. Your browser doesn‘t support pasting with the toolbar button or context menu option.',
 	title: 'Paste as Plain Text'
 } );

--- a/plugins/pastetext/lang/eo.js
+++ b/plugins/pastetext/lang/eo.js
@@ -4,6 +4,6 @@ For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-oss-license
 */
 CKEDITOR.plugins.setLang( 'pastetext', 'eo', {
 	button: 'Interglui kiel platan tekston',
-	pasteNotification: 'Your browser does not allow you to paste plain text this way. Press %1 to paste.', // MISSING
+	pasteNotification: 'Press %1 to paste. Your browser doesn‘t support pasting with the toolbar button or context menu option.', // MISSING
 	title: 'Interglui kiel platan tekston'
 } );

--- a/plugins/pastetext/lang/es-mx.js
+++ b/plugins/pastetext/lang/es-mx.js
@@ -4,6 +4,6 @@ For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-oss-license
 */
 CKEDITOR.plugins.setLang( 'pastetext', 'es-mx', {
 	button: 'Pegar como texto plano',
-	pasteNotification: 'Su navegador no permite esta forma de pegar texto plano. Presiona %1 para pegar.',
+	pasteNotification: 'Press %1 to paste. Your browser doesn‘t support pasting with the toolbar button or context menu option.', // MISSING
 	title: 'Paste as Plain Text' // MISSING
 } );

--- a/plugins/pastetext/lang/es.js
+++ b/plugins/pastetext/lang/es.js
@@ -4,6 +4,6 @@ For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-oss-license
 */
 CKEDITOR.plugins.setLang( 'pastetext', 'es', {
 	button: 'Pegar como Texto Plano',
-	pasteNotification: 'Your browser does not allow you to paste plain text this way. Press %1 to paste.', // MISSING
+	pasteNotification: 'Press %1 to paste. Your browser doesn‘t support pasting with the toolbar button or context menu option.', // MISSING
 	title: 'Pegar como Texto Plano'
 } );

--- a/plugins/pastetext/lang/et.js
+++ b/plugins/pastetext/lang/et.js
@@ -4,6 +4,6 @@ For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-oss-license
 */
 CKEDITOR.plugins.setLang( 'pastetext', 'et', {
 	button: 'Asetamine tavalise tekstina',
-	pasteNotification: 'Your browser does not allow you to paste plain text this way. Press %1 to paste.', // MISSING
+	pasteNotification: 'Press %1 to paste. Your browser doesn‘t support pasting with the toolbar button or context menu option.', // MISSING
 	title: 'Asetamine tavalise tekstina'
 } );

--- a/plugins/pastetext/lang/eu.js
+++ b/plugins/pastetext/lang/eu.js
@@ -4,6 +4,6 @@ For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-oss-license
 */
 CKEDITOR.plugins.setLang( 'pastetext', 'eu', {
 	button: 'Itsatsi testu arrunta bezala',
-	pasteNotification: 'Your browser does not allow you to paste plain text this way. Press %1 to paste.', // MISSING
+	pasteNotification: 'Press %1 to paste. Your browser doesn‘t support pasting with the toolbar button or context menu option.', // MISSING
 	title: 'Itsatsi testu arrunta bezala'
 } );

--- a/plugins/pastetext/lang/fa.js
+++ b/plugins/pastetext/lang/fa.js
@@ -4,6 +4,6 @@ For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-oss-license
 */
 CKEDITOR.plugins.setLang( 'pastetext', 'fa', {
 	button: 'چسباندن به عنوان متن ساده',
-	pasteNotification: 'Your browser does not allow you to paste plain text this way. Press %1 to paste.', // MISSING
+	pasteNotification: 'Press %1 to paste. Your browser doesn‘t support pasting with the toolbar button or context menu option.', // MISSING
 	title: 'چسباندن به عنوان متن ساده'
 } );

--- a/plugins/pastetext/lang/fi.js
+++ b/plugins/pastetext/lang/fi.js
@@ -4,6 +4,6 @@ For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-oss-license
 */
 CKEDITOR.plugins.setLang( 'pastetext', 'fi', {
 	button: 'Liitä tekstinä',
-	pasteNotification: 'Your browser does not allow you to paste plain text this way. Press %1 to paste.', // MISSING
+	pasteNotification: 'Press %1 to paste. Your browser doesn‘t support pasting with the toolbar button or context menu option.', // MISSING
 	title: 'Liitä tekstinä'
 } );

--- a/plugins/pastetext/lang/fo.js
+++ b/plugins/pastetext/lang/fo.js
@@ -4,6 +4,6 @@ For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-oss-license
 */
 CKEDITOR.plugins.setLang( 'pastetext', 'fo', {
 	button: 'Innrita som reinan tekst',
-	pasteNotification: 'Your browser does not allow you to paste plain text this way. Press %1 to paste.', // MISSING
+	pasteNotification: 'Press %1 to paste. Your browser doesn‘t support pasting with the toolbar button or context menu option.', // MISSING
 	title: 'Innrita som reinan tekst'
 } );

--- a/plugins/pastetext/lang/fr-ca.js
+++ b/plugins/pastetext/lang/fr-ca.js
@@ -4,6 +4,6 @@ For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-oss-license
 */
 CKEDITOR.plugins.setLang( 'pastetext', 'fr-ca', {
 	button: 'Coller comme texte',
-	pasteNotification: 'Your browser does not allow you to paste plain text this way. Press %1 to paste.', // MISSING
+	pasteNotification: 'Press %1 to paste. Your browser doesn‘t support pasting with the toolbar button or context menu option.', // MISSING
 	title: 'Coller comme texte'
 } );

--- a/plugins/pastetext/lang/fr.js
+++ b/plugins/pastetext/lang/fr.js
@@ -4,6 +4,6 @@ For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-oss-license
 */
 CKEDITOR.plugins.setLang( 'pastetext', 'fr', {
 	button: 'Coller comme texte brut',
-	pasteNotification: 'Your browser does not allow you to paste plain text this way. Press %1 to paste.', // MISSING
+	pasteNotification: 'Press %1 to paste. Your browser doesn‘t support pasting with the toolbar button or context menu option.', // MISSING
 	title: 'Coller comme texte brut'
 } );

--- a/plugins/pastetext/lang/gl.js
+++ b/plugins/pastetext/lang/gl.js
@@ -4,6 +4,6 @@ For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-oss-license
 */
 CKEDITOR.plugins.setLang( 'pastetext', 'gl', {
 	button: 'Pegar como texto simple',
-	pasteNotification: 'O seu navegador non permite pegar texto simple deste xeito. Prema %1 para pegar.',
+	pasteNotification: 'Press %1 to paste. Your browser doesn‘t support pasting with the toolbar button or context menu option.', // MISSING
 	title: 'Pegar como texto simple'
 } );

--- a/plugins/pastetext/lang/gu.js
+++ b/plugins/pastetext/lang/gu.js
@@ -4,6 +4,6 @@ For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-oss-license
 */
 CKEDITOR.plugins.setLang( 'pastetext', 'gu', {
 	button: 'પેસ્ટ (ટેક્સ્ટ)',
-	pasteNotification: 'Your browser does not allow you to paste plain text this way. Press %1 to paste.', // MISSING
+	pasteNotification: 'Press %1 to paste. Your browser doesn‘t support pasting with the toolbar button or context menu option.', // MISSING
 	title: 'પેસ્ટ (ટેક્સ્ટ)'
 } );

--- a/plugins/pastetext/lang/he.js
+++ b/plugins/pastetext/lang/he.js
@@ -4,6 +4,6 @@ For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-oss-license
 */
 CKEDITOR.plugins.setLang( 'pastetext', 'he', {
 	button: 'הדבקה כטקסט פשוט',
-	pasteNotification: 'Your browser does not allow you to paste plain text this way. Press %1 to paste.', // MISSING
+	pasteNotification: 'Press %1 to paste. Your browser doesn‘t support pasting with the toolbar button or context menu option.', // MISSING
 	title: 'הדבקה כטקסט פשוט'
 } );

--- a/plugins/pastetext/lang/hi.js
+++ b/plugins/pastetext/lang/hi.js
@@ -4,6 +4,6 @@ For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-oss-license
 */
 CKEDITOR.plugins.setLang( 'pastetext', 'hi', {
 	button: 'पेस्ट (सादा टॅक्स्ट)',
-	pasteNotification: 'Your browser does not allow you to paste plain text this way. Press %1 to paste.', // MISSING
+	pasteNotification: 'Press %1 to paste. Your browser doesn‘t support pasting with the toolbar button or context menu option.', // MISSING
 	title: 'पेस्ट (सादा टॅक्स्ट)'
 } );

--- a/plugins/pastetext/lang/hr.js
+++ b/plugins/pastetext/lang/hr.js
@@ -4,6 +4,6 @@ For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-oss-license
 */
 CKEDITOR.plugins.setLang( 'pastetext', 'hr', {
 	button: 'Zalijepi kao čisti tekst',
-	pasteNotification: 'Vaš preglednik Vam ne dozvoljava lijepljenje običnog teksta na ovaj način. Za lijepljenje, pritisnite %1.',
+	pasteNotification: 'Press %1 to paste. Your browser doesn‘t support pasting with the toolbar button or context menu option.', // MISSING
 	title: 'Zalijepi kao čisti tekst'
 } );

--- a/plugins/pastetext/lang/hu.js
+++ b/plugins/pastetext/lang/hu.js
@@ -4,6 +4,6 @@ For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-oss-license
 */
 CKEDITOR.plugins.setLang( 'pastetext', 'hu', {
 	button: 'Beillesztés formázatlan szövegként',
-	pasteNotification: 'Your browser does not allow you to paste plain text this way. Press %1 to paste.', // MISSING
+	pasteNotification: 'Press %1 to paste. Your browser doesn‘t support pasting with the toolbar button or context menu option.', // MISSING
 	title: 'Beillesztés formázatlan szövegként'
 } );

--- a/plugins/pastetext/lang/id.js
+++ b/plugins/pastetext/lang/id.js
@@ -4,6 +4,6 @@ For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-oss-license
 */
 CKEDITOR.plugins.setLang( 'pastetext', 'id', {
 	button: 'Tempel sebagai teks polos',
-	pasteNotification: 'Your browser does not allow you to paste plain text this way. Press %1 to paste.', // MISSING
+	pasteNotification: 'Press %1 to paste. Your browser doesn‘t support pasting with the toolbar button or context menu option.', // MISSING
 	title: 'Tempel sebagai Teks Polos'
 } );

--- a/plugins/pastetext/lang/is.js
+++ b/plugins/pastetext/lang/is.js
@@ -4,6 +4,6 @@ For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-oss-license
 */
 CKEDITOR.plugins.setLang( 'pastetext', 'is', {
 	button: 'Líma sem ósniðinn texta',
-	pasteNotification: 'Your browser does not allow you to paste plain text this way. Press %1 to paste.', // MISSING
+	pasteNotification: 'Press %1 to paste. Your browser doesn‘t support pasting with the toolbar button or context menu option.', // MISSING
 	title: 'Líma sem ósniðinn texta'
 } );

--- a/plugins/pastetext/lang/it.js
+++ b/plugins/pastetext/lang/it.js
@@ -4,6 +4,6 @@ For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-oss-license
 */
 CKEDITOR.plugins.setLang( 'pastetext', 'it', {
 	button: 'Incolla come testo semplice',
-	pasteNotification: 'Il browser non permette di incollare il testo semplice in questo modo. Premere %1 per incollare.',
+	pasteNotification: 'Press %1 to paste. Your browser doesn‘t support pasting with the toolbar button or context menu option.', // MISSING
 	title: 'Incolla come testo semplice'
 } );

--- a/plugins/pastetext/lang/ja.js
+++ b/plugins/pastetext/lang/ja.js
@@ -4,6 +4,6 @@ For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-oss-license
 */
 CKEDITOR.plugins.setLang( 'pastetext', 'ja', {
 	button: 'プレーンテキストとして貼り付け',
-	pasteNotification: 'ブラウザの設定によりこの方法でプレーンテキストを貼り付けることはできません。手動で実行するにはキーボードの「%1」を押してくださ\r\nい。',
+	pasteNotification: 'Press %1 to paste. Your browser doesn‘t support pasting with the toolbar button or context menu option.', // MISSING
 	title: 'プレーンテキストとして貼り付け'
 } );

--- a/plugins/pastetext/lang/ka.js
+++ b/plugins/pastetext/lang/ka.js
@@ -4,6 +4,6 @@ For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-oss-license
 */
 CKEDITOR.plugins.setLang( 'pastetext', 'ka', {
 	button: 'მხოლოდ ტექსტის ჩასმა',
-	pasteNotification: 'Your browser does not allow you to paste plain text this way. Press %1 to paste.', // MISSING
+	pasteNotification: 'Press %1 to paste. Your browser doesn‘t support pasting with the toolbar button or context menu option.', // MISSING
 	title: 'მხოლოდ ტექსტის ჩასმა'
 } );

--- a/plugins/pastetext/lang/km.js
+++ b/plugins/pastetext/lang/km.js
@@ -4,6 +4,6 @@ For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-oss-license
 */
 CKEDITOR.plugins.setLang( 'pastetext', 'km', {
 	button: 'បិទ​ភ្ជាប់​ជា​អត្ថបទ​ធម្មតា',
-	pasteNotification: 'Your browser does not allow you to paste plain text this way. Press %1 to paste.', // MISSING
+	pasteNotification: 'Press %1 to paste. Your browser doesn‘t support pasting with the toolbar button or context menu option.', // MISSING
 	title: 'បិទ​ភ្ជាប់​ជា​អត្ថបទ​ធម្មតា'
 } );

--- a/plugins/pastetext/lang/ko.js
+++ b/plugins/pastetext/lang/ko.js
@@ -4,6 +4,6 @@ For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-oss-license
 */
 CKEDITOR.plugins.setLang( 'pastetext', 'ko', {
 	button: '텍스트로 붙여넣기',
-	pasteNotification: 'Your browser does not allow you to paste plain text this way. Press %1 to paste.', // MISSING
+	pasteNotification: 'Press %1 to paste. Your browser doesn‘t support pasting with the toolbar button or context menu option.', // MISSING
 	title: '텍스트로 붙여넣기'
 } );

--- a/plugins/pastetext/lang/ku.js
+++ b/plugins/pastetext/lang/ku.js
@@ -4,6 +4,6 @@ For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-oss-license
 */
 CKEDITOR.plugins.setLang( 'pastetext', 'ku', {
 	button: 'لکاندنی وەك دەقی ڕوون',
-	pasteNotification: 'وێبگەڕەکەت ڕێگەت پێنادات بۆ لکاندنی تێکست بە ڕێگایە. کلیکی %1 بۆ لکاندن.',
+	pasteNotification: 'Press %1 to paste. Your browser doesn‘t support pasting with the toolbar button or context menu option.', // MISSING
 	title: 'لکاندنی وەك دەقی ڕوون'
 } );

--- a/plugins/pastetext/lang/lt.js
+++ b/plugins/pastetext/lang/lt.js
@@ -4,6 +4,6 @@ For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-oss-license
 */
 CKEDITOR.plugins.setLang( 'pastetext', 'lt', {
 	button: 'Įdėti kaip gryną tekstą',
-	pasteNotification: 'Your browser does not allow you to paste plain text this way. Press %1 to paste.', // MISSING
+	pasteNotification: 'Press %1 to paste. Your browser doesn‘t support pasting with the toolbar button or context menu option.', // MISSING
 	title: 'Įdėti kaip gryną tekstą'
 } );

--- a/plugins/pastetext/lang/lv.js
+++ b/plugins/pastetext/lang/lv.js
@@ -4,6 +4,6 @@ For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-oss-license
 */
 CKEDITOR.plugins.setLang( 'pastetext', 'lv', {
 	button: 'Ievietot kā vienkāršu tekstu',
-	pasteNotification: 'Your browser does not allow you to paste plain text this way. Press %1 to paste.', // MISSING
+	pasteNotification: 'Press %1 to paste. Your browser doesn‘t support pasting with the toolbar button or context menu option.', // MISSING
 	title: 'Ievietot kā vienkāršu tekstu'
 } );

--- a/plugins/pastetext/lang/mk.js
+++ b/plugins/pastetext/lang/mk.js
@@ -4,6 +4,6 @@ For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-oss-license
 */
 CKEDITOR.plugins.setLang( 'pastetext', 'mk', {
 	button: 'Paste as plain text', // MISSING
-	pasteNotification: 'Your browser does not allow you to paste plain text this way. Press %1 to paste.', // MISSING
+	pasteNotification: 'Press %1 to paste. Your browser doesn‘t support pasting with the toolbar button or context menu option.', // MISSING
 	title: 'Paste as Plain Text' // MISSING
 } );

--- a/plugins/pastetext/lang/mn.js
+++ b/plugins/pastetext/lang/mn.js
@@ -4,6 +4,6 @@ For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-oss-license
 */
 CKEDITOR.plugins.setLang( 'pastetext', 'mn', {
 	button: 'Энгийн бичвэрээр буулгах',
-	pasteNotification: 'Your browser does not allow you to paste plain text this way. Press %1 to paste.', // MISSING
+	pasteNotification: 'Press %1 to paste. Your browser doesn‘t support pasting with the toolbar button or context menu option.', // MISSING
 	title: 'Энгийн бичвэрээр буулгах'
 } );

--- a/plugins/pastetext/lang/ms.js
+++ b/plugins/pastetext/lang/ms.js
@@ -4,6 +4,6 @@ For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-oss-license
 */
 CKEDITOR.plugins.setLang( 'pastetext', 'ms', {
 	button: 'Tampal sebagai text biasa',
-	pasteNotification: 'Your browser does not allow you to paste plain text this way. Press %1 to paste.', // MISSING
+	pasteNotification: 'Press %1 to paste. Your browser doesn‘t support pasting with the toolbar button or context menu option.', // MISSING
 	title: 'Tampal sebagai text biasa'
 } );

--- a/plugins/pastetext/lang/nb.js
+++ b/plugins/pastetext/lang/nb.js
@@ -4,6 +4,6 @@ For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-oss-license
 */
 CKEDITOR.plugins.setLang( 'pastetext', 'nb', {
 	button: 'Lim inn som ren tekst',
-	pasteNotification: 'Nettleseren din lar deg ikke lime inn ren tekst på denne måten. Trykk %1 for å lime inn.',
+	pasteNotification: 'Press %1 to paste. Your browser doesn‘t support pasting with the toolbar button or context menu option.', // MISSING
 	title: 'Lim inn som ren tekst'
 } );

--- a/plugins/pastetext/lang/nl.js
+++ b/plugins/pastetext/lang/nl.js
@@ -4,6 +4,6 @@ For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-oss-license
 */
 CKEDITOR.plugins.setLang( 'pastetext', 'nl', {
 	button: 'Plakken als platte tekst',
-	pasteNotification: 'Your browser does not allow you to paste plain text this way. Press %1 to paste.', // MISSING
+	pasteNotification: 'Press %1 to paste. Your browser doesn‘t support pasting with the toolbar button or context menu option.', // MISSING
 	title: 'Plakken als platte tekst'
 } );

--- a/plugins/pastetext/lang/no.js
+++ b/plugins/pastetext/lang/no.js
@@ -4,6 +4,6 @@ For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-oss-license
 */
 CKEDITOR.plugins.setLang( 'pastetext', 'no', {
 	button: 'Lim inn som ren tekst',
-	pasteNotification: 'Your browser does not allow you to paste plain text this way. Press %1 to paste.', // MISSING
+	pasteNotification: 'Press %1 to paste. Your browser doesn‘t support pasting with the toolbar button or context menu option.', // MISSING
 	title: 'Lim inn som ren tekst'
 } );

--- a/plugins/pastetext/lang/oc.js
+++ b/plugins/pastetext/lang/oc.js
@@ -4,6 +4,6 @@ For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-oss-license
 */
 CKEDITOR.plugins.setLang( 'pastetext', 'oc', {
 	button: 'Pegar coma tèxte brut',
-	pasteNotification: 'Your browser does not allow you to paste plain text this way. Press %1 to paste.', // MISSING
+	pasteNotification: 'Press %1 to paste. Your browser doesn‘t support pasting with the toolbar button or context menu option.', // MISSING
 	title: 'Paste as Plain Text' // MISSING
 } );

--- a/plugins/pastetext/lang/pl.js
+++ b/plugins/pastetext/lang/pl.js
@@ -4,6 +4,6 @@ For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-oss-license
 */
 CKEDITOR.plugins.setLang( 'pastetext', 'pl', {
 	button: 'Wklej jako czysty tekst',
-	pasteNotification: 'Twoja przeglądarka nie pozwala na wklejanie treści w ten sposób. Naciśnij %1 by wkleić tekst.',
+	pasteNotification: 'Press %1 to paste. Your browser doesn‘t support pasting with the toolbar button or context menu option.', // MISSING
 	title: 'Wklej jako czysty tekst'
 } );

--- a/plugins/pastetext/lang/pt-br.js
+++ b/plugins/pastetext/lang/pt-br.js
@@ -4,6 +4,6 @@ For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-oss-license
 */
 CKEDITOR.plugins.setLang( 'pastetext', 'pt-br', {
 	button: 'Colar como Texto sem Formatação',
-	pasteNotification: 'Your browser does not allow you to paste plain text this way. Press %1 to paste.', // MISSING
+	pasteNotification: 'Press %1 to paste. Your browser doesn‘t support pasting with the toolbar button or context menu option.', // MISSING
 	title: 'Colar como Texto sem Formatação'
 } );

--- a/plugins/pastetext/lang/pt.js
+++ b/plugins/pastetext/lang/pt.js
@@ -4,6 +4,6 @@ For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-oss-license
 */
 CKEDITOR.plugins.setLang( 'pastetext', 'pt', {
 	button: 'Colar como texto simples',
-	pasteNotification: 'Your browser does not allow you to paste plain text this way. Press %1 to paste.', // MISSING
+	pasteNotification: 'Press %1 to paste. Your browser doesn‘t support pasting with the toolbar button or context menu option.', // MISSING
 	title: 'Colar como texto simples'
 } );

--- a/plugins/pastetext/lang/ro.js
+++ b/plugins/pastetext/lang/ro.js
@@ -4,6 +4,6 @@ For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-oss-license
 */
 CKEDITOR.plugins.setLang( 'pastetext', 'ro', {
 	button: 'Adaugă ca text simplu (Plain Text)',
-	pasteNotification: 'Se lipește conținut din clipboard. Confirmați?',
+	pasteNotification: 'Press %1 to paste. Your browser doesn‘t support pasting with the toolbar button or context menu option.', // MISSING
 	title: 'Adaugă ca text simplu (Plain Text)'
 } );

--- a/plugins/pastetext/lang/ru.js
+++ b/plugins/pastetext/lang/ru.js
@@ -4,6 +4,6 @@ For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-oss-license
 */
 CKEDITOR.plugins.setLang( 'pastetext', 'ru', {
 	button: 'Вставить только текст',
-	pasteNotification: 'Ваш браузер не поддерживает данный метод вставки. Для вставки нажмите %1',
+	pasteNotification: 'Press %1 to paste. Your browser doesn‘t support pasting with the toolbar button or context menu option.', // MISSING
 	title: 'Вставить только текст'
 } );

--- a/plugins/pastetext/lang/si.js
+++ b/plugins/pastetext/lang/si.js
@@ -4,6 +4,6 @@ For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-oss-license
 */
 CKEDITOR.plugins.setLang( 'pastetext', 'si', {
 	button: 'සාමාන්‍ය අක්ෂර ලෙස අලවන්න',
-	pasteNotification: 'Your browser does not allow you to paste plain text this way. Press %1 to paste.', // MISSING
+	pasteNotification: 'Press %1 to paste. Your browser doesn‘t support pasting with the toolbar button or context menu option.', // MISSING
 	title: 'සාමාන්‍ය අක්ෂර ලෙස අලවන්න'
 } );

--- a/plugins/pastetext/lang/sk.js
+++ b/plugins/pastetext/lang/sk.js
@@ -4,6 +4,6 @@ For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-oss-license
 */
 CKEDITOR.plugins.setLang( 'pastetext', 'sk', {
 	button: 'Vložiť ako čistý text',
-	pasteNotification: 'Váš prehliadač neumožňuje vložiť text týmto spôsobom. Na vloženie textu stlačte %1.',
+	pasteNotification: 'Press %1 to paste. Your browser doesn‘t support pasting with the toolbar button or context menu option.', // MISSING
 	title: 'Vložiť ako čistý text'
 } );

--- a/plugins/pastetext/lang/sl.js
+++ b/plugins/pastetext/lang/sl.js
@@ -4,6 +4,6 @@ For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-oss-license
 */
 CKEDITOR.plugins.setLang( 'pastetext', 'sl', {
 	button: 'Prilepi kot golo besedilo',
-	pasteNotification: 'Your browser does not allow you to paste plain text this way. Press %1 to paste.', // MISSING
+	pasteNotification: 'Press %1 to paste. Your browser doesn‘t support pasting with the toolbar button or context menu option.', // MISSING
 	title: 'Prilepi kot golo besedilo'
 } );

--- a/plugins/pastetext/lang/sq.js
+++ b/plugins/pastetext/lang/sq.js
@@ -4,6 +4,6 @@ For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-oss-license
 */
 CKEDITOR.plugins.setLang( 'pastetext', 'sq', {
 	button: 'Hidhe si tekst të thjeshtë',
-	pasteNotification: 'Your browser does not allow you to paste plain text this way. Press %1 to paste.', // MISSING
+	pasteNotification: 'Press %1 to paste. Your browser doesn‘t support pasting with the toolbar button or context menu option.', // MISSING
 	title: 'Hidhe si Tekst të Thjeshtë'
 } );

--- a/plugins/pastetext/lang/sr-latn.js
+++ b/plugins/pastetext/lang/sr-latn.js
@@ -4,6 +4,6 @@ For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-oss-license
 */
 CKEDITOR.plugins.setLang( 'pastetext', 'sr-latn', {
 	button: 'Zalepi kao čist tekst',
-	pasteNotification: 'Your browser does not allow you to paste plain text this way. Press %1 to paste.', // MISSING
+	pasteNotification: 'Press %1 to paste. Your browser doesn‘t support pasting with the toolbar button or context menu option.', // MISSING
 	title: 'Zalepi kao čist tekst'
 } );

--- a/plugins/pastetext/lang/sr.js
+++ b/plugins/pastetext/lang/sr.js
@@ -4,6 +4,6 @@ For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-oss-license
 */
 CKEDITOR.plugins.setLang( 'pastetext', 'sr', {
 	button: 'Залепи као чист текст',
-	pasteNotification: 'Your browser does not allow you to paste plain text this way. Press %1 to paste.', // MISSING
+	pasteNotification: 'Press %1 to paste. Your browser doesn‘t support pasting with the toolbar button or context menu option.', // MISSING
 	title: 'Залепи као чист текст'
 } );

--- a/plugins/pastetext/lang/sv.js
+++ b/plugins/pastetext/lang/sv.js
@@ -4,6 +4,6 @@ For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-oss-license
 */
 CKEDITOR.plugins.setLang( 'pastetext', 'sv', {
 	button: 'Klistra in som vanlig text',
-	pasteNotification: 'Din webbläsare tillåter dig inte att klistra in vanlig text på detta vis. Tryck på %1 för att klistra in.',
+	pasteNotification: 'Press %1 to paste. Your browser doesn‘t support pasting with the toolbar button or context menu option.', // MISSING
 	title: 'Klistra in som vanlig text'
 } );

--- a/plugins/pastetext/lang/th.js
+++ b/plugins/pastetext/lang/th.js
@@ -4,6 +4,6 @@ For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-oss-license
 */
 CKEDITOR.plugins.setLang( 'pastetext', 'th', {
 	button: 'วางแบบตัวอักษรธรรมดา',
-	pasteNotification: 'Your browser does not allow you to paste plain text this way. Press %1 to paste.', // MISSING
+	pasteNotification: 'Press %1 to paste. Your browser doesn‘t support pasting with the toolbar button or context menu option.', // MISSING
 	title: 'วางแบบตัวอักษรธรรมดา'
 } );

--- a/plugins/pastetext/lang/tr.js
+++ b/plugins/pastetext/lang/tr.js
@@ -4,6 +4,6 @@ For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-oss-license
 */
 CKEDITOR.plugins.setLang( 'pastetext', 'tr', {
 	button: 'Düz Metin Olarak Yapıştır',
-	pasteNotification: 'Web tarayıcınız bu şekilde düz metni yapıştırmanıza izin vermiyor. Yapıştırmak için %1 basınız.',
+	pasteNotification: 'Press %1 to paste. Your browser doesn‘t support pasting with the toolbar button or context menu option.', // MISSING
 	title: 'Düz Metin Olarak Yapıştır'
 } );

--- a/plugins/pastetext/lang/tt.js
+++ b/plugins/pastetext/lang/tt.js
@@ -4,6 +4,6 @@ For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-oss-license
 */
 CKEDITOR.plugins.setLang( 'pastetext', 'tt', {
 	button: 'Форматлаусыз текст өстәү',
-	pasteNotification: 'Your browser does not allow you to paste plain text this way. Press %1 to paste.', // MISSING
+	pasteNotification: 'Press %1 to paste. Your browser doesn‘t support pasting with the toolbar button or context menu option.', // MISSING
 	title: 'Форматлаусыз текст өстәү'
 } );

--- a/plugins/pastetext/lang/ug.js
+++ b/plugins/pastetext/lang/ug.js
@@ -4,6 +4,6 @@ For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-oss-license
 */
 CKEDITOR.plugins.setLang( 'pastetext', 'ug', {
 	button: 'پىچىمى يوق تېكىست سۈپىتىدە چاپلا',
-	pasteNotification: 'Your browser does not allow you to paste plain text this way. Press %1 to paste.', // MISSING
+	pasteNotification: 'Press %1 to paste. Your browser doesn‘t support pasting with the toolbar button or context menu option.', // MISSING
 	title: 'پىچىمى يوق تېكىست سۈپىتىدە چاپلا'
 } );

--- a/plugins/pastetext/lang/uk.js
+++ b/plugins/pastetext/lang/uk.js
@@ -4,6 +4,6 @@ For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-oss-license
 */
 CKEDITOR.plugins.setLang( 'pastetext', 'uk', {
 	button: 'Вставити тільки текст',
-	pasteNotification: 'Your browser does not allow you to paste plain text this way. Press %1 to paste.', // MISSING
+	pasteNotification: 'Press %1 to paste. Your browser doesn‘t support pasting with the toolbar button or context menu option.', // MISSING
 	title: 'Вставити тільки текст'
 } );

--- a/plugins/pastetext/lang/vi.js
+++ b/plugins/pastetext/lang/vi.js
@@ -4,6 +4,6 @@ For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-oss-license
 */
 CKEDITOR.plugins.setLang( 'pastetext', 'vi', {
 	button: 'Dán theo định dạng văn bản thuần',
-	pasteNotification: 'Your browser does not allow you to paste plain text this way. Press %1 to paste.', // MISSING
+	pasteNotification: 'Press %1 to paste. Your browser doesn‘t support pasting with the toolbar button or context menu option.', // MISSING
 	title: 'Dán theo định dạng văn bản thuần'
 } );

--- a/plugins/pastetext/lang/zh-cn.js
+++ b/plugins/pastetext/lang/zh-cn.js
@@ -4,6 +4,6 @@ For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-oss-license
 */
 CKEDITOR.plugins.setLang( 'pastetext', 'zh-cn', {
 	button: '粘贴为无格式文本',
-	pasteNotification: '您的浏览器不允许用此方式粘贴成纯文本，要粘贴请按 %1。',
+	pasteNotification: 'Press %1 to paste. Your browser doesn‘t support pasting with the toolbar button or context menu option.', // MISSING
 	title: '粘贴为无格式文本'
 } );

--- a/plugins/pastetext/lang/zh.js
+++ b/plugins/pastetext/lang/zh.js
@@ -4,6 +4,6 @@ For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-oss-license
 */
 CKEDITOR.plugins.setLang( 'pastetext', 'zh', {
 	button: '貼成純文字',
-	pasteNotification: 'Your browser does not allow you to paste plain text this way. Press %1 to paste.', // MISSING
+	pasteNotification: 'Press %1 to paste. Your browser doesn‘t support pasting with the toolbar button or context menu option.', // MISSING
 	title: '貼成純文字'
 } );

--- a/tests/plugins/clipboard/manual/pastenotification.md
+++ b/tests/plugins/clipboard/manual/pastenotification.md
@@ -1,4 +1,4 @@
-@bender-tags: bug, 4.7.0, tp2098
+@bender-tags: bug, 4.7.0, tp2098, 4.9.0, 1363
 @bender-ui: collapsed
 @bender-ckeditor-plugins: wysiwygarea, toolbar, clipboard, pastefromword, pastetext
 
@@ -6,7 +6,9 @@
 2. Repeat it for "Paste from Word" and "Paste as plain text"
 
 #### Expected result:
-* For "Paste" and "Paste from Word" the notification is shown mentioning "Cmd/Ctrl+V" keystroke.
+* For each button the notification is shown:
+	* Press `keystroke` to paste. Your browser doesn't support pasting with the toolbar button or context menu option.
+* For "Paste" and "Paste from Word" the notification keystroke is "Cmd/Ctrl+V".
 * For "Paste as plain text" the notification is shown mentioning:
 	* `Cmd+Alt+Shift+V` keystroke in Safari;
 	* `Ctrl+V` keystroke in Edge and IE;

--- a/tests/plugins/clipboard/manual/pastenotification.md
+++ b/tests/plugins/clipboard/manual/pastenotification.md
@@ -7,8 +7,8 @@
 
 #### Expected result:
 * For each button the notification is shown:
-	* Press `keystroke` to paste. Your browser doesn't support pasting with the toolbar button or context menu option.
-* For "Paste" and "Paste from Word" the notification keystroke is "Cmd/Ctrl+V".
+	> Press `keystroke` to paste. Your browser doesn't support pasting with the toolbar button or context menu option.
+* For "Paste" and "Paste from Word" the notification keystroke is `Cmd/Ctrl+V`.
 * For "Paste as plain text" the notification is shown mentioning:
 	* `Cmd+Alt+Shift+V` keystroke in Safari;
 	* `Ctrl+V` keystroke in Edge and IE;


### PR DESCRIPTION
## What is the purpose of this pull request?

Task

## Does your PR contain necessary tests?

All patches which change the editor code must include tests. You can always read more
on [PR testing](https://docs.ckeditor.com/ckeditor4/docs/#!/guide/dev_contributing_code-section-tests),
[how to set the testing environment](https://docs.ckeditor.com/ckeditor4/docs/#!/guide/dev_tests) and
[how to create tests](https://docs.ckeditor.com/ckeditor4/docs/#!/guide/dev_tests-section-creating-your-own-test)
in the official CKEditor documentation.

### This PR contains

- [ ] Unit tests
- [x] Manual tests
Updated description in existing test, so it covers this PR

## What changes did you make?

I've changed paste notification in lang files for `paste` and `clipboard` plugins, to

> [Press %1 to paste. Your browser doesn't support pasting with the toolbar button or context menu option.](https://github.com/ckeditor/ckeditor-dev/issues/1363#issuecomment-353261235)
 
Which was most upvoted in that discussion.

Closes #1363 