### PR TITLE
Remove Trac reference from the GitHub issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -6,10 +6,6 @@ Replace this comment with your issue type: Bug / Feature request / Other, please
 Please **do not report security issues here**, use the contact form at https://ckeditor.com/contact/ instead.
 -->
 
-## [Check if the issue is already reported](https://docs.ckeditor.com/ckeditor4/docs/#!/guide/dev_issues_readme-section-avoid-duplicates)
-
-*Put all reference links here…*
-
 ## Provide detailed reproduction steps (if any)
 
 1. …

--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,9 +1,11 @@
 ## Are you reporting a feature request or a bug?
 
 <!--
-Replace this comment with your issue type: Bug / Feature request / Other, please explain.
+Before reporting your issue make sure there are no duplicates already reported.
 
 Please **do not report security issues here**, use the contact form at https://ckeditor.com/contact/ instead.
+
+Replace this comment with your issue type: Bug / Feature request / Other, please explain.
 -->
 
 ## Provide detailed reproduction steps (if any)


### PR DESCRIPTION
## What is the purpose of this pull request?

Other, GH template update

## Does your PR contain necessary tests?

No need.

## What changes did you make?

Removed a section requesting for checking Trac for a duplicate and added request for checking the duplicates at the very beginning of the comment block.