### PR TITLE
Add language entry for Easy Image upload command

### DIFF
--- a/dev/langtool/meta/ckeditor.plugin-easyimage/meta.txt
+++ b/dev/langtool/meta/ckeditor.plugin-easyimage/meta.txt
@@ -4,5 +4,5 @@
 commands.fullImage = Label for the button converting an image to a full width image.
 commands.sideImage = Label for the button converting an image to a side image.
 commands.altText = Label for the button assigning the image an alternative text.
-commands.upload = Label for the button uploading an image to a server.
+commands.upload = Label for the editor toolbar button uploading an image to a server.
 uploadFailed = Alert message displayed when the image could not be uploaded due to a network error.

--- a/dev/langtool/meta/ckeditor.plugin-easyimage/meta.txt
+++ b/dev/langtool/meta/ckeditor.plugin-easyimage/meta.txt
@@ -4,4 +4,5 @@
 commands.fullImage = Label for the button converting an image to a full width image.
 commands.sideImage = Label for the button converting an image to a side image.
 commands.altText = Label for the button assigning the image an alternative text.
+commands.upload = Label for the button uploading an image to a server.
 uploadFailed = Alert message displayed when the image could not be uploaded due to a network error.

--- a/plugins/easyimage/lang/en.js
+++ b/plugins/easyimage/lang/en.js
@@ -7,7 +7,8 @@ CKEDITOR.plugins.setLang( 'easyimage', 'en', {
 	commands: {
 		fullImage: 'Full Size Image',
 		sideImage: 'Side Image',
-		altText: 'Change image alternative text'
+		altText: 'Change image alternative text',
+		upload: 'Upload Image'
 	},
 	uploadFailed: 'Your image could not be uploaded due to a network error.'
 } );

--- a/plugins/easyimage/plugin.js
+++ b/plugins/easyimage/plugin.js
@@ -507,7 +507,7 @@
 
 	function addUploadButtonToToolbar( editor ) {
 		editor.ui.addButton( BUTTON_PREFIX + 'Upload', {
-			label: editor.lang.common.upload,
+			label: editor.lang.easyimage.commands.upload,
 			command: 'easyimageUpload',
 			toolbar: 'insert,1'
 		} );


### PR DESCRIPTION
## What is the purpose of this pull request?

Bug fix

## Does your PR contain necessary tests?

No, it's just simple language entry addition.

## What changes did you make?

I've added `commands.upload` language entry to Easy Image plugin.

Closes #1792.
