### PR TITLE
Easy Image includes backend service error message (if available) on upload failure

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -3,6 +3,10 @@
 
 ## CKEditor 4.10.0
 
+New Features:
+
+* [#1763](https://github.com/ckeditor/ckeditor-dev/issues/1763): Easy Image includes backend service error message (if available) on upload failure.
+
 Fixed Issues:
 
 * [#1458](https://github.com/ckeditor/ckeditor-dev/issues/1458): [Edge] Fixed: After blurring editor it takes 2 clicks to focus a widget.

--- a/plugins/easyimage/plugin.js
+++ b/plugins/easyimage/plugin.js
@@ -340,8 +340,9 @@
 						} );
 					} );
 
-					this.on( 'uploadFailed', function() {
-						alert( this.editor.lang.easyimage.uploadFailed ); // jshint ignore:line
+					this.on( 'uploadFailed', function( evt ) {
+						var response = evt.data.loader.responseData.response;
+						alert( response && response.message || this.editor.lang.easyimage.uploadFailed ); // jshint ignore:line
 					} );
 
 					this._loadDefaultStyle();

--- a/tests/plugins/easyimage/manual/errormessage.html
+++ b/tests/plugins/easyimage/manual/errormessage.html
@@ -1,0 +1,18 @@
+<p>Note, this test uses a real Cloud Service connection, so you might want to be on-line 😉.</p>
+
+<div id="editor1">
+</div>
+
+<script src="_helpers/tools.js"></script>
+<script>
+	if ( easyImageTools.isUnsupportedEnvironment() ) {
+		bender.ignore();
+	}
+
+	easyImageTools.getToken( function( token ) {
+		CKEDITOR.replace( 'editor1', {
+				cloudServices_url: easyImageTools.CLOUD_SERVICES_UPLOAD_GATEWAY,
+				cloudServices_token: token + 'invalid' // Pass invalid token to fire uploadFailed event.
+			} );
+	} );
+</script>

--- a/tests/plugins/easyimage/manual/errormessage.md
+++ b/tests/plugins/easyimage/manual/errormessage.md
@@ -1,0 +1,15 @@
+@bender-tags: 4.10.0, feature, 1763
+@bender-ui: collapsed
+@bender-ckeditor-plugins: wysiwygarea, toolbar, basicstyles, easyimage
+@bender-include: ../_helpers/tools.js
+
+1. Drag an image into editor.
+2. Wait until image is uploaded.
+
+## Expected
+
+Alert shows up `Invalid token` message.
+
+## Unexpected
+
+Alert shows up `Your image could not be uploaded due to a network error.` message.


### PR DESCRIPTION
## What is the purpose of this pull request?

<!-- Bug fix / New feature / Typo fix / Other, please explain  -->

## Does your PR contain necessary tests?

All patches which change the editor code must include tests. You can always read more
on [PR testing](https://docs.ckeditor.com/ckeditor4/docs/#!/guide/dev_contributing_code-section-tests),
[how to set the testing environment](https://docs.ckeditor.com/ckeditor4/docs/#!/guide/dev_tests) and
[how to create tests](https://docs.ckeditor.com/ckeditor4/docs/#!/guide/dev_tests-section-creating-your-own-test)
in the official CKEditor documentation.

### This PR contains

- [x] Unit tests
- [x] Manual tests

## What changes did you make?

Changed `filetools` to include information about error response data on `fileUploadResponse` event. Updated `easyimage` to use backend service error message if available.

Closes #1763.
