### PR TITLE
Fixed failing tests for firefox tests/plugins/easyimage/uploadintegrations

### DIFF
--- a/tests/plugins/imagebase/features/_helpers/tools.js
+++ b/tests/plugins/imagebase/features/_helpers/tools.js
@@ -29,6 +29,7 @@
 			editor.once( 'paste', function( evt ) {
 				// Unfortunately at the time being we need to do additional timeout here, as
 				// the paste event gets cancelled.
+				// We have to add additional ms to wait for Firefox to finish asynchronous events (#1619).
 				setTimeout( function() {
 					var widgets = bender.tools.objToArray( editor.widgets.instances ),
 						listeners = [];
@@ -43,13 +44,9 @@
 							} );
 						}
 
-						// Some tests occasionally fail in Firefox. After making them asynchronous tests passes (#1571).
-						// Unfortunately we weren't able to figure out a better way than adding a timeout.
-						setTimeout( function() {
-							resume( function() {
-								callback( bender.tools.objToArray( editor.widgets.instances ), evt, uploadEvt );
-							} );
-						}, 0 );
+						resume( function() {
+							callback( bender.tools.objToArray( editor.widgets.instances ), evt, uploadEvt );
+						} );
 					}
 
 					if ( options.fullLoad && widgets.length ) {
@@ -60,7 +57,7 @@
 					} else {
 						wrappedCallback();
 					}
-				}, 0 );
+				}, 30 );
 			}, null, null, -1 );
 
 			// pasteFiles is defined in clipboard plugin helper.


### PR DESCRIPTION
## What is the purpose of this pull request?

Tests fix

## What changes did you make?

I changed some tests to run asynchronously and increased paste files assertion timeout. It looks like Firefox need some more time to finish paste events. 30ms is not so long but if you thing it will make some huge impact on tests performance it can be increased only for Firefox. I think it make more sense to go for a single code path for simplicity.

Closes #1619
