### PR TITLE
Make sure the ID is always inserted if entered in the advanced dialog

### DIFF
--- a/core/style.js
+++ b/core/style.js
@@ -1662,7 +1662,8 @@ CKEDITOR.STYLE_OBJECT = 3;
 
 		// Avoid ID duplication.
 		if ( targetDocument.getCustomData( 'doc_processing_style' ) && el.hasAttribute( 'id' ) )
-			el.removeAttribute( 'id' );
+			if ( targetDocument.getById(el.getAttribute('id')) != null )
+				el.removeAttribute( 'id' );
 		else
 			targetDocument.setCustomData( 'doc_processing_style', 1 );
 


### PR DESCRIPTION
## What is the purpose of this pull request?

Fixes issue #1046

## Does your PR contain necessary tests?

Not yet - will add later

All patches which change the editor code must include tests. You can always read more
on [PR testing](https://docs.ckeditor.com/ckeditor4/docs/#!/guide/dev_contributing_code-section-tests),
[how to set the testing environment](https://docs.ckeditor.com/ckeditor4/docs/#!/guide/dev_tests) and
[how to create tests](https://docs.ckeditor.com/ckeditor4/docs/#!/guide/dev_tests-section-creating-your-own-test)
in the official CKEditor documentation.

### This PR contains

- [ ] Unit tests
- [ ] Manual tests

## What changes did you make?

When creating a new element based on style it would remote the ID attribute to prevent duplicates.
This bit of code was added in 2011 to prevent an issue with copying links (according to the git blame and git log 235dc2a7edb21a6b8514ce189121e721b5ab2298) - I did not retest this use case as I did not know where to find this issue
I modified it so it only removes ID's if the chosen ID already exists in the targetDocument
