### PR TITLE
Get absolute rects via range.getClientRects

### DIFF
--- a/tests/core/dom/range/manual/getclientrectsfakesel.html
+++ b/tests/core/dom/range/manual/getclientrectsfakesel.html
@@ -1,0 +1,139 @@
+<style>
+	body {
+		padding-top: 150px;
+		margin-left: 0px;
+		padding-left: 330px;
+	}
+
+	#editable {
+		position: absolute;
+		width: 300px;
+		left: 600px;
+	}
+
+	#editable img {
+		width: 100px;
+		height: 30px;
+		vertical-align: text-bottom;
+	}
+
+	.marker {
+		position: absolute;
+		outline: 1px solid red;
+		pointer-events: none;
+	}
+
+	#output {
+		width: 250px;
+	}
+
+</style>
+
+<textarea name="output" id="output" cols="30" rows="10" readonly="readonly"></textarea>
+
+<div id="editor" contenteditable="true">
+	<p>Some text.</p>
+	<table border="1" cellspacing="1" cellpadding="1" style="width:250px">
+		<tbody>
+		<tr>
+			<td>Cell</td>
+			<td>Cell</td>
+			<td>Cell</td>
+		</tr>
+		<tr>
+			<td>Cell</td>
+			<td>Cell</td>
+			<td>Cell</td>
+		</tr>
+		<tr>
+			<td>Cell</td>
+			<td>Cell</td>
+			<td>Cell</td>
+		</tr>
+		</tbody>
+	</table>
+	<pre>
+		<code class="language-javascript">console.log( 'Hello World!' );</code>
+	</pre>
+</div>
+
+
+<script>
+	( function() {
+		// IE 8 polyfill doesn't work when selecting block elements like widget. Also it's unsupported by table selection.
+		if ( CKEDITOR.env.ie && CKEDITOR.env.version === 8 ) {
+			bender.ignore()
+		}
+
+		CKEDITOR.replace( 'editor', {
+			height: 500,
+			on: {
+				instanceReady: function() {
+					var rectMarkers = [];
+
+					var doc = CKEDITOR.document,
+						editable = this.editable(),
+						par = editable.findOne( 'p' ),
+						rng = new CKEDITOR.dom.range( editable ),
+						output = doc.getById( 'output' ),
+						editor = this;
+
+					rng.setStart( par.getParent(), par.getIndex() );
+					rng.setEnd( par.getParent(), par.getIndex() + 1 );
+
+					this.getSelection().selectRanges( [ rng ] );
+
+					window.setInterval( function() {
+						var ranges = editor.getSelection().getRanges(),
+							rects = ranges && CKEDITOR.tools.array.reduce( ranges, function( total, current ) {
+								return total.concat( current.getClientRects( true ) );
+							}, [] );
+
+						output.setValue( 'Selection rect\n---\nrectangle count: ' + ( rects ? rects.length : rects ) );
+
+						removeRectangles();
+
+						if ( !rng || !rects || !rects.length ) {
+							return;
+						}
+
+						output.setValue( output.getValue() + '\nwidth:' + rects[ 0 ].width + '\nheight: ' + rects[ 0 ].height );
+						output.setValue( output.getValue() + '\ntop:' + rects[ 0 ].top + '\nleft: ' + rects[ 0 ].left );
+
+						for ( var i = 0; i < rects.length; i++ ) {
+							drawRectangle( rects[ i ] );
+						}
+					}, 100 );
+
+					function drawRectangle( rect ) {
+						var rectMarker;
+						if ( !rectMarker ) {
+							rectMarker = doc.createElement( 'div' );
+							rectMarker.addClass( 'marker' );
+							doc.getBody().append( rectMarker );
+						}
+
+						rectMarker.setStyles( {
+							top: rect.top + 'px',
+							left: rect.left + 'px',
+							height: rect.height + 'px',
+							width: rect.width + 'px'
+						} );
+
+						rectMarkers.push( rectMarker );
+					}
+
+					function removeRectangles() {
+						if ( rectMarkers.length ) {
+							rectMarkers = CKEDITOR.tools.array.filter( rectMarkers, function( marker ) {
+								marker.remove();
+								return false;
+							} );
+						}
+					}
+				}
+			}
+		} );
+	} )();
+
+</script>

--- a/tests/core/dom/range/manual/getclientrectsfakesel.md
+++ b/tests/core/dom/range/manual/getclientrectsfakesel.md
@@ -1,0 +1,14 @@
+@bender-tags: 4.10.0, feature, range, selection, 1902, 1915, tableselection
+@bender-ckeditor-plugins: wysiwygarea, toolbar, codesnippet, table, tableselection, sourcearea
+
+# Selection rectangles
+
+This manual test checks the result returned by the `range.getClientRects()` on fake selection. Returned results are visualized with red rectangles.
+
+## Things to test:
+
+Select some table cells too see if red rectangles match the selection. Try different selections on the table and on the widget.
+
+### Note:
+
+Rectangles might vary depending on if you performed real selection on table or fake one. Fake selection happens when table cell are filled with blue color. Also keep in mind that the presented results, are values for the first rectangle from returned array.


### PR DESCRIPTION
## What is the purpose of this pull request?

Feature/task

## Does your PR contain necessary tests?

All patches which change the editor code must include tests. You can always read more
on [PR testing](https://docs.ckeditor.com/ckeditor4/docs/#!/guide/dev_contributing_code-section-tests),
[how to set the testing environment](https://docs.ckeditor.com/ckeditor4/docs/#!/guide/dev_tests) and
[how to create tests](https://docs.ckeditor.com/ckeditor4/docs/#!/guide/dev_tests-section-creating-your-own-test)
in the official CKEditor documentation.

### This PR contains

- [ ] Unit tests
- [x] Manual tests

## What changes did you make?

I've added option to get absolute rects via `range.getClientRects` and added manual test with table selection and code snippet plugins.

Closes #1902 
Closes #1915 