### PR TITLE
 First autocomplete option is now focused when typing

### DIFF
--- a/plugins/autocomplete/plugin.js
+++ b/plugins/autocomplete/plugin.js
@@ -354,6 +354,7 @@
 			if ( this.model.hasData() ) {
 				this.model.setPanelActive( true );
 				this.view.open();
+				this.model.selectFirst();
 				this.view.updatePosition();
 			}
 		},

--- a/tests/plugins/autocomplete/autocomplete.js
+++ b/tests/plugins/autocomplete/autocomplete.js
@@ -31,6 +31,20 @@
 			ac.destroy();
 		},
 
+		'test autocomplete starts with the first item selected': function() {
+			var editor = this.editor, bot = this.editorBot,
+				ac = new CKEDITOR.plugins.autocomplete( this.editor, matchTestCallback, dataCallback );
+
+			bot.setHtmlWithSelection( '' );
+
+			editor.editable().fire( 'keyup', new CKEDITOR.dom.event( {} ) );
+
+			assertViewOpened( ac, true );
+			assert.isTrue( ac.view.getItemById( 1 ).hasClass( 'cke_autocomplete_selected' ) );
+
+			ac.destroy();
+		},
+
 		'test arrow down selects next item': function() {
 			var editor = this.editor, bot = this.editorBot, editable = editor.editable(),
 				ac = new CKEDITOR.plugins.autocomplete( this.editor, matchTestCallback, dataCallback );
@@ -47,6 +61,16 @@
 			assertViewOpened( ac, true );
 			assert.isTrue( ac.view.getItemById( 2 ).hasClass( 'cke_autocomplete_selected' ) );
 
+			editable.fire( 'keydown', new CKEDITOR.dom.event( { keyCode: 40 } ) );
+
+			assertViewOpened( ac, true );
+			assert.isTrue( ac.view.getItemById( 3 ).hasClass( 'cke_autocomplete_selected' ) );
+
+			editable.fire( 'keydown', new CKEDITOR.dom.event( { keyCode: 40 } ) );
+
+			assertViewOpened( ac, true );
+			assert.isTrue( ac.view.getItemById( 1 ).hasClass( 'cke_autocomplete_selected' ) );
+
 			ac.destroy();
 		},
 
@@ -57,6 +81,21 @@
 			bot.setHtmlWithSelection( '' );
 
 			editor.editable().fire( 'keyup', new CKEDITOR.dom.event( {} ) );
+
+			assertViewOpened( ac, true );
+			assert.isTrue( ac.view.getItemById( 1 ).hasClass( 'cke_autocomplete_selected' ) );
+
+			editable.fire( 'keydown', new CKEDITOR.dom.event( { keyCode: 38 } ) );
+
+			assertViewOpened( ac, true );
+			assert.isTrue( ac.view.getItemById( 3 ).hasClass( 'cke_autocomplete_selected' ) );
+
+			editable.fire( 'keydown', new CKEDITOR.dom.event( { keyCode: 38 } ) );
+
+			assertViewOpened( ac, true );
+			assert.isTrue( ac.view.getItemById( 2 ).hasClass( 'cke_autocomplete_selected' ) );
+
+			editable.fire( 'keydown', new CKEDITOR.dom.event( { keyCode: 38 } ) );
 
 			assertViewOpened( ac, true );
 			assert.isTrue( ac.view.getItemById( 1 ).hasClass( 'cke_autocomplete_selected' ) );
@@ -85,7 +124,7 @@
 		},
 
 		'test click inserts match': function() {
-			var editor = this.editor, bot = this.editorBot, editable = editor.editable(),
+			var editor = this.editor, bot = this.editorBot,
 				ac = new CKEDITOR.plugins.autocomplete( this.editor, matchTestCallback, dataCallback );
 
 			bot.setHtmlWithSelection( '' );
@@ -97,13 +136,13 @@
 			assert.areEqual( '<p>item1</p>', editor.getData() );
 
 			ac.destroy();
-		},
+		}
 	} );
 
 	function assertViewOpened( ac, isOpened ) {
 		var opened = ac.view.element.hasClass( 'cke_autocomplete_opened' );
 		if ( isOpened ) {
-			assert.isTrue( opened )
+			assert.isTrue( opened );
 		} else {
 			assert.isFalse( opened );
 		}
@@ -113,7 +152,6 @@
 		return { text: 'text', range: selectionRange };
 	}
 
-	function textTestCallback() {}
 	function dataCallback( query, range, callback ) {
 		return callback( [ { id: 1, name: 'item1' }, { id: 2, name: 'item2' }, { id: 3, name: 'item3' } ] );
 	}

--- a/tests/plugins/autocomplete/autocomplete.js
+++ b/tests/plugins/autocomplete/autocomplete.js
@@ -24,7 +24,7 @@
 
 			assertViewOpened( ac, true );
 
-			editor.editable().fire( 'keydown', new CKEDITOR.dom.event( { keyCode: 27 } ) );
+			editor.editable().fire( 'keydown', new CKEDITOR.dom.event( { keyCode: 27 } ) ); // ESC
 
 			assertViewOpened( ac, false );
 
@@ -53,20 +53,17 @@
 
 			editor.editable().fire( 'keyup', new CKEDITOR.dom.event( {} ) );
 
-			assertViewOpened( ac, true );
-			assert.isTrue( ac.view.getItemById( 1 ).hasClass( 'cke_autocomplete_selected' ) );
-
-			editable.fire( 'keydown', new CKEDITOR.dom.event( { keyCode: 40 } ) );
+			editable.fire( 'keydown', new CKEDITOR.dom.event( { keyCode: 40 } ) ); // ARROW DOWN
 
 			assertViewOpened( ac, true );
 			assert.isTrue( ac.view.getItemById( 2 ).hasClass( 'cke_autocomplete_selected' ) );
 
-			editable.fire( 'keydown', new CKEDITOR.dom.event( { keyCode: 40 } ) );
+			editable.fire( 'keydown', new CKEDITOR.dom.event( { keyCode: 40 } ) ); // ARROW DOWN
 
 			assertViewOpened( ac, true );
 			assert.isTrue( ac.view.getItemById( 3 ).hasClass( 'cke_autocomplete_selected' ) );
 
-			editable.fire( 'keydown', new CKEDITOR.dom.event( { keyCode: 40 } ) );
+			editable.fire( 'keydown', new CKEDITOR.dom.event( { keyCode: 40 } ) ); // ARROW DOWN
 
 			assertViewOpened( ac, true );
 			assert.isTrue( ac.view.getItemById( 1 ).hasClass( 'cke_autocomplete_selected' ) );
@@ -82,25 +79,22 @@
 
 			editor.editable().fire( 'keyup', new CKEDITOR.dom.event( {} ) );
 
-			assertViewOpened( ac, true );
-			assert.isTrue( ac.view.getItemById( 1 ).hasClass( 'cke_autocomplete_selected' ) );
-
-			editable.fire( 'keydown', new CKEDITOR.dom.event( { keyCode: 38 } ) );
+			editable.fire( 'keydown', new CKEDITOR.dom.event( { keyCode: 38 } ) ); // ARROW UP
 
 			assertViewOpened( ac, true );
 			assert.isTrue( ac.view.getItemById( 3 ).hasClass( 'cke_autocomplete_selected' ) );
 
-			editable.fire( 'keydown', new CKEDITOR.dom.event( { keyCode: 38 } ) );
+			editable.fire( 'keydown', new CKEDITOR.dom.event( { keyCode: 38 } ) ); // ARROW UP
 
 			assertViewOpened( ac, true );
 			assert.isTrue( ac.view.getItemById( 2 ).hasClass( 'cke_autocomplete_selected' ) );
 
-			editable.fire( 'keydown', new CKEDITOR.dom.event( { keyCode: 38 } ) );
+			editable.fire( 'keydown', new CKEDITOR.dom.event( { keyCode: 38 } ) ); // ARROW UP
 
 			assertViewOpened( ac, true );
 			assert.isTrue( ac.view.getItemById( 1 ).hasClass( 'cke_autocomplete_selected' ) );
 
-			editable.fire( 'keydown', new CKEDITOR.dom.event( { keyCode: 38 } ) );
+			editable.fire( 'keydown', new CKEDITOR.dom.event( { keyCode: 38 } ) ); // ARROW UP
 
 			assertViewOpened( ac, true );
 			assert.isTrue( ac.view.getItemById( 3 ).hasClass( 'cke_autocomplete_selected' ) );
@@ -116,7 +110,7 @@
 
 			editor.editable().fire( 'keyup', new CKEDITOR.dom.event( {} ) );
 
-			editable.fire( 'keydown', new CKEDITOR.dom.event( { keyCode: 13 } ) );
+			editable.fire( 'keydown', new CKEDITOR.dom.event( { keyCode: 13 } ) ); // ENTER
 
 			assert.areEqual( '<p>item1</p>', editor.getData() );
 

--- a/tests/plugins/autocomplete/autocomplete.js
+++ b/tests/plugins/autocomplete/autocomplete.js
@@ -40,17 +40,11 @@
 			editor.editable().fire( 'keyup', new CKEDITOR.dom.event( {} ) );
 
 			assertViewOpened( ac, true );
-
-			editable.fire( 'keydown', new CKEDITOR.dom.event( { keyCode: 40 } ) );
-
-			assertViewOpened( ac, true );
 			assert.isTrue( ac.view.getItemById( 1 ).hasClass( 'cke_autocomplete_selected' ) );
 
 			editable.fire( 'keydown', new CKEDITOR.dom.event( { keyCode: 40 } ) );
 
 			assertViewOpened( ac, true );
-
-			assert.isFalse( ac.view.getItemById( 1 ).hasClass( 'cke_autocomplete_selected' ) );
 			assert.isTrue( ac.view.getItemById( 2 ).hasClass( 'cke_autocomplete_selected' ) );
 
 			ac.destroy();
@@ -65,18 +59,12 @@
 			editor.editable().fire( 'keyup', new CKEDITOR.dom.event( {} ) );
 
 			assertViewOpened( ac, true );
-
-			editable.fire( 'keydown', new CKEDITOR.dom.event( { keyCode: 38 } ) );
-
-			assertViewOpened( ac, true );
-			assert.isTrue( ac.view.getItemById( 2 ).hasClass( 'cke_autocomplete_selected' ) );
-
-			editable.fire( 'keydown', new CKEDITOR.dom.event( { keyCode: 38 } ) );
-
-			assertViewOpened( ac, true );
-
-			assert.isFalse( ac.view.getItemById( 2 ).hasClass( 'cke_autocomplete_selected' ) );
 			assert.isTrue( ac.view.getItemById( 1 ).hasClass( 'cke_autocomplete_selected' ) );
+
+			editable.fire( 'keydown', new CKEDITOR.dom.event( { keyCode: 38 } ) );
+
+			assertViewOpened( ac, true );
+			assert.isTrue( ac.view.getItemById( 3 ).hasClass( 'cke_autocomplete_selected' ) );
 
 			ac.destroy();
 		},
@@ -89,7 +77,6 @@
 
 			editor.editable().fire( 'keyup', new CKEDITOR.dom.event( {} ) );
 
-			editable.fire( 'keydown', new CKEDITOR.dom.event( { keyCode: 40 } ) );
 			editable.fire( 'keydown', new CKEDITOR.dom.event( { keyCode: 13 } ) );
 
 			assert.areEqual( '<p>item1</p>', editor.getData() );
@@ -128,7 +115,7 @@
 
 	function textTestCallback() {}
 	function dataCallback( query, range, callback ) {
-		return callback( [ { id: 1, name: 'item1' }, { id: 2, name: 'item2' } ] );
+		return callback( [ { id: 1, name: 'item1' }, { id: 2, name: 'item2' }, { id: 3, name: 'item3' } ] );
 	}
 
 } )();

--- a/tests/plugins/autocomplete/manual/__template__.html
+++ b/tests/plugins/autocomplete/manual/__template__.html
@@ -7,7 +7,9 @@
 </style>
 
 <textarea id="editor1" >
-	<p>Lorem ipsum dolor sit amet, consectetur adipisicing elit. Vitae perferendis architecto sapiente veniam eius eos enim mollitia, sint accusamus sed voluptatum, consectetur illum nam, ab quod id amet, dignissimos quasi possimus excepturi natus maxime ea. Nihil ea voluptatibus tempora, corporis reiciendis vitae quo tenetur sint distinctio perspiciatis error fugit incidunt eaque at asperiores numquam, similique dolorum.</p>
+	<p>Lorem ipsum dolor sit amet, consectetur adipisicing elit.</p>
+	<p>Vitae perferendis architecto sapiente veniam eius eos enim mollitia</p>
+	<p>Sint accusamus sed voluptatum, consectetur illum nam, ab quod id amet.</p>
 </textarea>
 
 <script>

--- a/tests/plugins/autocomplete/manual/__template__.html
+++ b/tests/plugins/autocomplete/manual/__template__.html
@@ -1,15 +1,14 @@
 <style>
+	/* Swap margin with padding to prevent moving autocomplete panel outside editor. */
 	body {
-		margin: 0px;
-		position: static;
+		margin-left: 0px;
+		padding-left: 350px;
 	}
 </style>
 
-<div style="padding: 1500px">
-	<textarea id="editor1" >
-		<p>Lorem ipsum dolor sit amet, consectetur adipisicing elit. Vitae perferendis architecto sapiente veniam eius eos enim mollitia, sint accusamus sed voluptatum, consectetur illum nam, ab quod id amet, dignissimos quasi possimus excepturi natus maxime ea. Nihil ea voluptatibus tempora, corporis reiciendis vitae quo tenetur sint distinctio perspiciatis error fugit incidunt eaque at asperiores numquam, similique dolorum.</p>
-	</textarea>
-</div>
+<textarea id="editor1" >
+	<p>Lorem ipsum dolor sit amet, consectetur adipisicing elit. Vitae perferendis architecto sapiente veniam eius eos enim mollitia, sint accusamus sed voluptatum, consectetur illum nam, ab quod id amet, dignissimos quasi possimus excepturi natus maxime ea. Nihil ea voluptatibus tempora, corporis reiciendis vitae quo tenetur sint distinctio perspiciatis error fugit incidunt eaque at asperiores numquam, similique dolorum.</p>
+</textarea>
 
 <script>
 	var editor;
@@ -25,12 +24,6 @@
 			}
 		}
 	} );
-
-	// The body of the root html element has additional margin-left to display bender manual-sidebar which has fixed position.
-	// Our autcomplete view lives inside root html so with its margin it has invalid position relative to the editor.
-	// We have to change position of our editor relative to the root html by setting position:static ( see style tag ) and move it to the center of the page
-	// so it won't be hidden below sidebar.
-	window.scrollTo( 1500, 1500 );
 
 	function getTextTestCallback() {
 		return function( range ) {

--- a/tests/plugins/autocomplete/manual/__template__.html
+++ b/tests/plugins/autocomplete/manual/__template__.html
@@ -7,12 +7,7 @@
 
 <div style="padding: 1500px">
 	<textarea id="editor1" >
-		<h1>Lorem ipsum dolor sit amet, consectetur.</h1>
-		<p>Lorem ipsum dolor sit amet, consectetur adipisicing elit. Cum veniam in eligendi, aliquid dicta odio, atque consequatur suscipit quas porro veritatis rerum libero deleniti vero aliquam animi unde voluptatibus dolores deserunt! Explicabo repellat sint pariatur. Sint tempora ea illo, harum quidem iste adipisci libero aliquid, incidunt ullam ex at maiores enim, quia animi quo porro fugiat nihil et. Id in ullam voluptatem a officia corporis consequuntur voluptatum error neque sequi, vitae magnam reprehenderit ipsa reiciendis hic. Totam atque explicabo adipisci debitis, id sit vel error laudantium animi, voluptas voluptate ipsam saepe, molestiae quidem reprehenderit excepturi odio. Eaque, hic quisquam amet.</p>
-		<h1>Lorem ipsum dolor sit amet, consectetur.</h1>
-		<p>Lorem ipsum dolor sit amet, consectetur adipisicing elit. Ut et rerum autem illo, necessitatibus maiores hic quia vitae fugit quasi ducimus eveniet veritatis amet modi error inventore similique beatae molestiae magnam reiciendis voluptatem quo fuga rem fugiat! Quas suscipit error labore id sit aliquid quia porro, sint quod modi harum laboriosam! Explicabo rerum, autem. Odio laborum quam quidem explicabo nobis, corporis quia maiores ad, sequi possimus consequuntur alias ipsa dolorem distinctio blanditiis saepe, veritatis iure praesentium dicta repudiandae, quos quasi doloribus tempore. Perferendis magni, cum voluptatibus accusantium totam mollitia. Quibusdam accusantium labore voluptates et pariatur animi, nam temporibus magnam vitae.</p>
-		<h1>Lorem ipsum dolor sit amet, consectetur.</h1>
-		<p>Lorem ipsum dolor sit amet, consectetur adipisicing elit. Illum asperiores reprehenderit delectus tempore ullam repellat, eius voluptate iste, minus deserunt architecto amet velit harum. Natus praesentium atque exercitationem, eum porro magnam molestiae tenetur consequatur delectus sapiente provident inventore unde pariatur voluptates aliquid nulla quidem. Nobis vitae est neque non quis aspernatur quasi culpa, omnis dolorem veniam, veritatis, atque quam nisi sed odit necessitatibus modi deleniti a! Explicabo inventore dolor veritatis, a placeat nobis accusamus! Illum autem a quia perspiciatis, provident eum consectetur quae aliquam recusandae reiciendis nesciunt ratione, fuga quam laborum natus laudantium nostrum, distinctio obcaecati? In officia quod, doloremque.</p>
+		<p>Lorem ipsum dolor sit amet, consectetur adipisicing elit. Vitae perferendis architecto sapiente veniam eius eos enim mollitia, sint accusamus sed voluptatum, consectetur illum nam, ab quod id amet, dignissimos quasi possimus excepturi natus maxime ea. Nihil ea voluptatibus tempora, corporis reiciendis vitae quo tenetur sint distinctio perspiciatis error fugit incidunt eaque at asperiores numquam, similique dolorum.</p>
 	</textarea>
 </div>
 
@@ -21,6 +16,7 @@
 
 	CKEDITOR.replace( 'editor1', {
 		width: 600,
+		extraPlugins: 'textmatch',
 		on: {
 			instanceReady: function( evt ) {
 				editor = evt.editor;
@@ -30,6 +26,10 @@
 		}
 	} );
 
+	// The body of the root html element has additional margin-left to display bender manual-sidebar which has fixed position.
+	// Our autcomplete view lives inside root html so with its margin it has invalid position relative to the editor.
+	// We have to change position of our editor relative to the root html by setting position:static ( see style tag ) and move it to the center of the page
+	// so it won't be hidden below sidebar.
 	window.scrollTo( 1500, 1500 );
 
 	function getTextTestCallback() {

--- a/tests/plugins/autocomplete/manual/optionselection.md
+++ b/tests/plugins/autocomplete/manual/optionselection.md
@@ -1,0 +1,15 @@
+@bender-tags: 4.10.0, feature, tp3558
+@bender-ui: collapsed
+@bender-ckeditor-plugins: wysiwygarea, toolbar, basicstyles, autocomplete, textmatch
+
+1. Focus the editor.
+2. Type `@`
+
+## Expected
+
+First autocomplete option is selected.
+
+## Unexpected
+
+No option is selected.
+

--- a/tests/plugins/autocomplete/manual/optionselection.md
+++ b/tests/plugins/autocomplete/manual/optionselection.md
@@ -1,9 +1,9 @@
-@bender-tags: 4.10.0, feature, tp3558
+@bender-tags: 4.10.0, bug, tp3558
 @bender-ui: collapsed
-@bender-ckeditor-plugins: wysiwygarea, toolbar, basicstyles, autocomplete, textmatch
+@bender-ckeditor-plugins: wysiwygarea, toolbar, basicstyles, autocomplete
 
 1. Focus the editor.
-2. Type `@`
+2. Type `@`.
 
 ## Expected
 
@@ -12,4 +12,3 @@ First autocomplete option is selected.
 ## Unexpected
 
 No option is selected.
-


### PR DESCRIPTION
## What is the purpose of this pull request?

New feature

## Does your PR contain necessary tests?

All patches which change the editor code must include tests. You can always read more
on [PR testing](https://docs.ckeditor.com/ckeditor4/docs/#!/guide/dev_contributing_code-section-tests),
[how to set the testing environment](https://docs.ckeditor.com/ckeditor4/docs/#!/guide/dev_tests) and
[how to create tests](https://docs.ckeditor.com/ckeditor4/docs/#!/guide/dev_tests-section-creating-your-own-test)
in the official CKEditor documentation.

### This PR contains

- [x] Unit tests
- [x] Manual tests

## What changes did you make?

Added auto-selection for first autocomplete option on view open.