### PR TITLE
Fixed view positioning on iOS for autocomplete plugin

### DIFF
--- a/plugins/autocomplete/plugin.js
+++ b/plugins/autocomplete/plugin.js
@@ -225,8 +225,8 @@
 				editable = editor.editable(),
 				editorScrollableElement = editable.isInline() ? editable : editable.getDocument();
 
-			// iOS editor listens on frame parent element for editor `scroll` event (#1910).
-			if ( CKEDITOR.env.iOS ) {
+			// iOS classic editor listens on frame parent element for editor `scroll` event (#1910).
+			if ( CKEDITOR.env.iOS && !editable.isInline() ) {
 				editorScrollableElement = iOSViewportElement( editor );
 			}
 
@@ -751,8 +751,8 @@
 				// Bounding rect where the view should fit (visible editor viewport).
 				editorViewportRect;
 
-			// iOS editor has different viewport element (#1910).
-			if ( CKEDITOR.env.iOS ) {
+			// iOS classic editor has different viewport element (#1910).
+			if ( CKEDITOR.env.iOS && !editable.isInline() ) {
 				editorViewportRect = iOSViewportElement( editor ).getClientRect( true );
 			} else {
 				editorViewportRect = editable.isInline() ? editable.getClientRect( true ) : editor.window.getFrame().getClientRect( true );
@@ -1199,7 +1199,6 @@
 	// Once upstream issue is resolved this function should be removed and its concurrences should be refactored to
 	// follow the default code path.
 	function iOSViewportElement( editor ) {
-		var editable = editor.editable();
-		return editable.isInline() ? editable : editor.window.getFrame().getParent();
+		return editor.window.getFrame().getParent();
 	}
 } )();

--- a/plugins/autocomplete/plugin.js
+++ b/plugins/autocomplete/plugin.js
@@ -223,13 +223,11 @@
 			var editor = this.editor,
 				win = CKEDITOR.document.getWindow(),
 				editable = editor.editable(),
-				editorScrollableElement;
-
-			// iOS classic editor listens on different element for editor `scroll` event (#1910).
-			if ( CKEDITOR.env.iOS && !editable.isInline() ) {
-				editorScrollableElement = CKEDITOR.document.getById( editor.id + '_contents' );
-			} else {
 				editorScrollableElement = editable.isInline() ? editable : editable.getDocument();
+
+			// iOS editor listens on frame parent element for editor `scroll` event (#1910).
+			if ( CKEDITOR.env.iOS ) {
+				editorScrollableElement = iOSViewportElement( editor );
 			}
 
 			this.view.append();
@@ -753,9 +751,9 @@
 				// Bounding rect where the view should fit (visible editor viewport).
 				editorViewportRect;
 
-			// iOS classic editor has different viewport element (#1910).
-			if ( CKEDITOR.env.iOS && !editable.isInline() ) {
-				editorViewportRect = CKEDITOR.document.getById( editor.id + '_contents' ).getClientRect( true );
+			// iOS editor has different viewport element (#1910).
+			if ( CKEDITOR.env.iOS ) {
+				editorViewportRect = iOSViewportElement( editor ).getClientRect( true );
 			} else {
 				editorViewportRect = editable.isInline() ? editable.getClientRect( true ) : editor.window.getFrame().getClientRect( true );
 			}
@@ -1196,4 +1194,11 @@
 	 * @member CKEDITOR.config
 	 */
 	CKEDITOR.config.autocomplete_commitKeystroke = [ 9, 13 ];
+
+	// Viewport on iOS is moved into iframe parent element because of https://bugs.webkit.org/show_bug.cgi?id=149264 issue.
+	// After issue fix this function should be removed and its occurences should be refactored to utilize default code path.
+	function iOSViewportElement( editor ) {
+		var editable = editor.editable();
+		return editable.isInline() ? editable : editor.window.getFrame().getParent();
+	}
 } )();

--- a/plugins/autocomplete/plugin.js
+++ b/plugins/autocomplete/plugin.js
@@ -225,7 +225,7 @@
 				editable = editor.editable(),
 				editorScrollableElement;
 
-			// iOS classic editor listenes on different element for editor `scroll` event (#1910).
+			// iOS classic editor listens on different element for editor `scroll` event (#1910).
 			if ( CKEDITOR.env.iOS && !editable.isInline() ) {
 				editorScrollableElement = CKEDITOR.document.getById( editor.id + '_contents' );
 			} else {

--- a/plugins/autocomplete/plugin.js
+++ b/plugins/autocomplete/plugin.js
@@ -1196,7 +1196,8 @@
 	CKEDITOR.config.autocomplete_commitKeystroke = [ 9, 13 ];
 
 	// Viewport on iOS is moved into iframe parent element because of https://bugs.webkit.org/show_bug.cgi?id=149264 issue.
-	// After issue fix this function should be removed and its occurences should be refactored to utilize default code path.
+	// Once upstream issue is resolved this function should be removed and its concurrences should be refactored to
+	// follow the default code path.
 	function iOSViewportElement( editor ) {
 		var editable = editor.editable();
 		return editable.isInline() ? editable : editor.window.getFrame().getParent();

--- a/plugins/autocomplete/plugin.js
+++ b/plugins/autocomplete/plugin.js
@@ -223,7 +223,14 @@
 			var editor = this.editor,
 				win = CKEDITOR.document.getWindow(),
 				editable = editor.editable(),
+				editorScrollableElement;
+
+			// iOS classic editor listenes on different element for editor `scroll` event (#1910).
+			if ( CKEDITOR.env.iOS && !editable.isInline() ) {
+				editorScrollableElement = CKEDITOR.document.getById( editor.id + '_contents' );
+			} else {
 				editorScrollableElement = editable.isInline() ? editable : editable.getDocument();
+			}
 
 			this.view.append();
 			this.view.attach();
@@ -744,9 +751,17 @@
 				viewHeight = this.element.getSize( 'height' ),
 				editable = editor.editable(),
 				// Bounding rect where the view should fit (visible editor viewport).
-				editorViewportRect = editable.isInline() ? editable.getClientRect( true ) : editor.window.getFrame().getClientRect( true ),
-				// How much space is there for the view above and below the specified rect.
-				spaceAbove = rect.top - editorViewportRect.top,
+				editorViewportRect;
+
+			// iOS classic editor has different viewport element (#1910).
+			if ( CKEDITOR.env.iOS && !editable.isInline() ) {
+				editorViewportRect = CKEDITOR.document.getById( editor.id + '_contents' ).getClientRect( true );
+			} else {
+				editorViewportRect = editable.isInline() ? editable.getClientRect( true ) : editor.window.getFrame().getClientRect( true );
+			}
+
+			// How much space is there for the view above and below the specified rect.
+			var spaceAbove = rect.top - editorViewportRect.top,
 				spaceBelow = editorViewportRect.bottom - rect.bottom,
 				top;
 

--- a/tests/plugins/autocomplete/autocomplete.js
+++ b/tests/plugins/autocomplete/autocomplete.js
@@ -256,7 +256,7 @@
 			sinon.stub( ac.view, 'getCaretRect' ).returns( { top: 150, bottom: 160, left: 50 } );
 			sinon.stub( ac.view.element, 'getSize' ).returns( 50 );
 
-			// View postion after scroll.
+			// View position after scroll.
 			// +-----+==============+------------------------+
 			// |     |              |                        |
 			// |     |     view     |                        |

--- a/tests/plugins/autocomplete/manual/viewposition.md
+++ b/tests/plugins/autocomplete/manual/viewposition.md
@@ -23,7 +23,7 @@ The view is not changing its position depending on space below and above a caret
 # Inline editor
 
 1. Focus the editor at the first line and type `@`.
-1. Close the view using `esc` key.
+1. Close the view using `esc` key ( or `backspace` key on mobile ).
 1. Focus the editor at the last line and type `@`
 
 ## Expected

--- a/tests/plugins/autocomplete/manual/viewposition.md
+++ b/tests/plugins/autocomplete/manual/viewposition.md
@@ -23,7 +23,7 @@ The view is not changing its position depending on space below and above a caret
 # Inline editor
 
 1. Focus the editor at the first line and type `@`.
-1. Close the view using `esc` key ( or `backspace` key on mobile ).
+1. Close the view using `esc` key (or `backspace` key on mobile).
 1. Focus the editor at the last line and type `@`
 
 ## Expected

--- a/tests/plugins/autocomplete/manual/viewposition.md
+++ b/tests/plugins/autocomplete/manual/viewposition.md
@@ -1,4 +1,4 @@
-@bender-tags: 4.10.0, bug, tp3559
+@bender-tags: 4.10.0, bug, 1910
 @bender-ui: collapsed
 @bender-ckeditor-plugins: wysiwygarea, toolbar, basicstyles, autocomplete, textmatch
 


### PR DESCRIPTION
## What is the purpose of this pull request?

Bug

## Does your PR contain necessary tests?

All patches which change the editor code must include tests. You can always read more
on [PR testing](https://docs.ckeditor.com/ckeditor4/docs/#!/guide/dev_contributing_code-section-tests),
[how to set the testing environment](https://docs.ckeditor.com/ckeditor4/docs/#!/guide/dev_tests) and
[how to create tests](https://docs.ckeditor.com/ckeditor4/docs/#!/guide/dev_tests-section-creating-your-own-test)
in the official CKEditor documentation.

### This PR contains

- [x] Unit tests
- [x] Manual tests ( tests already sits inside target branch i.e. `t/1751`, see `tests/plugins/autocomplete/manual/viewposition`)

## What changes did you make?

After my changes iOS editor listens on a correct element for `scroll` event.

**Note:** Because of #1926 bug manual tests can be bugged. Although issue occurs randomly so you should be able to run manual tests. 

Closes #1910 
