### PR TITLE
Remove progress bar during snapshot creation

### DIFF
--- a/plugins/imagebase/plugin.js
+++ b/plugins/imagebase/plugin.js
@@ -811,6 +811,7 @@
 		 * however it could be used via child classes to apply some more advanced behaviour, like listening to various
 		 * editor events.
 		 *
+		 * @since 4.10.0
 		 * @param {CKEDITOR.editor} editor
 		 */
 		bindEditor: function() {}
@@ -854,7 +855,7 @@
 			parent = this.wrapper.getParent();
 
 		// Hide progressbar during snapshot creation so it does not trigger saving new snapshot
-		// (as content will be changed due to progressbar progress).
+		// (as content will be changed due to progressbar progress) (#1532).
 		undoListeners.push(
 			editor.on( 'beforeUndoImage', function() {
 				if ( !this.wrapper.getParent() ) {

--- a/plugins/imagebase/plugin.js
+++ b/plugins/imagebase/plugin.js
@@ -857,13 +857,12 @@
 		// (as content will be changed due to progressbar progress).
 		undoListeners.push(
 			editor.on( 'beforeUndoImage', function() {
-				if ( this.wrapper.getParent() ) {
-					if ( !parent ) {
-						parent = this.wrapper.getParent();
-					}
-					// Detach wrapper only if it is attached.
-					this.wrapper.remove();
+				if ( !this.wrapper.getParent() ) {
+					// If wrapper is not attached do not try to detach it.
+					return;
 				}
+				parent = parent || this.wrapper.getParent();
+				this.wrapper.remove();
 			}, this )
 		);
 
@@ -879,10 +878,10 @@
 		var remove = this.remove;
 		this.remove = function() {
 			// Remove undo listeners when progress bar is removed.
-			CKEDITOR.tools.array.filter( undoListeners, function( listener ) {
+			CKEDITOR.tools.array.forEach( undoListeners, function( listener ) {
 				listener.removeListener();
-				return false;
 			} );
+			undoListeners.length = 0;
 			remove.call( this );
 		};
 	};

--- a/tests/plugins/easyimage/manual/progressbarundo.html
+++ b/tests/plugins/easyimage/manual/progressbarundo.html
@@ -1,0 +1,58 @@
+<p>Note, this test uses a real Cloud Service connection, so you might want to be on-line 😉.</p>
+
+<h2>Classic editor</h2>
+
+<p><strong>Saved undo steps: <em id="classic-us">0</em></strong></p>
+
+<div id="classic">
+	<h1>Sample editor</h1>
+	<p>Go on, put some content here.</p>
+</div>
+
+<h2>Divarea editor</h2>
+
+<p><strong>Saved undo steps: <em id="divarea-us">0</em></strong></p>
+
+<div id="divarea">
+	<h1>Sample editor</h1>
+	<p>Go on, put some content here.</p>
+</div>
+
+<h2>Inline editor</h2>
+
+<p><strong>Saved undo steps: <em id="inline-us">0</em></strong></p>
+
+<div id="inline" contenteditable="true">
+	<h1>Sample editor</h1>
+	<p>Go on, put some content here.</p>
+</div>
+
+<script src="_helpers/tools.js"></script>
+<script>
+	if ( CKEDITOR.env.ie && CKEDITOR.env.version < 11 ) {
+		bender.ignore();
+	}
+
+	getToken( function( token ) {
+		var commonConfig = {
+			cloudServices_url: 'https://files.cke-cs.com/upload/',
+			cloudServices_token: token,
+			on: {
+				instanceReady: function( evt ) {
+					var editor = evt.editor,
+						counterElement = document.querySelector( '#' + editor.name + '-us' );
+
+					setInterval( function() {
+						counterElement.innerHTML = editor.undoManager.snapshots.length;
+					}, 100 );
+				}
+			}
+		};
+
+		CKEDITOR.replace( 'classic', commonConfig );
+		CKEDITOR.replace( 'divarea', CKEDITOR.tools.extend( {
+			extraPlugins: 'divarea'
+		}, commonConfig ) );
+		CKEDITOR.inline( 'inline', commonConfig );
+	} );
+</script>

--- a/tests/plugins/easyimage/manual/progressbarundo.html
+++ b/tests/plugins/easyimage/manual/progressbarundo.html
@@ -1,8 +1,6 @@
-<p>Note, this test uses a real Cloud Service connection, so you might want to be on-line 😉.</p>
-
 <h2>Classic editor</h2>
 
-<p><strong>Saved undo steps: <em id="classic-us">0</em></strong></p>
+<p><strong>Snapshot contains progressbar: <em id="classic-pb">-</em></strong></p>
 
 <div id="classic">
 	<h1>Sample editor</h1>
@@ -11,7 +9,7 @@
 
 <h2>Divarea editor</h2>
 
-<p><strong>Saved undo steps: <em id="divarea-us">0</em></strong></p>
+<p><strong>Snapshot contains progressbar: <em id="divarea-pb">-</em></strong></p>
 
 <div id="divarea">
 	<h1>Sample editor</h1>
@@ -20,7 +18,7 @@
 
 <h2>Inline editor</h2>
 
-<p><strong>Saved undo steps: <em id="inline-us">0</em></strong></p>
+<p><strong>Snapshot contains progressbar: <em id="inline-pb">-</em></strong></p>
 
 <div id="inline" contenteditable="true">
 	<h1>Sample editor</h1>
@@ -33,26 +31,41 @@
 		bender.ignore();
 	}
 
-	getToken( function( token ) {
-		var commonConfig = {
+	var IMG_URL = '%BASE_PATH%_assets/logo.png',
+		commonConfig = {
 			cloudServices_url: 'https://files.cke-cs.com/upload/',
-			cloudServices_token: token,
+			cloudServices_token: 'dummy-token',
 			on: {
 				instanceReady: function( evt ) {
 					var editor = evt.editor,
-						counterElement = document.querySelector( '#' + editor.name + '-us' );
+						progressbarElement = document.querySelector( '#' + editor.name + '-pb' ),
+						latestSnapshot = null;
 
 					setInterval( function() {
-						counterElement.innerHTML = editor.undoManager.snapshots.length;
+						latestSnapshot = editor.undoManager.snapshots[ editor.undoManager.snapshots.length - 1 ];
+						progressbarElement.innerHTML = latestSnapshot.contents.indexOf( 'cke_loader' ) !== -1 ? 'true' : 'false';
 					}, 100 );
 				}
 			}
 		};
 
-		CKEDITOR.replace( 'classic', commonConfig );
-		CKEDITOR.replace( 'divarea', CKEDITOR.tools.extend( {
-			extraPlugins: 'divarea'
-		}, commonConfig ) );
-		CKEDITOR.inline( 'inline', commonConfig );
-	} );
+	window.XMLHttpRequestInterval = 1000;
+
+	window.XMLHttpRequest.responseData = {
+		100: IMG_URL,
+		200: IMG_URL,
+		default: IMG_URL,
+		// Unset properties set by the generic XHR mock implementation.
+		fileName: undefined,
+		uploaded: undefined,
+		url: undefined,
+		error: undefined
+	};
+
+	CKEDITOR.replace( 'classic', commonConfig );
+	CKEDITOR.replace( 'divarea', CKEDITOR.tools.extend( {
+		extraPlugins: 'divarea'
+	}, commonConfig ) );
+	CKEDITOR.inline( 'inline', commonConfig );
+
 </script>

--- a/tests/plugins/easyimage/manual/progressbarundo.html
+++ b/tests/plugins/easyimage/manual/progressbarundo.html
@@ -25,7 +25,6 @@
 	<p>Go on, put some content here.</p>
 </div>
 
-<script src="_helpers/tools.js"></script>
 <script>
 	if ( CKEDITOR.env.ie && CKEDITOR.env.version < 11 ) {
 		bender.ignore();
@@ -33,8 +32,8 @@
 
 	var IMG_URL = '%BASE_PATH%_assets/logo.png',
 		commonConfig = {
-			cloudServices_url: 'https://files.cke-cs.com/upload/',
-			cloudServices_token: 'dummy-token',
+			cloudServices_uploadUrl: easyImageTools.CLOUD_SERVICES_UPLOAD_GATEWAY,
+			cloudServices_tokenUrl: easyImageTools.CLOUD_SERVICES_TOKEN_URL,
 			on: {
 				instanceReady: function( evt ) {
 					var editor = evt.editor,

--- a/tests/plugins/easyimage/manual/progressbarundo.md
+++ b/tests/plugins/easyimage/manual/progressbarundo.md
@@ -1,0 +1,14 @@
+@bender-tags: 4.9.0, feature, 932
+@bender-ui: collapsed
+@bender-ckeditor-plugins: sourcearea, wysiwygarea, floatingspace, toolbar, easyimage, undo, resize
+
+## Easy Image Progressbar Undo
+
+1. Upload some images (using drag and drop, copy/paste, etc).
+2. During image upload manipulate selection (click somewhere, select some editor content, etc).
+
+### Expected
+
+**Saved undo steps** counter should not increment on selection manipulation.
+
+**Important**: Selecting or deselecting widget will create an undo step.

--- a/tests/plugins/easyimage/manual/progressbarundo.md
+++ b/tests/plugins/easyimage/manual/progressbarundo.md
@@ -1,14 +1,20 @@
 @bender-tags: 4.9.0, feature, 932
 @bender-ui: collapsed
 @bender-ckeditor-plugins: sourcearea, wysiwygarea, floatingspace, toolbar, easyimage, undo, resize
+@bender-include: ../../uploadwidget/manual/_helpers/xhr.js
 
-## Easy Image Progressbar Undo
+## Progressbar with Undo
 
-1. Upload some images (using drag and drop, copy/paste, etc).
+_Proceed for all editor instances._
+
+1. Upload some image or images (using drag and drop, copy/paste, etc).
 2. During image upload manipulate selection (click somewhere, select some editor content, etc).
 
 ### Expected
 
-**Saved undo steps** counter should not increment on selection manipulation.
+**Snapshot contains progressbar** should always be _false_.
 
-**Important**: Selecting or deselecting widget will create an undo step.
+### Remarks
+
+* In the end your image will be replaced with old CKEditor 4 logo.
+* Upload progress is intentionally slowed down.

--- a/tests/plugins/easyimage/manual/progressbarundo.md
+++ b/tests/plugins/easyimage/manual/progressbarundo.md
@@ -1,7 +1,7 @@
-@bender-tags: 4.9.0, feature, 932
+@bender-tags: 4.10.0, bug, 1532
 @bender-ui: collapsed
 @bender-ckeditor-plugins: sourcearea, wysiwygarea, floatingspace, toolbar, easyimage, undo, resize
-@bender-include: ../../uploadwidget/manual/_helpers/xhr.js
+@bender-include: ../../uploadwidget/manual/_helpers/xhr.js, ../_helpers/tools.js
 
 ## Progressbar with Undo
 

--- a/tests/plugins/imagebase/features/upload.js
+++ b/tests/plugins/imagebase/features/upload.js
@@ -64,6 +64,13 @@
 
 		wait();
 	}
+
+	function assertProgressbarAndSnapshots( editor, expectedSnapshots ) {
+		assert.isTrue( editor.undoManager.snapshots[ editor.undoManager.snapshots.length - 1 ].contents.indexOf( 'cke_loader' ) === -1,
+			'Progressbar HTML not in snapshot' );
+		assert.areSame( expectedSnapshots, editor.undoManager.snapshots.length, 'Snapshots count 1' );
+	}
+
 	var assertPasteFiles = imageBaseFeaturesTools.assertPasteFiles,
 		tests = {
 			init: function() {
@@ -665,31 +672,19 @@
 						loader.uploadTotal = 10;
 
 						updateLoader( loader, 2, function() {
-
-							assert.isTrue( editor.undoManager.snapshots[ editor.undoManager.snapshots.length - 1 ].contents.indexOf( 'cke_loader' ) === -1,
-								'Progressbar HTML not in snapshot' );
-							assert.areSame( initialSnapshots, editor.undoManager.snapshots.length, 'Snapshots count 1' );
+							assertProgressbarAndSnapshots( editor, initialSnapshots );
 							editor.fire( 'saveSnapshot' );
 
 							updateLoader( loader, 5, function() {
-
-								assert.isTrue( editor.undoManager.snapshots[ editor.undoManager.snapshots.length - 1 ].contents.indexOf( 'cke_loader' ) === -1,
-									'Progressbar HTML not in snapshot' );
-								assert.areSame( initialSnapshots, editor.undoManager.snapshots.length, 'Snapshots count 2' );
+								assertProgressbarAndSnapshots( editor, initialSnapshots );
 								editor.fire( 'saveSnapshot' );
 
 								updateLoader( loader, 8, function() {
-
-									assert.isTrue( editor.undoManager.snapshots[ editor.undoManager.snapshots.length - 1 ].contents.indexOf( 'cke_loader' ) === -1,
-										'Progressbar HTML not in snapshot' );
-									assert.areSame( initialSnapshots, editor.undoManager.snapshots.length, 'Snapshots count 3' );
+									assertProgressbarAndSnapshots( editor, initialSnapshots );
 									editor.fire( 'saveSnapshot' );
 
 									updateLoader( loader, 10, function() {
-
-										assert.isTrue( editor.undoManager.snapshots[ editor.undoManager.snapshots.length - 1 ].contents.indexOf( 'cke_loader' ) === -1,
-											'Progressbar HTML not in snapshot' );
-										assert.areSame( initialSnapshots, editor.undoManager.snapshots.length, 'Snapshots count 4' );
+										assertProgressbarAndSnapshots( editor, initialSnapshots );
 									} );
 								} );
 							} );

--- a/tests/plugins/imagebase/progressbar.js
+++ b/tests/plugins/imagebase/progressbar.js
@@ -6,6 +6,8 @@
 ( function() {
 	'use strict';
 
+	bender.editor = true;
+
 	var ProgressBar,
 		doc = CKEDITOR.document,
 		loaderMock = {},
@@ -173,6 +175,97 @@
 				loaderMock.fire( 'error' );
 
 				assert.areSame( 1, this.dummyProgress.failed.callCount, 'Failed call count' );
+			},
+
+			'test progressbar is detached on beforeUndoImage': function() {
+				var context = this;
+
+				bender.editorBot.create( {
+					name: 'editor1',
+					config: {
+						extraPlugins: 'undo'
+					}
+				}, function( bot ) {
+					var editor = bot.editor,
+						ret = context._createProgressBar();
+
+					ret.bindEditor( editor );
+
+					assert.isNotNull( ret.wrapper.getParent(), 'Attached' );
+
+					editor.fire( 'beforeUndoImage' );
+
+					assert.isNull( ret.wrapper.getParent(), 'Detached' );
+				} );
+			},
+
+			'test progressbar is attached on afterUndoImage': function() {
+				var context = this;
+
+				bender.editorBot.create( {
+					name: 'editor2',
+					config: {
+						extraPlugins: 'undo'
+					}
+				}, function( bot ) {
+					var editor = bot.editor,
+						ret = context._createProgressBar();
+
+					ret.bindEditor( editor );
+
+					assert.isNotNull( ret.wrapper.getParent(), 'Attached' );
+
+					// Remove element manually so it can be reattached.
+					ret.wrapper.remove();
+
+					assert.isNull( ret.wrapper.getParent(), 'Detached' );
+
+					editor.fire( 'afterUndoImage' );
+
+					assert.isNotNull( ret.wrapper.getParent(), 'Attached' );
+				} );
+			},
+
+			'test progressbar undo listeners are removed on success': function() {
+				var editor = this.editor,
+					ret = this._createProgressBar();
+
+				ret.bindEditor( editor );
+
+				ret.done();
+
+				// If listeners are not removed, firing 'afterUndoImage' would reattach the progress bar.
+				editor.fire( 'afterUndoImage' );
+
+				assert.isNull( ret.wrapper.getParent(), 'Attached' );
+			},
+
+			'test progressbar undo listeners are removed on abort': function() {
+				var editor = this.editor,
+					ret = this._createProgressBar();
+
+				ret.bindEditor( editor );
+
+				ret.aborted();
+
+				// If listeners are not removed, firing 'afterUndoImage' would reattach the progress bar.
+				editor.fire( 'afterUndoImage' );
+
+				assert.isNull( ret.wrapper.getParent(), 'Attached' );
+			},
+
+			'test progressbar undo listeners are removed on fail': function() {
+				var editor = this.editor,
+					ret = this._createProgressBar();
+
+				ret.bindEditor( editor );
+
+				ret.failed();
+
+				// If listeners are not removed, firing 'afterUndoImage' would reattach the progress bar.
+				editor.fire( 'afterUndoImage' );
+
+				assert.isNull( ret.wrapper.getParent(), 'Attached' );
 			},
 
 			// Adds the progress bar straight into DOM and returns ProgressBar instance.

--- a/tests/plugins/uploadwidget/manual/_helpers/xhr.js
+++ b/tests/plugins/uploadwidget/manual/_helpers/xhr.js
@@ -6,6 +6,7 @@
 'use strict';
 
 // Mock the real XMLHttpRequest so the upload test may work locally.
+// Upload interval is by default set to 400ms. It can be redefined by setting 'window.XMLHttpRequestInterval'.
 
 window.FormData = function() {
 	var total, uploadedFilename;
@@ -74,7 +75,7 @@ window.XMLHttpRequest = function() {
 					xhr.responseText = JSON.stringify( responseData );
 					onload();
 				}
-			}, 400 );
+			}, window.XMLHttpRequestInterval || 400 );
 		},
 
 		// Abort should call onabort.

--- a/tests/plugins/uploadwidget/manual/_helpers/xhr.js
+++ b/tests/plugins/uploadwidget/manual/_helpers/xhr.js
@@ -38,12 +38,21 @@ window.XMLHttpRequest = function() {
 		upload: {},
 
 		send: function( formData ) {
-			var total = formData.getTotal(),
+			var total = formData && formData.getTotal(),
 				loaded = 0,
 				step = Math.round( total / 10 ),
 				xhr = this,
 				onprogress = this.upload.onprogress,
+				onreadystatechange = this.onreadystatechange,
 				onload = this.onload;
+
+			// Request without any data is sent by Easy Image token fetcher.
+			if ( !formData ) {
+				xhr.status = 200;
+				xhr.readyState = 4;
+				xhr.responseText = 'dummy_response';
+				return onreadystatechange ? onreadystatechange() : onload();
+			}
 
 			// Wait 400 ms for every step.
 			interval = setInterval( function() {


### PR DESCRIPTION
## What is the purpose of this pull request?

Task

## Does your PR contain necessary tests?

All patches which change the editor code must include tests. You can always read more
on [PR testing](https://docs.ckeditor.com/ckeditor4/docs/#!/guide/dev_contributing_code-section-tests),
[how to set the testing environment](https://docs.ckeditor.com/ckeditor4/docs/#!/guide/dev_tests) and
[how to create tests](https://docs.ckeditor.com/ckeditor4/docs/#!/guide/dev_tests-section-creating-your-own-test)
in the official CKEditor documentation.

### This PR contains

- [x] Unit tests
- [x] Manual tests

## What changes did you make?

Progress bar is now removed from HTML during snapshot creation so it does not pollute the images causing undo manager to think something changes.
