### PR TITLE
Added mentions feed throttling

### DIFF
--- a/plugins/mentions/plugin.js
+++ b/plugins/mentions/plugin.js
@@ -95,6 +95,14 @@
 		this.cache = config.cache !== undefined ? config.cache : true;
 
 		/**
+		 * See {@link CKEDITOR.plugins.mentions.configDefinition#throttle throttle}.
+		 *
+		 * @property {Boolean} [throttle]
+		 * @readonly
+		 */
+		this.throttle = config.throttle !== undefined ? config.throttle : 200;
+
+		/**
 		 * {@link CKEDITOR.plugins.autocomplete Autocomplete} instance used by mentions feature to implement autocompletion logic.
 		 *
 		 * @property {CKEDITOR.plugins.autocomplete}
@@ -105,7 +113,7 @@
 			dataCallback: getDataCallback( feed, this ),
 			itemTemplate: config.itemTemplate,
 			outputTemplate: config.outputTemplate,
-			throttle: 0
+			throttle: this.throttle
 		} );
 	}
 
@@ -393,6 +401,12 @@
 	 * See {@link CKEDITOR.plugins.autocomplete#outputTemplate}.
 	 *
 	 * @property {String} [outputTemplate]
+	 */
+
+	/**
+	 * See {@link CKEDITOR.plugins.autocomplete.configDefinition#throttle}.
+	 *
+	 * @property {String} [throttle=200]
 	 */
 
 	/**

--- a/plugins/mentions/plugin.js
+++ b/plugins/mentions/plugin.js
@@ -97,7 +97,7 @@
 		/**
 		 * See {@link CKEDITOR.plugins.mentions.configDefinition#throttle throttle}.
 		 *
-		 * @property {Boolean} [throttle]
+		 * @property {Number} [throttle]
 		 * @readonly
 		 */
 		this.throttle = config.throttle !== undefined ? config.throttle : 200;
@@ -406,7 +406,7 @@
 	/**
 	 * See {@link CKEDITOR.plugins.autocomplete.configDefinition#throttle}.
 	 *
-	 * @property {String} [throttle=200]
+	 * @property {Number} [throttle=200]
 	 */
 
 	/**

--- a/plugins/mentions/plugin.js
+++ b/plugins/mentions/plugin.js
@@ -95,7 +95,7 @@
 		this.cache = config.cache !== undefined ? config.cache : true;
 
 		/**
-		 * See {@link CKEDITOR.plugins.mentions.configDefinition#throttle throttle}.
+		 * See {@link CKEDITOR.plugins.autocomplete.configDefinition#throttle}.
 		 *
 		 * @property {Number} [throttle]
 		 * @readonly


### PR DESCRIPTION
## What is the purpose of this pull request?

New feature

## Does your PR contain necessary tests?

All patches which change the editor code must include tests. You can always read more
on [PR testing](https://docs.ckeditor.com/ckeditor4/docs/#!/guide/dev_contributing_code-section-tests),
[how to set the testing environment](https://docs.ckeditor.com/ckeditor4/docs/#!/guide/dev_tests) and
[how to create tests](https://docs.ckeditor.com/ckeditor4/docs/#!/guide/dev_tests-section-creating-your-own-test)
in the official CKEditor documentation.

### This PR contains

- [x] Unit tests
- [x] Manual tests

Tests are available for autocomplete throttling.

## What changes did you make?

I added data request throttling for each feed type with default throttling time `200` ms
I did some testing on this issue and I think that proposed throttling thresholds in #1972 ticket (70-120ms) is too low for performance profit.

Also I tried to use [`CKEDITOR.tools.eventsBuffer`](https://docs.ckeditor.com/ckeditor4/latest/api/CKEDITOR_tools.html#method-eventsBuffer) for throttling implementation but this function doesn't allow to cancel buffered callback. It's always fired after provided timeout.

Closes #1972
