### PR TITLE
Updated target release for the Cloud Services plugin

### DIFF
--- a/plugins/cloudservices/plugin.js
+++ b/plugins/cloudservices/plugin.js
@@ -18,7 +18,7 @@
 			 * guaranteed to be available in dependent plugin's {@link CKEDITOR.pluginDefinition#beforeInit beforeInit},
 			 * {@link CKEDITOR.pluginDefinition#init init} and {@link CKEDITOR.pluginDefinition#afterInit} methods.
 			 *
-			 * @since 4.8.0
+			 * @since 4.9.0
 			 * @class CKEDITOR.plugins.cloudservices.cloudServicesLoader
 			 * @extends CKEDITOR.fileTools.fileLoader
 			 * @constructor
@@ -122,7 +122,7 @@
 	/**
 	 * Endpoint URL for [Cloud Services](https://ckeditor.com/ckeditor-cloud-services) uploads.
 	 *
-	 * @since 4.8.0
+	 * @since 4.9.0
 	 * @cfg {String} [cloudServices_url='']
 	 * @member CKEDITOR.config
 	 */
@@ -130,7 +130,7 @@
 	/**
 	 * Token used for [Cloud Services](https://ckeditor.com/ckeditor-cloud-services) authentication.
 	 *
-	 * @since 4.8.0
+	 * @since 4.9.0
 	 * @cfg {String} [cloudServices_token='']
 	 * @member CKEDITOR.config
 	 */

--- a/tests/plugins/cloudservices/manual/errors.md
+++ b/tests/plugins/cloudservices/manual/errors.md
@@ -1,4 +1,4 @@
-@bender-tags: 4.8.0, feature, 932
+@bender-tags: 4.9.0, feature, 932
 @bender-ui: collapsed
 @bender-ckeditor-plugins: sourcearea, wysiwygarea, toolbar, cloudservices
 


### PR DESCRIPTION
## What is the purpose of this pull request?

Task

### This PR contains

- [ ] Unit tests
- [ ] Manual tests

No need for unit tests, this is API docs correction for the most part.

## What changes did you make?

Cloudservices (and Easy Image) plugin was initially targeted at 4.8.0 but we changed it to 4.9.0 release.

While Easy Image got updated, Cloud Service did not get a proper change, so this PR fixes that.