### PR TITLE
Add onHide doc

### DIFF
--- a/plugins/dialog/dialogDefinition.js
+++ b/plugins/dialog/dialogDefinition.js
@@ -129,6 +129,12 @@
  */
 
 /**
+ * The function to execute when the dialog is hidden (executed every time the dialog is closed).
+ *
+ * @property {Function} onHide
+ */
+
+/**
  * This class is not really part of the API. It just illustrates the properties
  * that developers can use to define and create dialog content pages.
  *


### PR DESCRIPTION
## What is the purpose of this pull request?

Add lacking documentation. The "onHide" property of dialogDefinition is used (for example, plugins/link/dialogs/anchor.js) but it's not described in dialogDefinition.js.

## Does your PR contain necessary tests?

No. This PR add a comment only.

## What changes did you make?

Add a doc comment to dialogDefinition.js.

