### PR TITLE
Added possibility to call `CKEDITOR.editor.addCommand` with `CKEDITOR.command` instance as parameter

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -12,6 +12,10 @@ Fixed Issues:
 * [#1776](https://github.com/ckeditor/ckeditor-dev/issues/1776): [Image Base](https://ckeditor.com/cke4/addon/imagebase) empty caption placeholder is not hidden when blurred.
 * [#1592](https://github.com/ckeditor/ckeditor-dev/issues/1592): [Image Base](https://ckeditor.com/cke4/addon/imagebase) caption is not visible after paste.
 
+API Changes:
+
+* [#1582](https://github.com/ckeditor/ckeditor-dev/issues/1582): The [`CKEDITOR.editor.addCommand`](https://docs.ckeditor.com/ckeditor4/latest/api/CKEDITOR_editor.html#method-addCommand) can accept [`CKEDITOR.command`](https://docs.ckeditor.com/ckeditor4/latest/api/CKEDITOR_command.html) instance as parameter.
+
 ## CKEditor 4.9
 
 New Features:

--- a/core/editor.js
+++ b/core/editor.js
@@ -740,12 +740,14 @@
 		 * 			}
 		 * 		} );
 		 *
+		 * Since 4.10.0 this method accepts `CKEDITOR.command` instance as param.
+		 *
 		 * @param {String} commandName The indentifier name of the command.
-		 * @param {CKEDITOR.commandDefinition} commandDefinition The command definition.
+		 * @param {CKEDITOR.commandDefinition/CKEDITOR.command} commandDefinition The command definition or the command instance.
 		 */
 		addCommand: function( commandName, commandDefinition ) {
 			commandDefinition.name = commandName.toLowerCase();
-			var cmd = new CKEDITOR.command( this, commandDefinition );
+			var cmd = commandDefinition instanceof CKEDITOR.command ? commandDefinition : new CKEDITOR.command( this, commandDefinition );
 
 			// Update command when mode is set.
 			// This guarantees that commands added before first editor#mode

--- a/core/editor.js
+++ b/core/editor.js
@@ -740,7 +740,7 @@
 		 * 			}
 		 * 		} );
 		 *
-		 * Since 4.10.0 this method accepts `CKEDITOR.command` instance as param.
+		 * Since 4.10.0 this method also accepts `CKEDITOR.command` instance as param.
 		 *
 		 * @param {String} commandName The indentifier name of the command.
 		 * @param {CKEDITOR.commandDefinition/CKEDITOR.command} commandDefinition The command definition or the command instance.

--- a/tests/core/command/command.js
+++ b/tests/core/command/command.js
@@ -302,5 +302,30 @@ bender.test( {
 		editor._.elementsPath.onClick( 0 );
 
 		wait();
+	},
+
+	'test addCommand from command instance': function() {
+		var editor = this.editor,
+			styleDefinition = {
+				element: 'span',
+				attributes: {
+					bar: 'foo'
+				}
+			},
+			style = new CKEDITOR.style( styleDefinition ),
+			commandDefinition = new CKEDITOR.styleCommand( style ),
+			cmd1 = new CKEDITOR.command( editor, commandDefinition );
+
+		// Register command from command instance.
+		editor.addCommand( 'cmd1', cmd1 );
+
+		// Register command from command definition.
+		editor.addCommand( 'cmd2', commandDefinition );
+
+		// Registered command should be same as the command that was passed as definition.
+		assert.areSame( editor.getCommand( 'cmd1' ), cmd1 );
+
+		// Registered command should't be same to another command with same definition.
+		assert.areNotSame( editor.getCommand( 'cmd2' ), cmd1 );
 	}
 } );

--- a/tests/core/command/command.js
+++ b/tests/core/command/command.js
@@ -348,5 +348,4 @@ bender.test( {
 
 		assertCommand( editor, cmd, commandDefinition );
 	}
-
 } );

--- a/tests/core/command/command.js
+++ b/tests/core/command/command.js
@@ -9,6 +9,20 @@ var READ_ONLY_CMDS = [
 	'preview', 'print', 'showblocks', 'showborders', 'source', 'toolbarCollapse', 'toolbarFocus', 'selectAll'
 ];
 
+function assertCommand( editor, cmd, commandDefinition ) {
+	// Register command from command instance.
+	editor.addCommand( 'cmd1', cmd );
+
+	// Register command from command definition.
+	editor.addCommand( 'cmd2', commandDefinition );
+
+	// Registered command should be same as the command that was passed as definition.
+	assert.areSame( editor.getCommand( 'cmd1' ), cmd );
+
+	// Registered command should't be same to another command with same definition.
+	assert.areNotSame( editor.getCommand( 'cmd2' ), cmd );
+}
+
 bender.editor = true;
 
 bender.test( {
@@ -314,18 +328,25 @@ bender.test( {
 			},
 			style = new CKEDITOR.style( styleDefinition ),
 			commandDefinition = new CKEDITOR.styleCommand( style ),
-			cmd1 = new CKEDITOR.command( editor, commandDefinition );
+			cmd = new CKEDITOR.command( editor, commandDefinition );
 
-		// Register command from command instance.
-		editor.addCommand( 'cmd1', cmd1 );
+		assertCommand( editor, cmd, commandDefinition );
+	},
 
-		// Register command from command definition.
-		editor.addCommand( 'cmd2', commandDefinition );
+	'test addCommand from command subclass': function() {
+		var editor = this.editor,
+			styleDefinition = {
+				element: 'span',
+				attributes: {
+					bar: 'foo'
+				}
+			},
+			subCommand = CKEDITOR.tools.createClass( { base: CKEDITOR.command } ),
+			style = new CKEDITOR.style( styleDefinition ),
+			commandDefinition = new CKEDITOR.styleCommand( style ),
+			cmd = new subCommand( editor, commandDefinition );
 
-		// Registered command should be same as the command that was passed as definition.
-		assert.areSame( editor.getCommand( 'cmd1' ), cmd1 );
-
-		// Registered command should't be same to another command with same definition.
-		assert.areNotSame( editor.getCommand( 'cmd2' ), cmd1 );
+		assertCommand( editor, cmd, commandDefinition );
 	}
+
 } );

--- a/tests/core/command/command.js
+++ b/tests/core/command/command.js
@@ -318,6 +318,7 @@ bender.test( {
 		wait();
 	},
 
+	// (#1582)
 	'test addCommand from command instance': function() {
 		var editor = this.editor,
 			styleDefinition = {
@@ -333,6 +334,7 @@ bender.test( {
 		assertCommand( editor, cmd, commandDefinition );
 	},
 
+	// (#1582)
 	'test addCommand from command subclass': function() {
 		var editor = this.editor,
 			styleDefinition = {


### PR DESCRIPTION
## What is the purpose of this pull request?

New Feature

## Does your PR contain necessary tests?

All patches which change the editor code must include tests. You can always read more
on [PR testing](https://docs.ckeditor.com/ckeditor4/docs/#!/guide/dev_contributing_code-section-tests),
[how to set the testing environment](https://docs.ckeditor.com/ckeditor4/docs/#!/guide/dev_tests) and
[how to create tests](https://docs.ckeditor.com/ckeditor4/docs/#!/guide/dev_tests-section-creating-your-own-test)
in the official CKEditor documentation.

### This PR contains

- [x] Unit tests
- [ ] Manual tests

## What changes did you make?

I've added check if `CKEDITOR.editor.addComand` has command instance passed it will register this command in editor and return it instead of creating new one.

Also added unit test to cover that case.

Closes #1582