### PR TITLE
Update button names to be coherent with other plugins

### DIFF
--- a/plugins/easyimage/plugin.js
+++ b/plugins/easyimage/plugin.js
@@ -7,7 +7,8 @@
 	'use strict';
 
 	var stylesLoaded = false,
-		WIDGET_NAME = 'easyimage';
+		WIDGET_NAME = 'easyimage',
+		BUTTON_PREFIX = 'EasyImage';
 
 	function capitalize( str ) {
 		return CKEDITOR.tools.capitalize( str, true );
@@ -154,7 +155,7 @@
 
 	function addButtons( editor, styles ) {
 		function addDefaultButtons() {
-			editor.ui.addButton( 'EasyimageAlt', {
+			editor.ui.addButton( BUTTON_PREFIX + 'Alt', {
 				label: editor.lang.easyimage.commands.altText,
 				command: 'easyimageAlt',
 				toolbar: 'easyimage,3'
@@ -165,7 +166,7 @@
 			var style;
 
 			for ( style in styles ) {
-				editor.ui.addButton( 'Easyimage' + capitalize( style ), {
+				editor.ui.addButton( BUTTON_PREFIX + capitalize( style ), {
 					label: styles[ style ].label,
 					command: 'easyimage' + capitalize( style ),
 					toolbar: 'easyimage,99',
@@ -505,7 +506,7 @@
 	}
 
 	function addUploadButtonToToolbar( editor ) {
-		editor.ui.addButton( 'EasyimageUpload', {
+		editor.ui.addButton( BUTTON_PREFIX + 'Upload', {
 			label: editor.lang.common.upload,
 			command: 'easyimageUpload',
 			toolbar: 'insert,1'
@@ -600,9 +601,9 @@
 	 * * `alignCenter` &ndash; Adding an `easyimage-align-center` class to the `figure` element.
 	 * * `alignRight` &ndash; Adding an `easyimage-align-right` class to the `figure` element.
 	 *
-	 * Every style added by this configuration variable will result in adding the `Easyimage<name>` button
+	 * Every style added by this configuration variable will result in adding the `EasyImage<name>` button
 	 * and the `easyimage<name>` command, where `<name>` is the name of the style in Pascal case. For example, the
-	 * `left` style would produce a `EasyimageLeft` button and an `easyimageLeft` command.
+	 * `left` style would produce a `EasyImageLeft` button and an `easyimageLeft` command.
 	 *
 	 *		// Adds a custom alignment style.
 	 *		config.easyimage_styles = {
@@ -674,12 +675,12 @@
 	 *
 	 * ```js
 	 * // Change toolbar to alignment commands.
-	 * config.easyimage_toolbar = [ 'EasyimageAlignLeft', 'EasyimageAlignCenter', 'EasyimageAlignRight' ];
+	 * config.easyimage_toolbar = [ 'EasyImageAlignLeft', 'EasyImageAlignCenter', 'EasyImageAlignRight' ];
 	 * ```
 	 *
 	 * @since 4.9.0
-	 * @cfg {String[]/String} [easyimage_toolbar=[ 'EasyimageFull', 'EasyimageSide', 'EasyimageAlt' ]]
+	 * @cfg {String[]/String} [easyimage_toolbar=[ 'EasyImageFull', 'EasyImageSide', 'EasyImageAlt' ]]
 	 * @member CKEDITOR.config
 	 */
-	CKEDITOR.config.easyimage_toolbar = [ 'EasyimageFull', 'EasyimageSide', 'EasyimageAlt' ];
+	CKEDITOR.config.easyimage_toolbar = [ BUTTON_PREFIX + 'Full', BUTTON_PREFIX + 'Side', BUTTON_PREFIX + 'Alt' ];
 }() );

--- a/plugins/easyimage/samples/easyimage.html
+++ b/plugins/easyimage/samples/easyimage.html
@@ -87,7 +87,7 @@ CKEDITOR.replace( 'editor', {
 		{ name: 'basicstyles', items: [ 'Bold', 'Italic', 'Strike', '-', 'RemoveFormat' ] },
 		{ name: 'paragraph', items: [ 'NumberedList', 'BulletedList' ] },
 		{ name: 'links', items: [ 'Link', 'Unlink', 'Anchor' ] },
-		{ name: 'insert', items: [ 'EasyimageUpload' ] },
+		{ name: 'insert', items: [ 'EasyImageUpload' ] },
 		{ name: 'styles', items: [ 'Format' ] }
 	],
 	cloudServices_uploadUrl: 'https://33333.cke-cs.com/easyimage/upload/',

--- a/tests/plugins/easyimage/config.js
+++ b/tests/plugins/easyimage/config.js
@@ -160,7 +160,7 @@
 		'test default styles for alignRight': createCustomClassTest( 'AlignRight' ),
 
 		'test balloon toolbar buttons (default settings)': createToolbarTest( 'standard',
-			[ 'EasyimageFull', 'EasyimageSide', 'EasyimageAlt' ] ),
+			[ 'EasyImageFull', 'EasyImageSide', 'EasyImageAlt' ] ),
 		'test balloon toolbar buttons (string syntax)': createToolbarTest( 'toolbarString', [ 'Bold', 'Italic' ] ),
 		'test balloon toolbar buttons (array syntax)': createToolbarTest( 'toolbarArray', [ 'Bold', 'Italic' ] ),
 

--- a/tests/plugins/easyimage/customstyleicons.js
+++ b/tests/plugins/easyimage/customstyleicons.js
@@ -14,7 +14,7 @@
 					iconHiDpi: 'tests/_assets/sample_icon.hidpi.png'
 				}
 			},
-			easyimage_toolbar: [ 'EasyimageTest' ]
+			easyimage_toolbar: [ 'EasyImageTest' ]
 		};
 
 	bender.test( {

--- a/tests/plugins/easyimage/customstyles.js
+++ b/tests/plugins/easyimage/customstyles.js
@@ -7,7 +7,7 @@
 	'use strict';
 
 	var commonConfig = {
-		toolbar: [ [ 'Paste', 'EasyimageFull', 'EasyimageSide' ] ],
+		toolbar: [ [ 'Paste', 'EasyImageFull', 'EasyImageSide' ] ],
 		easyimage_styles: {
 			test: {
 				attributes: {

--- a/tests/plugins/easyimage/manual/customgroups.html
+++ b/tests/plugins/easyimage/manual/customgroups.html
@@ -41,7 +41,7 @@
 					group: 'easyimageborder'
 				}
 			},
-			easyimage_toolbar: [ 'EasyimageFull', 'EasyimageSide', 'EasyimageBorder1', 'EasyimageBorder2' ]
+			easyimage_toolbar: [ 'EasyImageFull', 'EasyImageSide', 'EasyImageBorder1', 'EasyImageBorder2' ]
 		};
 
 		CKEDITOR.addCss( '.border1 { border: 2px solid green }' );

--- a/tests/plugins/easyimage/manual/customstyleicons.html
+++ b/tests/plugins/easyimage/manual/customstyleicons.html
@@ -40,7 +40,7 @@
 				iconHiDpi: 'tests/_assets/sample_icon.hidpi.png'
 			}
 		},
-		easyimage_toolbar: [ 'EasyimageTest' ]
+		easyimage_toolbar: [ 'EasyImageTest' ]
 	};
 
 	CKEDITOR.replace( 'classic', commonConfig );

--- a/tests/plugins/easyimage/manual/customstyles.html
+++ b/tests/plugins/easyimage/manual/customstyles.html
@@ -36,7 +36,7 @@
 					label: 'Test Style'
 				}
 			},
-			easyimage_toolbar: [ 'EasyimageTest', 'EasyimageAlignLeft', 'EasyimageAlignCenter', 'EasyimageAlignRight' ]
+			easyimage_toolbar: [ 'EasyImageTest', 'EasyImageAlignLeft', 'EasyImageAlignCenter', 'EasyImageAlignRight' ]
 		};
 
 		CKEDITOR.replace( 'classic', commonConfig );


### PR DESCRIPTION
## What is the purpose of this pull request?

Variables rename

### This PR contains

- [ ] Unit tests
- [ ] Manual tests

## What changes did you make?

- change names of UI buttons to be coherent with other plugins. There is used global variable in plugin which easily kept button prefix use in entire plugin
- update docs with proper names
- update sample page and tests to work with new buttons' names

close #1769 
