### PR TITLE
Fixed: Column resize cursor shows up inside merged cells

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -16,6 +16,7 @@ Fixed Issues:
 * [#1776](https://github.com/ckeditor/ckeditor-dev/issues/1776): [Image Base](https://ckeditor.com/cke4/addon/imagebase) empty caption placeholder is not hidden when blurred.
 * [#1592](https://github.com/ckeditor/ckeditor-dev/issues/1592): [Image Base](https://ckeditor.com/cke4/addon/imagebase) caption is not visible after paste.
 * [#620](https://github.com/ckeditor/ckeditor-dev/issues/620): Fixed: [`forcePasteAsPlainText`](https://docs.ckeditor.com/ckeditor4/latest/api/CKEDITOR_config.html#cfg-forcePasteAsPlainText) will be respected when internal and cross-editor pasting happens.
+* [#1467](https://github.com/ckeditor/ckeditor-dev/issues/1467): Fixed: [Table Resize](https://ckeditor.com/cke4/addon/tableresize) resizing coursor appearing in middle of merged cell.
 
 API Changes:
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -15,7 +15,7 @@ Fixed Issues:
 * [#1321](https://github.com/ckeditor/ckeditor-dev/issues/1321): Ideographic space character `\u3000` is lost when pasting text.
 * [#1776](https://github.com/ckeditor/ckeditor-dev/issues/1776): [Image Base](https://ckeditor.com/cke4/addon/imagebase) empty caption placeholder is not hidden when blurred.
 * [#1592](https://github.com/ckeditor/ckeditor-dev/issues/1592): [Image Base](https://ckeditor.com/cke4/addon/imagebase) caption is not visible after paste.
-* [#620](https://github.com/ckeditor/ckeditor-dev/issues/620): Fixed: [`forcePasteAsPlainText`](https://docs.ckeditor.com/ckeditor4/latest/api/CKEDITOR_config.html#cfg-forcePasteAsPlainText) will be respected when internal and cross-editor pasting happens.
+* [#620](https://github.com/ckeditor/ckeditor-dev/issues/620): Fixed: [`forcePasteAsPlainText`](https://docs.ckeditor.com/ckeditor4/latest/api/CKEDITOR_config.html#cfg-forcePasteAsPlainText) will be respected when internal and cross-editor pasting happen
 * [#1467](https://github.com/ckeditor/ckeditor-dev/issues/1467): Fixed: [Table Resize](https://ckeditor.com/cke4/addon/tableresize) resizing coursor appearing in middle of merged cell.
 
 API Changes:

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -15,7 +15,7 @@ Fixed Issues:
 * [#1321](https://github.com/ckeditor/ckeditor-dev/issues/1321): Ideographic space character `\u3000` is lost when pasting text.
 * [#1776](https://github.com/ckeditor/ckeditor-dev/issues/1776): [Image Base](https://ckeditor.com/cke4/addon/imagebase) empty caption placeholder is not hidden when blurred.
 * [#1592](https://github.com/ckeditor/ckeditor-dev/issues/1592): [Image Base](https://ckeditor.com/cke4/addon/imagebase) caption is not visible after paste.
-* [#620](https://github.com/ckeditor/ckeditor-dev/issues/620): Fixed: [`forcePasteAsPlainText`](https://docs.ckeditor.com/ckeditor4/latest/api/CKEDITOR_config.html#cfg-forcePasteAsPlainText) will be respected when internal and cross-editor pasting happen
+* [#620](https://github.com/ckeditor/ckeditor-dev/issues/620): Fixed: [`forcePasteAsPlainText`](https://docs.ckeditor.com/ckeditor4/latest/api/CKEDITOR_config.html#cfg-forcePasteAsPlainText) will be respected when internal and cross-editor pasting happen.
 * [#1467](https://github.com/ckeditor/ckeditor-dev/issues/1467): Fixed: [Table Resize](https://ckeditor.com/cke4/addon/tableresize) resizing coursor appearing in middle of merged cell.
 
 API Changes:

--- a/plugins/tableresize/plugin.js
+++ b/plugins/tableresize/plugin.js
@@ -113,20 +113,19 @@
 		return pillars;
 	}
 
-	function checkWithinDimensions( coordinates, element ) {
-		return coordinates.x >= element.x && coordinates.x <= ( element.x + element.width ) &&
-			coordinates.y >= element.y && coordinates.y <= ( element.y + element.height );
+	function checkWithinDimensions( posX, posY, element ) {
+		return posX >= element.x && posX <= ( element.x + element.width ) &&
+			posY >= element.y && posY <= ( element.y + element.height );
 	}
 
 	function getPillarAtPosition( pillars, position ) {
 		for ( var i = 0, len = pillars.length; i < len; i++ ) {
 			var pillar = pillars[ i ];
 
-			if ( checkWithinDimensions( position, pillar ) ) {
+			if ( checkWithinDimensions( position.x, position.y, pillar ) ) {
 				return pillar;
 			}
 		}
-
 		return null;
 	}
 
@@ -328,16 +327,15 @@
 			resizer.show();
 		};
 
-		move = this.move = function( pos ) {
+		move = this.move = function( posX, posY ) {
 				if ( !pillar )
 					return 0;
 
-				if ( !isResizing && !checkWithinDimensions( pos, pillar ) ) {
+				if ( !isResizing && !checkWithinDimensions( posX, posY, pillar ) ) {
 					detach();
 					return 0;
 				}
-
-				var resizerNewPosition = pos.x - Math.round( resizer.$.offsetWidth / 2 );
+				var resizerNewPosition = posX - Math.round( resizer.$.offsetWidth / 2 );
 
 				if ( isResizing ) {
 					if ( resizerNewPosition == leftShiftBoundary || resizerNewPosition == rightShiftBoundary )
@@ -401,7 +399,7 @@
 
 					// If we're already attached to a pillar, simply move the
 					// resizer.
-					if ( resizer && resizer.move( page ) ) {
+					if ( resizer && resizer.move( page.x, page.y ) ) {
 						cancel( evt );
 						return;
 					}

--- a/plugins/tableresize/plugin.js
+++ b/plugins/tableresize/plugin.js
@@ -30,61 +30,42 @@
 		return parseInt( computed, 10 );
 	}
 
-	// Gets the table row that contains the most columns.
-	function getMasterPillarRow( table ) {
-		var $rows = table.$.rows,
-			maxCells = 0,
-			cellsCount, $elected, $tr;
-
-		for ( var i = 0, len = $rows.length; i < len; i++ ) {
-			$tr = $rows[ i ];
-			cellsCount = $tr.cells.length;
-
-			if ( cellsCount > maxCells ) {
-				maxCells = cellsCount;
-				$elected = $tr;
-			}
-		}
-
-		return $elected;
-	}
-
 	function buildTableColumnPillars( table ) {
 		var pillars = [],
-			pillarIndex = -1,
+			pillarIndex,
+			pillarRow,
 			pillarHeight = 0,
 			pillarPosition = null,
-			rtl = ( table.getComputedStyle( 'direction' ) == 'rtl' );
+			pillarIndexMap = {},
+			rtl = ( table.getComputedStyle( 'direction' ) == 'rtl' ),
+			$tr;
 
-		// Get the raw row element that contains the most columns.
-		var $tr = getMasterPillarRow( table );
+		var rows = table.$.rows;
 
 		// Sets pillar height and position based on given table element (head, body, footer).
 		function setPillarDimensions( nativeTableElement ) {
 			if ( nativeTableElement ) {
 				var tableElement = new CKEDITOR.dom.element( nativeTableElement );
-				pillarHeight += tableElement.$.offsetHeight;
-
-				if ( !pillarPosition ) {
-					pillarPosition = tableElement.getDocumentPosition();
-				}
+				pillarHeight = tableElement.$.offsetHeight;
+				pillarPosition = tableElement.getDocumentPosition();
 			}
 		}
 
-		// Table may contain only one of thead, tbody or tfoot elements so its existence should be checked (#417).
-		setPillarDimensions( table.$.tHead );
-		setPillarDimensions( table.$.tBodies[ 0 ] );
-		setPillarDimensions( table.$.tFoot );
+		CKEDITOR.tools.array.forEach( rows, function( item, index ) {
+			$tr = item;
+			pillarIndex = -1;
+			setPillarDimensions( $tr );
 
-		if ( $tr ) {
 			// Loop thorugh all cells, building pillars after each one of them.
 			for ( var i = 0, len = $tr.cells.length; i < len; i++ ) {
 				// Both the current cell and the successive one will be used in the
 				// pillar size calculation.
 				var td = new CKEDITOR.dom.element( $tr.cells[ i ] ),
-					nextTd = $tr.cells[ i + 1 ] && new CKEDITOR.dom.element( $tr.cells[ i + 1 ] );
+					nextTd = $tr.cells[ i + 1 ] && new CKEDITOR.dom.element( $tr.cells[ i + 1 ] ),
+					pillar;
 
 				pillarIndex += td.$.colSpan || 1;
+				pillarRow = index;
 
 				// Calculate the pillar boundary positions.
 				var pillarLeft, pillarRight, pillarWidth;
@@ -111,7 +92,7 @@
 
 				// The pillar should reflects exactly the shape of the hovered
 				// column border line.
-				pillars.push( {
+				pillar = {
 					table: table,
 					index: pillarIndex,
 					x: pillarLeft,
@@ -119,19 +100,31 @@
 					width: pillarWidth,
 					height: pillarHeight,
 					rtl: rtl
-				} );
+				};
+				pillarIndexMap[ pillarIndex ] = pillarIndexMap[ pillarIndex ] || [];
+				pillarIndexMap[ pillarIndex ].push( pillar );
+				pillar.alignedPillars = pillarIndexMap[ pillarIndex ];
+
+				pillars.push( pillar );
 			}
-		}
+
+		} );
 
 		return pillars;
 	}
 
-	function getPillarAtPosition( pillars, positionX ) {
+	function checkWithinDimensions( coordinates, element ) {
+		return coordinates.x >= element.x && coordinates.x <= ( element.x + element.width ) &&
+			coordinates.y >= element.y && coordinates.y <= ( element.y + element.height );
+	}
+
+	function getPillarAtPosition( pillars, position ) {
 		for ( var i = 0, len = pillars.length; i < len; i++ ) {
 			var pillar = pillars[ i ];
 
-			if ( positionX >= pillar.x && positionX <= ( pillar.x + pillar.width ) )
+			if ( checkWithinDimensions( position, pillar ) ) {
 				return pillar;
+			}
 		}
 
 		return null;
@@ -296,6 +289,9 @@
 			document.getDocumentElement().append( resizer );
 
 		this.attachTo = function( targetPillar ) {
+			var aligned,
+				resizerHeight,
+				resizerY;
 			// Accept only one pillar at a time.
 			if ( isResizing )
 				return;
@@ -307,12 +303,15 @@
 			}
 
 			pillar = targetPillar;
+			aligned = pillar.alignedPillars;
+			resizerY = aligned[ 0 ].y;
+			resizerHeight = aligned[ 0 ].height + aligned[ aligned.length - 1 ].y - resizerY;
 
 			resizer.setStyles( {
 				width: pxUnit( targetPillar.width ),
-				height: pxUnit( targetPillar.height ),
+				height: pxUnit( resizerHeight ),
 				left: pxUnit( targetPillar.x ),
-				top: pxUnit( targetPillar.y )
+				top: pxUnit( resizerY )
 			} );
 
 			// In IE6/7, it's not possible to have custom cursors for floating
@@ -329,16 +328,16 @@
 			resizer.show();
 		};
 
-		move = this.move = function( posX ) {
+		move = this.move = function( pos ) {
 				if ( !pillar )
 					return 0;
 
-				if ( !isResizing && ( posX < pillar.x || posX > ( pillar.x + pillar.width ) ) ) {
+				if ( !isResizing && !checkWithinDimensions( pos, pillar ) ) {
 					detach();
 					return 0;
 				}
 
-				var resizerNewPosition = posX - Math.round( resizer.$.offsetWidth / 2 );
+				var resizerNewPosition = pos.x - Math.round( resizer.$.offsetWidth / 2 );
 
 				if ( isResizing ) {
 					if ( resizerNewPosition == leftShiftBoundary || resizerNewPosition == rightShiftBoundary )
@@ -395,11 +394,14 @@
 					if ( target.type != CKEDITOR.NODE_ELEMENT )
 						return;
 
-					var pageX = evt.getPageOffset().x;
+					var page = {
+						x: evt.getPageOffset().x,
+						y: evt.getPageOffset().y
+					};
 
 					// If we're already attached to a pillar, simply move the
 					// resizer.
-					if ( resizer && resizer.move( pageX ) ) {
+					if ( resizer && resizer.move( page ) ) {
 						cancel( evt );
 						return;
 					}
@@ -426,7 +428,7 @@
 						table.on( 'mousedown', clearPillarsCache );
 					}
 
-					var pillar = getPillarAtPosition( pillars, pageX );
+					var pillar = getPillarAtPosition( pillars, page );
 					if ( pillar ) {
 						!resizer && ( resizer = new columnResizer( editor ) );
 						resizer.attachTo( pillar );

--- a/plugins/tableresize/plugin.js
+++ b/plugins/tableresize/plugin.js
@@ -30,31 +30,31 @@
 		return parseInt( computed, 10 );
 	}
 
+	// Sets pillar height and position based on given table element (head, body, footer).
+	function setPillarDimensions( nativeTableElement ) {
+		if ( nativeTableElement ) {
+			var tableElement = new CKEDITOR.dom.element( nativeTableElement );
+			return { height: tableElement.$.offsetHeight, position: tableElement.getDocumentPosition() };
+		}
+	}
+
 	function buildTableColumnPillars( table ) {
 		var pillars = [],
-			pillarIndex,
-			pillarRow,
-			pillarHeight = 0,
-			pillarPosition = null,
 			pillarIndexMap = {},
-			rtl = ( table.getComputedStyle( 'direction' ) == 'rtl' ),
-			$tr;
+			rtl = ( table.getComputedStyle( 'direction' ) == 'rtl' );
 
 		var rows = table.$.rows;
 
-		// Sets pillar height and position based on given table element (head, body, footer).
-		function setPillarDimensions( nativeTableElement ) {
-			if ( nativeTableElement ) {
-				var tableElement = new CKEDITOR.dom.element( nativeTableElement );
-				pillarHeight = tableElement.$.offsetHeight;
-				pillarPosition = tableElement.getDocumentPosition();
-			}
-		}
-
 		CKEDITOR.tools.array.forEach( rows, function( item, index ) {
-			$tr = item;
-			pillarIndex = -1;
-			setPillarDimensions( $tr );
+			var $tr = item,
+				pillarIndex = -1,
+				pillarRow,
+				pillarHeight = 0,
+				pillarPosition = null,
+				pillarDimensions = setPillarDimensions( $tr );
+
+			pillarHeight = pillarDimensions.height;
+			pillarPosition = pillarDimensions.position;
 
 			// Loop thorugh all cells, building pillars after each one of them.
 			for ( var i = 0, len = $tr.cells.length; i < len; i++ ) {

--- a/plugins/tableresize/plugin.js
+++ b/plugins/tableresize/plugin.js
@@ -288,7 +288,8 @@
 			document.getDocumentElement().append( resizer );
 
 		this.attachTo = function( targetPillar ) {
-			var aligned,
+			var firstAligned,
+				lastAligned,
 				resizerHeight,
 				resizerY;
 			// Accept only one pillar at a time.
@@ -302,9 +303,10 @@
 			}
 
 			pillar = targetPillar;
-			aligned = pillar.alignedPillars;
-			resizerY = aligned[ 0 ].y;
-			resizerHeight = aligned[ 0 ].height + aligned[ aligned.length - 1 ].y - resizerY;
+			firstAligned = pillar.alignedPillars[ 0 ];
+			lastAligned = pillar.alignedPillars[ pillar.alignedPillars.length - 1 ];
+			resizerY = firstAligned.y;
+			resizerHeight = lastAligned.height + lastAligned.y - firstAligned.y;
 
 			resizer.setStyles( {
 				width: pxUnit( targetPillar.width ),

--- a/tests/plugins/tableresize/manual/mergedcells.html
+++ b/tests/plugins/tableresize/manual/mergedcells.html
@@ -22,8 +22,7 @@
 		<tfoot>
 		<tr>
 			<th scope="row" style="width:150px">Header Footer</th>
-			<td style="width:150px">footer</td>
-			<td style="width:150px">footer</td>
+			<td style="width:150px" colspan="2">footer</td>
 			<td style="width:150px">footer</td>
 		</tr>
 		</tfoot>

--- a/tests/plugins/tableresize/manual/mergedcells.html
+++ b/tests/plugins/tableresize/manual/mergedcells.html
@@ -1,0 +1,35 @@
+<div id="editor">
+	<table border="1" cellpadding="1" cellspacing="1" style="width:600px">
+		<thead>
+		<tr>
+			<th scope="row" style="width:150px">Header</th>
+			<th scope="col" style="width:300px" colspan="2">Header</th>
+			<th scope="col" style="width:150px">Header</th>
+		</tr>
+		</thead>
+		<tbody>
+		<tr>
+			<th scope="row" style="width:150px">Header</th>
+			<td style="width:150px">not header</td>
+			<td style="width:150px">not header</td>
+			<td style="width:150px">not header</td>
+		</tr>
+		<tr>
+			<th scope="row" style="width:300px" colspan="2">Header</th>
+			<td style="width:300px" colspan="2">not header</td>
+		</tr>
+		</tbody>
+		<tfoot>
+		<tr>
+			<th scope="row" style="width:150px">Header Footer</th>
+			<td style="width:150px">footer</td>
+			<td style="width:150px">footer</td>
+			<td style="width:150px">footer</td>
+		</tr>
+		</tfoot>
+	</table>
+</div>
+
+<script>
+	CKEDITOR.replace( 'editor' );
+</script>

--- a/tests/plugins/tableresize/manual/mergedcells.md
+++ b/tests/plugins/tableresize/manual/mergedcells.md
@@ -1,0 +1,9 @@
+@bender-ui: collapsed
+@bender-tags: bug, 1467, 4.10.0
+@bender-ckeditor-plugins: wysiwygarea, toolbar, table, tableresize
+
+Hover mouse in the middle of any merged cell. Just over the vertical border of below cells.
+
+**Expected**: Cursor is in select text mode.
+
+**Unexpected**: Cursor is resize mode and you can resize table from middle of cell.

--- a/tests/plugins/tableresize/tableresize.js
+++ b/tests/plugins/tableresize/tableresize.js
@@ -18,10 +18,11 @@ function createMoveEventMock( table ) {
 				x:
 					// If x is defined use it.
 					definedX ? definedX :
-					// For the first run x does not matter, because we want to create pillars.
-					pillars ? pillars[ 0 ].x :
-					// Return 0 otherwise.
-					0
+						// For the first run x does not matter, because we want to create pillars.
+						pillars ? pillars[ 0 ].x :
+							// Return 0 otherwise.
+							0,
+				y: pillars ? pillars[ 0 ].y : 0
 			};
 		},
 


### PR DESCRIPTION
## What is the purpose of this pull request?

Bugfix

## Does your PR contain necessary tests?

All patches which change the editor code must include tests. You can always read more
on [PR testing](https://docs.ckeditor.com/ckeditor4/docs/#!/guide/dev_contributing_code-section-tests),
[how to set the testing environment](https://docs.ckeditor.com/ckeditor4/docs/#!/guide/dev_tests) and
[how to create tests](https://docs.ckeditor.com/ckeditor4/docs/#!/guide/dev_tests-section-creating-your-own-test)
in the official CKEditor documentation.

### This PR contains

- [ ] Unit tests
- [x] Manual tests

In theory I could cover this with unit test that would fail before this patch. But such test could just check if resizer appears on one spot. This should be tested manually to ensure that resizer fully acts as expected and doesn't show up in other unexpected places.

## What changes did you make?

Previously resize plugin created one `pillar` after each column which is basically reference to coordinates range in which resizer should showup once mouse is there. Each pillar had height of whole table and resizer would appear only when mouse coordinates were same as pillar coordinates + pillar width. After my change there is pillar after each cell from each row. Each of new pillars has now height same as rows height, so pillars won't leak to merged cells. Resizer although will appear covering all pillars that aligned with hovered pillar.

Closes #1467 