### PR TITLE
Widgets are now correctly destroyed on selection delete

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -28,6 +28,7 @@ Fixed Issues:
 * [#1470](https://github.com/ckeditor/ckeditor-dev/issues/1470): Fixed: [Balloon Toolbar](https://ckeditor.com/cke4/addon/balloontoolbar) is not visible after drag and drop of a widget it is attached to.
 * [#1535](https://github.com/ckeditor/ckeditor-dev/issues/1535): Fixed: Improve [Widget](https://ckeditor.com/cke4/addon/widget) mouse over border contrast.
 * [#1516](https://github.com/ckeditor/ckeditor-dev/issues/1516): Fixed: Fake selection allows removing in a readonly mode using `Backspace`/`Delete` keys.
+* [#1452](https://github.com/ckeditor/ckeditor-dev/issues/1452): Fixed: [Widget destroy](https://docs.ckeditor.com/ckeditor4/latest/api/CKEDITOR_plugins_widget.html#destroy) event is not fired directly after removing widget.
 
 API Changes:
 

--- a/core/selection.js
+++ b/core/selection.js
@@ -586,6 +586,10 @@
 			var editor = evt.editor,
 				selectedWidgets = editor.widgets.selected;
 
+			if ( editor.readOnly ) {
+				return;
+			}
+
 			for ( var i = 0; i < selectedWidgets.length; i++ ) {
 				selectedWidgets[ i ].destroy( true );
 			}

--- a/tests/core/selection/fake.js
+++ b/tests/core/selection/fake.js
@@ -74,6 +74,13 @@ function getKeyEvent( keyCode, preventDefaultCallback ) {
 	return evt;
 }
 
+function getFirstWidgetInstance( editor ) {
+	var instances = editor.widgets.instances;
+	for ( var id in instances ) {
+		return instances[ id ];
+	}
+}
+
 bender.test( {
 	tearDown: function() {
 		this.editor.setReadOnly( false );
@@ -1074,7 +1081,7 @@ bender.test( {
 		editor.setReadOnly( true );
 
 		bot.setData( '<p>[[placeholder]]</p>', function() {
-			var widget = editor.widgets.instances[ 0 ];
+			var widget = getFirstWidgetInstance( editor );
 
 			widget.focus();
 
@@ -1083,5 +1090,39 @@ bender.test( {
 
 			assert.areEqual( '<p>[[placeholder]]</p>', editor.getData() );
 		} );
+	},
+
+	// #1452
+	'Test delete key is destroying widgets': function() {
+		var editor = this.editor, bot = this.editorBot;
+
+		bot.setData( '<p>[[placeholder]]</p>', function() {
+			var widget = getFirstWidgetInstance( editor ),
+				spy = sinon.spy( widget, 'destroy' );
+
+			widget.focus();
+
+			editor.fire( 'key', { keyCode: 46 } ); // delete
+
+			assert.areEqual( '', editor.getData(), 'Widget has not been removed' );
+			assert.isTrue( spy.calledOnce, 'Widget has not been destroyed' );
+		} );
+	},
+
+	// #1452
+	'Test backspace key is destroying widgets': function() {
+		var editor = this.editor, bot = this.editorBot;
+
+		bot.setData( '<p>[[placeholder]]</p>', function() {
+			var widget = getFirstWidgetInstance( editor ),
+				spy = sinon.spy( widget, 'destroy' );
+
+			widget.focus();
+
+			editor.fire( 'key', { keyCode: 8 } ); // backspace
+
+			assert.isTrue( spy.calledOnce, 'Widget has not been destroyed' );
+		} );
 	}
+
 } );

--- a/tests/core/selection/manual/widgetdestroy.html
+++ b/tests/core/selection/manual/widgetdestroy.html
@@ -1,0 +1,14 @@
+<textarea id="editor1" cols="10" rows="10"><p>[[placeholder]] foo bar</p></textarea>
+
+<script>
+	CKEDITOR.replace( 'editor1', {
+		on: {
+			instanceReady: function( evt ) {
+				var editor = evt.editor, widget = editor.widgets.instances[ 0 ];
+				widget.on( 'destroy', function() {
+					editor.showNotification( 'Yarr! The test passed!' );
+				} );
+			}
+		}
+	} );
+</script>

--- a/tests/core/selection/manual/widgetdestroy.md
+++ b/tests/core/selection/manual/widgetdestroy.md
@@ -1,0 +1,24 @@
+@bender-tags: selection, fake, widget, 4.9.0, bug, 1452
+@bender-ui: collapsed
+@bender-ckeditor-plugins: wysiwygarea, placeholder, basicstyles, toolbar, floatingspace
+
+Reproduce 2 different scenarios. After each scenario refresh the page
+
+## 1:
+
+1. Focus the placeholder widget.
+2. Press `delete` / `backspace` key.
+
+## 2:
+
+1. Focus the editor.
+2. Select editor content using `cmd/ctrl + a`.
+3. Press `delete/backspace` key.
+
+## Expected
+
+Notification should showed up with information about passing test.
+
+## Unexpected
+
+No notification displayed.

--- a/tests/core/selection/selection.js
+++ b/tests/core/selection/selection.js
@@ -23,35 +23,15 @@ function getFirstWidgetInstance( editor ) {
 	}
 }
 
-function testSelectedWidgetDestroyOnKeyEvent( editorName, keyCode) {
-	return function() {
-		bender.editorBot.create( { name: editorName, config: { extraPlugins: 'placeholder' } }, function( bot ) {
-			var editor = bot.editor;
-
-			bot.setData( '<p>x</p><p>[[placeholder]]</p><p>y</p>', function() {
-				var widget = getFirstWidgetInstance( editor ),
-					spy = sinon.spy( widget, 'destroy' );
-
-				var paragraphs = editor.editable().find( 'p' ),
-					first = paragraphs.getItem( 0 ), last = paragraphs.getItem( 2 ), range = editor.createRange();
-
-				range.setStartBefore( first );
-				range.setEndAfter( last );
-				range.select();
-
-				editor.fire( 'key', {
-					keyCode: keyCode,
-					domEvent: {
-						getKey: function() {
-							return keyCode;
-						}
-					}
-				} );
-
-				assert.isTrue( spy.calledOnce, 'Widget has not been destroyed' );
-			} );
-		} );
-	}
+function fireKeyEvent( editor, key ) {
+	editor.fire( 'key', {
+		keyCode: key,
+		domEvent: {
+			getKey: function() {
+				return key;
+			}
+		}
+	} );
 }
 
 bender.test( {
@@ -827,7 +807,74 @@ bender.test( {
 	},
 
 	// #1452
-	'Test backspace key is destroying widgets': testSelectedWidgetDestroyOnKeyEvent( 'editor_selection_backspace', 8 ),
+	'Test backspace key is destroying widgets': function() {
+		bender.editorBot.create( { name: 'editor_selection_backspace', config: { extraPlugins: 'placeholder' } }, function( bot ) {
+			var editor = bot.editor;
+
+			bot.setData( '<p>x</p><p>[[placeholder]]</p><p>y</p>', function() {
+				var widget = getFirstWidgetInstance( editor ),
+					spy = sinon.spy( widget, 'destroy' );
+
+				var paragraphs = editor.editable().find( 'p' ),
+					first = paragraphs.getItem( 0 ), last = paragraphs.getItem( 2 ), range = editor.createRange();
+
+				range.setStartBefore( first );
+				range.setEndAfter( last );
+				range.select();
+
+				fireKeyEvent( editor, 8 );
+
+				assert.isTrue( spy.calledOnce, 'Widget has not been destroyed' );
+			} );
+		} );
+	},
+
 	// #1452
-	'Test delete key is destroying widgets': testSelectedWidgetDestroyOnKeyEvent( 'editor_selection_delete', 46 )
+	'Test delete key is destroying widgets': function() {
+		bender.editorBot.create( { name: 'editor_selection_delete', config: { extraPlugins: 'placeholder' } }, function( bot ) {
+			var editor = bot.editor;
+
+			bot.setData( '<p>x</p><p>[[placeholder]]</p><p>y</p>', function() {
+				var widget = getFirstWidgetInstance( editor ),
+					spy = sinon.spy( widget, 'destroy' );
+
+				var paragraphs = editor.editable().find( 'p' ),
+					first = paragraphs.getItem( 0 ), last = paragraphs.getItem( 2 ), range = editor.createRange();
+
+				range.setStartBefore( first );
+				range.setEndAfter( last );
+				range.select();
+
+				fireKeyEvent( editor, 46 );
+
+				assert.isTrue( spy.calledOnce, 'Widget has not been destroyed' );
+			} );
+		} );
+	},
+
+	// #1452
+	'Test delete/backspace key is not destroying read only widgets': function() {
+		bender.editorBot.create( { name: 'editor_selection_readonly', config: { extraPlugins: 'placeholder' } }, function( bot ) {
+			var editor = bot.editor;
+
+			editor.setReadOnly( true );
+
+			bot.setData( '<p>x</p><p>[[placeholder]]</p><p>y</p>', function() {
+				var widget = getFirstWidgetInstance( editor ),
+					spy = sinon.spy( widget, 'destroy' );
+
+				var paragraphs = editor.editable().find( 'p' ),
+					first = paragraphs.getItem( 0 ), last = paragraphs.getItem( 2 ), range = editor.createRange();
+
+				range.setStartBefore( first );
+				range.setEndAfter( last );
+				range.select();
+
+				fireKeyEvent( editor, 8 );
+				fireKeyEvent( editor, 46 );
+
+				assert.isFalse( spy.called, 'Widget has been destroyed' );
+			} );
+		} );
+	}
 } );


### PR DESCRIPTION
## What is the purpose of this pull request?

Bug fix.

## Does your PR contain necessary tests?

All patches which change the editor code must include tests. You can always read more
on [PR testing](https://docs.ckeditor.com/ckeditor4/docs/#!/guide/dev_contributing_code-section-tests),
[how to set the testing environment](https://docs.ckeditor.com/ckeditor4/docs/#!/guide/dev_tests) and
[how to create tests](https://docs.ckeditor.com/ckeditor4/docs/#!/guide/dev_tests-section-creating-your-own-test)
in the official CKEditor documentation.

### This PR contains

- [x] Unit tests
- [x] Manual tests

## What changes did you make?

Handled destroying widgets on selection delete for native and fake selections.

Closes #1452