### PR TITLE
Fixed: easy image caption is hidden after paste

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -10,6 +10,7 @@ Fixed Issues:
 * [#1748](https://github.com/ckeditor/ckeditor-dev/pull/1748): Fixed: Added missing [`CKEDITOR.dialog.definition.onHide`](https://docs.ckeditor.com/ckeditor4/latest/api/CKEDITOR_dialog_definition.html#property-onHide) API documentation. Thanks to [sunnyone](https://github.com/sunnyone)!
 * [#1321](https://github.com/ckeditor/ckeditor-dev/issues/1321): Ideographic space character `\u3000` is lost when pasting text.
 * [#1776](https://github.com/ckeditor/ckeditor-dev/issues/1776): [Image Base](https://ckeditor.com/cke4/addon/imagebase) empty caption placeholder is not hidden when blurred.
+* [#1592](https://github.com/ckeditor/ckeditor-dev/issues/1592): [Image Base](https://ckeditor.com/cke4/addon/imagebase) caption is not visible after paste.
 
 ## CKEditor 4.9
 

--- a/plugins/imagebase/plugin.js
+++ b/plugins/imagebase/plugin.js
@@ -522,10 +522,6 @@
 			return !widget.editables.caption.getData() || !!widget.parts.caption.data( 'cke-caption-placeholder' );
 		}
 
-		function isEmptyAndNotActive( widget ) {
-			return !widget.editables.caption.getData() && !widget.parts.caption.data( 'cke-caption-active' );
-		}
-
 		function addPlaceholder( widget ) {
 			widget.parts.caption.data( 'cke-caption-placeholder', widget.editor.lang.imagebase.captionPlaceholder );
 		}

--- a/plugins/imagebase/plugin.js
+++ b/plugins/imagebase/plugin.js
@@ -522,6 +522,10 @@
 			return !widget.editables.caption.getData() || !!widget.parts.caption.data( 'cke-caption-placeholder' );
 		}
 
+		function isEmptyAndNotActive( widget ) {
+			return !widget.editables.caption.getData() && !widget.parts.caption.data( 'cke-caption-active' );
+		}
+
 		function addPlaceholder( widget ) {
 			widget.parts.caption.data( 'cke-caption-placeholder', widget.editor.lang.imagebase.captionPlaceholder );
 		}
@@ -580,7 +584,10 @@
 					this.parts.caption = createCaption( this );
 				}
 
-				this._refreshCaption();
+				// Refresh caption only if it's empty and doesn't have a placeholder to prevent hiding caption on paste (#1592).
+				if ( !this.editables.caption.getData() && !this.parts.caption.data( 'cke-caption-placeholder' ) ) {
+					this._refreshCaption();
+				}
 			},
 
 			/**

--- a/tests/plugins/imagebase/features/caption.html
+++ b/tests/plugins/imagebase/features/caption.html
@@ -24,6 +24,15 @@
 	</figure>
 </div>
 
+<div id="toggleActive">
+	<p>Focus trap!</p>
+
+	<figure>
+		<img src="%BASE_PATH%_assets/logo.png">
+		<figcaption data-cke-caption-placeholder="Placeholder"></figcaption>
+	</figure>
+</div>
+
 
 <div id="toggleTwoEmpty">
 	<figure>

--- a/tests/plugins/imagebase/features/caption.js
+++ b/tests/plugins/imagebase/features/caption.js
@@ -410,6 +410,13 @@
 			}
 		} ),
 
+		'test toggling active caption': createToggleTest( {
+			fixture: 'toggleActive',
+			initial: true,
+			focus: true,
+			blur: false
+		} ),
+
 		'test blurring editor does not hide the caption': createToggleTest( {
 			fixture: 'toggleOne',
 			initial: true,

--- a/tests/plugins/imagebase/features/caption.js
+++ b/tests/plugins/imagebase/features/caption.js
@@ -410,6 +410,7 @@
 			}
 		} ),
 
+		// (#1592)
 		'test toggling active caption': createToggleTest( {
 			fixture: 'toggleActive',
 			initial: true,

--- a/tests/plugins/imagebase/features/manual/captionafterpaste.html
+++ b/tests/plugins/imagebase/features/manual/captionafterpaste.html
@@ -1,0 +1,22 @@
+<div id="editor1">
+	<figure>
+		<img src="../../../image2/_assets/foo.png" alt="foo">
+	</figure>
+</div>
+
+	<script>
+		if ( easyImageTools.isUnsupportedEnvironment() ) {
+			bender.ignore();
+		}
+		CKEDITOR.replace( 'editor1', {
+			on: {
+				pluginsLoaded: function( evt ) {
+					var editor = evt.editor,
+						plugin = CKEDITOR.plugins.imagebase;
+
+					plugin.addImageWidget( editor, 'testWidget', plugin.addFeature( editor, 'caption', {} ) );
+				}
+			}
+		} );
+	</script>
+</body>

--- a/tests/plugins/imagebase/features/manual/captionafterpaste.md
+++ b/tests/plugins/imagebase/features/manual/captionafterpaste.md
@@ -1,0 +1,16 @@
+@bender-tags: 4.9.1, bug, 1592
+@bender-ui: collapsed
+@bender-ckeditor-plugins: wysiwygarea, toolbar, imagebase
+@bender-include: %BASE_PATH%/plugins/easyimage/_helpers/tools.js
+
+1. Focus the image.
+2. Cut the image using `ctrl/cmd + x`.
+3. Paste the image using `ctrl/cmd + v`.
+
+## Expected
+
+Caption placeholder is visible before cutting and after pasting.
+
+## Unexpected
+
+Caption placeholder is not visible before cutting and/or after pasting.

--- a/tests/plugins/imagebase/features/manual/captionafterpaste.md
+++ b/tests/plugins/imagebase/features/manual/captionafterpaste.md
@@ -1,4 +1,4 @@
-@bender-tags: 4.9.1, bug, 1592
+@bender-tags: 4.10.0, bug, 1592
 @bender-ui: collapsed
 @bender-ckeditor-plugins: wysiwygarea, toolbar, imagebase
 @bender-include: %BASE_PATH%/plugins/easyimage/_helpers/tools.js


### PR DESCRIPTION
## What is the purpose of this pull request?

<!-- Bug fix / New feature / Typo fix / Other, please explain  -->

## Does your PR contain necessary tests?

All patches which change the editor code must include tests. You can always read more
on [PR testing](https://docs.ckeditor.com/ckeditor4/docs/#!/guide/dev_contributing_code-section-tests),
[how to set the testing environment](https://docs.ckeditor.com/ckeditor4/docs/#!/guide/dev_tests) and
[how to create tests](https://docs.ckeditor.com/ckeditor4/docs/#!/guide/dev_tests-section-creating-your-own-test)
in the official CKEditor documentation.

### This PR contains

- [x] Unit tests
- [x] Manual tests

## What changes did you make?

Caption is refreshed only when empty and without placeholder. With this change caption is preserved on paste.

Based on #1793

Closes #1592
