### PR TITLE
Added mentions URL requests caching

### DIFF
--- a/plugins/mentions/plugin.js
+++ b/plugins/mentions/plugin.js
@@ -6,9 +6,12 @@
 'use strict';
 
 ( function() {
+
+	CKEDITOR._.mentions = { cache: {} };
+
 	var MARKER = '@',
 		MIN_CHARS = 2,
-		cache = {};
+		cache = CKEDITOR._.mentions.cache;
 
 	CKEDITOR.plugins.add( 'mentions', {
 		requires: 'autocomplete,textmatch,ajax',
@@ -92,10 +95,10 @@
 		/**
 		 * See {@link CKEDITOR.plugins.mentions.configDefinition#cache cache}.
 		 *
-		 * @property {Boolean} [cache=false]
+		 * @property {Boolean} [cache=true]
 		 * @readonly
 		 */
-		this.cache = Boolean( config.cache );
+		this.cache = config.hasOwnProperty( 'cache' ) ? config.cache : true;
 
 		/**
 		 * {@link CKEDITOR.plugins.autocomplete Autocomplete} instance used by mentions feature to implement autocompletion logic.
@@ -231,7 +234,7 @@
 					var items = JSON.parse( data );
 
 					// Cache URL responses for performance improvement (#1969).
-					if ( mentions.cache ) {
+					if ( mentions.cache && items !== null ) {
 						cache[ encodedUrl ] = items;
 					}
 
@@ -333,7 +336,7 @@
 	 * var definition = { feed: '/users?query={encodedQuery}' };
 	 * ```
 	 *
-	 * To avoid multiple HTTP requests to your endpoint service you can enable caching mechanism.
+	 * To avoid multiple HTTP requests to your endpoint service each HTTP response is cached by default and shared globally.
 	 * See {@link #cache cache} property for more details.
 	 *
 	 * # Function feed
@@ -447,7 +450,7 @@
 	 *
 	 * The cache is based on URL request and shared between all mentions instances (including different editors).
 	 *
-	 * @property {Boolean} [cache=false]
+	 * @property {Boolean} [cache=true]
 	 */
 
 	/**

--- a/plugins/mentions/plugin.js
+++ b/plugins/mentions/plugin.js
@@ -333,6 +333,9 @@
 	 * var definition = { feed: '/users?query={encodedQuery}' };
 	 * ```
 	 *
+	 * To avoid multiple HTTP requests to your endpoint service you can enable caching mechanism.
+	 * See {@link #cache cache} property for more details.
+	 *
 	 * # Function feed
 	 * This method is recommended for advanced users who would like to take full control of the data feed.
 	 * It allows you to provide data feed as an function which accepts two parameters: `options` and `callback`.

--- a/plugins/mentions/plugin.js
+++ b/plugins/mentions/plugin.js
@@ -222,7 +222,7 @@
 				var encodedUrl = new CKEDITOR.template( feed )
 					.output( { encodedQuery: encodeURIComponent( query ) } );
 
-				if ( mentions.cache && cache[ encodedUrl ] ) {
+				if ( mentions.cache && cache.hasOwnProperty( encodedUrl ) ) {
 					resolveCallbackData( cache[ encodedUrl ] );
 					return;
 				}

--- a/plugins/mentions/plugin.js
+++ b/plugins/mentions/plugin.js
@@ -440,7 +440,7 @@
 	 */
 
 	/**
-	 * Indicates if backend URL feed query responses will be cached.
+	 * Indicates if URL feed responses will be cached.
 	 *
 	 * The cache is based on URL request and shared between all mentions instances (including different editors).
 	 *

--- a/plugins/mentions/plugin.js
+++ b/plugins/mentions/plugin.js
@@ -230,6 +230,7 @@
 				CKEDITOR.ajax.load( encodedUrl, function( data ) {
 					var items = JSON.parse( data );
 
+					// Cache URL responses for performance improvement (#1969).
 					if ( mentions.cache ) {
 						cache[ encodedUrl ] = items;
 					}

--- a/plugins/mentions/plugin.js
+++ b/plugins/mentions/plugin.js
@@ -7,7 +7,9 @@
 
 ( function() {
 
-	CKEDITOR._.mentions = { cache: {} };
+	CKEDITOR._.mentions = {
+		cache: {}
+	};
 
 	var MARKER = '@',
 		MIN_CHARS = 2,
@@ -98,7 +100,7 @@
 		 * @property {Boolean} [cache=true]
 		 * @readonly
 		 */
-		this.cache = config.hasOwnProperty( 'cache' ) ? config.cache : true;
+		this.cache = config.cache !== undefined ? config.cache : true;
 
 		/**
 		 * {@link CKEDITOR.plugins.autocomplete Autocomplete} instance used by mentions feature to implement autocompletion logic.
@@ -225,9 +227,8 @@
 				var encodedUrl = new CKEDITOR.template( feed )
 					.output( { encodedQuery: encodeURIComponent( query ) } );
 
-				if ( mentions.cache && cache.hasOwnProperty( encodedUrl ) ) {
-					resolveCallbackData( cache[ encodedUrl ] );
-					return;
+				if ( mentions.cache && cache[ encodedUrl ] ) {
+					return resolveCallbackData( cache[ encodedUrl ] );
 				}
 
 				CKEDITOR.ajax.load( encodedUrl, function( data ) {

--- a/plugins/mentions/plugin.js
+++ b/plugins/mentions/plugin.js
@@ -7,7 +7,8 @@
 
 ( function() {
 	var MARKER = '@',
-		MIN_CHARS = 2;
+		MIN_CHARS = 2,
+		cache = {};
 
 	CKEDITOR.plugins.add( 'mentions', {
 		requires: 'autocomplete,textmatch,ajax',
@@ -89,6 +90,14 @@
 		this.pattern = config.pattern || createPattern( this.marker, this.minChars );
 
 		/**
+		 * See {@link CKEDITOR.plugins.mentions.configDefinition#cache cache}.
+		 *
+		 * @property {Boolean} [cache=false]
+		 * @readonly
+		 */
+		this.cache = Boolean( config.cache );
+
+		/**
 		 * {@link CKEDITOR.plugins.autocomplete Autocomplete} instance used by mentions feature to implement autocompletion logic.
 		 *
 		 * @property {CKEDITOR.plugins.autocomplete}
@@ -96,7 +105,7 @@
 		 */
 		this._autocomplete = new CKEDITOR.plugins.autocomplete( editor,
 			getTextTestCallback( this.marker, this.minChars, this.pattern ),
-			getDataCallback( feed, this.marker, this.caseSensitive ) );
+			getDataCallback( feed, this ) );
 
 		if ( this.template ) {
 			this.changeViewTemplate( this.template );
@@ -168,10 +177,10 @@
 		}
 	}
 
-	function getDataCallback( feed, marker, caseSensitive ) {
+	function getDataCallback( feed, mentions ) {
 		return function( query, range, callback ) {
 			// We are removing marker here to give clean query result for the endpoint callback.
-			if ( marker ) {
+			if ( mentions.marker ) {
 				query = query.substring( 1 );
 			}
 
@@ -182,7 +191,7 @@
 			} else {
 				feed( {
 					query: query,
-					marker: marker
+					marker: mentions.marker
 				}, resolveCallbackData );
 			}
 
@@ -190,7 +199,7 @@
 				var data = indexArrayFeed( feed ).filter( function( item ) {
 					var itemName = item.name;
 
-					if ( !caseSensitive ) {
+					if ( !mentions.caseSensitive ) {
 						itemName = itemName.toLowerCase();
 						query = query.toLowerCase();
 					}
@@ -213,8 +222,19 @@
 				var encodedUrl = new CKEDITOR.template( feed )
 					.output( { encodedQuery: encodeURIComponent( query ) } );
 
+				if ( mentions.cache && cache[ encodedUrl ] ) {
+					resolveCallbackData( cache[ encodedUrl ] );
+					return;
+				}
+
 				CKEDITOR.ajax.load( encodedUrl, function( data ) {
-					resolveCallbackData( JSON.parse( data ) );
+					var items = JSON.parse( data );
+
+					if ( mentions.cache ) {
+						cache[ encodedUrl ] = items;
+					}
+
+					resolveCallbackData( items );
 				} );
 			}
 
@@ -225,7 +245,7 @@
 
 				// We don't want to change item data, so lets create new one.
 				var newData = CKEDITOR.tools.array.map( data, function( item ) {
-					var name = marker + item.name;
+					var name = mentions.marker + item.name;
 					return CKEDITOR.tools.object.merge( item, { name: name } );
 				} );
 
@@ -416,6 +436,14 @@
 	 * be already filtered.
 	 *
 	 * @property {Boolean} [caseSensitive=false]
+	 */
+
+	/**
+	 * Indicates if backend URL feed query responses will be cached.
+	 *
+	 * The cache is based on URL request and shared between all mentions instances (including different editors).
+	 *
+	 * @property {Boolean} [cache=false]
 	 */
 
 	/**

--- a/tests/plugins/mentions/manual/cache.html
+++ b/tests/plugins/mentions/manual/cache.html
@@ -1,0 +1,51 @@
+<style>
+#history{
+	background: #eaebed;
+	height: 200px;
+	width: 300px;
+	overflow-y: auto;
+	padding: 20px;
+	list-style-type: none;
+}
+</style>
+
+<ul id="history"></ul>
+<div id="editor"></div>
+
+<script>
+	var data = [
+			{ id: 1, name: 'john' },
+			{ id: 2, name: 'thomas' },
+			{ id: 3, name: 'anna' },
+			{ id: 4, name: 'annabelle' },
+			{ id: 5, name: 'cris' },
+			{ id: 6, name: 'julia' }
+		],
+		historyEl = document.getElementById( 'history' );
+
+	CKEDITOR.replace( 'editor', {
+		width: 600,
+		mentions: [
+			{
+				feed: '{encodedQuery}',
+				minChars: 0,
+				cache: true
+			}
+		],
+		on: {
+			instanceReady: function() {
+				CKEDITOR.ajax.load = function( query, callback ) {
+					var results = data.filter( function( item ) {
+							return item.name.indexOf( query ) == 0;
+						} ),
+						historyItem = document.createElement( 'li' );
+
+					callback( JSON.stringify( results ) );
+
+					historyItem.innerText = 'Request: "' + query + '"';
+					historyEl.appendChild( historyItem );
+				}
+			}
+		}
+	} );
+</script>

--- a/tests/plugins/mentions/manual/cache.html
+++ b/tests/plugins/mentions/manual/cache.html
@@ -1,5 +1,5 @@
 <style>
-#history{
+#history {
 	background: #eaebed;
 	height: 200px;
 	width: 300px;
@@ -18,7 +18,7 @@
 			{ id: 2, name: 'thomas' },
 			{ id: 3, name: 'anna' },
 			{ id: 4, name: 'annabelle' },
-			{ id: 5, name: 'cris' },
+			{ id: 5, name: 'chris' },
 			{ id: 6, name: 'julia' }
 		],
 		historyEl = document.getElementById( 'history' );

--- a/tests/plugins/mentions/manual/cache.md
+++ b/tests/plugins/mentions/manual/cache.md
@@ -1,0 +1,19 @@
+@bender-tags: mentions, feature, 4.10.0, 1969
+@bender-ui: collapsed
+@bender-ckeditor-plugins: wysiwygarea, toolbar, basicstyles, mentions
+
+1. Focus the editor.
+1. Type `@anna`.
+1. Press enter.
+1. Type `@anna` again.
+1. Press enter. 
+1. Check request history log above the editor.
+
+
+## Expected
+
+History log doesn't contain duplicated URL requests.
+
+## Unexpected
+
+There are duplicated URL requests inside history log.

--- a/tests/plugins/mentions/mentions.js
+++ b/tests/plugins/mentions/mentions.js
@@ -275,7 +275,7 @@
 		},
 
 		// (#1969)
-		'test URL feed responses are not cached': function() {
+		'test URL feed cache can be disabled': function() {
 			var mentions = this.createMentionsInstance( {
 					feed: '{encodedQuery}',
 					cache: false,
@@ -285,12 +285,7 @@
 					{ id: 1, name: 'Anna' },
 					{ id: 2, name: 'Annabelle' }
 				],
-				calledTimes = 0,
 				ajaxStub = sinon.stub( CKEDITOR.ajax, 'load', function( url, callback ) {
-					if ( url === 'An' ) {
-						calledTimes++;
-					}
-
 					callback( JSON.stringify( dataSet ) );
 				} );
 
@@ -303,7 +298,7 @@
 			this.editorBot.setHtmlWithSelection( '<p>@An^</p>' );
 			testView( mentions, expectedFeedData );
 
-			assert.areEqual( 2, calledTimes );
+			assert.areEqual( 3, ajaxStub.callCount, 'CKEDITOR.ajax.load call count' );
 
 			ajaxStub.restore();
 		},
@@ -318,12 +313,7 @@
 					{ id: 1, name: 'Anna' },
 					{ id: 2, name: 'Annabelle' }
 				],
-				calledTimes = 0,
 				ajaxStub = sinon.stub( CKEDITOR.ajax, 'load', function( url, callback ) {
-					if ( url === 'An' ) {
-						calledTimes++;
-					}
-
 					callback( JSON.stringify( dataSet ) );
 				} );
 
@@ -336,7 +326,7 @@
 			this.editorBot.setHtmlWithSelection( '<p>@An^</p>' );
 			testView( mentions, expectedFeedData );
 
-			assert.areEqual( 1, calledTimes );
+			assert.areEqual( 2, ajaxStub.callCount );
 
 			ajaxStub.restore();
 		},

--- a/tests/plugins/mentions/mentions.js
+++ b/tests/plugins/mentions/mentions.js
@@ -22,6 +22,8 @@
 			if ( this._mentions ) {
 				this._mentions.destroy();
 				this._mentions = null;
+
+				CKEDITOR._.mentions.cache = {};
 			}
 		},
 
@@ -310,7 +312,6 @@
 		'test URL feed responses are cached': function() {
 			var mentions = this.createMentionsInstance( {
 					feed: '{encodedQuery}',
-					cache: true,
 					minChars: 0
 				} ),
 				dataSet = [
@@ -336,6 +337,24 @@
 			testView( mentions, expectedFeedData );
 
 			assert.areEqual( 1, calledTimes );
+
+			ajaxStub.restore();
+		},
+
+		// (#1969)
+		'test URL feed invalid responses are not cached': function() {
+			var mentions = this.createMentionsInstance( {
+					feed: '{encodedQuery}',
+					minChars: 0
+				} ),
+				ajaxStub = sinon.stub( CKEDITOR.ajax, 'load', function( url, callback ) {
+					callback( null );
+				} );
+
+			this.editorBot.setHtmlWithSelection( '<p>@test^</p>' );
+			testView( mentions, [] );
+
+			assert.isUndefined( CKEDITOR._.mentions.cache.test );
 
 			ajaxStub.restore();
 		}

--- a/tests/plugins/mentions/mentions.js
+++ b/tests/plugins/mentions/mentions.js
@@ -270,6 +270,74 @@
 			mentions._autocomplete.editor.editable().fire( 'keyup', new CKEDITOR.dom.event( {} ) );
 
 			wait();
+		},
+
+		// (#1969)
+		'test URL feed responses are not cached': function() {
+			var mentions = this.createMentionsInstance( {
+					feed: '{encodedQuery}',
+					cache: false,
+					minChars: 0
+				} ),
+				dataSet = [
+					{ id: 1, name: 'Anna' },
+					{ id: 2, name: 'Annabelle' }
+				],
+				calledTimes = 0,
+				ajaxStub = sinon.stub( CKEDITOR.ajax, 'load', function( url, callback ) {
+					if ( url === 'An' ) {
+						calledTimes++;
+					}
+
+					callback( JSON.stringify( dataSet ) );
+				} );
+
+			this.editorBot.setHtmlWithSelection( '<p>@An^</p>' );
+			testView( mentions, expectedFeedData );
+
+			this.editor.editable().findOne( 'p' ).getFirst().setText( '@Ann' );
+			testView( mentions, expectedFeedData );
+
+			this.editorBot.setHtmlWithSelection( '<p>@An^</p>' );
+			testView( mentions, expectedFeedData );
+
+			assert.areEqual( 2, calledTimes );
+
+			ajaxStub.restore();
+		},
+
+		// (#1969)
+		'test URL feed responses are cached': function() {
+			var mentions = this.createMentionsInstance( {
+					feed: '{encodedQuery}',
+					cache: true,
+					minChars: 0
+				} ),
+				dataSet = [
+					{ id: 1, name: 'Anna' },
+					{ id: 2, name: 'Annabelle' }
+				],
+				calledTimes = 0,
+				ajaxStub = sinon.stub( CKEDITOR.ajax, 'load', function( url, callback ) {
+					if ( url === 'An' ) {
+						calledTimes++;
+					}
+
+					callback( JSON.stringify( dataSet ) );
+				} );
+
+			this.editorBot.setHtmlWithSelection( '<p>@An^</p>' );
+			testView( mentions, expectedFeedData );
+
+			this.editor.editable().findOne( 'p' ).getFirst().setText( '@Ann' );
+			testView( mentions, expectedFeedData );
+
+			this.editorBot.setHtmlWithSelection( '<p>@An^</p>' );
+			testView( mentions, expectedFeedData );
+
+			assert.areEqual( 1, calledTimes );
+
+			ajaxStub.restore();
 		}
 	} );
 


### PR DESCRIPTION
## What is the purpose of this pull request?

New feature

## Does your PR contain necessary tests?

All patches which change the editor code must include tests. You can always read more
on [PR testing](https://docs.ckeditor.com/ckeditor4/docs/#!/guide/dev_contributing_code-section-tests),
[how to set the testing environment](https://docs.ckeditor.com/ckeditor4/docs/#!/guide/dev_tests) and
[how to create tests](https://docs.ckeditor.com/ckeditor4/docs/#!/guide/dev_tests-section-creating-your-own-test)
in the official CKEditor documentation.

### This PR contains

- [x] Unit tests
- [x] Manual tests

## What changes did you make?

Introduced URL requests caching for mentions plugin. This cache implementation is very simple and it's based on object keys. I decided to not overcompliacate it. Nevertheless, I think in the future we could replace it with implementation allowing to garbage collecting expired cache items so the cache will be refreshed after the given time. For me, it makes more business sense because most of the time you want to keep your data up to date with a client-side application.

Closes #1969
