### PR TITLE
Change margins for Easy Image widget

### DIFF
--- a/plugins/easyimage/styles/easyimage.css
+++ b/plugins/easyimage/styles/easyimage.css
@@ -107,8 +107,8 @@ body.cke_editable > .cke_widget_wrapper_easyimage-side {
 
 /* It is important to have top, left, right in sync with figure margins, to algin the loader nicely. */
 .cke_widget_wrapper_easyimage .cke_loader {
-	left: 40px;
-	right: 40px;
+	left: 0;
+	right: 0;
 }
 
 /* Fancy opacity effect discussed in #1533. Transition is assigned in this awkward way so that it **does not** happen for

--- a/plugins/easyimage/styles/easyimage.css
+++ b/plugins/easyimage/styles/easyimage.css
@@ -105,12 +105,6 @@ body.cke_editable > .cke_widget_wrapper_easyimage-side {
 	width: 0;
 }
 
-/* It is important to have top, left, right in sync with figure margins, to algin the loader nicely. */
-.cke_widget_wrapper_easyimage .cke_loader {
-	left: 0;
-	right: 0;
-}
-
 /* Fancy opacity effect discussed in #1533. Transition is assigned in this awkward way so that it **does not** happen for
 the initial render, otherwise it would start transitioning from opacity 1 to 0.x upon the first render. */
 

--- a/plugins/easyimage/styles/easyimage.css
+++ b/plugins/easyimage/styles/easyimage.css
@@ -23,9 +23,7 @@ The outline is not a part of the element's dimensions. A border needs to be used
 }
 
 .cke_widget_wrapper_easyimage figure {
-	margin-top: 0px;
-	margin-left: 40px;
-	margin-right: 40px;
+	margin: 0;
 }
 
 .easyimage img, .cke_widget_uploadeasyimage img {
@@ -48,6 +46,7 @@ The outline is not a part of the element's dimensions. A border needs to be used
 	tiny sizes. The `em` unit is used so it works well and has proper proportions to the textual content around (#1553).
 	*/
 	min-width: 10em;
+	margin-left: 1.5em;
 }
 
 /*
@@ -61,6 +60,7 @@ body.cke_editable > .cke_widget_wrapper_easyimage-side {
 .cke_widget_wrapper_easyimage-align-left, :not(.cke_widget_wrapper_easyimage):not(.cke_widget_wrapper_easyimage-align-left) > .easyimage-align-left {
 	float: left;
 	max-width: 25%;
+	margin-right: 1.5em;
 }
 
 .cke_widget_wrapper_easyimage-align-center, :not(.cke_widget_wrapper_easyimage):not(.cke_widget_wrapper_easyimage-align-center) > .easyimage-align-center {


### PR DESCRIPTION
## What is the purpose of this pull request?

Restyling

## Does your PR contain necessary tests?

All patches which change the editor code must include tests. You can always read more
on [PR testing](https://docs.ckeditor.com/ckeditor4/docs/#!/guide/dev_contributing_code-section-tests),
[how to set the testing environment](https://docs.ckeditor.com/ckeditor4/docs/#!/guide/dev_tests) and
[how to create tests](https://docs.ckeditor.com/ckeditor4/docs/#!/guide/dev_tests-section-creating-your-own-test)
in the official CKEditor documentation.

### This PR contains

- [ ] Unit tests
- [ ] Manual tests

It just changes styles…

## What changes did you make?

Change default margins to 0 and to `1.5em` in case of side images.

Closes #1736.
