### PR TITLE
Fixed blurring empty image base caption

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -9,7 +9,7 @@ Fixed Issues:
 * [#1034](https://github.com/ckeditor/ckeditor-dev/issues/1034): Fixed: JAWS leaves forms mode after pressing <kbd>Enter</kbd> key in an inline CKEditor instance.
 * [#1748](https://github.com/ckeditor/ckeditor-dev/pull/1748): Fixed: Added missing [`CKEDITOR.dialog.definition.onHide`](https://docs.ckeditor.com/ckeditor4/latest/api/CKEDITOR_dialog_definition.html#property-onHide) API documentation. Thanks to [sunnyone](https://github.com/sunnyone)!
 * [#1321](https://github.com/ckeditor/ckeditor-dev/issues/1321): Ideographic space character `\u3000` is lost when pasting text.
-* [#1776](https://github.com/ckeditor/ckeditor-dev/issues/1776): Image base empty caption placeholder is not hidden when blurred.
+* [#1776](https://github.com/ckeditor/ckeditor-dev/issues/1776): [Image Base](https://ckeditor.com/cke4/addon/imagebase) empty caption placeholder is not hidden when blurred.
 
 ## CKEditor 4.9
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,7 +1,7 @@
 ﻿CKEditor 4 Changelog
 ====================
 
-## CKEditor 4.10.0
+## CKEditor 4.10
 
 Fixed Issues:
 
@@ -9,6 +9,7 @@ Fixed Issues:
 * [#1034](https://github.com/ckeditor/ckeditor-dev/issues/1034): Fixed: JAWS leaves forms mode after pressing <kbd>Enter</kbd> key in an inline CKEditor instance.
 * [#1748](https://github.com/ckeditor/ckeditor-dev/pull/1748): Fixed: Added missing [`CKEDITOR.dialog.definition.onHide`](https://docs.ckeditor.com/ckeditor4/latest/api/CKEDITOR_dialog_definition.html#property-onHide) API documentation. Thanks to [sunnyone](https://github.com/sunnyone)!
 * [#1321](https://github.com/ckeditor/ckeditor-dev/issues/1321): Ideographic space character `\u3000` is lost when pasting text.
+* [#1776](https://github.com/ckeditor/ckeditor-dev/issues/1776): Image base empty caption placeholder is not hidden when blurred.
 
 ## CKEditor 4.9
 

--- a/plugins/imagebase/plugin.js
+++ b/plugins/imagebase/plugin.js
@@ -544,9 +544,7 @@
 				function listener( evt ) {
 					var path = evt.name === 'blur' ? editor.elementPath() : evt.data.path,
 						sender = path ? path.lastElement : null,
-						focused = getFocusedWidget( editor ),
-						previous = editor.widgets.getByElement(
-							editor.editable().findOne( 'figcaption[data-cke-caption-active]' ) );
+						widgets = getWidgetsWithFeature( editor.widgets.instances, 'caption' );
 
 					if ( !editor.filter.check( 'figcaption' ) ) {
 						return CKEDITOR.tools.array.forEach( listeners, function( listener ) {
@@ -554,13 +552,9 @@
 						} );
 					}
 
-					if ( focused && hasWidgetFeature( focused, 'caption' ) ) {
-						focused._refreshCaption( sender );
-					}
-
-					if ( previous && hasWidgetFeature( previous, 'caption' ) ) {
-						previous._refreshCaption( sender );
-					}
+					CKEDITOR.tools.array.forEach( widgets, function( widget ) {
+						widget._refreshCaption( sender );
+					} );
 				}
 
 				listeners.push( editor.on( 'selectionChange', listener , null, null, 9 ) );
@@ -613,6 +607,16 @@
 		upload: getUploadFeature(),
 		link: getLinkFeature()
 	};
+
+	function getWidgetsWithFeature( widgets, feature ) {
+		return CKEDITOR.tools.array.reduce( CKEDITOR.tools.objectKeys( widgets ), function( featuredWidgets, id ) {
+			var widget = widgets[ id ];
+			if ( hasWidgetFeature( widget, feature ) ) {
+				featuredWidgets.push( widget );
+			}
+			return featuredWidgets;
+		}, [] );
+	}
 
 	function createWidgetDefinition( editor, definition ) {
 		var baseDefinition;

--- a/plugins/imagebase/plugin.js
+++ b/plugins/imagebase/plugin.js
@@ -40,6 +40,16 @@
 		return widget.features && CKEDITOR.tools.array.indexOf( widget.features, feature ) !== -1;
 	}
 
+	function getWidgetsWithFeature( widgets, feature ) {
+		return CKEDITOR.tools.array.reduce( CKEDITOR.tools.objectKeys( widgets ), function( featuredWidgets, id ) {
+			var widget = widgets[ id ];
+			if ( hasWidgetFeature( widget, feature ) ) {
+				featuredWidgets.push( widget );
+			}
+			return featuredWidgets;
+		}, [] );
+	}
+
 	function getLinkFeature() {
 		function isLinkable( widget ) {
 			return widget && hasWidgetFeature( widget, 'link' );
@@ -607,16 +617,6 @@
 		upload: getUploadFeature(),
 		link: getLinkFeature()
 	};
-
-	function getWidgetsWithFeature( widgets, feature ) {
-		return CKEDITOR.tools.array.reduce( CKEDITOR.tools.objectKeys( widgets ), function( featuredWidgets, id ) {
-			var widget = widgets[ id ];
-			if ( hasWidgetFeature( widget, feature ) ) {
-				featuredWidgets.push( widget );
-			}
-			return featuredWidgets;
-		}, [] );
-	}
 
 	function createWidgetDefinition( editor, definition ) {
 		var baseDefinition;

--- a/tests/plugins/imagebase/features/caption.html
+++ b/tests/plugins/imagebase/features/caption.html
@@ -48,3 +48,15 @@
 		<figcaption>Test caption</figcaption>
 	</figure>
 </div>
+
+<div id="blurEmpty">
+	<figure>
+		<img src="%BASE_PATH%_assets/logo.png">
+		<figcaption>Test caption</figcaption>
+	</figure>
+
+	<figure>
+		<img src="%BASE_PATH%_assets/logo.png">
+		<figcaption></figcaption>
+	</figure>
+</div>

--- a/tests/plugins/imagebase/features/caption.js
+++ b/tests/plugins/imagebase/features/caption.js
@@ -435,7 +435,31 @@
 			onFocus: function( widget ) {
 				assert.isNotMatching( /Enter image caption/, widget.editor.getData() );
 			}
-		} )
+		} ),
+
+		// (#1776)
+		'test empty caption placeholder is hidden when blurred': function( editor, bot ) {
+				addTestWidget( editor );
+
+				// Make sure the editor is focused, otherwise Edge/IE11 will throw Permission Denied error.
+				editor.focus();
+
+				bot.setData( getFixture( 'blurEmpty' ), function() {
+					var widgets = widgetTestsTools.obj2Array( editor.widgets.instances ).slice( 0, 2 ),
+						emptyCaptionWidget = widgets[ 0 ],
+						widgetWithCaption = widgets[ 1 ];
+
+					widgetWithCaption.focus();
+					emptyCaptionWidget.focus();
+
+					blurEditor( {
+						assert: function() {
+							assert.areEqual( 'true', emptyCaptionWidget.parts.caption.data( 'cke-caption-hidden' ) );
+						},
+						blurHost: emptyCaptionWidget
+					} );
+				} );
+			}
 	};
 
 	tests = bender.tools.createTestsForEditors( CKEDITOR.tools.objectKeys( bender.editors ), tests );

--- a/tests/plugins/imagebase/features/manual/captionemptyplaceholder.html
+++ b/tests/plugins/imagebase/features/manual/captionemptyplaceholder.html
@@ -1,14 +1,13 @@
 <div id="editor1">
-	<p>Widget without caption:</p>
+	<p>First image:</p>
 	<figure>
 		<img src="../../../image2/_assets/foo.png" alt="foo">
-	</figure>
-	<p>Widget with caption:</p>
-	<figure>
-		<a href="https://cksource.com">
-			<img src="../../../image2/_assets/foo.png" alt="foo">
-		</a>
 		<figcaption>Test caption</figcaption>
+	</figure>
+	<p>Second image:</p>
+	<figure>
+		<img src="../../../image2/_assets/foo.png" alt="foo">
+		<figcaption></figcaption>
 	</figure>
 </div>
 

--- a/tests/plugins/imagebase/features/manual/captionemptyplaceholder.html
+++ b/tests/plugins/imagebase/features/manual/captionemptyplaceholder.html
@@ -1,0 +1,31 @@
+<div id="editor1">
+	<p>Widget without caption:</p>
+	<figure>
+		<img src="../../../image2/_assets/foo.png" alt="foo">
+	</figure>
+	<p>Widget with caption:</p>
+	<figure>
+		<a href="https://cksource.com">
+			<img src="../../../image2/_assets/foo.png" alt="foo">
+		</a>
+		<figcaption>Test caption</figcaption>
+	</figure>
+</div>
+
+<script>
+	if ( easyImageTools.isUnsupportedEnvironment() ) {
+		bender.ignore();
+	}
+
+	CKEDITOR.replace( 'editor1', {
+		on: {
+			pluginsLoaded: function( evt ) {
+				var editor = evt.editor,
+					plugin = CKEDITOR.plugins.imagebase;
+
+				plugin.addImageWidget( editor, 'testWidget', plugin.addFeature( editor, 'caption', {} ) );
+			}
+		},
+		height: 500
+	} );
+</script>

--- a/tests/plugins/imagebase/features/manual/captionemptyplaceholder.md
+++ b/tests/plugins/imagebase/features/manual/captionemptyplaceholder.md
@@ -1,4 +1,4 @@
-@bender-tags: 4.9.1, bug, 1776
+@bender-tags: 4.10.0, bug, 1776
 @bender-ui: collapsed
 @bender-ckeditor-plugins: wysiwygarea, toolbar, basicstyles, imagebase
 @bender-include: %BASE_PATH%/plugins/easyimage/_helpers/tools.js

--- a/tests/plugins/imagebase/features/manual/captionemptyplaceholder.md
+++ b/tests/plugins/imagebase/features/manual/captionemptyplaceholder.md
@@ -3,15 +3,13 @@
 @bender-ckeditor-plugins: wysiwygarea, toolbar, basicstyles, imagebase
 @bender-include: %BASE_PATH%/plugins/easyimage/_helpers/tools.js
 
-1. Focus widget without caption.
-1. Put some content into the empty caption.
-1. Focus widget with non-empty caption.
-1. Select all content inside the caption and delete it.
-1. Blur the widget.
+1. Focus first image.
+1. Focus second image.
+1. Blur the image.
 
 ## Expected result
 
-Caption for the last widget is hidden.
+Caption for the second image is hidden.
 
 ## Actual result
 Caption is still visible, despite the fact it's empty.

--- a/tests/plugins/imagebase/features/manual/captionemptyplaceholder.md
+++ b/tests/plugins/imagebase/features/manual/captionemptyplaceholder.md
@@ -1,0 +1,17 @@
+@bender-tags: 4.9.1, bug, 1776
+@bender-ui: collapsed
+@bender-ckeditor-plugins: wysiwygarea, toolbar, basicstyles, imagebase
+@bender-include: %BASE_PATH%/plugins/easyimage/_helpers/tools.js
+
+1. Focus widget without caption.
+1. Put some content into the empty caption.
+1. Focus widget with non-empty caption.
+1. Select all content inside the caption and delete it.
+1. Blur the widget.
+
+## Expected result
+
+Caption for the last widget is hidden.
+
+## Actual result
+Caption is still visible, despite the fact it's empty.


### PR DESCRIPTION
## What is the purpose of this pull request?

Bug fix.

## Does your PR contain necessary tests?

All patches which change the editor code must include tests. You can always read more
on [PR testing](https://docs.ckeditor.com/ckeditor4/docs/#!/guide/dev_contributing_code-section-tests),
[how to set the testing environment](https://docs.ckeditor.com/ckeditor4/docs/#!/guide/dev_tests) and
[how to create tests](https://docs.ckeditor.com/ckeditor4/docs/#!/guide/dev_tests-section-creating-your-own-test)
in the official CKEditor documentation.

### This PR contains

- [x] Unit tests
- [x] Manual tests

## What changes did you make?

Changed `imagebase` plugin to refresh every caption featured widget on `selectionChange`.

Closes #1776

