### PR TITLE
Removed memory leak caused by CKEDITOR.filter.instances

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -41,7 +41,7 @@ API Changes:
 * [#2045](https://github.com/ckeditor/ckeditor-dev/issues/2045): Extracted [`tools.eventsBuffer`](https://docs.ckeditor.com/ckeditor4/latest/api/CKEDITOR_tools.html#method-eventsBuffer) and [`tools.throttle`](https://docs.ckeditor.com/ckeditor4/latest/api/CKEDITOR_tools.html#method-throttle) functions logic into separate namespace.
 	* [`tools.eventsBuffer`](https://docs.ckeditor.com/ckeditor4/latest/api/CKEDITOR_tools.html#method-eventsBuffer) has been extracted into [`tools.buffers.event`](https://docs.ckeditor.com/ckeditor4/latest/api/CKEDITOR_tools_buffers_event.html)
 	* [`tools.throttle`](https://docs.ckeditor.com/ckeditor4/latest/api/CKEDITOR_tools.html#method-throttle) has been extracted into [`tools.buffers.throttle`](https://docs.ckeditor.com/ckeditor4/latest/api/CKEDITOR_tools_buffers_throttle.html)
-* [#2466](https://github.com/ckeditor/ckeditor-dev/issues/2466):  The [`CKEDITOR.filter`](https://docs.ckeditor.com/ckeditor4/latest/api/CKEDITOR_tools.html#method-constructor) constructor accepts additional `rules` parameter allowing to bind editor and filter together preventing memory leaks.
+* [#2466](https://github.com/ckeditor/ckeditor-dev/issues/2466):  The [`CKEDITOR.filter`](https://docs.ckeditor.com/ckeditor4/latest/api/CKEDITOR_tools.html#method-constructor) constructor accepts additional `rules` parameter allowing to bind editor and filter together.
 
 ## CKEditor 4.10.1
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -32,6 +32,7 @@ Fixed Issues:
 * [#421](https://github.com/ckeditor/ckeditor-dev/issues/421) Fixed: Expandable [Button](https://ckeditor.com/cke4/addon/button) puts `(Selected)` text at the end of the label when clicked.
 * [#1454](https://github.com/ckeditor/ckeditor-dev/issues/1454): Fixed: [Upload Widget](https://ckeditor.com/cke4/addon/uploadwidget) [`onAbort`](https://docs.ckeditor.com/ckeditor4/docs/#!/api/CKEDITOR.fileTools.uploadWidgetDefinition-property-onAbort) method is not called when loader is aborted.
 * [#1451](https://github.com/ckeditor/ckeditor-dev/issues/1451): Fixed: Context menu is incorrectly positioned when opened with `Shift-F10`.
+* [#1722](https://github.com/ckeditor/ckeditor-dev/issues/1722): [`CKEDITOR.filter.instances`](https://docs.ckeditor.com/ckeditor4/latest/api/CKEDITOR_filter.html#static-property-instances) is causing memory leaks.
 
 API Changes:
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -41,6 +41,7 @@ API Changes:
 * [#2045](https://github.com/ckeditor/ckeditor-dev/issues/2045): Extracted [`tools.eventsBuffer`](https://docs.ckeditor.com/ckeditor4/latest/api/CKEDITOR_tools.html#method-eventsBuffer) and [`tools.throttle`](https://docs.ckeditor.com/ckeditor4/latest/api/CKEDITOR_tools.html#method-throttle) functions logic into separate namespace.
 	* [`tools.eventsBuffer`](https://docs.ckeditor.com/ckeditor4/latest/api/CKEDITOR_tools.html#method-eventsBuffer) has been extracted into [`tools.buffers.event`](https://docs.ckeditor.com/ckeditor4/latest/api/CKEDITOR_tools_buffers_event.html)
 	* [`tools.throttle`](https://docs.ckeditor.com/ckeditor4/latest/api/CKEDITOR_tools.html#method-throttle) has been extracted into [`tools.buffers.throttle`](https://docs.ckeditor.com/ckeditor4/latest/api/CKEDITOR_tools_buffers_throttle.html)
+* [#2466](https://github.com/ckeditor/ckeditor-dev/issues/2466):  The [`CKEDITOR.filter`](https://docs.ckeditor.com/ckeditor4/latest/api/CKEDITOR_tools.html#method-constructor) constructor accepts additional `rules` parameter allowing to bind editor and filter together.
 
 ## CKEditor 4.10.1
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -41,7 +41,7 @@ API Changes:
 * [#2045](https://github.com/ckeditor/ckeditor-dev/issues/2045): Extracted [`tools.eventsBuffer`](https://docs.ckeditor.com/ckeditor4/latest/api/CKEDITOR_tools.html#method-eventsBuffer) and [`tools.throttle`](https://docs.ckeditor.com/ckeditor4/latest/api/CKEDITOR_tools.html#method-throttle) functions logic into separate namespace.
 	* [`tools.eventsBuffer`](https://docs.ckeditor.com/ckeditor4/latest/api/CKEDITOR_tools.html#method-eventsBuffer) has been extracted into [`tools.buffers.event`](https://docs.ckeditor.com/ckeditor4/latest/api/CKEDITOR_tools_buffers_event.html)
 	* [`tools.throttle`](https://docs.ckeditor.com/ckeditor4/latest/api/CKEDITOR_tools.html#method-throttle) has been extracted into [`tools.buffers.throttle`](https://docs.ckeditor.com/ckeditor4/latest/api/CKEDITOR_tools_buffers_throttle.html)
-* [#2466](https://github.com/ckeditor/ckeditor-dev/issues/2466):  The [`CKEDITOR.filter`](https://docs.ckeditor.com/ckeditor4/latest/api/CKEDITOR_tools.html#method-constructor) constructor accepts additional `rules` parameter allowing to bind editor and filter together.
+* [#2466](https://github.com/ckeditor/ckeditor-dev/issues/2466):  The [`CKEDITOR.filter`](https://docs.ckeditor.com/ckeditor4/latest/api/CKEDITOR_tools.html#method-constructor) constructor accepts additional `rules` parameter allowing to bind editor and filter together preventing memory leaks.
 
 ## CKEditor 4.10.1
 

--- a/core/editor.js
+++ b/core/editor.js
@@ -886,6 +886,9 @@
 		 * element with the instance content.
 		 */
 		destroy: function( noUpdate ) {
+			var filters = CKEDITOR.filter.instances,
+				self = this;
+
 			this.fire( 'beforeDestroy' );
 
 			!noUpdate && updateEditorElement.call( this );
@@ -893,9 +896,16 @@
 			this.editable( null );
 
 			if ( this.filter ) {
-				this.filter.destroy();
 				delete this.filter;
 			}
+
+			// Destroy filters attached to the editor (#1722).
+			CKEDITOR.tools.array.forEach( CKEDITOR.tools.objectKeys( filters ), function( id ) {
+				var filter = filters[ id ];
+				if ( self === filter.editor ) {
+					filter.destroy();
+				}
+			} );
 
 			delete this.activeFilter;
 

--- a/core/filter.js
+++ b/core/filter.js
@@ -79,7 +79,7 @@
 	 * @class
 	 * @constructor Creates a filter class instance.
 	 * @param {CKEDITOR.editor/CKEDITOR.filter.allowedContentRules} editorOrRules
-	 * @param {CKEDITOR.editor} owner Editor owning the filter instance.
+	 * @param {CKEDITOR.editor} owner Editor owning the filter instance. This parameter is available since 4.10.0.
 	 */
 	CKEDITOR.filter = function( editorOrRules, owner ) {
 		/**

--- a/core/filter.js
+++ b/core/filter.js
@@ -59,19 +59,29 @@
 	 * {@link CKEDITOR.filter.allowedContentRules} instead of {@link CKEDITOR.editor}
 	 * to the constructor:
 	 *
-	 *		var filter = new CKEDITOR.filter( 'b' );
+	 * ```javascript
+	 * var filter = new CKEDITOR.filter( 'b' );
 	 *
-	 *		filter.check( 'b' ); // -> true
-	 *		filter.check( 'i' ); // -> false
-	 *		filter.allow( 'i' );
-	 *		filter.check( 'i' ); // -> true
+	 * filter.check( 'b' ); // -> true
+	 * filter.check( 'i' ); // -> false
+	 * filter.allow( 'i' );
+	 * filter.check( 'i' ); // -> true
+	 * ```
+	 *
+	 * If filter is only used by a single editor instance, you should pass additional owner editor instance
+	 * so the filter could be removed with {@link CKEDITOR.editor#destroy} method.
+	 *
+	 * ```javascript
+	 * var filter = new CKEDITOR.filter( 'b', editor );
+	 * ```
 	 *
 	 * @since 4.1
 	 * @class
 	 * @constructor Creates a filter class instance.
 	 * @param {CKEDITOR.editor/CKEDITOR.filter.allowedContentRules} editorOrRules
+	 * @param {CKEDITOR.editor} owner Editor owning the filter instance.
 	 */
-	CKEDITOR.filter = function( editorOrRules ) {
+	CKEDITOR.filter = function( editorOrRules, owner ) {
 		/**
 		 * Whether custom {@link CKEDITOR.config#allowedContent} was set.
 		 *
@@ -191,6 +201,7 @@
 		// Rules object passed in editorOrRules argument - initialize standalone filter.
 		else {
 			this.customConfig = false;
+			this.editor = owner;
 			this.allow( editorOrRules, 'default', 1 );
 		}
 	};

--- a/core/filter.js
+++ b/core/filter.js
@@ -68,20 +68,20 @@
 	 * filter.check( 'i' ); // -> true
 	 * ```
 	 *
-	 * If filter is only used by a single editor instance, you should pass additional owner editor instance
+	 * If filter is only used by a single editor instance, you should pass editor instance alongside with the rules
 	 * so the filter could be removed with {@link CKEDITOR.editor#destroy} method.
 	 *
 	 * ```javascript
-	 * var filter = new CKEDITOR.filter( 'b', editor );
+	 * var filter = new CKEDITOR.filter( editor, 'b' );
 	 * ```
 	 *
 	 * @since 4.1
 	 * @class
 	 * @constructor Creates a filter class instance.
 	 * @param {CKEDITOR.editor/CKEDITOR.filter.allowedContentRules} editorOrRules
-	 * @param {CKEDITOR.editor} owner Editor owning the filter instance. This parameter is available since 4.10.0.
+	 * @param {CKEDITOR.editor} rules This parameter is available since 4.10.0.
 	 */
-	CKEDITOR.filter = function( editorOrRules, owner ) {
+	CKEDITOR.filter = function( editorOrRules, rules ) {
 		/**
 		 * Whether custom {@link CKEDITOR.config#allowedContent} was set.
 		 *
@@ -175,11 +175,12 @@
 		// Register filter instance.
 		CKEDITOR.filter.instances[ this.id ] = this;
 
-		if ( editorOrRules instanceof CKEDITOR.editor ) {
-			var editor = this.editor = editorOrRules;
+		this.editor = editorOrRules instanceof CKEDITOR.editor ? editorOrRules : null;
+
+		if ( this.editor && !rules ) {
 			this.customConfig = true;
 
-			var allowedContent = editor.config.allowedContent;
+			var allowedContent = this.editor.config.allowedContent;
 
 			// Disable filter completely by setting config.allowedContent = true.
 			if ( allowedContent === true ) {
@@ -191,18 +192,17 @@
 				this.customConfig = false;
 
 			this.allow( allowedContent, 'config', 1 );
-			this.allow( editor.config.extraAllowedContent, 'extra', 1 );
+			this.allow( this.editor.config.extraAllowedContent, 'extra', 1 );
 
 			// Enter modes should extend filter rules (ENTER_P adds 'p' rule, etc.).
-			this.allow( enterModeTags[ editor.enterMode ] + ' ' + enterModeTags[ editor.shiftEnterMode ], 'default', 1 );
+			this.allow( enterModeTags[ this.editor.enterMode ] + ' ' + enterModeTags[ this.editor.shiftEnterMode ], 'default', 1 );
 
-			this.disallow( editor.config.disallowedContent );
+			this.disallow( this.editor.config.disallowedContent );
 		}
 		// Rules object passed in editorOrRules argument - initialize standalone filter.
 		else {
 			this.customConfig = false;
-			this.editor = owner;
-			this.allow( editorOrRules, 'default', 1 );
+			this.allow( rules || editorOrRules, 'default', 1 );
 		}
 	};
 

--- a/core/filter.js
+++ b/core/filter.js
@@ -79,7 +79,7 @@
 	 * @class
 	 * @constructor Creates a filter class instance.
 	 * @param {CKEDITOR.editor/CKEDITOR.filter.allowedContentRules} editorOrRules
-	 * @param {CKEDITOR.editor} rules This parameter is available since 4.10.0.
+	 * @param {CKEDITOR.filter.allowedContentRules} rules This parameter is available since 4.10.2
 	 */
 	CKEDITOR.filter = function( editorOrRules, rules ) {
 		/**

--- a/core/filter.js
+++ b/core/filter.js
@@ -175,12 +175,12 @@
 		// Register filter instance.
 		CKEDITOR.filter.instances[ this.id ] = this;
 
-		this.editor = editorOrRules instanceof CKEDITOR.editor ? editorOrRules : null;
+		var editor = this.editor = editorOrRules instanceof CKEDITOR.editor ? editorOrRules : null;
 
-		if ( this.editor && !rules ) {
+		if ( editor && !rules ) {
 			this.customConfig = true;
 
-			var allowedContent = this.editor.config.allowedContent;
+			var allowedContent = editor.config.allowedContent;
 
 			// Disable filter completely by setting config.allowedContent = true.
 			if ( allowedContent === true ) {
@@ -192,12 +192,12 @@
 				this.customConfig = false;
 
 			this.allow( allowedContent, 'config', 1 );
-			this.allow( this.editor.config.extraAllowedContent, 'extra', 1 );
+			this.allow( editor.config.extraAllowedContent, 'extra', 1 );
 
 			// Enter modes should extend filter rules (ENTER_P adds 'p' rule, etc.).
-			this.allow( enterModeTags[ this.editor.enterMode ] + ' ' + enterModeTags[ this.editor.shiftEnterMode ], 'default', 1 );
+			this.allow( enterModeTags[ editor.enterMode ] + ' ' + enterModeTags[ editor.shiftEnterMode ], 'default', 1 );
 
-			this.disallow( this.editor.config.disallowedContent );
+			this.disallow( editor.config.disallowedContent );
 		}
 		// Rules object passed in editorOrRules argument - initialize standalone filter.
 		else {

--- a/core/filter.js
+++ b/core/filter.js
@@ -68,18 +68,21 @@
 	 * filter.check( 'i' ); // -> true
 	 * ```
 	 *
-	 * If filter is only used by a single editor instance, you should pass editor instance alongside with the rules
-	 * so the filter could be removed with {@link CKEDITOR.editor#destroy} method.
+	 * If filter is only used by a single editor instance, you should pass editor instance alongside with the rules.
+	 * Passing editor as a first parameter binds it with the filter so the filter can be removed
+	 * with {@link CKEDITOR.editor#destroy} method to prevent memory leaks.
 	 *
 	 * ```javascript
-	 * var filter = new CKEDITOR.filter( editor, 'b' );
+	 * // In both cases filter will be removed during {@link CKEDITOR.editor#destroy} function execution.
+	 * var filter1 = new CKEDITOR.filter( editor );
+	 * var filter2 = new CKEDITOR.filter( editor, 'b' );
 	 * ```
 	 *
 	 * @since 4.1
 	 * @class
 	 * @constructor Creates a filter class instance.
 	 * @param {CKEDITOR.editor/CKEDITOR.filter.allowedContentRules} editorOrRules
-	 * @param {CKEDITOR.filter.allowedContentRules} rules This parameter is available since 4.10.2
+	 * @param {CKEDITOR.filter.allowedContentRules} [rules] This parameter is available since 4.11.0.
 	 */
 	CKEDITOR.filter = function( editorOrRules, rules ) {
 		/**

--- a/plugins/clipboard/plugin.js
+++ b/plugins/clipboard/plugin.js
@@ -126,7 +126,7 @@
 		hidpi: true, // %REMOVE_LINE_CORE%
 		init: function( editor ) {
 			var filterType,
-				filtersFactory = filtersFactoryFactory();
+				filtersFactory = filtersFactoryFactory( editor );
 
 			if ( editor.config.forcePasteAsPlainText ) {
 				filterType = 'plain-text';
@@ -1330,7 +1330,7 @@
 		return switchEnterMode( config, data );
 	}
 
-	function filtersFactoryFactory() {
+	function filtersFactoryFactory( editor ) {
 		var filters = {};
 
 		function setUpTags() {
@@ -1346,7 +1346,7 @@
 		}
 
 		function createSemanticContentFilter() {
-			var filter = new CKEDITOR.filter();
+			var filter = new CKEDITOR.filter( null, editor );
 
 			filter.allow( {
 				$1: {
@@ -1374,12 +1374,12 @@
 					// so it tries to replace it with an element created based on the active enter mode, eventually doing nothing.
 					//
 					// Now you can sleep well.
-					return filters.plainText || ( filters.plainText = new CKEDITOR.filter( 'br' ) );
+					return filters.plainText || ( filters.plainText = new CKEDITOR.filter( 'br', editor ) );
 				} else if ( type == 'semantic-content' ) {
 					return filters.semanticContent || ( filters.semanticContent = createSemanticContentFilter() );
 				} else if ( type ) {
 					// Create filter based on rules (string or object).
-					return new CKEDITOR.filter( type );
+					return new CKEDITOR.filter( type, editor );
 				}
 
 				return null;

--- a/plugins/clipboard/plugin.js
+++ b/plugins/clipboard/plugin.js
@@ -1346,7 +1346,7 @@
 		}
 
 		function createSemanticContentFilter() {
-			var filter = new CKEDITOR.filter( null, editor );
+			var filter = new CKEDITOR.filter( editor, {} );
 
 			filter.allow( {
 				$1: {
@@ -1374,12 +1374,12 @@
 					// so it tries to replace it with an element created based on the active enter mode, eventually doing nothing.
 					//
 					// Now you can sleep well.
-					return filters.plainText || ( filters.plainText = new CKEDITOR.filter( 'br', editor ) );
+					return filters.plainText || ( filters.plainText = new CKEDITOR.filter( editor, 'br' ) );
 				} else if ( type == 'semantic-content' ) {
 					return filters.semanticContent || ( filters.semanticContent = createSemanticContentFilter() );
 				} else if ( type ) {
 					// Create filter based on rules (string or object).
-					return new CKEDITOR.filter( type, editor );
+					return new CKEDITOR.filter( editor, type );
 				}
 
 				return null;

--- a/plugins/copyformatting/plugin.js
+++ b/plugins/copyformatting/plugin.js
@@ -260,7 +260,7 @@
 		 * @member CKEDITOR.plugins.copyformatting.state
 		 * @property {CKEDITOR.filter}
 		 */
-		this.filter = new CKEDITOR.filter( editor.config.copyFormatting_allowRules );
+		this.filter = new CKEDITOR.filter( editor.config.copyFormatting_allowRules, editor );
 
 		if ( editor.config.copyFormatting_allowRules === true ) {
 			this.filter.disabled = true;

--- a/plugins/copyformatting/plugin.js
+++ b/plugins/copyformatting/plugin.js
@@ -260,7 +260,7 @@
 		 * @member CKEDITOR.plugins.copyformatting.state
 		 * @property {CKEDITOR.filter}
 		 */
-		this.filter = new CKEDITOR.filter( editor.config.copyFormatting_allowRules, editor );
+		this.filter = new CKEDITOR.filter( editor, editor.config.copyFormatting_allowRules );
 
 		if ( editor.config.copyFormatting_allowRules === true ) {
 			this.filter.disabled = true;

--- a/plugins/widget/plugin.js
+++ b/plugins/widget/plugin.js
@@ -1127,19 +1127,28 @@
 				for ( var widgetName in this.repository.instances ) {
 					var widget = this.repository.instances[ widgetName ];
 
-					if ( this === widget || !widget.editables ) {
+					if ( !widget.editables ) {
 						continue;
 					}
 
 					var widgetEditable = widget.editables[ editableName ];
 
-					if ( widgetEditable && editable.filter === widgetEditable.filter ) {
+					if ( !widgetEditable || widgetEditable === editable ) {
+						continue;
+					}
+
+					if ( editable.filter === widgetEditable.filter ) {
 						canDestroyFilter = false;
 					}
 				}
 
 				if ( canDestroyFilter ) {
 					editable.filter.destroy();
+
+					var filters = this.repository._.filters[ this.name ];
+					if ( filters ) {
+						delete filters[ editableName ];
+					}
 				}
 			}
 

--- a/plugins/widget/plugin.js
+++ b/plugins/widget/plugin.js
@@ -2213,7 +2213,7 @@
 		var filter = editables[ editableName ];
 
 		if ( !filter ) {
-			filter = editableDefinition.allowedContent ? new CKEDITOR.filter( editableDefinition.allowedContent ) : this.editor.filter.clone();
+			filter = editableDefinition.allowedContent ? new CKEDITOR.filter( editableDefinition.allowedContent, this.editor ) : this.editor.filter.clone();
 
 			editables[ editableName ] = filter;
 

--- a/plugins/widget/plugin.js
+++ b/plugins/widget/plugin.js
@@ -2213,7 +2213,7 @@
 		var filter = editables[ editableName ];
 
 		if ( !filter ) {
-			filter = editableDefinition.allowedContent ? new CKEDITOR.filter( editableDefinition.allowedContent, this.editor ) : this.editor.filter.clone();
+			filter = editableDefinition.allowedContent ? new CKEDITOR.filter( editableDefinition.allowedContent ) : this.editor.filter.clone();
 
 			editables[ editableName ] = filter;
 

--- a/tests/core/editor/destroy.js
+++ b/tests/core/editor/destroy.js
@@ -2,6 +2,8 @@
 /* bender-ckeditor-plugins: toolbar,button,stylescombo,wysiwygarea */
 
 ( function() {
+	'use strict';
+
 	bender.editor = {
 		config: {
 			startupFocus: true
@@ -32,22 +34,19 @@
 		},
 
 		// (#1722)
-		'test destroy destorys attached filters': function() {
-			bender.editorBot.create( { name: 'editor_destorys_filters' }, function( bot ) {
+		'test destroy attached filters': function() {
+			var filters = countFilters();
+			bender.editorBot.create( { name: 'editor_filter_destroy' }, function( bot ) {
 				var editor = bot.editor;
 
 				new CKEDITOR.filter( 'b', editor );
 				new CKEDITOR.filter( editor );
 				new CKEDITOR.filter( 'b ' );
 
-				// +1 because there is additional filter attached on editor creation.
-				assert.areEqual( 3, getEditorFilters( editor ).length, 'Should be 3 editor filters' );
-				assert.areEqual( 1, getEditorFilters().length, 'Should be 1 global filter' );
-
 				editor.destroy();
 
-				assert.areEqual( 0, getEditorFilters( editor ).length, 'Editor filters should have been destroyed' );
-				assert.areEqual( 1, getEditorFilters().length, 'Global filter should not have been destroyed' );
+				assert.areEqual( 0, countFilters( editor ) );
+				assert.areEqual( filters + 1, countFilters() );
 			} );
 		},
 
@@ -104,10 +103,11 @@
 		}
 	} );
 
-	function getEditorFilters( editor ) {
-		return bender.tools.objToArray( CKEDITOR.filter.instances ).filter( function( filter ) {
+	function countFilters( editor ) {
+		var filters = bender.tools.objToArray( CKEDITOR.filter.instances );
+		return editor ? filters.filter( function( filter ) {
 			return filter.editor === editor;
-		} );
+		} ).length : filters.length;
 	}
 
 } )();

--- a/tests/core/editor/destroy.js
+++ b/tests/core/editor/destroy.js
@@ -2,7 +2,6 @@
 /* bender-ckeditor-plugins: toolbar,button,stylescombo,wysiwygarea */
 
 ( function() {
-	'use strict';
 
 	bender.editor = {
 		config: {
@@ -30,23 +29,6 @@
 					}, 0 );
 				} );
 
-			} );
-		},
-
-		// (#1722)
-		'test destroy attached filters': function() {
-			var filters = countFilters();
-			bender.editorBot.create( { name: 'editor_filter_destroy' }, function( bot ) {
-				var editor = bot.editor;
-
-				new CKEDITOR.filter( 'b', editor );
-				new CKEDITOR.filter( editor );
-				new CKEDITOR.filter( 'b ' );
-
-				editor.destroy();
-
-				assert.areEqual( 0, countFilters( editor ) );
-				assert.areEqual( filters + 1, countFilters() );
 			} );
 		},
 
@@ -100,6 +82,23 @@
 			} );
 
 			wait();
+		},
+
+		// (#1722)
+		'test destroy attached filters': function() {
+			var filters = countFilters();
+			bender.editorBot.create( { name: 'editor_filter_destroy' }, function( bot ) {
+				var editor = bot.editor;
+
+				new CKEDITOR.filter( 'b', editor );
+				new CKEDITOR.filter( editor );
+				new CKEDITOR.filter( 'b ' );
+
+				editor.destroy();
+
+				assert.areEqual( 0, countFilters( editor ) );
+				assert.areEqual( filters + 1, countFilters() );
+			} );
 		}
 	} );
 

--- a/tests/core/editor/destroy.js
+++ b/tests/core/editor/destroy.js
@@ -1,84 +1,113 @@
 /* bender-tags: editor */
 /* bender-ckeditor-plugins: toolbar,button,stylescombo,wysiwygarea */
 
-bender.editor = {
-	config: {
-		startupFocus: true
-	}
-};
+( function() {
+	bender.editor = {
+		config: {
+			startupFocus: true
+		}
+	};
 
-bender.test( {
-	'test destroy editor with rich combo panel opened': function() {
-		var bot = this.editorBot, editor = this.editor;
-		bot.combo( 'Styles', function( combo ) {
-			var panelEl = combo._.panel.element;
-			editor.destroy();
-			assert.isFalse( CKEDITOR.document.getBody().contains( panelEl ) );
+	bender.test( {
+		'test destroy editor with rich combo panel opened': function() {
+			var bot = this.editorBot, editor = this.editor;
+			bot.combo( 'Styles', function( combo ) {
+				var panelEl = combo._.panel.element;
+				editor.destroy();
+				assert.isFalse( CKEDITOR.document.getBody().contains( panelEl ) );
 
-			// https://dev.ckeditor.com/ticket/4552: Do that one more time.
+				// https://dev.ckeditor.com/ticket/4552: Do that one more time.
+				bender.editorBot.create( {}, function( bot ) {
+					this.wait( function() {
+						bot.combo( 'Styles', function( combo ) {
+							var panelEl = combo._.panel.element;
+
+							bot.editor.destroy();
+							assert.isFalse( CKEDITOR.document.getBody().contains( panelEl ) );
+						} );
+					}, 0 );
+				} );
+
+			} );
+		},
+
+		// (#1722)
+		'test destroy destorys attached filters': function() {
+			bender.editorBot.create( { name: 'editor_destorys_filters' }, function( bot ) {
+				var editor = bot.editor;
+
+				new CKEDITOR.filter( 'b', editor );
+				new CKEDITOR.filter( editor );
+				new CKEDITOR.filter( 'b ' );
+
+				// +1 because there is additional filter attached on editor creation.
+				assert.areEqual( 3, getEditorFilters( editor ).length, 'Should be 3 editor filters' );
+				assert.areEqual( 1, getEditorFilters().length, 'Should be 1 global filter' );
+
+				editor.destroy();
+
+				assert.areEqual( 0, getEditorFilters( editor ).length, 'Editor filters should have been destroyed' );
+				assert.areEqual( 1, getEditorFilters().length, 'Global filter should not have been destroyed' );
+			} );
+		},
+
+		// https://dev.ckeditor.com/ticket/13385.
+		'test getSnapshot returns empty string after editor destroyed': function() {
 			bender.editorBot.create( {}, function( bot ) {
 				this.wait( function() {
-					bot.combo( 'Styles', function( combo ) {
-						var panelEl = combo._.panel.element;
-
-						bot.editor.destroy();
-						assert.isFalse( CKEDITOR.document.getBody().contains( panelEl ) );
-					} );
+					var editor = bot.editor;
+					editor.destroy();
+					assert.areSame( '', editor.getSnapshot() );
 				}, 0 );
 			} );
+		},
 
-		} );
-	},
+		'test destroy editor before it is fully initialized': function() {
+			var name = 'test_editor',
+				element,
+				editor,
+				warnStub = sinon.stub( CKEDITOR, 'warn' );
 
-	// https://dev.ckeditor.com/ticket/13385.
-	'test getSnapshot returns empty string after editor destroyed': function() {
-		bender.editorBot.create( {}, function( bot ) {
-			this.wait( function() {
-				var editor = bot.editor;
-				editor.destroy();
-				assert.areSame( '', editor.getSnapshot() );
+			element = CKEDITOR.document.getById( name );
+			this.editor.destroy();
+
+			editor = CKEDITOR.replace( element );
+			editor.destroy();
+
+			// initConfig is called asynchronously.
+			wait( function() {
+				warnStub.restore();
+				assert.isTrue( warnStub.calledOnce, 'CKEDITOR.warn should be called once.' );
+				assert.areEqual( 'editor-incorrect-destroy', warnStub.firstCall.args[ 0 ],
+					'CKEDITOR.warn error code should be "editor-incorrect-destroy".' );
 			}, 0 );
-		} );
-	},
 
-	'test destroy editor before it is fully initialized': function() {
-		var name = 'test_editor',
-			element,
-			editor,
-			warnStub = sinon.stub( CKEDITOR, 'warn' );
+		},
 
-		element = CKEDITOR.document.getById( name );
-		this.editor.destroy();
-
-		editor = CKEDITOR.replace( element );
-		editor.destroy();
-
-		// initConfig is called asynchronously.
-		wait( function() {
-			warnStub.restore();
-			assert.isTrue( warnStub.calledOnce, 'CKEDITOR.warn should be called once.' );
-			assert.areEqual( 'editor-incorrect-destroy', warnStub.firstCall.args[ 0 ],
-				'CKEDITOR.warn error code should be "editor-incorrect-destroy".' );
-		}, 0 );
-
-	},
-
-	'test check editable existence on blur': function() {
-		CKEDITOR.replace( 'focused', {
-			on: {
-				instanceReady: function( evt ) {
-					resume( function() {
-						var editor = evt.sender;
-						// Simulate the circumstances instead of creating them.
-						editor.focusManager.hasFocus = true;
-						sinon.stub( editor, 'editable' ).returns( null );
-						editor.focusManager.blur( 1 );
-						assert.pass();
-					} );
+		'test check editable existence on blur': function() {
+			CKEDITOR.replace( 'focused', {
+				on: {
+					instanceReady: function( evt ) {
+						resume( function() {
+							var editor = evt.sender;
+							// Simulate the circumstances instead of creating them.
+							editor.focusManager.hasFocus = true;
+							sinon.stub( editor, 'editable' ).returns( null );
+							editor.focusManager.blur( 1 );
+							assert.pass();
+						} );
+					}
 				}
-			}
-		} );
+			} );
 
-		wait();
+			wait();
+		}
+	} );
+
+	function getEditorFilters( editor ) {
+		return bender.tools.objToArray( CKEDITOR.filter.instances ).filter( function( filter ) {
+			return filter.editor === editor;
+		} );
 	}
-} );
+
+} )();

--- a/tests/core/editor/destroy.js
+++ b/tests/core/editor/destroy.js
@@ -90,9 +90,9 @@
 			bender.editorBot.create( { name: 'editor_filter_destroy' }, function( bot ) {
 				var editor = bot.editor;
 
-				new CKEDITOR.filter( 'b', editor );
+				new CKEDITOR.filter( editor, 'br' );
 				new CKEDITOR.filter( editor );
-				new CKEDITOR.filter( 'b ' );
+				new CKEDITOR.filter( 'br' );
 
 				editor.destroy();
 

--- a/tests/core/editor/destroy.js
+++ b/tests/core/editor/destroy.js
@@ -104,7 +104,7 @@
 
 	function countFilters( editor ) {
 		var filters = bender.tools.objToArray( CKEDITOR.filter.instances );
-		return editor ? filters.filter( function( filter ) {
+		return editor ? CKEDITOR.tools.array.filter( filters, function( filter ) {
 			return filter.editor === editor;
 		} ).length : filters.length;
 	}

--- a/tests/core/editor/manual/filterdestroy.html
+++ b/tests/core/editor/manual/filterdestroy.html
@@ -1,0 +1,29 @@
+
+
+<button id="rebuild">Rebuild editor</button>
+<span id="counter"></span>
+<textarea id="editor">
+</textarea>
+<script>
+	var counter = document.getElementById( 'counter' );
+	document.getElementById( 'rebuild' ).addEventListener( 'click', rebuildEditor );
+
+	// Global filter.
+	new CKEDITOR.filter( 'b' );
+
+	rebuildEditor();
+
+	function rebuildEditor() {
+		var currentEditor = CKEDITOR.instances.editor;
+
+		if( currentEditor ) {
+			currentEditor.destroy();
+		}
+
+		var editor = CKEDITOR.replace( 'editor' );
+		new CKEDITOR.filter( 'b', editor );
+		new CKEDITOR.filter( editor );
+
+		counter.innerText = 'Filters count: ' + bender.tools.objToArray( CKEDITOR.filter.instances ).length;
+	}
+</script>

--- a/tests/core/editor/manual/filterdestroy.html
+++ b/tests/core/editor/manual/filterdestroy.html
@@ -9,7 +9,7 @@
 	document.getElementById( 'rebuild' ).addEventListener( 'click', rebuildEditor );
 
 	// Global filter.
-	new CKEDITOR.filter( 'b' );
+	new CKEDITOR.filter( 'br' );
 
 	rebuildEditor();
 
@@ -21,7 +21,7 @@
 		}
 
 		var editor = CKEDITOR.replace( 'editor' );
-		new CKEDITOR.filter( 'b', editor );
+		new CKEDITOR.filter( editor, 'br' );
 		new CKEDITOR.filter( editor );
 
 		counter.innerText = 'Filters count: ' + bender.tools.objToArray( CKEDITOR.filter.instances ).length;

--- a/tests/core/editor/manual/filterdestroy.html
+++ b/tests/core/editor/manual/filterdestroy.html
@@ -1,5 +1,3 @@
-
-
 <button id="rebuild">Rebuild editor</button>
 <span id="counter"></span>
 <textarea id="editor">

--- a/tests/core/editor/manual/filterdestroy.md
+++ b/tests/core/editor/manual/filterdestroy.md
@@ -1,0 +1,14 @@
+@bender-tags: bug, 4.9.1, 1722
+@bender-ui: collapsed
+@bender-ckeditor-plugins: toolbar, wysiwygarea, basicstyles
+
+1. Memrise `Filters count` value.
+2. Click `Rebuild editor` button.
+
+## Expected
+
+Every time when you click `Rebuild editor` button `Filters count` shouldn't change.
+
+## Unexpected
+
+`Filters count` changes.

--- a/tests/core/editor/manual/filterdestroy.md
+++ b/tests/core/editor/manual/filterdestroy.md
@@ -1,4 +1,4 @@
-@bender-tags: bug, 4.9.1, 1722
+@bender-tags: bug, 4.10.2, 1722
 @bender-ui: collapsed
 @bender-ckeditor-plugins: toolbar, wysiwygarea, basicstyles
 

--- a/tests/core/editor/manual/filterdestroy.md
+++ b/tests/core/editor/manual/filterdestroy.md
@@ -1,4 +1,4 @@
-@bender-tags: bug, 4.10.2, 1722
+@bender-tags: bug, 4.11.0, 1722
 @bender-ui: collapsed
 @bender-ckeditor-plugins: toolbar, wysiwygarea, basicstyles
 

--- a/tests/plugins/widget/manual/nestededitablefilters.html
+++ b/tests/plugins/widget/manual/nestededitablefilters.html
@@ -1,0 +1,60 @@
+<button id="button">Destroy</button>
+<strong>Filter: </strong>
+<span id="info">active</span>
+
+<div id="editor"></div>
+
+<script>
+	var editor = CKEDITOR.replace( 'editor', {
+			extraPlugins: 'test1'
+		} ),
+		widgetId = 0,
+		button = document.getElementById( 'button' ),
+		info = document.getElementById( 'info' );
+
+	CKEDITOR.plugins.add( 'test1', {
+		requires: 'widget',
+		init: function( editor ) {
+			editor.widgets.add( 'test1', {
+				button: 'Create autoparagraph test',
+				pathName: 'test-widget',
+
+				template:
+					'<div class="test1">' +
+						'<div class="content"></div>' +
+					'</div>',
+
+				editables: {
+					content: {
+						selector: '.content',
+						allowedContent: 'br'
+					}
+				},
+
+				allowedContent: 'div(test1,content)',
+				requiredContent: 'div(test1)',
+
+				upcast: function( element ) {
+					return element.name == 'div' && element.hasClass( 'test1' );
+				}
+			} );
+		}
+	} );
+
+	editor.once( 'pluginsLoaded', function() {
+		editor.setData( '<div class="test1">x<div class="content">Widget1</div>y</div> ' +
+			'<div class="test1">x<div class="content">Widget2</div>y</div>' );
+	} );
+
+	editor.once( 'instanceReady', function() {
+		button.addEventListener( 'click', function() {
+			var widget = editor.widgets.instances[ widgetId++ ];
+
+			if ( widget ) {
+				editor.widgets.destroy( widget );
+			}
+
+			info.innerText = editor.widgets._.filters.test1.content ? 'active' : 'removed';
+		} );
+	} );
+</script>

--- a/tests/plugins/widget/manual/nestededitablefilters.md
+++ b/tests/plugins/widget/manual/nestededitablefilters.md
@@ -1,0 +1,14 @@
+@bender-tags: widget, bug, 4.10.0, 1722
+@bender-ui: collapsed
+@bender-ckeditor-plugins: widget, wysiwygarea
+
+1. Click `Destroy` button first time.
+1. Click `Destroy` button second time.
+
+## Expected
+
+After first click `Filter` label should stay `active`. Second click should change `Filter` label into `removed`.
+
+## Unexpected
+
+`Filter` label stays `active` regardless of button clicks or changes status into `removed` after first click.

--- a/tests/plugins/widget/manual/nestededitablefilters.md
+++ b/tests/plugins/widget/manual/nestededitablefilters.md
@@ -1,4 +1,4 @@
-@bender-tags: widget, bug, 4.10.0, 1722
+@bender-tags: widget, bug, 4.10.2, 1722
 @bender-ui: collapsed
 @bender-ckeditor-plugins: widget, wysiwygarea
 

--- a/tests/plugins/widget/manual/nestededitablefilters.md
+++ b/tests/plugins/widget/manual/nestededitablefilters.md
@@ -1,4 +1,4 @@
-@bender-tags: widget, bug, 4.10.2, 1722
+@bender-tags: widget, bug, 4.11.0, 1722
 @bender-ui: collapsed
 @bender-ckeditor-plugins: widget, wysiwygarea
 

--- a/tests/plugins/widget/nestededitables.js
+++ b/tests/plugins/widget/nestededitables.js
@@ -219,6 +219,52 @@
 			} );
 		},
 
+		// (#1722)
+		'test #destroyEditable destroys unused editable filters': function() {
+			var editor = this.editor;
+
+			editor.widgets.add( 'testmethod5', {
+				editables: {
+					foo: '#foo'
+				}
+			} );
+
+			var widget1Html = '<div data-widget="testmethod5" id="w1"><p>A</p><p class="foo">B</p></div>',
+				widget2Html = '<div data-widget="testmethod5" id="w2"><p>A</p><p class="foo">B</p></div>';
+
+			this.editorBot.setData( widget1Html + widget2Html, function() {
+				var widget1 = getWidgetById( editor, 'w1' ),
+					widget2 = getWidgetById( editor, 'w2' );
+
+				widget1.initEditable( 'foo', { selector: '.foo', allowedContent: 'p br' } );
+				widget2.initEditable( 'foo', { selector: '.foo', allowedContent: 'p br' } );
+
+				var removedListeners = [],
+					filters = editor.widgets._.filters.testmethod5,
+					filterSpy = sinon.spy( filters.foo, 'destroy' );
+
+				widget1.editables.foo.removeListener = function( evtName ) {
+					removedListeners.push( evtName );
+				};
+
+				widget2.editables.foo.removeListener = function( evtName ) {
+					removedListeners.push( evtName );
+				};
+
+				widget1.destroyEditable( 'foo' );
+
+				assert.isNotUndefined( filters.foo );
+
+				widget2.destroyEditable( 'foo' );
+
+				assert.isUndefined( filters.foo );
+
+				assert.isTrue( filterSpy.calledOnce );
+
+				filterSpy.restore();
+			} );
+		},
+
 		'test nestedEditable enter modes are limited by ACF': function() {
 			var editor = this.editor;
 

--- a/tests/plugins/widget/nestedwidgets.js
+++ b/tests/plugins/widget/nestedwidgets.js
@@ -274,24 +274,6 @@
 			}
 		},
 
-		// (#1722)
-		'test all nested editable filters are destroyed when widget is destroyed': function() {
-			var editor = this.editors.editor,
-				initialFilters = bender.tools.objToArray( CKEDITOR.filter.instances ).length;
-
-			this.editorBots.editor.setData( generateWidgetsData( 2 ), function() {
-				for ( var widgetId in editor.widgets.instances ) {
-					var widget = editor.widgets.instances[ widgetId ];
-					for ( var editableId in widget.editables ) {
-						widget.editables[ editableId ].filter = new CKEDITOR.filter();
-					}
-					widget.destroy();
-				}
-
-				assert.areEqual( initialFilters, bender.tools.objToArray( CKEDITOR.filter.instances ).length );
-			} );
-		},
-
 		'test all nested widgets are destroyed when setting nested editable data': function() {
 			var editor = this.editors.editor,
 				bot = this.editorBots.editor,

--- a/tests/plugins/widget/nestedwidgets.js
+++ b/tests/plugins/widget/nestedwidgets.js
@@ -274,6 +274,24 @@
 			}
 		},
 
+		// (#1722)
+		'test all nested editable filters are destroyed when widget is destroyed': function() {
+			var editor = this.editors.editor,
+				initialFilters = bender.tools.objToArray( CKEDITOR.filter.instances ).length;
+
+			this.editorBots.editor.setData( generateWidgetsData( 2 ), function() {
+				for ( var widgetId in editor.widgets.instances ) {
+					var widget = editor.widgets.instances[ widgetId ];
+					for ( var editableId in widget.editables ) {
+						widget.editables[ editableId ].filter = new CKEDITOR.filter();
+					}
+					widget.destroy();
+				}
+
+				assert.areEqual( initialFilters, bender.tools.objToArray( CKEDITOR.filter.instances ).length );
+			} );
+		},
+
 		'test all nested widgets are destroyed when setting nested editable data': function() {
 			var editor = this.editors.editor,
 				bot = this.editorBots.editor,


### PR DESCRIPTION
## What is the purpose of this pull request?

Bug fix

## Does your PR contain necessary tests?

All patches which change the editor code must include tests. You can always read more
on [PR testing](https://docs.ckeditor.com/ckeditor4/docs/#!/guide/dev_contributing_code-section-tests),
[how to set the testing environment](https://docs.ckeditor.com/ckeditor4/docs/#!/guide/dev_tests) and
[how to create tests](https://docs.ckeditor.com/ckeditor4/docs/#!/guide/dev_tests-section-creating-your-own-test)
in the official CKEditor documentation.

### This PR contains

- [x] Unit tests
- [x] Manual tests

## What changes did you make?

Added additional option to `CKEDITOR.filter` constructor to pass an editor owning filter instance. Changed `editor.destroy` function to remove correct editors and refactored plugins using `CKEDITOR.filter`. With this change we are now able to remove orphaned editor filters and prevent memory leak with `CKEDITOR.filter.instances`.

Additional parameter doesn't look most beautiful because we should probably go with something like `new CKEDITOR.filter( editor, rules)` but it would require to provide breaking change for our API.

Based on #1690

Closes #1722, closes #2466
