### PR TITLE
Make manual tests for plugins configuration mobile- & built-friendly

### DIFF
--- a/tests/core/config/manual/extraplugins.html
+++ b/tests/core/config/manual/extraplugins.html
@@ -2,6 +2,12 @@
 </textarea>
 <script>
 	var editor = CKEDITOR.replace( 'editor1', {
-		extraPlugins: 'basicstyles, toolbar'
+		plugins: 'wysiwygarea',
+		extraPlugins: 'basicstyles, toolbar',
+		on: {
+			instanceReady: function() {
+				this.setData( '<p>I have following plugins loaded: ' + CKEDITOR.tools.objectKeys( this.plugins ) + '</p>' );
+			}
+		}
 	} );
 </script>

--- a/tests/core/config/manual/extraplugins.md
+++ b/tests/core/config/manual/extraplugins.md
@@ -1,14 +1,19 @@
 @bender-tags: feature, 4.10.0, 1712
 @bender-ui: collapsed
-@bender-ckeditor-plugins: wysiwygarea
 
-1. Open console.
-2. Check if plugins loaded correctly with an editor.
+1. Check if plugins listed inside the editor are the same as listed below.
 
 ## Expected
 
-Toolbar and basicstyles plugins has been loaded. There are no console errors.
+All listed plugins have been loaded (list below).
 
 ## Unexpected
 
-There are console errors or basicstyles and toolbar plugins are not loaded.
+The loaded plugins are not the same as the ones in the list.
+
+## Expected plugins
+
+* wysiwygarea
+* basicstyles
+* toolbar
+* button

--- a/tests/core/config/manual/plugins.html
+++ b/tests/core/config/manual/plugins.html
@@ -2,6 +2,11 @@
 </textarea>
 <script>
 	var editor = CKEDITOR.replace( 'editor1', {
-		plugins: 'wysiwygarea,basicstyles, toolbar '
+		plugins: 'wysiwygarea,basicstyles, toolbar ',
+		on: {
+			instanceReady: function() {
+				this.setData( '<p>I have following plugins loaded: ' + CKEDITOR.tools.objectKeys( this.plugins ) + '</p>' );
+			}
+		}
 	} );
 </script>

--- a/tests/core/config/manual/plugins.md
+++ b/tests/core/config/manual/plugins.md
@@ -1,13 +1,19 @@
 @bender-tags: feature, 4.10.0, 1712
 @bender-ui: collapsed
 
-1. Open console.
-2. Check if plugins loaded correctly with an editor.
+1. Check if plugins listed inside the editor are the same as listed below.
 
 ## Expected
 
-Toolbar, basicstyles and wysiwygarea plugins has been loaded. There are no console errors.
+All listed plugins have been loaded (list below).
 
 ## Unexpected
 
-There are console errors or expected plugins are not loaded.
+The loaded plugins are not the same as the ones in the list.
+
+## Expected plugins
+
+* wysiwygarea
+* basicstyles
+* toolbar
+* button

--- a/tests/core/config/manual/removeplugins.html
+++ b/tests/core/config/manual/removeplugins.html
@@ -2,6 +2,12 @@
 </textarea>
 <script>
 	var editor = CKEDITOR.replace( 'editor1', {
-		removePlugins: 'basicstyles, toolbar'
+		plugins: 'wysiwygarea,basicstyles,toolbar',
+		removePlugins: 'basicstyles, toolbar',
+		on: {
+			instanceReady: function() {
+				this.setData( '<p>I have following plugins loaded: ' + CKEDITOR.tools.objectKeys( this.plugins ) + '</p>' );
+			}
+		}
 	} );
 </script>

--- a/tests/core/config/manual/removeplugins.md
+++ b/tests/core/config/manual/removeplugins.md
@@ -1,14 +1,16 @@
 @bender-tags: feature, 4.10.0, 1712
 @bender-ui: collapsed
-@bender-ckeditor-plugins: wysiwygarea, basicstyles, toolbar
 
-1. Open console.
-2. Check if plugins loaded correctly with an editor.
+1. Check if plugins listed inside the editor are the same as listed below.
 
 ## Expected
 
-Toolbar and basicstyles plugins has not been loaded. There are no console errors.
+All listed plugins have been loaded (list below).
 
 ## Unexpected
 
-There are console errors or basicstyles and toolbar plugins has not been loaded.
+The loaded plugins are not the same as the ones in the list.
+
+## Expected plugins
+
+* wysiwygarea


### PR DESCRIPTION
## What is the purpose of this pull request?

Failing test/task

## Does your PR contain necessary tests?

All patches which change the editor code must include tests. You can always read more
on [PR testing](https://docs.ckeditor.com/ckeditor4/docs/#!/guide/dev_contributing_code-section-tests),
[how to set the testing environment](https://docs.ckeditor.com/ckeditor4/docs/#!/guide/dev_tests) and
[how to create tests](https://docs.ckeditor.com/ckeditor4/docs/#!/guide/dev_tests-section-creating-your-own-test)
in the official CKEditor documentation.

### This PR contains

- [ ] Unit tests
- [ ] Manual tests

It's just fix for manual tests.

## What changes did you make?

I've made manual tests for #1712 mobile friendly. They also pass in built version now.

I didn't change unit tests as they got fixed in #1929.

Closes #1994.
