### PR TITLE
Edge loses selection position when focused the first time

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -15,6 +15,7 @@ Fixed Issues:
 	* [#2857](https://github.com/ckeditor/ckeditor-dev/issues/2857): [List Block](https://ckeditor.com/cke4/addon/listblock).
 	* [#2858](https://github.com/ckeditor/ckeditor-dev/issues/2858): [Menu](https://ckeditor.com/cke4/addon/menu).
 * [#3158](https://github.com/ckeditor/ckeditor-dev/issues/3158): [Chrome, Safari] Fixed: [Undo](https://ckeditor.com/cke4/addon/undo) plugin breaks with filling character.
+* [#504](https://github.com/ckeditor/ckeditor-dev/issues/504): [Edge] Fixed: Editor's selection is collapsed to the beginning of the content when focusing editor for the first time.
 
 API Changes:
 

--- a/core/editable.js
+++ b/core/editable.js
@@ -1397,7 +1397,9 @@
 				blockNeedsFiller.appendBogus();
 				// IE tends to place selection after appended bogus, so we need to
 				// select the original range (placed before bogus).
-				selectionUpdateNeeded = CKEDITOR.env.ie;
+				// In Edge update selection only if editor has gained focus before (#504).
+				selectionUpdateNeeded = ( CKEDITOR.env.ie && !CKEDITOR.env.edge ) ||
+					( CKEDITOR.env.edge && editor._.previousActive );
 			}
 		}
 

--- a/tests/core/editable/domfix3.js
+++ b/tests/core/editable/domfix3.js
@@ -1,0 +1,30 @@
+/* bender-tags: editor,edge */
+
+bender.test( {
+	// This test is as dirty as hack for Edge itself. To detect if reselection in domFix is not
+	// happening for the first focus, we stub selection's selectRanges to detect any
+	// selection after focus (#504).
+	'test first focus in Edge': function() {
+		if ( !CKEDITOR.env.edge ) {
+			return assert.ignore();
+		}
+
+		bender.editorBot.create( {
+			name: 'edgefirstfocus',
+			startupData: '<p>Lorem ipsum dolor sit amet</p>'
+		}, function( bot ) {
+			var editor = bot.editor,
+				stub = sinon.stub( CKEDITOR.dom.selection.prototype, 'selectRanges' );
+
+			setTimeout( function() {
+				resume( function() {
+					stub.restore();
+					assert.areSame( 0, stub.callCount, 'reselection count' );
+				} );
+			}, 150 );
+
+			editor.focus();
+			wait();
+		} );
+	}
+} );

--- a/tests/core/editable/manual/edgefirstfocus.html
+++ b/tests/core/editable/manual/edgefirstfocus.html
@@ -1,0 +1,85 @@
+<h2>Classic editor</h2>
+<div id="classic">
+	<p>Test</p>
+	<p>Test</p>
+	<p>Test</p>
+	<p>Test</p>
+	<p>Test</p>
+	<p>Test</p>
+	<p>Test</p>
+	<p>Test</p>
+	<p>Test</p>
+	<p>Test</p>
+	<p>Test</p>
+	<p>Test</p>
+	<p>Test</p>
+	<p>Test</p>
+	<p>Test</p>
+	<p>Test</p>
+	<p>Test</p>
+	<p>Test</p>
+	<p>Test</p>
+	<p>Test</p>
+	<p>Test</p>
+</div>
+
+<h2>Divarea editor</h2>
+<div id="divarea" contenteditable="true">
+	<p>Test</p>
+	<p>Test</p>
+	<p>Test</p>
+	<p>Test</p>
+	<p>Test</p>
+	<p>Test</p>
+	<p>Test</p>
+	<p>Test</p>
+	<p>Test</p>
+	<p>Test</p>
+	<p>Test</p>
+	<p>Test</p>
+	<p>Test</p>
+	<p>Test</p>
+	<p>Test</p>
+	<p>Test</p>
+	<p>Test</p>
+	<p>Test</p>
+	<p>Test</p>
+	<p>Test</p>
+	<p>Test</p>
+</div>
+
+<h2>Inline editor</h2>
+<div id="inline" contenteditable="true">
+	<p>Test</p>
+	<p>Test</p>
+	<p>Test</p>
+	<p>Test</p>
+	<p>Test</p>
+	<p>Test</p>
+	<p>Test</p>
+	<p>Test</p>
+	<p>Test</p>
+	<p>Test</p>
+	<p>Test</p>
+	<p>Test</p>
+	<p>Test</p>
+	<p>Test</p>
+	<p>Test</p>
+	<p>Test</p>
+	<p>Test</p>
+	<p>Test</p>
+	<p>Test</p>
+	<p>Test</p>
+	<p>Test</p>
+</div>
+<script>
+	if ( !CKEDITOR.env.edge ) {
+		bender.ignore();
+	}
+
+	CKEDITOR.replace( 'classic' );
+	CKEDITOR.replace( 'divarea', {
+		extraPlugins: 'divarea'
+	} );
+	CKEDITOR.inline( 'inline' );
+</script>

--- a/tests/core/editable/manual/edgefirstfocus.md
+++ b/tests/core/editable/manual/edgefirstfocus.md
@@ -1,0 +1,19 @@
+@bender-tags: 4.10.0, bug, 504
+@bender-ui: collapsed
+@bender-ckeditor-plugins: toolbar, wysiwygarea, floatingspace, basicstyles
+
+## Test scenario
+
+For each editor:
+1. Scroll it without focusing.
+2. Click into content to focus the editor.
+
+## Expected result
+
+* Scroll position remains unchanged.
+* Caret is placed exactly where the click ocurred.
+
+## Unexpected
+
+* Editor scroll position is moved to top.
+* Caret is placed at the beginning of the editor's content.

--- a/tests/core/editable/manual/edgefirstfocus.md
+++ b/tests/core/editable/manual/edgefirstfocus.md
@@ -1,4 +1,4 @@
-@bender-tags: 4.10.0, bug, 504
+@bender-tags: 4.13.0, bug, 504
 @bender-ui: collapsed
 @bender-ckeditor-plugins: toolbar, wysiwygarea, floatingspace, basicstyles
 


### PR DESCRIPTION
## What is the purpose of this pull request?

Bug fix

## Does your PR contain necessary tests?

All patches which change the editor code must include tests. You can always read more
on [PR testing](https://docs.ckeditor.com/ckeditor4/docs/#!/guide/dev_contributing_code-section-tests),
[how to set the testing environment](https://docs.ckeditor.com/ckeditor4/docs/#!/guide/dev_tests) and
[how to create tests](https://docs.ckeditor.com/ckeditor4/docs/#!/guide/dev_tests-section-creating-your-own-test)
in the official CKEditor documentation.

### This PR contains

- [x] Unit tests
- [x] Manual tests

## What changes did you make?

It's just a dirty hack for Edge. I've added check in `domFix` to allow reselection in Edge only if the editor was previously focused. To check it I use `editor._.previousActive`.

The real source of the issue is buried deep in our selection. It seems that call to `selection.removeAllRanges` somehow prevents Edge from changing selection. The procedure for clicking the first time into editable area is:

* treat `focus` event as clicking at the beginning of the content
* then treat the click as a separate selection change.

Our `domFix` method interrupts this procedure and changes it to:

* treat `focus` event as clicking at the beginning of the content
* **add missing bogus `br`s and reselect the current selection**
* then treat the click as a separate selection change.

It works this way in IE. However Edge seems to stop after reselecting and does not change selection to the place of the click. But how it is connected with removing ranges – I don't really know.

As this issue is visible only on the first focus and researching our whole flow of focusing and selecting could take very long, I decided to apply some minimal hack instead.

Closes #504.