### PR TITLE
Fixed JAWS leaving forms mode after pressing enter in CKEditor inline instances

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -6,6 +6,7 @@
 Fixed Issues:
 
 * [#1458](https://github.com/ckeditor/ckeditor-dev/issues/1458): [Edge] Fixed: After blurring editor it takes 2 clicks to focus a widget.
+* [#1034](https://github.com/ckeditor/ckeditor-dev/issues/1034): Fixed: JAWS leaves forms mode after pressing <kbd>enter</kbd> key in an inline CKEditor instance.
 
 ## CKEditor 4.9.1
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -6,7 +6,7 @@
 Fixed Issues:
 
 * [#1458](https://github.com/ckeditor/ckeditor-dev/issues/1458): [Edge] Fixed: After blurring editor it takes 2 clicks to focus a widget.
-* [#1034](https://github.com/ckeditor/ckeditor-dev/issues/1034): Fixed: JAWS leaves forms mode after pressing <kbd>enter</kbd> key in an inline CKEditor instance.
+* [#1034](https://github.com/ckeditor/ckeditor-dev/issues/1034): Fixed: JAWS leaves forms mode after pressing <kbd>Enter</kbd> key in an inline CKEditor instance.
 
 ## CKEditor 4.9.1
 

--- a/core/editable.js
+++ b/core/editable.js
@@ -1330,6 +1330,7 @@
 				var ariaLabel = editor.title;
 
 				editable.changeAttr( 'role', 'textbox' );
+				editable.changeAttr( 'aria-multiline', 'true' ); // (#1034)
 				editable.changeAttr( 'aria-label', ariaLabel );
 
 				if ( ariaLabel )

--- a/tests/core/editable/manual/multilinejaws.html
+++ b/tests/core/editable/manual/multilinejaws.html
@@ -1,0 +1,25 @@
+<h2>Inline</h2>
+
+<textarea name="editor1">
+	<p>Test</p>
+	<p>Test</p>
+</textarea>
+
+<h2>Divarea</h2>
+
+<textarea name="editor2">
+	<p>Test</p>
+	<p>Test</p>
+</textarea>
+
+<script type="text/javascript">
+	if ( !CKEDITOR.env.gecko ) {
+		// JAWS is supported only with Firefox.
+		bender.ignore();
+	}
+
+	CKEDITOR.inline( 'editor1' );
+	CKEDITOR.replace( 'editor2', {
+		extraPlugins: 'divarea'
+	} );
+</script>

--- a/tests/core/editable/manual/multilinejaws.md
+++ b/tests/core/editable/manual/multilinejaws.md
@@ -1,0 +1,17 @@
+@bender-tags: 4.10.0, bug, 1034, accessibility
+@bender-ui: collapsed
+@bender-ckeditor-plugins: clipboard, toolbar, wysiwygarea, link, floatingspace, elementspath
+
+For each editor:
+
+1. Run JAWS.
+1. Focus the editor.
+1. Press enter twice.
+
+## Expected
+
+Two paragraphs are created. No beep sound can be heard.
+
+## Unexpected
+
+Only one paragraph is created. Beep sound is heard, telling JAWS left forms mode.


### PR DESCRIPTION
## What is the purpose of this pull request?

Bug fix

## Does your PR contain necessary tests?

All patches which change the editor code must include tests. You can always read more
on [PR testing](https://docs.ckeditor.com/ckeditor4/docs/#!/guide/dev_contributing_code-section-tests),
[how to set the testing environment](https://docs.ckeditor.com/ckeditor4/docs/#!/guide/dev_tests) and
[how to create tests](https://docs.ckeditor.com/ckeditor4/docs/#!/guide/dev_tests-section-creating-your-own-test)
in the official CKEditor documentation.

### This PR contains

- [ ] Unit tests
- [x] Manual tests

## What changes did you make?

The reason why JAWS was leaving forms mode was that we're using [`[role="textbox"]`](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/ARIA_Techniques/Using_the_textbox_role) but no `[aria-multiline]` attr.

After adding the latter the issue is gone.

Closes #1034.