### PR TITLE
Exposed getAbsoluteClientRect function

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -28,10 +28,6 @@ Fixed Issues:
 
 * [#1835](https://github.com/ckeditor/ckeditor-dev/issues/1835): Fixed: Integration between [CKFinder](https://ckeditor.com/ckeditor-4/ckfinder/) and the [File Browser](https://ckeditor.com/cke4/addon/filebrowser) plugin does not work.
 
-API Changes:
-
-* [#1742](https://github.com/ckeditor/ckeditor-dev/issues/1724): Added option to [`getClientRect`](https://docs.ckeditor.com/ckeditor4/latest/api/CKEDITOR_dom_element.html#method-getClientRect) function allowing to calculate an element absolute bounding rectangle including browser's and editor's scroll position.
-
 ## CKEditor 4.9
 
 New Features:

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -3,6 +3,7 @@
 
 ## CKEditor 4.10
 
+<<<<<<< HEAD
 New Features:
 
 * [#1761](https://github.com/ckeditor/ckeditor-dev/issues/1761): [Autolink](https://ckeditor.com/cke4/addon/autolink) plugin supports email links.
@@ -26,6 +27,11 @@ API Changes:
 Fixed Issues:
 
 * [#1835](https://github.com/ckeditor/ckeditor-dev/issues/1835): Fixed: Integration between [CKFinder](https://ckeditor.com/ckeditor-4/ckfinder/) and the [File Browser](https://ckeditor.com/cke4/addon/filebrowser) plugin does not work.
+=======
+API Changes:
+
+* [#1742](https://github.com/ckeditor/ckeditor-dev/issues/1724): Added [`getAbsoluteClientRect`](https://docs.ckeditor.com/ckeditor4/latest/api/CKEDITOR_dom_element.html#method-getAbsoluteClientRect) function allowing to calculate an element absolute bounding rectangle includes browser's and editor's scroll position.
+>>>>>>> 314c529ba... Moved changelog entry.
 
 ## CKEditor 4.9
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -3,7 +3,6 @@
 
 ## CKEditor 4.10
 
-<<<<<<< HEAD
 New Features:
 
 * [#1761](https://github.com/ckeditor/ckeditor-dev/issues/1761): [Autolink](https://ckeditor.com/cke4/addon/autolink) plugin supports email links.
@@ -27,11 +26,10 @@ API Changes:
 Fixed Issues:
 
 * [#1835](https://github.com/ckeditor/ckeditor-dev/issues/1835): Fixed: Integration between [CKFinder](https://ckeditor.com/ckeditor-4/ckfinder/) and the [File Browser](https://ckeditor.com/cke4/addon/filebrowser) plugin does not work.
-=======
+
 API Changes:
 
-* [#1742](https://github.com/ckeditor/ckeditor-dev/issues/1724): Added [`getAbsoluteClientRect`](https://docs.ckeditor.com/ckeditor4/latest/api/CKEDITOR_dom_element.html#method-getAbsoluteClientRect) function allowing to calculate an element absolute bounding rectangle includes browser's and editor's scroll position.
->>>>>>> 314c529ba... Moved changelog entry.
+* [#1742](https://github.com/ckeditor/ckeditor-dev/issues/1724): Added option to [`getClientRect`](https://docs.ckeditor.com/ckeditor4/latest/api/CKEDITOR_dom_element.html#method-getClientRect) function allowing to calculate an element absolute bounding rectangle including browser's and editor's scroll position.
 
 ## CKEditor 4.9
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -20,6 +20,7 @@ API Changes:
 
 * [#1582](https://github.com/ckeditor/ckeditor-dev/issues/1582): The [`CKEDITOR.editor.addCommand`](https://docs.ckeditor.com/ckeditor4/latest/api/CKEDITOR_editor.html#method-addCommand) can accept [`CKEDITOR.command`](https://docs.ckeditor.com/ckeditor4/latest/api/CKEDITOR_command.html) instance as parameter.
 * [#1712](https://github.com/ckeditor/ckeditor-dev/issues/1712): [`extraPlugins`](https://docs.ckeditor.com/ckeditor4/latest/api/CKEDITOR_config.html#cfg-extraPlugins), [`removePlugins`](https://docs.ckeditor.com/ckeditor4/latest/api/CKEDITOR_config.html#cfg-removePlugins) and [`plugins`](https://docs.ckeditor.com/ckeditor4/latest/api/CKEDITOR_config.html#cfg-plugins) configuration options allow whitespace.
+* [#1724](https://github.com/ckeditor/ckeditor-dev/issues/1724): Added option to [`getClientRect`](https://docs.ckeditor.com/ckeditor4/latest/api/CKEDITOR_dom_element.html#method-getClientRect) function allowing to retrieve an absolute bounding rectangle of the element i.e. position relative to the upper-left corner of the topmost viewport.
 
 ## CKEditor 4.9.1
 

--- a/core/dom/element.js
+++ b/core/dom/element.js
@@ -493,6 +493,7 @@ CKEDITOR.dom.element.clearMarkers = function( database, element, removeFromDatab
 		 * frame.getClientRect( true );
 		 * ```
 		 *
+		 * @since 4.10.0
 		 * @param {Boolean} [isAbsolute=false] The function will retrieve absolute rectangle of the currect element i.e. including scroll position.
 		 * @returns {Object.<String, Number>} The dimensions of the DOM element.
 		 * @returns {Number} return.top Top offset.

--- a/core/dom/element.js
+++ b/core/dom/element.js
@@ -502,6 +502,8 @@ CKEDITOR.dom.element.clearMarkers = function( database, element, removeFromDatab
 		 * @returns {Number} return.right Right offset.
 		 * @returns {Number} return.height Element height.
 		 * @returns {Number} return.width Element width.
+		 * @returns {Number} return.x X coordinate value. This property is not available in Internet Explorer or Edge browsers.
+		 * @returns {Number} return.y Y coordinate value. This property is not available in Internet Explorer or Edge browsers.
 		 */
 		getClientRect: function( isAbsolute ) {
 			// http://help.dottoro.com/ljvmcrrn.php
@@ -521,6 +523,9 @@ CKEDITOR.dom.element.clearMarkers = function( database, element, removeFromDatab
 			elementRect.top += winGlobalScroll.y;
 			elementRect.left += winGlobalScroll.x;
 
+			elementRect.y += winGlobalScroll.y;
+			elementRect.x += winGlobalScroll.x;
+
 			elementRect.right = elementRect.left + elementRect.width;
 			elementRect.bottom = elementRect.top + elementRect.height;
 
@@ -535,6 +540,9 @@ CKEDITOR.dom.element.clearMarkers = function( database, element, removeFromDatab
 
 				elementRect.top += frameRect.top;
 				elementRect.left += frameRect.left;
+
+				elementRect.x += frameRect.x;
+				elementRect.y += frameRect.y;
 
 				appendParentFramePosition( frame.getWindow().getFrame() );
 			}

--- a/core/dom/element.js
+++ b/core/dom/element.js
@@ -487,7 +487,7 @@ CKEDITOR.dom.element.clearMarkers = function( database, element, removeFromDatab
 		 * As an example you could use this function with {@link CKEDITOR.dom.window#getFrame editor's window frame} to
 		 * calculate the bounding rectangle of the visible area of the editor and the viewport.
 		 * The retrieved bounding rectangle could be used to position elements like toolbars or notifications (elements outside editor)
-		 * to always keep them inside editor viewport independantly from the scroll position.
+		 * to always keep them inside editor viewport independently from the scroll position.
 		 *
 		 * ```javascript
 		 * var frame = editor.window.getFrame();
@@ -496,8 +496,13 @@ CKEDITOR.dom.element.clearMarkers = function( database, element, removeFromDatab
 		 *
 		 * @since 4.10.0
 		 * @param {CKEDITOR.editor} editor The editor used to calculate scroll position.
-		 * @returns {Object} The dimensions of the DOM element (scroll position included) including
-		 * `left`, `top`, `right`, `bottom`, `width` and `height`.
+		 * @returns {Object.<String, Number>} The dimensions of the DOM element (scroll position included).
+		 * @returns {Number} return.top Top offset.
+		 * @returns {Number} return.bottom Bottom offset.
+		 * @returns {Number} return.left Left offset.
+		 * @returns {Number} return.right Right offset.
+		 * @returns {Number} return.height Element height.
+		 * @returns {Number} return.width Element width.
 		 */
 		getAbsoluteClientRect: function( editor ) {
 			var elementRect = this.getClientRect(),

--- a/core/dom/element.js
+++ b/core/dom/element.js
@@ -480,7 +480,7 @@ CKEDITOR.dom.element.clearMarkers = function( database, element, removeFromDatab
 		 * Retrieve the bounding rectangle of the current element, in pixels,
 		 * relative to the upper-left corner of the browser's client area.
 		 *
-		 * You can pass additional parameter if the function should give absolute element position which can be used for positioning elements
+		 * Since 4.10.0 you can pass additional parameter if the function should give absolute element position which can be used for positioning elements
 		 * inside scrollable areas.
 		 *
 		 * E.g. you could use this function with {@link CKEDITOR.dom.window#getFrame editor's window frame} to
@@ -493,8 +493,7 @@ CKEDITOR.dom.element.clearMarkers = function( database, element, removeFromDatab
 		 * frame.getClientRect( true );
 		 * ```
 		 *
-		 * @since 4.10.0
-		 * @param {Boolean} [isAbsolute=false] The function will retrieve absolute rectangle of the currect element i.e. including scroll position.
+		 * @param {Boolean} [isAbsolute=false] The function will retrieve an absolute rectangle of the element i.e. position relative to the upper-left corner of the topmost viewport. This option is available since 4.10.0.
 		 * @returns {Object.<String, Number>} The dimensions of the DOM element.
 		 * @returns {Number} return.top Top offset.
 		 * @returns {Number} return.bottom Bottom offset.

--- a/core/dom/element.js
+++ b/core/dom/element.js
@@ -477,6 +477,52 @@ CKEDITOR.dom.element.clearMarkers = function( database, element, removeFromDatab
 		},
 
 		/**
+		 * Retrieve the absolute bounding rectangle of the current element, in pixels,
+		 * relative to the upper-left corner of the browser's client area
+		 * including browser's and editor's scroll.
+		 *
+		 * This function gives absolute element position which can be used for positioning elements
+		 * inside scrollable areas.
+		 *
+		 * As an example you could use this function with {@link CKEDITOR.dom.window#getFrame editor's window frame} to
+		 * calculate the bounding rectangle of the visible area of the editor and the viewport.
+		 * The retrieved bounding rectangle could be used to position elements like toolbars or notifications (elements outside editor)
+		 * to always keep them inside editor viewport independantly from the scroll position.
+		 *
+		 * ```javascript
+		 * var frame = editor.window.getFrame();
+		 * frame.getAbsoluteClientRect( editor );
+		 * ```
+		 *
+		 * @since 4.10.0
+		 * @param {CKEDITOR.editor} editor The editor used to calculate scroll position.
+		 * @returns {Object} The dimensions of the DOM element (scroll position included) including
+		 * `left`, `top`, `right`, `bottom`, `width` and `height`.
+		 */
+		getAbsoluteClientRect: function( editor ) {
+			var elementRect = this.getClientRect(),
+				winGlobalScroll = CKEDITOR.document.getWindow().getScrollPosition(),
+				frame = editor.window.getFrame(),
+				frameRect;
+
+			if ( editor.editable().isInline() || this.equals( frame ) ) {
+				elementRect.top = elementRect.top + winGlobalScroll.y;
+				elementRect.left = elementRect.left + winGlobalScroll.x;
+				elementRect.right = elementRect.left + elementRect.width;
+				elementRect.bottom = elementRect.top + elementRect.height;
+			} else {
+				frameRect = frame.getClientRect();
+
+				elementRect.top = frameRect.top + elementRect.top + winGlobalScroll.y;
+				elementRect.left = frameRect.left + elementRect.left + winGlobalScroll.x;
+				elementRect.right = elementRect.left + elementRect.width;
+				elementRect.bottom = elementRect.top + elementRect.height;
+			}
+
+			return elementRect;
+		},
+
+		/**
 		 * Retrieve the bounding rectangle of the current element, in pixels,
 		 * relative to the upper-left corner of the browser's client area.
 		 *

--- a/core/dom/element.js
+++ b/core/dom/element.js
@@ -530,6 +530,8 @@ CKEDITOR.dom.element.clearMarkers = function( database, element, removeFromDatab
 					return;
 				}
 
+				var frameRect = frame.getClientRect();
+
 				elementRect.top += frameRect.top;
 				elementRect.left += frameRect.left;
 

--- a/core/dom/element.js
+++ b/core/dom/element.js
@@ -494,15 +494,7 @@ CKEDITOR.dom.element.clearMarkers = function( database, element, removeFromDatab
 		 * ```
 		 *
 		 * @param {Boolean} [isAbsolute=false] The function will retrieve an absolute rectangle of the element i.e. position relative to the upper-left corner of the topmost viewport. This option is available since 4.10.0.
-		 * @returns {Object.<String, Number>} The dimensions of the DOM element.
-		 * @returns {Number} return.top Top offset.
-		 * @returns {Number} return.bottom Bottom offset.
-		 * @returns {Number} return.left Left offset.
-		 * @returns {Number} return.right Right offset.
-		 * @returns {Number} return.height Element height.
-		 * @returns {Number} return.width Element width.
-		 * @returns {Number} return.x X coordinate value. This property is not available in Internet Explorer or Edge browsers.
-		 * @returns {Number} return.y Y coordinate value. This property is not available in Internet Explorer or Edge browsers.
+		 * @returns {CKEDITOR.dom.rect} The dimensions of the DOM element.
 		 */
 		getClientRect: function( isAbsolute ) {
 			// http://help.dottoro.com/ljvmcrrn.php

--- a/plugins/balloonpanel/plugin.js
+++ b/plugins/balloonpanel/plugin.js
@@ -385,8 +385,8 @@
 				var panelWidth = this.getWidth(),
 					panelHeight = this.getHeight(),
 
-					elementRect = element.getAbsoluteClientRect( this.editor ),
-					editorRect = isInline ? editable.getAbsoluteClientRect( this.editor ) : frame.getAbsoluteClientRect( this.editor ),
+					elementRect = element.getClientRect( true ),
+					editorRect = isInline ? editable.getClientRect( true ) : frame.getClientRect( true ),
 
 					viewPaneSize = winGlobal.getViewPaneSize(),
 					winGlobalScroll = winGlobal.getScrollPosition();

--- a/plugins/balloonpanel/plugin.js
+++ b/plugins/balloonpanel/plugin.js
@@ -385,8 +385,8 @@
 				var panelWidth = this.getWidth(),
 					panelHeight = this.getHeight(),
 
-					elementRect = this._getAbsoluteRect( element ),
-					editorRect = this._getAbsoluteRect( isInline ? editable : frame ),
+					elementRect = element.getAbsoluteClientRect( this.editor ),
+					editorRect = isInline ? editable.getAbsoluteClientRect( this.editor ) : frame.getAbsoluteClientRect( this.editor ),
 
 					viewPaneSize = winGlobal.getViewPaneSize(),
 					winGlobalScroll = winGlobal.getScrollPosition();
@@ -784,41 +784,6 @@
 				left: pos.x,
 				right: pos.x + viewSize.width
 			};
-		},
-
-		/**
-		 * Returns the position of the element on the screen.
-		 *
-		 * @since 4.9.0
-		 * @private
-		 * @param {CKEDITOR.dom.element} element The element whose position is calculated.
-		 * @returns {Object} The element position (scroll position included).
-		 * @returns {Number} return.top Top offset.
-		 * @returns {Number} return.bottom Bottom offset.
-		 * @returns {Number} return.left Left offset.
-		 * @returns {Number} return.right Right offset.
-		 */
-		_getAbsoluteRect: function( element ) {
-			var elementRect = element.getClientRect(),
-				winGlobalScroll = CKEDITOR.document.getWindow().getScrollPosition(),
-				frame = this.editor.window.getFrame(),
-				frameRect;
-
-			if ( this.editor.editable().isInline() || element.equals( frame ) ) {
-				elementRect.top = elementRect.top + winGlobalScroll.y;
-				elementRect.left = elementRect.left + winGlobalScroll.x;
-				elementRect.right = elementRect.left + elementRect.width;
-				elementRect.bottom = elementRect.top + elementRect.height;
-			} else {
-				frameRect = frame.getClientRect();
-
-				elementRect.top = frameRect.top + elementRect.top + winGlobalScroll.y;
-				elementRect.left = frameRect.left + elementRect.left + winGlobalScroll.x;
-				elementRect.right = elementRect.left + elementRect.width;
-				elementRect.bottom = elementRect.top + elementRect.height;
-			}
-
-			return elementRect;
 		}
 	};
 

--- a/tests/core/dom/element/_assets/framerect.html
+++ b/tests/core/dom/element/_assets/framerect.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html>
+<head>
+	<meta charset="utf-8">
+	<meta http-equiv="X-UA-Compatible" content="IE=edge">
+	<title></title>
+	<link rel="stylesheet" href="">
+</head>
+<body>
+	<iframe id="frame" style="top: 10px; left: 10px; position: absolute; width: 15px; height: 20px" src="rect.html"></iframe>
+</body>
+</html>

--- a/tests/core/dom/element/_assets/rect.html
+++ b/tests/core/dom/element/_assets/rect.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html>
+<head>
+	<meta charset="utf-8">
+	<meta http-equiv="X-UA-Compatible" content="IE=edge">
+	<title></title>
+	<link rel="stylesheet" href="">
+</head>
+<body>
+	<div id="rect" style="top: 5px; left: 5px; width: 10px; height: 10px; position: fixed;"></div>
+</body>
+</html>

--- a/tests/core/dom/element/absoluterect.html
+++ b/tests/core/dom/element/absoluterect.html
@@ -1,3 +1,4 @@
 <div id="rect1" style="top: 5px; left: 5px; width: 10px; height: 10px; position: absolute;"></div>
 <div id="rect2" style="top: 10px; left: 0; width: 15px; height: 20px; position: absolute;"></div>
 <iframe id="nested" style="top: 10px; left: 10px; position: absolute; width: 15px; height: 20px" src="_assets/rect.html"></iframe>
+<iframe id="deepnested" style="top: 10px; left: 10px; position: absolute; width: 15px; height: 20px" src="_assets/framerect.html"></iframe>

--- a/tests/core/dom/element/absoluterect.html
+++ b/tests/core/dom/element/absoluterect.html
@@ -1,2 +1,3 @@
-<div id="rect1" style="top: 5px; left: 5px; width: 10px; height: 10px; position: fixed;"></div>
-<div id="rect2" style="top: 10px; left: 0; width: 15px; height: 20px; position: fixed;"></div>
+<div id="rect1" style="top: 5px; left: 5px; width: 10px; height: 10px; position: absolute;"></div>
+<div id="rect2" style="top: 10px; left: 0; width: 15px; height: 20px; position: absolute;"></div>
+<iframe id="nested" style="top: 10px; left: 10px; position: absolute; width: 15px; height: 20px" src="_assets/rect.html"></iframe>

--- a/tests/core/dom/element/absoluterect.html
+++ b/tests/core/dom/element/absoluterect.html
@@ -1,0 +1,2 @@
+<div id="rect1" style="top: 5px; left: 5px; width: 10px; height: 10px; position: fixed;"></div>
+<div id="rect2" style="top: 10px; left: 0; width: 15px; height: 20px; position: fixed;"></div>

--- a/tests/core/dom/element/absoluterect.html
+++ b/tests/core/dom/element/absoluterect.html
@@ -1,4 +1,4 @@
 <div id="rect1" style="top: 5px; left: 5px; width: 10px; height: 10px; position: absolute;"></div>
-<div id="rect2" style="top: 10px; left: 0; width: 15px; height: 20px; position: absolute;"></div>
+<div id="rect2" style="top: 10px; left: 5px; width: 15px; height: 20px; position: absolute;"></div>
 <iframe id="nested" style="top: 10px; left: 10px; position: absolute; width: 15px; height: 20px" src="_assets/rect.html"></iframe>
 <iframe id="deepnested" style="top: 10px; left: 10px; position: absolute; width: 15px; height: 20px" src="_assets/framerect.html"></iframe>

--- a/tests/core/dom/element/absoluterect.js
+++ b/tests/core/dom/element/absoluterect.js
@@ -15,6 +15,8 @@
 			assert.isNumberInRange( absoluteRect.left, 5, 7, 'left' );
 			assert.isNumberInRange( absoluteRect.right, 15, 17, 'right' );
 			assert.isNumberInRange( absoluteRect.height, 9, 11, 'height' );
+			!CKEDITOR.env.ie && assert.isNumberInRange( absoluteRect.x, 15, 17, 'x' );
+			!CKEDITOR.env.ie && assert.isNumberInRange( absoluteRect.y, 9, 11, 'y' );
 		},
 
 		// (#1724)
@@ -27,6 +29,8 @@
 			assert.isNumberInRange( absoluteRect.left, 0, 2, 'left' );
 			assert.isNumberInRange( absoluteRect.right, 15, 17, 'right' );
 			assert.isNumberInRange( absoluteRect.height, 19, 21, 'height' );
+			!CKEDITOR.env.ie && assert.isNumberInRange( absoluteRect.x, 15, 17, 'x' );
+			!CKEDITOR.env.ie && assert.isNumberInRange( absoluteRect.y, 9, 11, 'y' );
 		},
 
 		// (#1724)
@@ -39,6 +43,8 @@
 			assert.isNumberInRange( absoluteRect.left, 14, 16, 'left' );
 			assert.isNumberInRange( absoluteRect.right, 24, 26, 'right' );
 			assert.isNumberInRange( absoluteRect.height, 9, 11, 'height' );
+			!CKEDITOR.env.ie && assert.isNumberInRange( absoluteRect.x, 15, 17, 'x' );
+			!CKEDITOR.env.ie && assert.isNumberInRange( absoluteRect.y, 9, 11, 'y' );
 		},
 
 		// (#1724)
@@ -53,6 +59,8 @@
 			assert.isNumberInRange( absoluteRect.left, 24, 26, 'left' );
 			assert.isNumberInRange( absoluteRect.right, 34, 36, 'right' );
 			assert.isNumberInRange( absoluteRect.height, 9, 11, 'height' );
+			!CKEDITOR.env.ie && assert.isNumberInRange( absoluteRect.x, 15, 17, 'x' );
+			!CKEDITOR.env.ie && assert.isNumberInRange( absoluteRect.y, 9, 11, 'y' );
 		}
 	} );
 

--- a/tests/core/dom/element/absoluterect.js
+++ b/tests/core/dom/element/absoluterect.js
@@ -30,7 +30,7 @@
 		},
 
 		// (#1724)
-		'test nested iframe element has correct absolute rect': function() {
+		'test nested iframe (1lvl) element has correct absolute rect': function() {
 			var el = CKEDITOR.document.getById( 'nested' ).getFrameDocument().getById( 'rect' ),
 				absoluteRect = el.getClientRect( true );
 
@@ -38,6 +38,20 @@
 			assert.isNumberInRange( absoluteRect.bottom, 24, 26, 'bottom' );
 			assert.isNumberInRange( absoluteRect.left, 14, 16, 'left' );
 			assert.isNumberInRange( absoluteRect.right, 24, 26, 'right' );
+			assert.isNumberInRange( absoluteRect.height, 9, 11, 'height' );
+		},
+
+		// (#1724)
+		'test nested iframe (2lvls) element has correct absolute rect': function() {
+			var el = CKEDITOR.document.getById( 'deepnested' )
+				.getFrameDocument().getById( 'frame' )
+				.getFrameDocument().getById( 'rect' ),
+				absoluteRect = el.getClientRect( true );
+
+			assert.isNumberInRange( absoluteRect.top, 24, 26, 'top' );
+			assert.isNumberInRange( absoluteRect.bottom, 34, 36, 'bottom' );
+			assert.isNumberInRange( absoluteRect.left, 24, 26, 'left' );
+			assert.isNumberInRange( absoluteRect.right, 34, 36, 'right' );
 			assert.isNumberInRange( absoluteRect.height, 9, 11, 'height' );
 		}
 	} );

--- a/tests/core/dom/element/absoluterect.js
+++ b/tests/core/dom/element/absoluterect.js
@@ -7,9 +7,8 @@
 	bender.test( {
 		// (#1724)
 		'test element has correct absolute rect (rect1)': function() {
-			var editor = this.editor,
-				el = CKEDITOR.document.getById( 'rect1' ),
-				absoluteRect = el.getAbsoluteClientRect( editor );
+			var el = CKEDITOR.document.getById( 'rect1' ),
+				absoluteRect = el.getClientRect( true );
 
 			assert.isNumberInRange( absoluteRect.top, 5, 7, 'top' );
 			assert.isNumberInRange( absoluteRect.bottom, 15, 17, 'bottom' );
@@ -20,9 +19,8 @@
 
 		// (#1724)
 		'test element has correct absolute rect (rect2)': function() {
-			var editor = this.editor,
-				el = CKEDITOR.document.getById( 'rect2' ),
-				absoluteRect = el.getAbsoluteClientRect( editor );
+			var el = CKEDITOR.document.getById( 'rect2' ),
+				absoluteRect = el.getClientRect( true );
 
 			assert.isNumberInRange( absoluteRect.top, 10, 12, 'top' );
 			assert.isNumberInRange( absoluteRect.bottom, 30, 32, 'bottom' );

--- a/tests/core/dom/element/absoluterect.js
+++ b/tests/core/dom/element/absoluterect.js
@@ -1,0 +1,47 @@
+/* bender-tags: editor,dom */
+
+( function() {
+
+	bender.editor = true;
+
+	bender.test( {
+		// (#1724)
+		'test element has correct absolute rect (rect1)': function() {
+			var editor = this.editor,
+				el = CKEDITOR.document.getById( 'rect1' ),
+				absoluteRect = el.getAbsoluteClientRect( editor );
+
+			assert.isNumberInRange( absoluteRect.top, 5, 7, 'top' );
+			assert.isNumberInRange( absoluteRect.bottom, 15, 17, 'bottom' );
+			assert.isNumberInRange( absoluteRect.left, 5, 7, 'left' );
+			assert.isNumberInRange( absoluteRect.right, 15, 17, 'right' );
+			assert.isNumberInRange( absoluteRect.height, 9, 11, 'height' );
+
+			// getBoundingClientRect for IE browsers doesn't contain information about x and y.
+			if( !CKEDITOR.env.ie ) {
+				assert.isNumberInRange( absoluteRect.x, 4, 5, 'x' );
+				assert.isNumberInRange( absoluteRect.y, 4, 5, 'y' );
+			}
+		},
+
+		// (#1724)
+		'test element has correct absolute rect (rect2)': function() {
+			var editor = this.editor,
+				el = CKEDITOR.document.getById( 'rect2' ),
+				absoluteRect = el.getAbsoluteClientRect( editor );
+
+			assert.isNumberInRange( absoluteRect.top, 10, 12, 'top' );
+			assert.isNumberInRange( absoluteRect.bottom, 30, 32, 'bottom' );
+			assert.isNumberInRange( absoluteRect.left, 0, 2, 'left' );
+			assert.isNumberInRange( absoluteRect.right, 15, 17, 'right' );
+			assert.isNumberInRange( absoluteRect.height, 19, 21, 'height' );
+
+			// getBoundingClientRect for IE browsers doesn't contain information about x and y.
+			if( !CKEDITOR.env.ie ) {
+				assert.isNumberInRange( absoluteRect.x, 0, 2, 'x' );
+				assert.isNumberInRange( absoluteRect.y, 9, 11, 'y' );
+			}
+		}
+	} );
+
+} )();

--- a/tests/core/dom/element/absoluterect.js
+++ b/tests/core/dom/element/absoluterect.js
@@ -27,6 +27,18 @@
 			assert.isNumberInRange( absoluteRect.left, 0, 2, 'left' );
 			assert.isNumberInRange( absoluteRect.right, 15, 17, 'right' );
 			assert.isNumberInRange( absoluteRect.height, 19, 21, 'height' );
+		},
+
+		// (#1724)
+		'test nested iframe element has correct absolute rect': function() {
+			var el = CKEDITOR.document.getById( 'nested' ).getFrameDocument().getById( 'rect' ),
+				absoluteRect = el.getClientRect( true );
+
+			assert.isNumberInRange( absoluteRect.top, 14, 16, 'top' );
+			assert.isNumberInRange( absoluteRect.bottom, 24, 26, 'bottom' );
+			assert.isNumberInRange( absoluteRect.left, 14, 16, 'left' );
+			assert.isNumberInRange( absoluteRect.right, 24, 26, 'right' );
+			assert.isNumberInRange( absoluteRect.height, 9, 11, 'height' );
 		}
 	} );
 

--- a/tests/core/dom/element/absoluterect.js
+++ b/tests/core/dom/element/absoluterect.js
@@ -16,12 +16,6 @@
 			assert.isNumberInRange( absoluteRect.left, 5, 7, 'left' );
 			assert.isNumberInRange( absoluteRect.right, 15, 17, 'right' );
 			assert.isNumberInRange( absoluteRect.height, 9, 11, 'height' );
-
-			// getBoundingClientRect for IE browsers doesn't contain information about x and y.
-			if( !CKEDITOR.env.ie ) {
-				assert.isNumberInRange( absoluteRect.x, 4, 5, 'x' );
-				assert.isNumberInRange( absoluteRect.y, 4, 5, 'y' );
-			}
 		},
 
 		// (#1724)
@@ -35,12 +29,6 @@
 			assert.isNumberInRange( absoluteRect.left, 0, 2, 'left' );
 			assert.isNumberInRange( absoluteRect.right, 15, 17, 'right' );
 			assert.isNumberInRange( absoluteRect.height, 19, 21, 'height' );
-
-			// getBoundingClientRect for IE browsers doesn't contain information about x and y.
-			if( !CKEDITOR.env.ie ) {
-				assert.isNumberInRange( absoluteRect.x, 0, 2, 'x' );
-				assert.isNumberInRange( absoluteRect.y, 9, 11, 'y' );
-			}
 		}
 	} );
 

--- a/tests/core/dom/element/absoluterect.js
+++ b/tests/core/dom/element/absoluterect.js
@@ -12,11 +12,11 @@
 
 			assert.isNumberInRange( absoluteRect.top, 5, 7, 'top' );
 			assert.isNumberInRange( absoluteRect.bottom, 15, 17, 'bottom' );
-			assert.isNumberInRange( absoluteRect.left, 5, 7, 'left' );
+			assert.isNumberInRange( absoluteRect.left, 4, 6, 'left' );
 			assert.isNumberInRange( absoluteRect.right, 15, 17, 'right' );
 			assert.isNumberInRange( absoluteRect.height, 9, 11, 'height' );
-			!CKEDITOR.env.ie && assert.isNumberInRange( absoluteRect.x, 15, 17, 'x' );
-			!CKEDITOR.env.ie && assert.isNumberInRange( absoluteRect.y, 9, 11, 'y' );
+			!CKEDITOR.env.ie && assert.isNumberInRange( absoluteRect.x, 4, 6, 'x' );
+			!CKEDITOR.env.ie && assert.isNumberInRange( absoluteRect.y, 4, 6, 'y' );
 		},
 
 		// (#1724)
@@ -26,10 +26,10 @@
 
 			assert.isNumberInRange( absoluteRect.top, 10, 12, 'top' );
 			assert.isNumberInRange( absoluteRect.bottom, 30, 32, 'bottom' );
-			assert.isNumberInRange( absoluteRect.left, 0, 2, 'left' );
-			assert.isNumberInRange( absoluteRect.right, 15, 17, 'right' );
+			assert.isNumberInRange( absoluteRect.left, 4, 6, 'left' );
+			assert.isNumberInRange( absoluteRect.right, 19, 21, 'right' );
 			assert.isNumberInRange( absoluteRect.height, 19, 21, 'height' );
-			!CKEDITOR.env.ie && assert.isNumberInRange( absoluteRect.x, 15, 17, 'x' );
+			!CKEDITOR.env.ie && assert.isNumberInRange( absoluteRect.x, 4, 6, 'x' );
 			!CKEDITOR.env.ie && assert.isNumberInRange( absoluteRect.y, 9, 11, 'y' );
 		},
 
@@ -43,8 +43,8 @@
 			assert.isNumberInRange( absoluteRect.left, 14, 16, 'left' );
 			assert.isNumberInRange( absoluteRect.right, 24, 26, 'right' );
 			assert.isNumberInRange( absoluteRect.height, 9, 11, 'height' );
-			!CKEDITOR.env.ie && assert.isNumberInRange( absoluteRect.x, 15, 17, 'x' );
-			!CKEDITOR.env.ie && assert.isNumberInRange( absoluteRect.y, 9, 11, 'y' );
+			!CKEDITOR.env.ie && assert.isNumberInRange( absoluteRect.x, 14, 17, 'x' );
+			!CKEDITOR.env.ie && assert.isNumberInRange( absoluteRect.y, 14, 17, 'y' );
 		},
 
 		// (#1724)
@@ -59,8 +59,8 @@
 			assert.isNumberInRange( absoluteRect.left, 24, 26, 'left' );
 			assert.isNumberInRange( absoluteRect.right, 34, 36, 'right' );
 			assert.isNumberInRange( absoluteRect.height, 9, 11, 'height' );
-			!CKEDITOR.env.ie && assert.isNumberInRange( absoluteRect.x, 15, 17, 'x' );
-			!CKEDITOR.env.ie && assert.isNumberInRange( absoluteRect.y, 9, 11, 'y' );
+			!CKEDITOR.env.ie && assert.isNumberInRange( absoluteRect.x, 24, 26, 'x' );
+			!CKEDITOR.env.ie && assert.isNumberInRange( absoluteRect.y, 24, 26, 'y' );
 		}
 	} );
 

--- a/tests/core/dom/element/manual/absoluterect.html
+++ b/tests/core/dom/element/manual/absoluterect.html
@@ -1,8 +1,6 @@
 <style>
-	body{ height:200vh; width: 200vh; }
 	#output{
 		width: 100vh;
-		position: fixed;
 	}
 </style>
 
@@ -15,7 +13,7 @@
 
 <script>
 	var output = document.getElementById( 'output' ),
-		editableRect, frameRect, editor;
+		editableRect, editor;
 
 	CKEDITOR.replace( 'editor1', {
 		extraAllowedContent: 'p{height,width}',
@@ -37,11 +35,10 @@
 	} );
 
 	function updatePosition() {
-		var editable = editor.editable(), frame = editor.window.getFrame();
+		var editable = editor.editable();
 
 		editableRect = editable.getClientRect( true ),
-		frameRect = frame.getClientRect( true );
-		output.innerHTML = '<strong>editor scroll:</strong> ' + getRectHtml( editableRect ) + '</br><strong>browser scroll:</strong> ' + getRectHtml( frameRect );
+		output.innerHTML = '<strong>editor scroll:</strong> ' + getRectHtml( editableRect );
 	}
 
 	function getRectHtml( rect ) {

--- a/tests/core/dom/element/manual/absoluterect.html
+++ b/tests/core/dom/element/manual/absoluterect.html
@@ -39,8 +39,8 @@
 	function updatePosition() {
 		var editable = editor.editable(), frame = editor.window.getFrame();
 
-		editableRect = editable.getAbsoluteClientRect( editor ),
-		frameRect = frame.getAbsoluteClientRect( editor );
+		editableRect = editable.getClientRect( true ),
+		frameRect = frame.getClientRect( true );
 		output.innerHTML = '<strong>editor scroll:</strong> ' + getRectHtml( editableRect ) + '</br><strong>browser scroll:</strong> ' + getRectHtml( frameRect );
 	}
 

--- a/tests/core/dom/element/manual/absoluterect.html
+++ b/tests/core/dom/element/manual/absoluterect.html
@@ -1,0 +1,51 @@
+<style>
+	body{ height:1000em; width: 100em; }
+	#output{
+		width: 100vh;
+		position: fixed;
+	}
+</style>
+
+<textarea id="editor1">
+	<p style="height: 100em; width: 200em"></p>
+</textarea>
+
+<div id="output">
+</div>
+
+<script>
+	var output = document.getElementById( 'output' ),
+		editableRect, frameRect, editor;
+
+	CKEDITOR.replace( 'editor1', {
+		extraAllowedContent: 'p{height,width}',
+		on: {
+			instanceReady: function( evt ) {
+				editor = evt.editor;
+
+				updatePosition();
+
+				CKEDITOR.document.getWindow().on( 'scroll', function() {
+					updatePosition();
+				} );
+
+				editor.window.on( 'scroll', function() {
+					updatePosition();
+				} );
+			}
+		}
+	} );
+
+	function updatePosition() {
+		var editable = editor.editable(), frame = editor.window.getFrame();
+
+		editableRect = editable.getAbsoluteClientRect( editor ),
+		frameRect = frame.getAbsoluteClientRect( editor );
+		output.innerHTML = '<strong>editor scroll:</strong> ' + getRectHtml( editableRect ) + '</br><strong>browser scroll:</strong> ' + getRectHtml( frameRect );
+	}
+
+	function getRectHtml( rect ) {
+		return 'height: ' + rect.height + ', top: ' + rect.top + ', bottom: ' + rect.bottom + ', width: ' +
+			rect.width + ', left: ' + rect.left + ', right: ' + rect.right + ', x: ' + rect.x + ', y: ' + rect.y;
+	}
+</script>

--- a/tests/core/dom/element/manual/absoluterect.html
+++ b/tests/core/dom/element/manual/absoluterect.html
@@ -1,5 +1,5 @@
 <style>
-	body{ height:1000em; width: 100em; }
+	body{ height:200vh; width: 200vh; }
 	#output{
 		width: 100vh;
 		position: fixed;

--- a/tests/core/dom/element/manual/absoluterect.md
+++ b/tests/core/dom/element/manual/absoluterect.md
@@ -2,15 +2,11 @@
 @bender-tags: 4.10.0, feature, 1724
 @bender-ckeditor-plugins: wysiwygarea,toolbar
 
-Use scrollbar to change scroll position of the browser and the editor. You should use both vertical and horizontal scrollbars.
+Use scrollbar to change scroll position of the editor. You should use both vertical and horizontal scrollbars.
 
 ## Expected
 
 You should observe changing properties on scroll:
-
-Vertical browser scroll: y
-
-Horizontal browser scroll: x
 
 Vertical editor scroll: top, bottom, y
 
@@ -19,3 +15,5 @@ Horizontal editor scroll: left, right, x
 ## Unexpected
 
 Mentioned properties doesn't change on scroll.
+
+***Note:*** `x` and `y` properties are not available for IE or Edge browsers.

--- a/tests/core/dom/element/manual/absoluterect.md
+++ b/tests/core/dom/element/manual/absoluterect.md
@@ -1,0 +1,21 @@
+@bender-ui: collapsed
+@bender-tags: 4.10.0, feature, 1724
+@bender-ckeditor-plugins: wysiwygarea,toolbar
+
+Use scrollbar to change scroll position of the browser and the editor. You should use both vertical and horizontal scrollbars.
+
+## Expected
+
+You should observe changing properties on scroll:
+
+Vertical browser scroll: y
+
+Horizontal browser scroll: x
+
+Vertical editor scroll: top, bottom, y
+
+Horizontal editor scroll: left, right, x
+
+## Unexpected
+
+Mentioned properties doesn't change on scroll.

--- a/tests/plugins/balloonpanel/positioning.js
+++ b/tests/plugins/balloonpanel/positioning.js
@@ -112,7 +112,7 @@
 				// |                         |
 				// +-------------------------+
 				// Position acts as if the editor viewport was at position x: 0, 305.
-				this.markerElement.getClientRect = sinon.stub().returns( { height: 15, width: 25, left: 389, bottom: 111.34375, right: 414, top: 96.34375 } );
+				this.markerElement.getClientRect = sinon.stub().returns( { height: 15, width: 25, left: 390, bottom: 454.34375, right: 415, top: 439.34375 } );
 				var moveSpy = spy( this.balloon, 'move' );
 				balloonTestsTools.attachBalloon( this.balloon, this.markerElement );
 
@@ -123,7 +123,7 @@
 
 			'test classic - out of view - bottom center': function() {
 				// Position acts as if the editor viewport was at position x: 260, 0.
-				this.markerElement.getClientRect = sinon.stub().returns( { height: 15, width: 25, left: 129, bottom: 416.34375, right: 154, top: 401.34375 } );
+				this.markerElement.getClientRect = sinon.stub().returns( { height: 15, width: 25, left: 130, bottom: 759.34375, right: 155, top: 744.34375 } );
 				var moveSpy = spy( this.balloon, 'move' );
 				balloonTestsTools.attachBalloon( this.balloon, this.markerElement );
 
@@ -134,7 +134,7 @@
 
 			'test classic - out of view - left vcenter': function() {
 				// Position acts as if the editor viewport was at position x: 420, 260.
-				this.markerElement.getClientRect = sinon.stub().returns( { height: 15, width: 25, left: -31, bottom: 156.34375, right: -6, top: 141.34375 } );
+				this.markerElement.getClientRect = sinon.stub().returns( { height: 15, width: 25, left: -30, bottom: 499.34375, right: -5, top: 484.34375 } );
 				var moveSpy = spy( this.balloon, 'move' );
 				balloonTestsTools.attachBalloon( this.balloon, this.markerElement );
 
@@ -145,7 +145,7 @@
 
 			'test classic - out of view - hcenter top': function() {
 				// Position acts as if the editor viewport was at position x: 260, 500.
-				this.markerElement.getClientRect = sinon.stub().returns( { height: 15, width: 25, left: 129, bottom: -75.65625, right: 154, top: -90.65625 } );
+				this.markerElement.getClientRect = sinon.stub().returns( { height: 15, width: 25, left: 130, bottom: 267.34375, right: 155, top: 252.3475 } );
 				var moveSpy = spy( this.balloon, 'move' );
 				balloonTestsTools.attachBalloon( this.balloon, this.markerElement );
 
@@ -156,7 +156,7 @@
 
 			'test classic - inside viewport - left top': function() {
 				// Position acts as if the editor viewport was at position x: 388, 400.
-				this.markerElement.getClientRect = sinon.stub().returns( { height: 15, width: 25, left: 1, bottom: 16.34375, right: 26, top: 1.34375 } );
+				this.markerElement.getClientRect = sinon.stub().returns( { height: 15, width: 25, left: 2, bottom: 359.34375, right: 27, top: 344.34375 } );
 				var moveSpy = spy( this.balloon, 'move' );
 				balloonTestsTools.attachBalloon( this.balloon, this.markerElement );
 
@@ -168,7 +168,7 @@
 
 			'test classic - inside viewport - right bottom': function() {
 				// Position acts as if the editor viewport was at position x: 114, 101.
-				this.markerElement.getClientRect = sinon.stub().returns( { height: 15, width: 25, left: 275, bottom: 315.34375, right: 300, top: 300.34375 } );
+				this.markerElement.getClientRect = sinon.stub().returns( { height: 15, width: 25, left: 276, bottom: 658.34375, right: 301, top: 643.34375 } );
 				var moveSpy = spy( this.balloon, 'move' );
 				balloonTestsTools.attachBalloon( this.balloon, this.markerElement );
 

--- a/tests/plugins/balloonpanel/positioningnonstatic.js
+++ b/tests/plugins/balloonpanel/positioningnonstatic.js
@@ -52,7 +52,7 @@
 		panel.attach( element );
 
 		return {
-			elementRect: panel._getAbsoluteRect( element ),
+			elementRect: element.getAbsoluteClientRect( editor ),
 			triangleTip: balloonTestsTools.getTriangleTipPosition( panel ),
 			panel: panel
 		};

--- a/tests/plugins/balloonpanel/positioningnonstatic.js
+++ b/tests/plugins/balloonpanel/positioningnonstatic.js
@@ -52,7 +52,7 @@
 		panel.attach( element );
 
 		return {
-			elementRect: element.getAbsoluteClientRect( editor ),
+			elementRect: element.getClientRect( true ),
 			triangleTip: balloonTestsTools.getTriangleTipPosition( panel ),
 			panel: panel
 		};


### PR DESCRIPTION
## What is the purpose of this pull request?

New feature

## Does your PR contain necessary tests?

All patches which change the editor code must include tests. You can always read more
on [PR testing](https://docs.ckeditor.com/ckeditor4/docs/#!/guide/dev_contributing_code-section-tests),
[how to set the testing environment](https://docs.ckeditor.com/ckeditor4/docs/#!/guide/dev_tests) and
[how to create tests](https://docs.ckeditor.com/ckeditor4/docs/#!/guide/dev_tests-section-creating-your-own-test)
in the official CKEditor documentation.

### This PR contains

- [x] Unit tests
- [x] Manual tests

## What changes did you make?

Moved `_getAbsoluteRect` balloon toolbar private function to `core/element` as `getAbsoluteClientPosition`

I wasn't sure how to unit test this function because it behaves differently depending of used browser, monitor etc (because it depends on rendered pixels).  A tests would fail either if you open console etc. Because of that I only added manual test, but if you have some idea how to unit test this function, I would be grateful for some tips.

Closes #1724