### PR TITLE
Fix failing test for custom button inside mobile paste fix

### DIFF
--- a/tests/plugins/clipboard/mobilefix.js
+++ b/tests/plugins/clipboard/mobilefix.js
@@ -116,6 +116,7 @@
 			name: 'custom_button',
 			config: {
 				language: 'en',
+				removePlugins: 'pastetext,pastefromword',
 				on: {
 					pluginsLoaded: function( evt ) {
 						var editor = evt.editor;
@@ -125,12 +126,11 @@
 							command: 'paste',
 							toolbar: 'clipboard,40'
 						} );
-
-						arrayAssert.itemsAreEqual( [ 'Paste', 'CustomPaste' ], editor._.pasteButtons );
 					}
 				}
 			}
 		}, function( bot ) {
+			arrayAssert.itemsAreEqual( [ 'Paste', 'CustomPaste' ], bot.editor._.pasteButtons );
 			assertTouchEnd( bot.editor, 'CustomPaste' );
 		} );
 	};


### PR DESCRIPTION
## What is the purpose of this pull request?

Fix failing test

## Does your PR contain necessary tests?

All patches which change the editor code must include tests. You can always read more
on [PR testing](https://docs.ckeditor.com/ckeditor4/docs/#!/guide/dev_contributing_code-section-tests),
[how to set the testing environment](https://docs.ckeditor.com/ckeditor4/docs/#!/guide/dev_tests) and
[how to create tests](https://docs.ckeditor.com/ckeditor4/docs/#!/guide/dev_tests-section-creating-your-own-test)
in the official CKEditor documentation.

### This PR contains

- [ ] Unit tests
- [ ] Manual tests

## What changes did you make?

I've explicitly removed offending plugins and move assertion directly into `createEditor` callback.

Closes #1615.
