### PR TITLE
forceAsPlainText will be respected inside internal and cross-editor pasting

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -15,6 +15,7 @@ Fixed Issues:
 * [#1321](https://github.com/ckeditor/ckeditor-dev/issues/1321): Ideographic space character `\u3000` is lost when pasting text.
 * [#1776](https://github.com/ckeditor/ckeditor-dev/issues/1776): [Image Base](https://ckeditor.com/cke4/addon/imagebase) empty caption placeholder is not hidden when blurred.
 * [#1592](https://github.com/ckeditor/ckeditor-dev/issues/1592): [Image Base](https://ckeditor.com/cke4/addon/imagebase) caption is not visible after paste.
+* [#620](https://github.com/ckeditor/ckeditor-dev/issues/620): Fixed: [`forcePasteAsPlainText`](https://docs.ckeditor.com/ckeditor4/latest/api/CKEDITOR_config.html#cfg-forcePasteAsPlainText) will be respected when internal and cross-editor pasting happens.
 
 API Changes:
 

--- a/plugins/clipboard/plugin.js
+++ b/plugins/clipboard/plugin.js
@@ -305,7 +305,9 @@
 					trueType,
 					// Default is 'html'.
 					defaultType = editor.config.clipboard_defaultContentType || 'html',
-					transferType = dataObj.dataTransfer.getTransferType( editor );
+					transferType = dataObj.dataTransfer.getTransferType( editor ),
+					isExternalPaste = transferType == CKEDITOR.DATA_TRANSFER_EXTERNAL,
+					isActiveForcePAPT = editor.config.forcePasteAsPlainText === true;
 
 				// If forced type is 'html' we don't need to know true data type.
 				if ( type == 'html' || dataObj.preSniffing == 'html' ) {
@@ -330,7 +332,8 @@
 					data = filterContent( editor, data, filtersFactory.get( 'plain-text' ) );
 				}
 				// External paste and pasteFilter exists and filtering isn't disabled.
-				else if ( transferType == CKEDITOR.DATA_TRANSFER_EXTERNAL && editor.pasteFilter && !dataObj.dontFilter ) {
+				// Or force filtering even for internal and cross-editor paste, when forcePAPT is active (#620).
+				else if ( isExternalPaste && editor.pasteFilter && !dataObj.dontFilter || isActiveForcePAPT ) {
 					data = filterContent( editor, data, editor.pasteFilter );
 				}
 

--- a/tests/plugins/clipboard/manual/nonexternalforceasplaintext.html
+++ b/tests/plugins/clipboard/manual/nonexternalforceasplaintext.html
@@ -1,0 +1,28 @@
+<div>
+		<h2><pre>forcePasteAsPlainText=false</pre></h2>
+		<div>
+			<textarea cols="80" id="classic1"rows="10">
+					<p><strong>Lorem ipsum</strong> <u>dolor</u> <em>sit amet</em>, <strong>co<sub>ns<u>ec<s>tetu<sup>r <em>a</em>d</sup>ipis</s>ci</u>ng </sub>eli</strong>t. Sed scelerisque aliquam <u>lacus, nec cursus</u> ante facilisis vel.</p>
+			</textarea>
+		</div>
+	</div>
+	<hr>
+	<div>
+		<h2><pre>forcePasteAsPlainText=true</pre></h2>
+		<div>
+			<textarea cols="80" id="classic2"rows="10">
+					<p><strong>Lorem ipsum</strong> <u>dolor</u> <em>sit amet</em>, <strong>co<sub>ns<u>ec<s>tetu<sup>r <em>a</em>d</sup>ipis</s>ci</u>ng </sub>eli</strong>t. Sed scelerisque aliquam <u>lacus, nec cursus</u> ante facilisis vel.</p>
+			</textarea>
+		</div>
+	</div>
+	<script>
+		CKEDITOR.replace( 'classic1', {
+			forcePasteAsPlainText: false,
+			width: 600
+		} );
+
+		CKEDITOR.replace( 'classic2', {
+			forcePasteAsPlainText: true,
+			width: 600
+		} );
+	</script>

--- a/tests/plugins/clipboard/manual/nonexternalforceasplaintext.md
+++ b/tests/plugins/clipboard/manual/nonexternalforceasplaintext.md
@@ -1,0 +1,18 @@
+@bender-ui: collapsed
+@bender-tags: 4.10.0, bug, 620
+@bender-ckeditor-plugins: wysiwygarea,toolbar,undo,basicstyles,font,stylescombo,format,blockquote,list,table,elementspath,justify,clipboard,link,pastetext
+
+## Instruction:
+
+Perform below scenario for 2 cases:
+- inside single editor
+- between editors
+
+## Test Scenario
+
+1. Copy and paste rich content, containing some styling.
+
+
+**Expected:**
+* `forcePasteAsPlainText=false` - when styled text is paste, text formatting is preserved.
+* `forcePasteAsPlainText=true` - when styled text is paste, text formating is lost. Only plain text is copied to editor.

--- a/tests/plugins/clipboard/pastefilter.js
+++ b/tests/plugins/clipboard/pastefilter.js
@@ -220,6 +220,20 @@
 			{ dataValue: '<h2>Foo <strong>bar</strong></h2>' } );
 	};
 
+	tests[ 'internal paste is filtered for forceAsPlainText' ] = function() {
+		var editor = this.editors.editorForcePAPT;
+
+		assertPasteEvent( editor, { dataValue: '<h2>Foo <strong>bar</strong></h2>', dataTransfer: mockDataTransfer( CKEDITOR.DATA_TRANSFER_INTERNAL ) },
+			{ dataValue: '<p>Foo bar</p>' } );
+	};
+
+	tests[ 'cross-editors paste is filtered for forceAsPlainText' ] = function() {
+		var editor = this.editors.editorForcePAPT;
+
+		assertPasteEvent( editor, { dataValue: '<h2>Foo <strong>bar</strong></h2>', dataTransfer: mockDataTransfer( CKEDITOR.DATA_TRANSFER_CROSS_EDITORS ) },
+			{ dataValue: '<p>Foo bar</p>' } );
+	};
+
 	tests[ 'external paste is filtered' ] = function() {
 		var editor = this.editors.editorPlain;
 


### PR DESCRIPTION
## What is the purpose of this pull request?

Bug fix

## Does your PR contain necessary tests?

All patches which change the editor code must include tests. You can always read more
on [PR testing](https://docs.ckeditor.com/ckeditor4/docs/#!/guide/dev_contributing_code-section-tests),
[how to set the testing environment](https://docs.ckeditor.com/ckeditor4/docs/#!/guide/dev_tests) and
[how to create tests](https://docs.ckeditor.com/ckeditor4/docs/#!/guide/dev_tests-section-creating-your-own-test)
in the official CKEditor documentation.

### This PR contains

- [x] Unit tests
- [x] Manual tests

## What changes did you make?

- activate content filtering during paste, when forcePasteAsPlainText is set to true, regardless of paste origin.

close #620 
