### PR TITLE
Remove tc test tag

### DIFF
--- a/tests/plugins/clipboard/manual/pastedialogwordbreak.md
+++ b/tests/plugins/clipboard/manual/pastedialogwordbreak.md
@@ -1,4 +1,4 @@
-@bender-tags: tc, 4.5.2, 13495
+@bender-tags: bug, 4.5.2, 13495
 @bender-ui: collapsed
 @bender-ckeditor-plugins: wysiwygarea, toolbar, clipboard, floatingspace, htmlwriter,
 


### PR DESCRIPTION
## What is the purpose of this pull request?

Other: task

## Does your PR contain necessary tests?

All patches which change the editor code must include tests. You can always read more
on [PR testing](https://docs.ckeditor.com/ckeditor4/docs/#!/guide/dev_contributing_code-section-tests),
[how to set the testing environment](https://docs.ckeditor.com/ckeditor4/docs/#!/guide/dev_tests) and
[how to create tests](https://docs.ckeditor.com/ckeditor4/docs/#!/guide/dev_tests-section-creating-your-own-test)
in the official CKEditor documentation.

### This PR contains

- [ ] Unit tests
- [ ] Manual tests

## What changes did you make?

I've removed `tc` tag, which appeared after readding some old test for paste dialog.
