### PR TITLE
Min width fix for left-aligned Easy Image widgets

### DIFF
--- a/plugins/easyimage/styles/easyimage.css
+++ b/plugins/easyimage/styles/easyimage.css
@@ -60,6 +60,7 @@ body.cke_editable > .cke_widget_wrapper_easyimage-side {
 .cke_widget_wrapper_easyimage-align-left, :not(.cke_widget_wrapper_easyimage):not(.cke_widget_wrapper_easyimage-align-left) > .easyimage-align-left {
 	float: left;
 	max-width: 25%;
+	min-width: 10em;
 	margin-right: 1.5em;
 }
 


### PR DESCRIPTION
## What is the purpose of this pull request?

Fix for bug fix

## Does your PR contain necessary tests?

All patches which change the editor code must include tests. You can always read more
on [PR testing](https://docs.ckeditor.com/ckeditor4/docs/#!/guide/dev_contributing_code-section-tests),
[how to set the testing environment](https://docs.ckeditor.com/ckeditor4/docs/#!/guide/dev_tests) and
[how to create tests](https://docs.ckeditor.com/ckeditor4/docs/#!/guide/dev_tests-section-creating-your-own-test)
in the official CKEditor documentation.

### This PR contains

- [ ] Unit tests
- [ ] Manual tests

## What changes did you make?

I've added `min-width` styles also to align left images.
