### PR TITLE
Fix typo in MathJax `en-gb.js`

### DIFF
--- a/plugins/mathjax/lang/en-gb.js
+++ b/plugins/mathjax/lang/en-gb.js
@@ -5,7 +5,7 @@ For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-oss-license
 CKEDITOR.plugins.setLang( 'mathjax', 'en-gb', {
 	title: 'Mathematics in TeX',
 	button: 'Math',
-	dialogInput: 'Write you TeX here',
+	dialogInput: 'Write your TeX here',
 	docUrl: 'http://en.wikibooks.org/wiki/LaTeX/Mathematics',
 	docLabel: 'TeX documentation',
 	loading: 'loading...',


### PR DESCRIPTION
## What is the purpose of this pull request?

Typo fix.