### PR TITLE
Fixed failing 'tests/plugins/balloontoolbar/context/widgetdnd ' test

### DIFF
--- a/tests/plugins/balloontoolbar/context/widgetdnd.js
+++ b/tests/plugins/balloontoolbar/context/widgetdnd.js
@@ -148,9 +148,6 @@
 				editor.focus();
 
 				try {
-					// Testing if widget is selected is meaningful only if it is not selected at the beginning. (https://dev.ckeditor.com/ticket/13129)
-					// assert.isNull( editor.widgets.focused, 'widget not focused before mousedown' );
-
 					img.fire( 'mousedown', {
 						$: {
 							button: 0
@@ -161,7 +158,9 @@
 					// making if feel that there's a place for the widget to be dropped.
 					editor.widgets.liner.showLine( editor.widgets.liner.addLine() );
 
-					editor.document.fire( 'mouseup' );
+					// Mouseup needs target so tableselection `evt.data.getTarget().getName` check inside
+					// its `fakeSelectionMouseHandler` method does not throw an error (#1614).
+					editor.document.fire( 'mouseup', new CKEDITOR.dom.event( { target: img } ) );
 
 					assert.areSame( widget, editor.widgets.focused, 'widget focused after mouseup' );
 


### PR DESCRIPTION
## What is the purpose of this pull request?

Other: failing test fix

## Does your PR contain necessary tests?

All patches which change the editor code must include tests. You can always read more
on [PR testing](https://docs.ckeditor.com/ckeditor4/docs/#!/guide/dev_contributing_code-section-tests),
[how to set the testing environment](https://docs.ckeditor.com/ckeditor4/docs/#!/guide/dev_tests) and
[how to create tests](https://docs.ckeditor.com/ckeditor4/docs/#!/guide/dev_tests-section-creating-your-own-test)
in the official CKEditor documentation.

### This PR contains

- [ ] Unit tests
- [ ] Manual tests

## What changes did you make?

The `target` was missing in simulated `mouseup` event which caused `tableselection` plugin to throw an error.

Also removed some leftover comments from the test.

Closes #1614.
