### PR TITLE
Fixed: Failing test on builded version: tests/core/selection/fake

### DIFF
--- a/tests/core/selection/fake.js
+++ b/tests/core/selection/fake.js
@@ -1074,12 +1074,16 @@ bender.test( {
 		editor.setReadOnly( true );
 
 		bot.setData( '<p>[[placeholder]]</p>', function() {
-			var widget = editor.widgets.instances[ 0 ];
-
+			var widget = editor.widgets.instances[ 0 ],
+				domEvent = {
+					getKey: function() {
+						return false;
+					}
+				};
 			widget.focus();
 
-			editor.fire( 'key', { keyCode: 8 } ); // backspace
-			editor.fire( 'key', { keyCode: 46 } ); // delete
+			editor.fire( 'key', { keyCode: 8, domEvent: domEvent } ); // backspace
+			editor.fire( 'key', { keyCode: 46, domEvent: domEvent } ); // delete
 
 			assert.areEqual( '<p>[[placeholder]]</p>', editor.getData() );
 		} );


### PR DESCRIPTION
## What is the purpose of this pull request?

Bugfix

## Does your PR contain necessary tests?

All patches which change the editor code must include tests. You can always read more
on [PR testing](https://docs.ckeditor.com/ckeditor4/docs/#!/guide/dev_contributing_code-section-tests),
[how to set the testing environment](https://docs.ckeditor.com/ckeditor4/docs/#!/guide/dev_tests) and
[how to create tests](https://docs.ckeditor.com/ckeditor4/docs/#!/guide/dev_tests-section-creating-your-own-test)
in the official CKEditor documentation.

### This PR contains

- [x] Unit tests
- [ ] Manual tests

## What changes did you make?

Some plugins have event listeners that use property `event.data.domEvent`, and method `event.data.domEvent.getKey`. I've added such property and method to faked test event and test passes in builded version.

Closes #1612 