### PR TITLE
Ignored widget/widgetsintegration unit test for Edge

### DIFF
--- a/tests/plugins/widget/widgetsintegration.js
+++ b/tests/plugins/widget/widgetsintegration.js
@@ -641,8 +641,8 @@
 
 		// #1570
 		'test cutting single focused widget with readonly mode': function() {
-			// Test has been ignored for IE due to #1575 issue. Remove this ignore statement after the issue fix.
-			if ( CKEDITOR.env.ie && !CKEDITOR.env.edge ) {
+			// Test has been ignored for IE due to #1632 issue. Remove this ignore statement after the issue fix.
+			if ( CKEDITOR.env.ie ) {
 				assert.ignore();
 			}
 


### PR DESCRIPTION
## What is the purpose of this pull request?

Task

## What changes did you make?

The source issue of this has been described in #1632, however the change is too risky to do this in the last moment. So the unit test for Edge will be ignored the same way as it is for IEs, and we'll get back to that in 4.9.1.