### PR TITLE
 Added option to set completing key codes

### DIFF
--- a/plugins/autocomplete/plugin.js
+++ b/plugins/autocomplete/plugin.js
@@ -188,6 +188,15 @@
 		this.textWatcher = this.getTextWatcher( textTestCallback );
 
 		/**
+		 * The autocomplete key codes used to finish autocompletion with selected view item.
+		 * The property is using {@link CKEDITOR.config#autocomplete_completingKeyCodes} configuration option as default key codes.
+		 * You can change this property to set individual key codes for plugin instance.
+		 *
+		 * @property {Number[]}
+		 */
+		this.completingKeyCodes = CKEDITOR.config.autocomplete_completingKeyCodes.slice(); // Remove reference to configuration property.
+
+		/**
 		 * Listeners registered by this autocomplete instance.
 		 *
 		 * @private
@@ -427,8 +436,8 @@
 			} else if ( keyCode == 38 ) {
 				this.model.selectPrevious();
 				handled = true;
-			// Enter key.
-			} else if ( keyCode == 13 ) {
+			// Completition keys.
+			} else if ( ~this.completingKeyCodes.indexOf( keyCode ) ) {
 				this.commit();
 				this.textWatcher.unmatch();
 				handled = true;
@@ -1076,4 +1085,14 @@
 	CKEDITOR.plugins.autocomplete = Autocomplete;
 	Autocomplete.view = View;
 	Autocomplete.model = Model;
+
+	/**
+	 * The autocomplete key codes used to finish autocompletion with selected view item.
+	 * This setting will set completing key codes for each autocomplete plugin respectively.
+	 * To change completing key codes individually use {@link CKEDITOR.plugins.autocomplete#completingKeyCodes} plugin property.
+	 *
+	 * @cfg {Number[]} [autocomplete_completingKeyCodes=[9, 13] (9 = tab, 13 = enter, empty array = disabled)]
+	 * @member CKEDITOR.config
+	 */
+	CKEDITOR.config.autocomplete_completingKeyCodes = [ 9, 13 ];
 } )();

--- a/plugins/autocomplete/plugin.js
+++ b/plugins/autocomplete/plugin.js
@@ -155,6 +155,9 @@
 	 * {@link CKEDITOR.plugins.autocomplete.model.item} interface.
 	 */
 	function Autocomplete( editor, textTestCallback, dataCallback ) {
+		var commitKeystroke = CKEDITOR.config.autocomplete_commitKeystroke;
+		commitKeystroke = CKEDITOR.tools.array.isArray( commitKeystroke ) ? commitKeystroke.slice() : commitKeystroke;
+
 		/**
 		 * The editor instance to which this autocomplete is attached (meaning &mdash; on which it listens).
 		 *
@@ -188,13 +191,13 @@
 		this.textWatcher = this.getTextWatcher( textTestCallback );
 
 		/**
-		 * The autocomplete key codes used to finish autocompletion with selected view item.
-		 * The property is using {@link CKEDITOR.config#autocomplete_completingKeyCodes} configuration option as default key codes.
-		 * You can change this property to set individual key codes for plugin instance.
+		 * The autocomplete keystrokes used to finish autocompletion with selected view item.
+		 * The property is using {@link CKEDITOR.config#autocomplete_commitKeystroke} configuration option as default keystrokes.
+		 * You can change this property to set individual keystrokes for plugin instance.
 		 *
-		 * @property {Number[]}
+		 * @property {Number/Number[]}
 		 */
-		this.completingKeyCodes = CKEDITOR.config.autocomplete_completingKeyCodes.slice(); // Remove reference to configuration property.
+		this.commitKeystroke = commitKeystroke;
 
 		/**
 		 * Listeners registered by this autocomplete instance.
@@ -437,7 +440,7 @@
 				this.model.selectPrevious();
 				handled = true;
 			// Completition keys.
-			} else if ( ~this.completingKeyCodes.indexOf( keyCode ) ) {
+			} else if ( this.commitKeystroke == keyCode || ~CKEDITOR.tools.indexOf( this.commitKeystroke, keyCode ) ) {
 				this.commit();
 				this.textWatcher.unmatch();
 				handled = true;
@@ -1087,12 +1090,13 @@
 	Autocomplete.model = Model;
 
 	/**
-	 * The autocomplete key codes used to finish autocompletion with selected view item.
-	 * This setting will set completing key codes for each autocomplete plugin respectively.
-	 * To change completing key codes individually use {@link CKEDITOR.plugins.autocomplete#completingKeyCodes} plugin property.
+	 * The autocomplete keystrokes used to finish autocompletion with selected view item.
+	 * This setting will set completing keystrokes for each autocomplete plugin respectively.
+	 * To change completing keystrokes individually use {@link CKEDITOR.plugins.autocomplete#commitKeystroke} plugin property.
 	 *
-	 * @cfg {Number[]} [autocomplete_completingKeyCodes=[9, 13] (9 = tab, 13 = enter, empty array = disabled)]
+	 * @since 4.10.0
+	 * @cfg {Number/Number[]} [autocomplete_commitKeystroke=[9, 13] (9 = tab, 13 = enter, empty array = disabled)]
 	 * @member CKEDITOR.config
 	 */
-	CKEDITOR.config.autocomplete_completingKeyCodes = [ 9, 13 ];
+	CKEDITOR.config.autocomplete_commitKeystroke = [ 9, 13 ];
 } )();

--- a/plugins/autocomplete/plugin.js
+++ b/plugins/autocomplete/plugin.js
@@ -1091,10 +1091,23 @@
 	/**
 	 * The autocomplete keystrokes used to finish autocompletion with selected view item.
 	 * This setting will set completing keystrokes for each autocomplete plugin respectively.
+	 *
 	 * To change completing keystrokes individually use {@link CKEDITOR.plugins.autocomplete#commitKeystroke} plugin property.
 	 *
+	 * ```js
+	 * // Default config (9 = tab, 13 = enter).
+	 * config.autocomplete_commitKeystroke = [ 9, 13 ];
+	 * ```
+	 *
+	 * Commit keystroke can be also disabled by setting it to an empty array.
+	 *
+	 * ```js
+	 * // Disable autocomplete commit keystroke.
+	 * config.autocomplete_commitKeystroke = [];
+	 * ```
+	 *
 	 * @since 4.10.0
-	 * @cfg {Number/Number[]} [autocomplete_commitKeystroke=[9, 13] (9 = tab, 13 = enter, empty array = disabled)]
+	 * @cfg {Number/Number[]} [autocomplete_commitKeystroke=[9, 13]]
 	 * @member CKEDITOR.config
 	 */
 	CKEDITOR.config.autocomplete_commitKeystroke = [ 9, 13 ];

--- a/plugins/autocomplete/plugin.js
+++ b/plugins/autocomplete/plugin.js
@@ -155,8 +155,7 @@
 	 * {@link CKEDITOR.plugins.autocomplete.model.item} interface.
 	 */
 	function Autocomplete( editor, textTestCallback, dataCallback ) {
-		var commitKeystroke = CKEDITOR.config.autocomplete_commitKeystroke;
-		commitKeystroke = CKEDITOR.tools.array.isArray( commitKeystroke ) ? commitKeystroke.slice() : commitKeystroke;
+		var configKeystroke = editor.config.autocomplete_commitKeystroke || CKEDITOR.config.autocomplete_commitKeystroke;
 
 		/**
 		 * The editor instance to which this autocomplete is attached (meaning &mdash; on which it listens).
@@ -195,9 +194,9 @@
 		 * The property is using {@link CKEDITOR.config#autocomplete_commitKeystroke} configuration option as default keystrokes.
 		 * You can change this property to set individual keystrokes for plugin instance.
 		 *
-		 * @property {Number/Number[]}
+		 * @property {Number[]}
 		 */
-		this.commitKeystroke = commitKeystroke;
+		this.commitKeystroke = CKEDITOR.tools.array.isArray( configKeystroke ) ? configKeystroke.slice() : [ configKeystroke ];
 
 		/**
 		 * Listeners registered by this autocomplete instance.
@@ -440,7 +439,7 @@
 				this.model.selectPrevious();
 				handled = true;
 			// Completition keys.
-			} else if ( this.commitKeystroke == keyCode || ~CKEDITOR.tools.indexOf( this.commitKeystroke, keyCode ) ) {
+			} else if ( CKEDITOR.tools.indexOf( this.commitKeystroke, keyCode ) != -1 ) {
 				this.commit();
 				this.textWatcher.unmatch();
 				handled = true;

--- a/tests/plugins/autocomplete/autocomplete.js
+++ b/tests/plugins/autocomplete/autocomplete.js
@@ -117,6 +117,62 @@
 			ac.destroy();
 		},
 
+		'test tab inserts match': function() {
+			var editor = this.editor, bot = this.editorBot, editable = editor.editable(),
+				ac = new CKEDITOR.plugins.autocomplete( this.editor, matchTestCallback, dataCallback );
+
+			bot.setHtmlWithSelection( '' );
+
+			editor.editable().fire( 'keyup', new CKEDITOR.dom.event( {} ) );
+
+			editable.fire( 'keydown', new CKEDITOR.dom.event( { keyCode: 40 } ) );
+			editable.fire( 'keydown', new CKEDITOR.dom.event( { keyCode: 9 } ) );
+
+			assert.areEqual( '<p>item1</p>', editor.getData() );
+
+			ac.destroy();
+		},
+
+		'test custom key inserts match': function() {
+			var editor = this.editor, bot = this.editorBot, editable = editor.editable(),
+				ac = new CKEDITOR.plugins.autocomplete( this.editor, matchTestCallback, dataCallback );
+
+			bot.setHtmlWithSelection( '' );
+
+			ac.completingKeyCodes.push( 16 );
+
+			editor.editable().fire( 'keyup', new CKEDITOR.dom.event( {} ) );
+
+			editable.fire( 'keydown', new CKEDITOR.dom.event( { keyCode: 40 } ) );
+			editable.fire( 'keydown', new CKEDITOR.dom.event( { keyCode: 16 } ) );
+
+			assert.areEqual( '<p>item1</p>', editor.getData() );
+
+			ac.destroy();
+		},
+
+		'test custom key inserts match (global configuration)': function() {
+			var editor = this.editor, bot = this.editorBot, editable = editor.editable(),
+				configKeyCodes = CKEDITOR.config.autocomplete_completingKeyCodes.slice();
+
+			bot.setHtmlWithSelection( '' );
+
+			CKEDITOR.config.autocomplete_completingKeyCodes.push( 16 );
+
+			var ac = new CKEDITOR.plugins.autocomplete( this.editor, matchTestCallback, dataCallback );
+
+			editor.editable().fire( 'keyup', new CKEDITOR.dom.event( {} ) );
+
+			editable.fire( 'keydown', new CKEDITOR.dom.event( { keyCode: 40 } ) );
+			editable.fire( 'keydown', new CKEDITOR.dom.event( { keyCode: 16 } ) );
+
+			assert.areEqual( '<p>item1</p>', editor.getData() );
+
+			ac.destroy();
+
+			CKEDITOR.config.autocomplete_completingKeyCodes = configKeyCodes;
+		},
+
 		'test click inserts match': function() {
 			var editor = this.editor, bot = this.editorBot,
 				ac = new CKEDITOR.plugins.autocomplete( this.editor, matchTestCallback, dataCallback );

--- a/tests/plugins/autocomplete/autocomplete.js
+++ b/tests/plugins/autocomplete/autocomplete.js
@@ -4,7 +4,19 @@
 ( function() {
 	'use strict';
 
-	bender.editor = true;
+	bender.editors = {
+		standard: {},
+		arrayKeystrokes: {
+			config: {
+				autocomplete_commitKeystroke: [ 16 ] // SHIFT
+			}
+		},
+		singleKeystroke: {
+			config: {
+				autocomplete_commitKeystroke: 16 // SHIFT
+			}
+		}
+	};
 
 	bender.test( {
 
@@ -15,10 +27,10 @@
 		},
 
 		'test esc key closes view': function() {
-			var editor = this.editor, bot = this.editorBot,
-				ac = new CKEDITOR.plugins.autocomplete( this.editor, matchTestCallback, dataCallback );
+			var editor = this.editors.standard,
+				ac = new CKEDITOR.plugins.autocomplete( editor, matchTestCallback, dataCallback );
 
-			bot.setHtmlWithSelection( '' );
+			this.editorBots.standard.setHtmlWithSelection( '' );
 
 			editor.editable().fire( 'keyup', new CKEDITOR.dom.event( {} ) );
 
@@ -32,10 +44,10 @@
 		},
 
 		'test autocomplete starts with the first item selected': function() {
-			var editor = this.editor, bot = this.editorBot,
-				ac = new CKEDITOR.plugins.autocomplete( this.editor, matchTestCallback, dataCallback );
+			var editor = this.editors.standard,
+				ac = new CKEDITOR.plugins.autocomplete( editor, matchTestCallback, dataCallback );
 
-			bot.setHtmlWithSelection( '' );
+			this.editorBots.standard.setHtmlWithSelection( '' );
 
 			editor.editable().fire( 'keyup', new CKEDITOR.dom.event( {} ) );
 
@@ -46,10 +58,11 @@
 		},
 
 		'test arrow down selects next item': function() {
-			var editor = this.editor, bot = this.editorBot, editable = editor.editable(),
-				ac = new CKEDITOR.plugins.autocomplete( this.editor, matchTestCallback, dataCallback );
+			var editor = this.editors.standard,
+				editable = editor.editable(),
+				ac = new CKEDITOR.plugins.autocomplete( editor, matchTestCallback, dataCallback );
 
-			bot.setHtmlWithSelection( '' );
+			this.editorBots.standard.setHtmlWithSelection( '' );
 
 			editor.editable().fire( 'keyup', new CKEDITOR.dom.event( {} ) );
 
@@ -72,10 +85,11 @@
 		},
 
 		'test arrow up selects previous item': function() {
-			var editor = this.editor, bot = this.editorBot, editable = editor.editable(),
-				ac = new CKEDITOR.plugins.autocomplete( this.editor, matchTestCallback, dataCallback );
+			var editor = this.editors.standard,
+				editable = editor.editable(),
+				ac = new CKEDITOR.plugins.autocomplete( editor, matchTestCallback, dataCallback );
 
-			bot.setHtmlWithSelection( '' );
+			this.editorBots.standard.setHtmlWithSelection( '' );
 
 			editor.editable().fire( 'keyup', new CKEDITOR.dom.event( {} ) );
 
@@ -103,10 +117,11 @@
 		},
 
 		'test enter inserts match': function() {
-			var editor = this.editor, bot = this.editorBot, editable = editor.editable(),
-				ac = new CKEDITOR.plugins.autocomplete( this.editor, matchTestCallback, dataCallback );
+			var editor = this.editors.standard,
+				editable = editor.editable(),
+				ac = new CKEDITOR.plugins.autocomplete( editor, matchTestCallback, dataCallback );
 
-			bot.setHtmlWithSelection( '' );
+			this.editorBots.standard.setHtmlWithSelection( '' );
 
 			editor.editable().fire( 'keyup', new CKEDITOR.dom.event( {} ) );
 
@@ -118,14 +133,14 @@
 		},
 
 		'test tab inserts match': function() {
-			var editor = this.editor, bot = this.editorBot, editable = editor.editable(),
-				ac = new CKEDITOR.plugins.autocomplete( this.editor, matchTestCallback, dataCallback );
+			var editor = this.editors.standard,
+				editable = editor.editable(),
+				ac = new CKEDITOR.plugins.autocomplete( editor, matchTestCallback, dataCallback );
 
-			bot.setHtmlWithSelection( '' );
+			this.editorBots.standard.setHtmlWithSelection( '' );
 
 			editor.editable().fire( 'keyup', new CKEDITOR.dom.event( {} ) );
 
-			editable.fire( 'keydown', new CKEDITOR.dom.event( { keyCode: 40 } ) ); // ARROW DOWN
 			editable.fire( 'keydown', new CKEDITOR.dom.event( { keyCode: 9 } ) ); // TAB
 
 			assert.areEqual( '<p>item1</p>', editor.getData() );
@@ -133,35 +148,20 @@
 			ac.destroy();
 		},
 
-		'test custom single key inserts match': function() {
-			var editor = this.editor, bot = this.editorBot, editable = editor.editable(),
-				ac = new CKEDITOR.plugins.autocomplete( this.editor, matchTestCallback, dataCallback );
-
-			bot.setHtmlWithSelection( '' );
-
-			ac.commitKeystroke = 16; // SHIFT
-
-			editor.editable().fire( 'keyup', new CKEDITOR.dom.event( {} ) );
-
-			editable.fire( 'keydown', new CKEDITOR.dom.event( { keyCode: 40 } ) ); // ARROW DOWN
-			editable.fire( 'keydown', new CKEDITOR.dom.event( { keyCode: 16 } ) ); // SHIFT
-
-			assert.areEqual( '<p>item1</p>', editor.getData() );
-
-			ac.destroy();
-		},
-
 		'test custom keys inserts match': function() {
-			var editor = this.editor, bot = this.editorBot, editable = editor.editable(),
-				ac = new CKEDITOR.plugins.autocomplete( this.editor, matchTestCallback, dataCallback );
+			var editor = this.editors.standard,
+				editable = editor.editable(),
+				ac = new CKEDITOR.plugins.autocomplete( editor, matchTestCallback, dataCallback );
 
-			bot.setHtmlWithSelection( '' );
+			this.editorBots.standard.setHtmlWithSelection( '' );
 
-			ac.commitKeystroke.push( 16 ); // SHIFT
+			ac.commitKeystroke = [ 16 ]; // SHIFT
 
 			editor.editable().fire( 'keyup', new CKEDITOR.dom.event( {} ) );
 
-			editable.fire( 'keydown', new CKEDITOR.dom.event( { keyCode: 40 } ) ); // ARROW DOWN
+			editable.fire( 'keydown', new CKEDITOR.dom.event( { keyCode: 9 } ) ); // TAB
+			assert.areEqual( '', editor.getData(), 'Tab caused insertion' );
+
 			editable.fire( 'keydown', new CKEDITOR.dom.event( { keyCode: 16 } ) ); // SHIFT
 
 			assert.areEqual( '<p>item1</p>', editor.getData() );
@@ -170,39 +170,36 @@
 		},
 
 		'test custom keys inserts match (global configuration)': function() {
-			var editor = this.editor, bot = this.editorBot, editable = editor.editable(),
-				configKeyCodes = CKEDITOR.config.autocomplete_commitKeystroke.slice();
+			var editor = this.editors.arrayKeystrokes,
+				editable = editor.editable(),
+				ac = new CKEDITOR.plugins.autocomplete( editor, matchTestCallback, dataCallback );
 
-			bot.setHtmlWithSelection( '' );
-
-			CKEDITOR.config.autocomplete_commitKeystroke.push( 16 ); // SHIFT
-
-			var ac = new CKEDITOR.plugins.autocomplete( this.editor, matchTestCallback, dataCallback );
+			this.editorBots.arrayKeystrokes.setHtmlWithSelection( '' );
 
 			editor.editable().fire( 'keyup', new CKEDITOR.dom.event( {} ) );
 
-			editable.fire( 'keydown', new CKEDITOR.dom.event( { keyCode: 40 } ) ); // ARROW DOWN
+			editable.fire( 'keydown', new CKEDITOR.dom.event( { keyCode: 9 } ) ); // TAB
+			assert.areEqual( '', editor.getData(), 'Tab caused insertion' );
+
 			editable.fire( 'keydown', new CKEDITOR.dom.event( { keyCode: 16 } ) ); // SHIFT
 
 			assert.areEqual( '<p>item1</p>', editor.getData() );
 
 			ac.destroy();
-
-			CKEDITOR.config.autocomplete_commitKeystroke = configKeyCodes;
 		},
 
 		'test custom single key inserts match (global configuration)': function() {
-			var editor = this.editor, bot = this.editorBot, editable = editor.editable();
+			var editor = this.editors.singleKeystroke,
+				editable = editor.editable(),
+				ac = new CKEDITOR.plugins.autocomplete( editor, matchTestCallback, dataCallback );
 
-			bot.setHtmlWithSelection( '' );
-
-			CKEDITOR.config.autocomplete_commitKeystroke = 16; // SHIFT
-
-			var ac = new CKEDITOR.plugins.autocomplete( this.editor, matchTestCallback, dataCallback );
+			this.editorBots.singleKeystroke.setHtmlWithSelection( '' );
 
 			editor.editable().fire( 'keyup', new CKEDITOR.dom.event( {} ) );
 
-			editable.fire( 'keydown', new CKEDITOR.dom.event( { keyCode: 40 } ) ); // ARROW DOWN
+			editable.fire( 'keydown', new CKEDITOR.dom.event( { keyCode: 9 } ) ); // TAB
+			assert.areEqual( '', editor.getData(), 'Tab caused insertion' );
+
 			editable.fire( 'keydown', new CKEDITOR.dom.event( { keyCode: 16 } ) ); // SHIFT
 
 			assert.areEqual( '<p>item1</p>', editor.getData() );
@@ -211,10 +208,10 @@
 		},
 
 		'test click inserts match': function() {
-			var editor = this.editor, bot = this.editorBot,
-				ac = new CKEDITOR.plugins.autocomplete( this.editor, matchTestCallback, dataCallback );
+			var editor = this.editors.standard,
+				ac = new CKEDITOR.plugins.autocomplete( editor, matchTestCallback, dataCallback );
 
-			bot.setHtmlWithSelection( '' );
+			this.editorBots.standard.setHtmlWithSelection( '' );
 
 			editor.editable().fire( 'keyup', new CKEDITOR.dom.event( {} ) );
 

--- a/tests/plugins/autocomplete/autocomplete.js
+++ b/tests/plugins/autocomplete/autocomplete.js
@@ -125,52 +125,89 @@
 
 			editor.editable().fire( 'keyup', new CKEDITOR.dom.event( {} ) );
 
-			editable.fire( 'keydown', new CKEDITOR.dom.event( { keyCode: 40 } ) );
-			editable.fire( 'keydown', new CKEDITOR.dom.event( { keyCode: 9 } ) );
+			editable.fire( 'keydown', new CKEDITOR.dom.event( { keyCode: 40 } ) ); // ARROW DOWN
+			editable.fire( 'keydown', new CKEDITOR.dom.event( { keyCode: 9 } ) ); // TAB
 
 			assert.areEqual( '<p>item1</p>', editor.getData() );
 
 			ac.destroy();
 		},
 
-		'test custom key inserts match': function() {
+		'test custom single key inserts match': function() {
 			var editor = this.editor, bot = this.editorBot, editable = editor.editable(),
 				ac = new CKEDITOR.plugins.autocomplete( this.editor, matchTestCallback, dataCallback );
 
 			bot.setHtmlWithSelection( '' );
 
-			ac.completingKeyCodes.push( 16 );
+			ac.commitKeystroke = 16; // SHIFT
 
 			editor.editable().fire( 'keyup', new CKEDITOR.dom.event( {} ) );
 
-			editable.fire( 'keydown', new CKEDITOR.dom.event( { keyCode: 40 } ) );
-			editable.fire( 'keydown', new CKEDITOR.dom.event( { keyCode: 16 } ) );
+			editable.fire( 'keydown', new CKEDITOR.dom.event( { keyCode: 40 } ) ); // ARROW DOWN
+			editable.fire( 'keydown', new CKEDITOR.dom.event( { keyCode: 16 } ) ); // SHIFT
 
 			assert.areEqual( '<p>item1</p>', editor.getData() );
 
 			ac.destroy();
 		},
 
-		'test custom key inserts match (global configuration)': function() {
+		'test custom keys inserts match': function() {
 			var editor = this.editor, bot = this.editorBot, editable = editor.editable(),
-				configKeyCodes = CKEDITOR.config.autocomplete_completingKeyCodes.slice();
+				ac = new CKEDITOR.plugins.autocomplete( this.editor, matchTestCallback, dataCallback );
 
 			bot.setHtmlWithSelection( '' );
 
-			CKEDITOR.config.autocomplete_completingKeyCodes.push( 16 );
+			ac.commitKeystroke.push( 16 ); // SHIFT
+
+			editor.editable().fire( 'keyup', new CKEDITOR.dom.event( {} ) );
+
+			editable.fire( 'keydown', new CKEDITOR.dom.event( { keyCode: 40 } ) ); // ARROW DOWN
+			editable.fire( 'keydown', new CKEDITOR.dom.event( { keyCode: 16 } ) ); // SHIFT
+
+			assert.areEqual( '<p>item1</p>', editor.getData() );
+
+			ac.destroy();
+		},
+
+		'test custom keys inserts match (global configuration)': function() {
+			var editor = this.editor, bot = this.editorBot, editable = editor.editable(),
+				configKeyCodes = CKEDITOR.config.autocomplete_commitKeystroke.slice();
+
+			bot.setHtmlWithSelection( '' );
+
+			CKEDITOR.config.autocomplete_commitKeystroke.push( 16 ); // SHIFT
 
 			var ac = new CKEDITOR.plugins.autocomplete( this.editor, matchTestCallback, dataCallback );
 
 			editor.editable().fire( 'keyup', new CKEDITOR.dom.event( {} ) );
 
-			editable.fire( 'keydown', new CKEDITOR.dom.event( { keyCode: 40 } ) );
-			editable.fire( 'keydown', new CKEDITOR.dom.event( { keyCode: 16 } ) );
+			editable.fire( 'keydown', new CKEDITOR.dom.event( { keyCode: 40 } ) ); // ARROW DOWN
+			editable.fire( 'keydown', new CKEDITOR.dom.event( { keyCode: 16 } ) ); // SHIFT
 
 			assert.areEqual( '<p>item1</p>', editor.getData() );
 
 			ac.destroy();
 
-			CKEDITOR.config.autocomplete_completingKeyCodes = configKeyCodes;
+			CKEDITOR.config.autocomplete_commitKeystroke = configKeyCodes;
+		},
+
+		'test custom single key inserts match (global configuration)': function() {
+			var editor = this.editor, bot = this.editorBot, editable = editor.editable();
+
+			bot.setHtmlWithSelection( '' );
+
+			CKEDITOR.config.autocomplete_commitKeystroke = 16; // SHIFT
+
+			var ac = new CKEDITOR.plugins.autocomplete( this.editor, matchTestCallback, dataCallback );
+
+			editor.editable().fire( 'keyup', new CKEDITOR.dom.event( {} ) );
+
+			editable.fire( 'keydown', new CKEDITOR.dom.event( { keyCode: 40 } ) ); // ARROW DOWN
+			editable.fire( 'keydown', new CKEDITOR.dom.event( { keyCode: 16 } ) ); // SHIFT
+
+			assert.areEqual( '<p>item1</p>', editor.getData() );
+
+			ac.destroy();
 		},
 
 		'test click inserts match': function() {

--- a/tests/plugins/autocomplete/autocomplete.js
+++ b/tests/plugins/autocomplete/autocomplete.js
@@ -148,7 +148,7 @@
 			ac.destroy();
 		},
 
-		'test custom keys inserts match': function() {
+		'test custom autocomplete.commitKeystroke value': function() {
 			var editor = this.editors.standard,
 				editable = editor.editable(),
 				ac = new CKEDITOR.plugins.autocomplete( editor, matchTestCallback, dataCallback );
@@ -169,7 +169,7 @@
 			ac.destroy();
 		},
 
-		'test custom keys inserts match (global configuration)': function() {
+		'test custom config.autocomplete_commitKeystroke (array format)': function() {
 			var editor = this.editors.arrayKeystrokes,
 				editable = editor.editable(),
 				ac = new CKEDITOR.plugins.autocomplete( editor, matchTestCallback, dataCallback );
@@ -188,7 +188,7 @@
 			ac.destroy();
 		},
 
-		'test custom single key inserts match (global configuration)': function() {
+		'test custom config.autocomplete_commitKeystroke (primitive number)': function() {
 			var editor = this.editors.singleKeystroke,
 				editable = editor.editable(),
 				ac = new CKEDITOR.plugins.autocomplete( editor, matchTestCallback, dataCallback );

--- a/tests/plugins/autocomplete/manual/__template__.html
+++ b/tests/plugins/autocomplete/manual/__template__.html
@@ -35,7 +35,6 @@
 
 	function matchCallback( text, offset ) {
 		var left = text.slice( 0, offset ),
-			right = text.slice( offset ),
 			match = left.match( new RegExp( '@\\w*$' ) );
 
 		if ( !match ) {

--- a/tests/plugins/autocomplete/manual/completingkeycodes.md
+++ b/tests/plugins/autocomplete/manual/completingkeycodes.md
@@ -1,0 +1,18 @@
+@bender-tags: 4.10.0, feature, tp3560
+@bender-ui: collapsed
+@bender-ckeditor-plugins: wysiwygarea, toolbar, basicstyles, autocomplete, textmatch
+
+1. Focus the editor.
+2. Type `@`.
+3. Press `arrow down`.
+3. Press `enter`.
+4. Repeat 1-3 and press `tab`.
+
+## Expected
+
+Match has been completed for `tab` and `enter` keys.
+
+## Unexpected
+
+Match has not been completed.
+

--- a/tests/plugins/autocomplete/manual/completingkeycodes.md
+++ b/tests/plugins/autocomplete/manual/completingkeycodes.md
@@ -1,12 +1,11 @@
 @bender-tags: 4.10.0, feature, tp3560
 @bender-ui: collapsed
-@bender-ckeditor-plugins: wysiwygarea, toolbar, basicstyles, autocomplete, textmatch
+@bender-ckeditor-plugins: wysiwygarea, toolbar, basicstyles, autocomplete
 
 1. Focus the editor.
-2. Type `@`.
-3. Press `arrow down`.
-3. Press `enter`.
-4. Repeat 1-3 and press `tab`.
+1. Type `@`.
+1. Press `enter`.
+1. Repeat 1-2 and press `tab`.
 
 ## Expected
 
@@ -15,4 +14,3 @@ Match has been completed for `tab` and `enter` keys.
 ## Unexpected
 
 Match has not been completed.
-


### PR DESCRIPTION
## What is the purpose of this pull request?

Feature request

## Does your PR contain necessary tests?

All patches which change the editor code must include tests. You can always read more
on [PR testing](https://docs.ckeditor.com/ckeditor4/docs/#!/guide/dev_contributing_code-section-tests),
[how to set the testing environment](https://docs.ckeditor.com/ckeditor4/docs/#!/guide/dev_tests) and
[how to create tests](https://docs.ckeditor.com/ckeditor4/docs/#!/guide/dev_tests-section-creating-your-own-test)
in the official CKEditor documentation.

### This PR contains

- [x] Unit tests
- [x] Manual tests

## What changes did you make?

Added global configuration and autocomplete options to choose completing key codes. Default key codes are now `enter` and `tab`.
