### PR TITLE
Fixed a bug that was causing certain selection in read only mode to report an error

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -21,6 +21,8 @@ Fixed Issues:
 API Changes:
 
 * [#2249](https://github.com/ckeditor/ckeditor-dev/issues/1791): Added [`CKEDITOR.tools.detectPluginsConflict`](http://docs.ckeditor.com/ckeditor4/docs/#!/api/CKEDITOR_tools.html#method-detectPluginsConflict) function finding conflicts between provided plugins.
+* [#1184](https://github.com/ckeditor/ckeditor-dev/issues/1184): [IE8-11] Fixed: Copying and pasting data in [read-only mode](https://docs.ckeditor.com/ckeditor4/latest/api/CKEDITOR_editor.html#property-readOnly) throws an error.
+* [#1916](https://github.com/ckeditor/ckeditor-dev/issues/1916): [IE9-11] Fixed: Pressing <kbd>Delete</kbd> key in [read-only mode](https://docs.ckeditor.com/ckeditor4/latest/api/CKEDITOR_editor.html#property-readOnly) throws an error.
 
 ## CKEditor 4.10
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -17,12 +17,12 @@ Fixed Issues:
 * [#1046](https://github.com/ckeditor/ckeditor-dev/issues/1046): Fixed: Subsequent new links do not include `id` attribute. Thanks to [Nathan Samson](https://github.com/nathansamson)!
 * [#2195](https://github.com/ckeditor/ckeditor-dev/issues/2195): Fixed: [Emoji](https://ckeditor.com/cke4/addon/emoji) shows suggestion box when colon preceded with other character than white space.
 * [#1791](https://github.com/ckeditor/ckeditor-dev/issues/1791): Fixed: [Image](https://ckeditor.com/cke4/addon/image) and [Enhanced Image](https://ckeditor.com/cke4/addon/image2) plugins are enabled when [Easy Image](https://ckeditor.com/cke4/addon/easyimage) is present.
+* [#1184](https://github.com/ckeditor/ckeditor-dev/issues/1184): [IE8-11] Fixed: Copying and pasting data in [read-only mode](https://docs.ckeditor.com/ckeditor4/latest/api/CKEDITOR_editor.html#property-readOnly) throws an error.
+* [#1916](https://github.com/ckeditor/ckeditor-dev/issues/1916): [IE9-11] Fixed: Pressing <kbd>Delete</kbd> key in [read-only mode](https://docs.ckeditor.com/ckeditor4/latest/api/CKEDITOR_editor.html#property-readOnly) throws an error.
 
 API Changes:
 
 * [#2249](https://github.com/ckeditor/ckeditor-dev/issues/1791): Added [`CKEDITOR.tools.detectPluginsConflict`](http://docs.ckeditor.com/ckeditor4/docs/#!/api/CKEDITOR_tools.html#method-detectPluginsConflict) function finding conflicts between provided plugins.
-* [#1184](https://github.com/ckeditor/ckeditor-dev/issues/1184): [IE8-11] Fixed: Copying and pasting data in [read-only mode](https://docs.ckeditor.com/ckeditor4/latest/api/CKEDITOR_editor.html#property-readOnly) throws an error.
-* [#1916](https://github.com/ckeditor/ckeditor-dev/issues/1916): [IE9-11] Fixed: Pressing <kbd>Delete</kbd> key in [read-only mode](https://docs.ckeditor.com/ckeditor4/latest/api/CKEDITOR_editor.html#property-readOnly) throws an error.
 
 ## CKEditor 4.10
 

--- a/core/selection.js
+++ b/core/selection.js
@@ -929,6 +929,7 @@
 					ascendant = nonEditableAscendant( sel );
 
 				if ( ascendant ) {
+					// Prevent changing selection when an ascendant is an entire editable (#1632).
 					if ( !ascendant.equals( editable ) ) {
 						sel.selectElement( ascendant );
 					}

--- a/core/selection.js
+++ b/core/selection.js
@@ -923,20 +923,23 @@
 			// 2. After the accomplish of keyboard and mouse events.
 			editable.attachListener( editable, 'selectionchange', checkSelectionChange, editor );
 			editable.attachListener( editable, 'keyup', checkSelectionChangeTimeout, editor );
-			// https://dev.ckeditor.com/ticket/14407 - Don't even let anything happen if the selection is in a non-editable element.
-			editable.attachListener( editable, 'keydown', function( evt ) {
-				var sel = this.getSelection( 1 ),
-					ascendant = nonEditableAscendant( sel );
 
-				if ( ascendant ) {
-					// Prevent changing selection when an ascendant is an entire editable (#1632).
-					if ( !ascendant.equals( editable ) ) {
-						sel.selectElement( ascendant );
+			if ( CKEDITOR.env.ie ) {
+				// https://dev.ckeditor.com/ticket/14407 - Don't even let anything happen if the selection is in a non-editable element.
+				editable.attachListener( editable, 'keydown', function( evt ) {
+					var sel = this.getSelection( 1 ),
+						ascendant = nonEditableAscendant( sel );
+
+					if ( ascendant ) {
+						// Prevent changing selection when an ascendant is an entire editable (#1632).
+						if ( !ascendant.equals( editable ) ) {
+							sel.selectElement( ascendant );
+							evt.data.preventDefault();
+						}
 					}
+				}, editor );
+			}
 
-					evt.data.preventDefault();
-				}
-			}, editor );
 			// Always fire the selection change on focus gain.
 			// On Webkit do this on DOMFocusIn, because the selection is unlocked on it too and
 			// we need synchronization between those listeners to not lost cached editor._.previousActive property
@@ -1024,15 +1027,13 @@
 			}
 
 			function nonEditableAscendant( sel ) {
-				if ( CKEDITOR.env.ie ) {
-					var range = sel.getRanges()[ 0 ],
-						ascendant = range ? range.startContainer.getAscendant( function( parent ) {
-								return parent.type == CKEDITOR.NODE_ELEMENT &&
-									( parent.getAttribute( 'contenteditable' ) == 'false' || parent.getAttribute( 'contenteditable' ) == 'true' );
-							}, true ) : null ;
+				var range = sel.getRanges()[ 0 ],
+					ascendant = range ? range.startContainer.getAscendant( function( parent ) {
+						return parent.type == CKEDITOR.NODE_ELEMENT &&
+							( parent.getAttribute( 'contenteditable' ) == 'false' || parent.getAttribute( 'contenteditable' ) == 'true' );
+					}, true ) : null ;
 
-					return range && ascendant.getAttribute( 'contenteditable' ) == 'false' && ascendant;
-				}
+				return range && ascendant.getAttribute( 'contenteditable' ) == 'false' && ascendant;
 			}
 		} );
 

--- a/core/selection.js
+++ b/core/selection.js
@@ -925,6 +925,10 @@
 			editable.attachListener( editable, 'keyup', checkSelectionChangeTimeout, editor );
 			// https://dev.ckeditor.com/ticket/14407 - Don't even let anything happen if the selection is in a non-editable element.
 			editable.attachListener( editable, 'keydown', function( evt ) {
+				// Prevent changing selection for readonly mode where entire editable is non editable (#1632).
+				if ( this.readOnly ) {
+					return;
+				}
 				var sel = this.getSelection( 1 );
 				if ( nonEditableAscendant( sel ) ) {
 					sel.selectElement( nonEditableAscendant( sel ) );

--- a/core/selection.js
+++ b/core/selection.js
@@ -925,13 +925,14 @@
 			editable.attachListener( editable, 'keyup', checkSelectionChangeTimeout, editor );
 			// https://dev.ckeditor.com/ticket/14407 - Don't even let anything happen if the selection is in a non-editable element.
 			editable.attachListener( editable, 'keydown', function( evt ) {
-				// Prevent changing selection for readonly mode where entire editable is non editable (#1632).
-				if ( this.readOnly ) {
-					return;
-				}
-				var sel = this.getSelection( 1 );
-				if ( nonEditableAscendant( sel ) ) {
-					sel.selectElement( nonEditableAscendant( sel ) );
+				var sel = this.getSelection( 1 ),
+					ascendant = nonEditableAscendant( sel );
+
+				if ( ascendant ) {
+					if ( !ascendant.equals( editable ) ) {
+						sel.selectElement( ascendant );
+					}
+
 					evt.data.preventDefault();
 				}
 			}, editor );

--- a/core/selection.js
+++ b/core/selection.js
@@ -1033,7 +1033,7 @@
 							( parent.getAttribute( 'contenteditable' ) == 'false' || parent.getAttribute( 'contenteditable' ) == 'true' );
 					}, true ) : null ;
 
-				return range && ascendant.getAttribute( 'contenteditable' ) == 'false' && ascendant;
+				return ascendant && ascendant.getAttribute( 'contenteditable' ) == 'false' ? ascendant : null;
 			}
 		} );
 

--- a/core/selection.js
+++ b/core/selection.js
@@ -928,14 +928,12 @@
 				// https://dev.ckeditor.com/ticket/14407 - Don't even let anything happen if the selection is in a non-editable element.
 				editable.attachListener( editable, 'keydown', function( evt ) {
 					var sel = this.getSelection( 1 ),
-						ascendant = nonEditableAscendant( sel );
+						ascendant = getNonEditableAscendant( sel );
 
-					if ( ascendant ) {
-						// Prevent changing selection when an ascendant is an entire editable (#1632).
-						if ( !ascendant.equals( editable ) ) {
-							sel.selectElement( ascendant );
-							evt.data.preventDefault();
-						}
+					// Prevent changing selection when an ascendant is an entire editable (#1632).
+					if ( ascendant && !ascendant.equals( editable ) ) {
+						sel.selectElement( ascendant );
+						evt.data.preventDefault();
 					}
 				}, editor );
 			}
@@ -1026,14 +1024,23 @@
 					range.select();
 			}
 
-			function nonEditableAscendant( sel ) {
-				var range = sel.getRanges()[ 0 ],
-					ascendant = range ? range.startContainer.getAscendant( function( parent ) {
-						return parent.type == CKEDITOR.NODE_ELEMENT &&
-							( parent.getAttribute( 'contenteditable' ) == 'false' || parent.getAttribute( 'contenteditable' ) == 'true' );
-					}, true ) : null ;
+			function getNonEditableAscendant( sel ) {
+				var range = sel.getRanges()[ 0 ];
 
-				return ascendant && ascendant.getAttribute( 'contenteditable' ) == 'false' ? ascendant : null;
+				if ( !range ) {
+					return null;
+				}
+
+				// Fetch first contenteditable parent.
+				var ascendant = range.startContainer.getAscendant( function( parent ) {
+					return parent.type == CKEDITOR.NODE_ELEMENT && parent.hasAttribute( 'contenteditable' );
+				}, true );
+
+				if ( ascendant && ascendant.getAttribute( 'contenteditable' ) === 'false' ) {
+					return ascendant;
+				}
+
+				return null;
 			}
 		} );
 

--- a/tests/core/selection/fake.js
+++ b/tests/core/selection/fake.js
@@ -1106,11 +1106,11 @@ bender.test( {
 			assert.ignore();
 		}
 
-		var editor = this.editor, bot = this.editorBot;
+		var editor = this.editor;
 
 		editor.setReadOnly( true );
 
-		bot.setData( '<p>[[placeholder]]</p>', function() {
+		this.editorBot.setData( '<p>[[placeholder]]</p>', function() {
 			var widget = bender.tools.objToArray( editor.widgets.instances )[ 0 ];
 
 			widget.focus();
@@ -1118,6 +1118,31 @@ bender.test( {
 			editor.editable().fire( 'keydown', new CKEDITOR.dom.event( { keyCode: CKEDITOR.CTRL + 88 } ) );
 
 			assert.isFalse( !!editor.getSelection().isFake, 'selection is faked' );
+		} );
+	},
+
+	// (#1632)
+	'Test keys with readonly mode are not prevented': function() {
+
+		// Test has been ignored for IE due to #1575 issue. Remove this ignore statement after the issue fix.
+		if ( CKEDITOR.env.ie && !CKEDITOR.env.edge ) {
+			assert.ignore();
+		}
+
+		var editor = this.editor;
+
+		editor.setReadOnly( true );
+
+		this.editorBot.setData( '<p>[[placeholder]]</p>', function() {
+			var widget = bender.tools.objToArray( editor.widgets.instances )[ 0 ],
+				event = new CKEDITOR.dom.event( { keyCode: CKEDITOR.CTRL + 88 } ),
+				eventSpy = sinon.spy( event, 'preventDefault' );
+
+			widget.focus();
+
+			editor.editable().fire( 'keydown', event );
+
+			assert.isFalse( eventSpy.called );
 		} );
 	}
 } );

--- a/tests/core/selection/fake.js
+++ b/tests/core/selection/fake.js
@@ -1115,7 +1115,7 @@ bender.test( {
 
 			widget.focus();
 
-			editor.editable().fire( 'keydown', new CKEDITOR.dom.event( { keyCode: CKEDITOR.CTRL + 88 } ) );
+			editor.editable().fire( 'keydown', new CKEDITOR.dom.event( { keyCode: CKEDITOR.CTRL + 88 } ) ); // CUT
 
 			assert.isFalse( !!editor.getSelection().isFake, 'selection is faked' );
 		} );
@@ -1135,7 +1135,7 @@ bender.test( {
 
 		this.editorBot.setData( '<p>[[placeholder]]</p>', function() {
 			var widget = bender.tools.objToArray( editor.widgets.instances )[ 0 ],
-				event = new CKEDITOR.dom.event( { keyCode: CKEDITOR.CTRL + 88 } ),
+				event = new CKEDITOR.dom.event( { keyCode: CKEDITOR.CTRL + 88 } ), // CUT
 				eventSpy = sinon.spy( event, 'preventDefault' );
 
 			widget.focus();

--- a/tests/core/selection/fake.js
+++ b/tests/core/selection/fake.js
@@ -1096,5 +1096,28 @@ bender.test( {
 
 			assert.areEqual( '<p>[[placeholder]]</p>', editor.getData() );
 		} );
+	},
+
+	// (#1632)
+	'Test selection is not faked on keydown with readonly mode': function() {
+
+		// Test has been ignored for IE due to #1575 issue. Remove this ignore statement after the issue fix.
+		if ( CKEDITOR.env.ie && !CKEDITOR.env.edge ) {
+			assert.ignore();
+		}
+
+		var editor = this.editor, bot = this.editorBot;
+
+		editor.setReadOnly( true );
+
+		bot.setData( '<p>[[placeholder]]</p>', function() {
+			var widget = bender.tools.objToArray( editor.widgets.instances )[ 0 ];
+
+			widget.focus();
+
+			editor.editable().fire( 'keydown', new CKEDITOR.dom.event( { keyCode: CKEDITOR.CTRL + 88 } ) );
+
+			assert.isFalse( !!editor.getSelection().isFake, 'selection is faked' );
+		} );
 	}
 } );

--- a/tests/core/selection/fake.js
+++ b/tests/core/selection/fake.js
@@ -1096,53 +1096,6 @@ bender.test( {
 
 			assert.areEqual( '<p>[[placeholder]]</p>', editor.getData() );
 		} );
-	},
-
-	// (#1632)
-	'Test selection is not faked on keydown with readonly mode': function() {
-
-		// Test has been ignored for IE due to #1575 issue. Remove this ignore statement after the issue fix.
-		if ( CKEDITOR.env.ie && !CKEDITOR.env.edge ) {
-			assert.ignore();
-		}
-
-		var editor = this.editor;
-
-		editor.setReadOnly( true );
-
-		this.editorBot.setData( '<p>[[placeholder]]</p>', function() {
-			var widget = bender.tools.objToArray( editor.widgets.instances )[ 0 ];
-
-			widget.focus();
-
-			editor.editable().fire( 'keydown', new CKEDITOR.dom.event( { keyCode: CKEDITOR.CTRL + 88 } ) ); // CUT
-
-			assert.isFalse( !!editor.getSelection().isFake, 'selection is faked' );
-		} );
-	},
-
-	// (#1632)
-	'Test keys with readonly mode are not prevented': function() {
-
-		// Test has been ignored for IE due to #1575 issue. Remove this ignore statement after the issue fix.
-		if ( CKEDITOR.env.ie && !CKEDITOR.env.edge ) {
-			assert.ignore();
-		}
-
-		var editor = this.editor;
-
-		editor.setReadOnly( true );
-
-		this.editorBot.setData( '<p>[[placeholder]]</p>', function() {
-			var widget = bender.tools.objToArray( editor.widgets.instances )[ 0 ],
-				event = new CKEDITOR.dom.event( { keyCode: CKEDITOR.CTRL + 88 } ), // CUT
-				eventSpy = sinon.spy( event, 'preventDefault' );
-
-			widget.focus();
-
-			editor.editable().fire( 'keydown', event );
-
-			assert.isFalse( eventSpy.called );
-		} );
 	}
+
 } );

--- a/tests/core/selection/fake.js
+++ b/tests/core/selection/fake.js
@@ -1097,5 +1097,4 @@ bender.test( {
 			assert.areEqual( '<p>[[placeholder]]</p>', editor.getData() );
 		} );
 	}
-
 } );

--- a/tests/core/selection/manual/iereadonly.html
+++ b/tests/core/selection/manual/iereadonly.html
@@ -1,0 +1,13 @@
+<div id="editor">
+	 Some content [[placeholder]] and more here!
+</div>
+
+<script>
+	if ( !CKEDITOR.env.ie ) {
+		bender.ignore();
+	}
+
+	CKEDITOR.replace( 'editor', {
+		readOnly: true
+	} );
+</script>

--- a/tests/core/selection/manual/iereadonly.md
+++ b/tests/core/selection/manual/iereadonly.md
@@ -1,0 +1,15 @@
+@bender-tags: bug, 4.10.0, 1632, selection, widget
+@bender-ui: collapsed
+@bender-ckeditor-plugins: wysiwygarea, toolbar, placeholder
+
+1. Open console.
+1. Select whole editor content.
+1. Press `ctrl`.
+
+## Expected
+
+No warning or errors inside console.
+
+## Unexpected
+
+Console registered multiple warnings about invalid selection.

--- a/tests/core/selection/manual/iereadonly.md
+++ b/tests/core/selection/manual/iereadonly.md
@@ -1,4 +1,4 @@
-@bender-tags: bug, 4.10.0, 1632, selection, widget
+@bender-tags: bug, 4.10.1, 1632, selection, widget
 @bender-ui: collapsed
 @bender-ckeditor-plugins: wysiwygarea, toolbar, placeholder
 

--- a/tests/core/selection/manual/iereadonly.md
+++ b/tests/core/selection/manual/iereadonly.md
@@ -5,6 +5,7 @@
 1. Open console.
 1. Select whole editor content.
 1. Press `ctrl`.
+1. Repeat 1-2 with `delete` key.
 
 ## Expected
 

--- a/tests/core/selection/selection.js
+++ b/tests/core/selection/selection.js
@@ -1,4 +1,5 @@
 /* bender-tags: editor */
+/* bender-ckeditor-plugins: placeholder */
 /* global testSelection, testSelectedElement, testSelectedText, testStartElement, rangy, doc, makeSelection,
 	convertRange, checkRangeEqual, checkSelection, assertSelectionsAreEqual, tools */
 
@@ -785,5 +786,57 @@ bender.test( {
 		bender.tools.setHtmlWithSelection( editor, '<p>T^es^t</p>' );
 
 		assert.isFalse( editor.getSelection().isCollapsed() );
+	},
+
+	// (#1632)
+	'test keys with readonly editor': function() {
+
+		// Test has been ignored for IE due to #1575 issue. Remove this ignore statement after the issue fix.
+		if ( CKEDITOR.env.ie && !CKEDITOR.env.edge ) {
+			assert.ignore();
+		}
+
+		var editor = this.editor;
+
+		editor.setReadOnly( true );
+
+		this.editorBot.setData( '<p>[[placeholder]]</p>', function() {
+			var widget = bender.tools.objToArray( editor.widgets.instances )[ 0 ],
+				spy = sinon.spy( CKEDITOR.dom.selection.prototype, 'selectElement' ),
+				editable = editor.editable();
+
+			widget.focus();
+
+			editable.fire( 'keydown', new CKEDITOR.dom.event( { keyCode: CKEDITOR.CTRL } ) );
+			editable.fire( 'keydown', new CKEDITOR.dom.event( { keyCode: 46 } ) ); // DELETE
+
+			spy.restore();
+			assert.isFalse( spy.called );
+		} );
+	},
+
+	// (#1632)
+	'test keys with readonly mode are not prevented': function() {
+
+		// Test has been ignored for IE due to #1575 issue. Remove this ignore statement after the issue fix.
+		if ( CKEDITOR.env.ie && !CKEDITOR.env.edge ) {
+			assert.ignore();
+		}
+
+		var editor = this.editor;
+
+		editor.setReadOnly( true );
+
+		this.editorBot.setData( '<p>[[placeholder]]</p>', function() {
+			var widget = bender.tools.objToArray( editor.widgets.instances )[ 0 ],
+				event = new CKEDITOR.dom.event( { keyCode: CKEDITOR.CTRL } ),
+				eventSpy = sinon.spy( event, 'preventDefault' );
+
+			widget.focus();
+
+			editor.editable().fire( 'keydown', event );
+
+			assert.isFalse( eventSpy.called );
+		} );
 	}
 } );

--- a/tests/plugins/widget/widgetsintegration.js
+++ b/tests/plugins/widget/widgetsintegration.js
@@ -641,8 +641,8 @@
 
 		// #1570
 		'test cutting single focused widget with readonly mode': function() {
-			// Test has been ignored for IE due to #1632 issue. Remove this ignore statement after the issue fix.
-			if ( CKEDITOR.env.ie ) {
+			// Test has been ignored for IE due to #1575 issue. Remove this ignore statement after the issue fix.
+			if ( CKEDITOR.env.ie && !CKEDITOR.env.edge ) {
 				assert.ignore();
 			}
 

--- a/tests/plugins/widget/widgetsintegration.js
+++ b/tests/plugins/widget/widgetsintegration.js
@@ -53,10 +53,6 @@
 	}
 
 	bender.test( {
-		tearDown: function() {
-			this.editor.setReadOnly( false );
-		},
-
 		'test initializing widgets': function() {
 			var editor = this.editor;
 
@@ -641,11 +637,6 @@
 
 		// #1570
 		'test cutting single focused widget with readonly mode': function() {
-			// Test has been ignored for IE due to #1575 issue. Remove this ignore statement after the issue fix.
-			if ( CKEDITOR.env.ie && !CKEDITOR.env.edge ) {
-				assert.ignore();
-			}
-
 			var editor = this.editor;
 
 			this.editorBot.setData( '<p>X</p><p id="w1" data-widget="test2">A</p><p>X</p>', function() {
@@ -673,6 +664,8 @@
 					assert.isTrue( !!getWidgetById( editor, 'w1' ), 'widget has not been deleted' );
 					assert.isFalse( !!editor.getSelection().isFake, 'selection is not faked' );
 					assert.isFalse( !!editor.document.getById( 'cke_copybin' ), 'copybin was removed' );
+
+					this.editor.setReadOnly( false );
 				}, 150 );
 			} );
 		},

--- a/tests/plugins/widget/widgetsintegration.js
+++ b/tests/plugins/widget/widgetsintegration.js
@@ -53,6 +53,10 @@
 	}
 
 	bender.test( {
+		tearDown: function() {
+			this.editor.setReadOnly( false );
+		},
+
 		'test initializing widgets': function() {
 			var editor = this.editor;
 
@@ -664,8 +668,6 @@
 					assert.isTrue( !!getWidgetById( editor, 'w1' ), 'widget has not been deleted' );
 					assert.isFalse( !!editor.getSelection().isFake, 'selection is not faked' );
 					assert.isFalse( !!editor.document.getById( 'cke_copybin' ), 'copybin was removed' );
-
-					this.editor.setReadOnly( false );
 				}, 150 );
 			} );
 		},


### PR DESCRIPTION
## What is the purpose of this pull request?

Bug fix

## Does your PR contain necessary tests?

All patches which change the editor code must include tests. You can always read more
on [PR testing](https://docs.ckeditor.com/ckeditor4/docs/#!/guide/dev_contributing_code-section-tests),
[how to set the testing environment](https://docs.ckeditor.com/ckeditor4/docs/#!/guide/dev_tests) and
[how to create tests](https://docs.ckeditor.com/ckeditor4/docs/#!/guide/dev_tests-section-creating-your-own-test)
in the official CKEditor documentation.

### This PR contains

- [x] Unit tests
- [x] Manual tests

## What changes did you make?

The first idea was to skip changing selection on keydown events for read-only mode which was little naive. I found out there is a change proposed by @mlewand which works pretty well. In this version, we are selecting widget only if it's not an entire editable for keydown events. I added an additional unit test. 
I'm not sure how to test this case differently than in already existing manual test for [original issue](https://dev.ckeditor.com/ticket/14407) at `tests/core/selection/manual/iecontenteditablefalse`. Let me know if you think there should be an additional manual test.

This PR depends on #1690

Closes #1632, closes #1184, closes #1916