### PR TITLE
Fix for incorrect table selection styles in readonly mode

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -9,6 +9,7 @@ Fixed Issues:
 * [#2169](https://github.com/ckeditor/ckeditor-dev/issues/2169): [Edge] Fixed: Error thrown when pasting into editor.
 * [#2107](https://github.com/ckeditor/ckeditor-dev/issues/2107): Fixed: [Autocomplete](https://ckeditor.com/cke4/addon/autocomplete): holding and releasing mouse button is not inserting autocomplete item.
 * [#2167](https://github.com/ckeditor/ckeditor-dev/issues/2167): Fixed: Matching in [Emoji](https://ckeditor.com/cke4/addon/emoji) plugin is not case insensitive.
+* [#1887](https://github.com/ckeditor/ckeditor-dev/issues/1887): Fixed: Incorrect selection styling in readonly editor for selection made by [Table Selection](https://ckeditor.com/cke4/addon/tableselection) plugin.
 
 ## CKEditor 4.10
 

--- a/plugins/tableselection/styles/tableselection.css
+++ b/plugins/tableselection/styles/tableselection.css
@@ -9,13 +9,13 @@
 .cke_table-faked-selection a {
 	color: black;
 }
-.cke_editable:focus .cke_table-faked-selection {
+.cke_editable:focus .cke_table-faked-selection, .cke_table-faked-selection-focused-editor .cke_table-faked-selection {
 	/* We have to use !important here, as td might specify it's own background, thus table selection
 	would not be visible. */
 	background: #0076cb !important;
 	color: white;
 }
-.cke_editable:focus .cke_table-faked-selection a {
+.cke_editable:focus .cke_table-faked-selection a, .cke_table-faked-selection-focused-editor .cke_table-faked-selection a {
 	color: white;
 }
 .cke_table-faked-selection::-moz-selection, .cke_table-faked-selection ::-moz-selection {

--- a/tests/plugins/tableselection/manual/readonlystyle.html
+++ b/tests/plugins/tableselection/manual/readonlystyle.html
@@ -1,0 +1,118 @@
+<h2>Classic editor</h2>
+
+<div id="editor1">
+	<p>Some text</p>
+
+	<table border="1">
+		<tr>
+			<td>Cell 1.1</td>
+			<td>Cell 1.2</td>
+			<td>Cell 1.3</td>
+			<td>Cell 1.4</td>
+		</tr>
+		<tr>
+			<td>Cell 2.1</td>
+			<td>Cell 2.2</td>
+			<td>Cell 2.3</td>
+			<td>Cell 2.4</td>
+		</tr>
+		<tr>
+			<td>Cell 3.1</td>
+			<td>Cell 3.2</td>
+			<td>Cell 3.3</td>
+			<td>Cell 3.4</td>
+		</tr>
+		<tr>
+			<td>Cell 4.1</td>
+			<td>Cell 4.2</td>
+			<td>Cell 4.3</td>
+			<td>Cell 4.4</td>
+		</tr>
+	</table>
+</div>
+
+<h2>Divarea editor</h2>
+
+<div id="editor2">
+	<p>Some text</p>
+
+	<table border="1">
+		<tr>
+			<td>Cell 1.1</td>
+			<td>Cell 1.2</td>
+			<td>Cell 1.3</td>
+			<td>Cell 1.4</td>
+		</tr>
+		<tr>
+			<td>Cell 2.1</td>
+			<td>Cell 2.2</td>
+			<td>Cell 2.3</td>
+			<td>Cell 2.4</td>
+		</tr>
+		<tr>
+			<td>Cell 3.1</td>
+			<td>Cell 3.2</td>
+			<td>Cell 3.3</td>
+			<td>Cell 3.4</td>
+		</tr>
+		<tr>
+			<td>Cell 4.1</td>
+			<td>Cell 4.2</td>
+			<td>Cell 4.3</td>
+			<td>Cell 4.4</td>
+		</tr>
+	</table>
+</div>
+
+<h2>Inline editor</h2>
+
+<div id="editor3" contenteditable="true">
+	<p>Some text</p>
+
+	<table border="1">
+		<tr>
+			<td>Cell 1.1</td>
+			<td>Cell 1.2</td>
+			<td>Cell 1.3</td>
+			<td>Cell 1.4</td>
+		</tr>
+		<tr>
+			<td>Cell 2.1</td>
+			<td>Cell 2.2</td>
+			<td>Cell 2.3</td>
+			<td>Cell 2.4</td>
+		</tr>
+		<tr>
+			<td>Cell 3.1</td>
+			<td>Cell 3.2</td>
+			<td>Cell 3.3</td>
+			<td>Cell 3.4</td>
+		</tr>
+		<tr>
+			<td>Cell 4.1</td>
+			<td>Cell 4.2</td>
+			<td>Cell 4.3</td>
+			<td>Cell 4.4</td>
+		</tr>
+	</table>
+</div>
+
+<script>
+	( function() {
+		if ( ( CKEDITOR.env.ie && CKEDITOR.env.version < 11 ) || bender.tools.env.mobile ) {
+			bender.ignore();
+		}
+
+		var commonConfig = {
+			readOnly: true
+		};
+
+		CKEDITOR.replace( 'editor1', commonConfig );
+		CKEDITOR.replace( 'editor2', CKEDITOR.tools.object.merge( commonConfig, {
+			extraPlugins: 'divarea'
+		} ) );
+		CKEDITOR.inline( 'editor3', CKEDITOR.tools.object.merge( commonConfig, {
+			extraPlugins: 'floatingspace'
+		} ) );
+	} )();
+</script>

--- a/tests/plugins/tableselection/manual/readonlystyle.md
+++ b/tests/plugins/tableselection/manual/readonlystyle.md
@@ -1,0 +1,13 @@
+@bender-ui: collapsed
+@bender-tags: tableselection, bug, 1887, 4.10.0
+@bender-ckeditor-plugins: wysiwygarea, toolbar, tableselection
+
+Select some table cells.
+
+### Expected
+* Selected cells have blue background.
+
+### Unexpected
+* Seleccted cells have gray background.
+
+Repeat the procedure for every editor.

--- a/tests/plugins/tableselection/tableselection.js
+++ b/tests/plugins/tableselection/tableselection.js
@@ -145,6 +145,29 @@
 			mockMouseSelection( editor, [ cells.getItem( 1 ), cells.getItem( 3 ), cells.getItem( 8 ) ], function() {
 				assert.pass();
 			} );
+		},
+
+		// (#1887)
+		'test toggling class while focusing/bluring editor': function( editor ) {
+			var editable = editor.editable(),
+				assertion = editable.isInline() ? 'isFalse' : 'isTrue',
+				className = 'cke_table-faked-selection-focused-editor';
+
+			// We move focus to the iframe to force blur of the editor.
+			CKEDITOR.document.findOne( '#focusIframe' ).getWindow().focus();
+			editable.$.focus();
+
+			// setTimeout is needed for IE.
+			setTimeout( function() {
+				resume( function() {
+					assert.isFalse( editable.hasClass( className ) );
+				} );
+			}, 100 );
+
+			assert[ assertion ]( editable.hasClass( className ) );
+
+			CKEDITOR.document.findOne( '#focusIframe' ).getWindow().focus();
+			wait();
 		}
 	};
 

--- a/tests/plugins/tableselection/tableselection.js
+++ b/tests/plugins/tableselection/tableselection.js
@@ -151,10 +151,11 @@
 		'test toggling class while focusing/bluring editor': function( editor ) {
 			var editable = editor.editable(),
 				assertion = editable.isInline() ? 'isFalse' : 'isTrue',
-				className = 'cke_table-faked-selection-focused-editor';
+				className = 'cke_table-faked-selection-focused-editor',
+				focusTrap = CKEDITOR.document.findOne( '#focusIframe' ).getFrameDocument().findOne( 'div' );
 
 			// We move focus to the iframe to force blur of the editor.
-			CKEDITOR.document.findOne( '#focusIframe' ).getWindow().focus();
+			focusTrap.focus();
 			editable.$.focus();
 
 			// setTimeout is needed for IE.
@@ -166,7 +167,7 @@
 
 			assert[ assertion ]( editable.hasClass( className ) );
 
-			CKEDITOR.document.findOne( '#focusIframe' ).getWindow().focus();
+			focusTrap.focus();
 			wait();
 		}
 	};


### PR DESCRIPTION
## What is the purpose of this pull request?

Bug fix

## Does your PR contain necessary tests?

All patches which change the editor code must include tests. You can always read more
on [PR testing](https://docs.ckeditor.com/ckeditor4/docs/#!/guide/dev_contributing_code-section-tests),
[how to set the testing environment](https://docs.ckeditor.com/ckeditor4/docs/#!/guide/dev_tests) and
[how to create tests](https://docs.ckeditor.com/ckeditor4/docs/#!/guide/dev_tests-section-creating-your-own-test)
in the official CKEditor documentation.

### This PR contains

- [x] Unit tests
- [x] Manual tests

## What changes did you make?

I've added new clas, `.cke_table-faked-selection-focused-editor`, that is added to iframe-based editor when editor is focused. It is necessary as editor has issues with managing focus in readonly mode.

Closes #1887.
