### PR TITLE
Added autocomplete throttle feature

### DIFF
--- a/plugins/autocomplete/plugin.js
+++ b/plugins/autocomplete/plugin.js
@@ -1266,6 +1266,24 @@
 	 * Callback executed to get suggestion data based on search query. The returned data will be
 	 * displayed in the autocomplete view.
 	 *
+	 * ```javascript
+	 *	// Returns (through its callback) the suggestions for the current query.
+	 *	// Note: the itemsArray variable is our example "database".
+	 *	function dataCallback( query, range, callback ) {
+	 *		// Simple search.
+	 *		// Filter the entire items array so only the items that start
+	 *		// with the query remain.
+	 *		var suggestions = itemsArray.filter( function( item ) {
+	 *			return item.name.indexOf( query ) === 0;
+	 *		} );
+	 *
+	 *		// Note - the callback function can also be executed asynchronously
+	 *		// so dataCallback can do an XHR requests or use any other asynchronous API.
+	 *		callback( suggestions );
+	 *	}
+	 *
+	 * ```
+	 *
 	 * @method dataCallback
 	 * @param {String} query The query string that was accepted by the `textTestCallback`.
 	 * @param {CKEDITOR.dom.range} range The range in the DOM where the query text is.
@@ -1278,6 +1296,37 @@
 	/**
 	 * Callback executed to check if a text next to the selection should open
 	 * the autocomplete. See the {@link CKEDITOR.plugins.textWatcher}'s `callback` argument.
+	 *
+	 * ```javascript
+	 *	// Called when the user types in the editor or moves the caret.
+	 *	// The range represents the caret position.
+	 *	function textTestCallback( range ) {
+	 *		// We don't want to autocomplete a non-empty selection.
+	 *		if ( !range.collapsed ) {
+	 *			return null;
+	 *		}
+	 *
+	 *		// Use the textmatch plugin which does the tricky job of doing
+	 *		// a text search in the DOM. The matchCallback function should return
+	 *		// a matching fragment of the text.
+	 *		return CKEDITOR.plugins.textMatch.match( range, matchCallback );
+	 *	}
+	 *
+	 *	// Returns a position of the matching text.
+	 *	// It matches with text starting from the '@' character
+	 *	// followed by spaces, up to the caret position.
+	 *	function matchCallback( text, offset ) {
+	 *			// Get the text before the caret.
+	 *		var left = text.slice( 0, offset ),
+	 *			// Will look for an '@' character followed by word characters.
+	 *			match = left.match( /@\w*$/ );
+	 *
+	 *		if ( !match ) {
+	 *			return null;
+	 *		}
+	 *		return { start: match.index, end: offset };
+	 *	}
+	 * ```
 	 *
 	 * @method textTestCallback
 	 */

--- a/plugins/autocomplete/plugin.js
+++ b/plugins/autocomplete/plugin.js
@@ -227,10 +227,10 @@
 		 * @readonly
 		 * @property {CKEDITOR.template} [outputTemplate=null]
 		 */
-		this.outputTemplate = outputTemplate !== undefined ? new CKEDITOR.template( outputTemplate ) : null;
+		this.outputTemplate = config.outputTemplate !== undefined ? new CKEDITOR.template( config.outputTemplate ) : null;
 
-		if ( itemTemplate ) {
-			this.view.itemTemplate = new CKEDITOR.template( itemTemplate );
+		if ( config.itemTemplate ) {
+			this.view.itemTemplate = new CKEDITOR.template( config.itemTemplate );
 		}
 
 		this.attach();
@@ -1329,8 +1329,8 @@
 	 * ```
 	 *
 	 * @method textTestCallback
+	 * @param {CKEDITOR.dom.range} range Range representing the caret position.
 	 */
-
 
 	/**
 	 * Indicates throttle threshold mitigating text checks.
@@ -1348,7 +1348,7 @@
 	 */
 
 	/**
-	 * Template for match rendering. See {@link CKEDITOR.plugin.autocomplete#outputTemplate}.
+	 * Template for match rendering. See {@link CKEDITOR.plugins.autocomplete#outputTemplate} for more information.
 	 *
 	 * @property {String} [outputTemplate]
 	 */

--- a/plugins/autocomplete/plugin.js
+++ b/plugins/autocomplete/plugin.js
@@ -148,20 +148,15 @@
 	 *	} );
 	 * ```
 	 * @param {CKEDITOR.editor} editor The editor to watch.
-	 * @param {Function} textTestCallback Callback executed to check if a text next to the selection should open
-	 * the autocomplete. See the {@link CKEDITOR.plugins.textWatcher}'s `callback` argument.
-	 * @param {Function} dataCallback Callback executed to get suggestion data based on search query. The returned data will be
-	 * displayed in the autocomplete view.
-	 * @param {String} dataCallback.query The query string that was accepted by the `textTestCallback`.
-	 * @param {CKEDITOR.dom.range} dataCallback.range The range in the DOM where the query text is.
-	 * @param {Function} dataCallback.callback The callback which should be executed with the data.
-	 * @param {CKEDITOR.plugins.autocomplete.model.item[]} dataCallback.callback.data The suggestion data that should be
-	 * displayed in the autocomplete view for a given query. The data items should implement the
-	 * {@link CKEDITOR.plugins.autocomplete.model.item} interface.
-	 * @param {String} [itemTemplate] Template for list item in dropdown. See {@link CKEDITOR.plugins.autocomplete.view#itemTemplate} for more information.
-	 * @param {String} [outputTemplate] Template for match rendering. See {@link #outputTemplate}.
+	 * @param {CKEDITOR.plugins.autocomplete.configDefinition} config Configuration object keeping information
+	 * how to instantiate autocomplete plugin.
 	 */
-	function Autocomplete( editor, textTestCallback, dataCallback, itemTemplate, outputTemplate ) {
+	function Autocomplete( editor, config ) {
+		var configKeystrokes = editor.config.autocomplete_commitKeystrokes || CKEDITOR.config.autocomplete_commitKeystrokes;
+
+		/**
+		 * The editor instance to which autocomplete is attached to.
+		 *
 		var configKeystrokes = editor.config.autocomplete_commitKeystrokes || CKEDITOR.config.autocomplete_commitKeystrokes;
 
 		/**
@@ -171,6 +166,13 @@
 		 * @property {CKEDITOR.editor}
 		 */
 		this.editor = editor;
+
+		/**
+		 * See {@link CKEDITOR.plugins.autocomplete.configDefinition#throttle}.
+		 *
+		 * @property {Number} [throttle=0]
+		 */
+		this.throttle = config.throttle || 0;
 
 		/**
 		 * The autocomplete view instance.
@@ -186,7 +188,7 @@
 		 * @readonly
 		 * @property {CKEDITOR.plugins.autocomplete.model}
 		 */
-		this.model = this.getModel( dataCallback );
+		this.model = this.getModel( config.dataCallback );
 
 		/**
 		 * The autocomplete text watcher instance.
@@ -194,7 +196,7 @@
 		 * @readonly
 		 * @property {CKEDITOR.plugins.textWatcher}
 		 */
-		this.textWatcher = this.getTextWatcher( textTestCallback );
+		this.textWatcher = this.getTextWatcher( config.textTestCallback );
 
 		/**
 		 * The autocomplete keystrokes used to finish autocompletion with selected view item.
@@ -382,7 +384,7 @@
 		 * @returns {CKEDITOR.plugins.textWatcher} The text watcher instance.
 		 */
 		getTextWatcher: function( textTestCallback ) {
-			return new CKEDITOR.plugins.textWatcher( this.editor, textTestCallback );
+			return new CKEDITOR.plugins.textWatcher( this.editor, textTestCallback, this.throttle );
 		},
 
 		/**
@@ -1241,5 +1243,65 @@
 	function iOSViewportElement( editor ) {
 		return editor.window.getFrame().getParent();
 	}
+
+	/**
+	 * Abstract class describing the definition of a {@link CKEDITOR.plugins.autocomplete autocomplete} plugin configuration.
+	 *
+	 * This virtual class illustrates the properties that developers can use to define and create
+	 * autocomplete configuration definition.
+	 *
+	 * Simple usage:
+	 *
+	 * ```javascript
+	 * var definition = { dataCallback: dataCallback, textTestCallback: textTestCallback, throttle: 200 };
+	 * ```
+	 *
+	 * @class CKEDITOR.plugins.autocomplete.configDefinition
+	 * @abstract
+	 * @since 4.10.0
+	 */
+
+
+	/**
+	 * Callback executed to get suggestion data based on search query. The returned data will be
+	 * displayed in the autocomplete view.
+	 *
+	 * @method dataCallback
+	 * @param {String} query The query string that was accepted by the `textTestCallback`.
+	 * @param {CKEDITOR.dom.range} range The range in the DOM where the query text is.
+	 * @param {Function} callback The callback which should be executed with the data.
+	 * @param {CKEDITOR.plugins.autocomplete.model.item[]} callback.data The suggestion data that should be
+	 * displayed in the autocomplete view for a given query. The data items should implement the
+	 * {@link CKEDITOR.plugins.autocomplete.model.item} interface.
+	 */
+
+	/**
+	 * Callback executed to check if a text next to the selection should open
+	 * the autocomplete. See the {@link CKEDITOR.plugins.textWatcher}'s `callback` argument.
+	 *
+	 * @method textTestCallback
+	 */
+
+
+	/**
+	 * Indicates throttle threshold mitigating text checks.
+	 *
+	 * Higher levels of throttle threshold will create visible delay for autocomplete view
+	 * but also save the number of {@link #dataCallback} calls.
+	 *
+	 * @property {Number} [throttle=0]
+	 */
+
+	/**
+	 * Template for list item in dropdown. See {@link CKEDITOR.plugins.autocomplete.view#itemTemplate} for more information.
+	 *
+	 * @property {String} [itemTemplate]
+	 */
+
+	/**
+	 * Template for match rendering. See {@link CKEDITOR.plugin.autocomplete#outputTemplate}.
+	 *
+	 * @property {String} [outputTemplate]
+	 */
 
 } )();

--- a/plugins/autocomplete/plugin.js
+++ b/plugins/autocomplete/plugin.js
@@ -91,7 +91,10 @@
 	 *	}
 	 *
 	 *	// Finally, instantiate the autocomplete class.
-	 *	new CKEDITOR.plugins.autocomplete( editor, textTestCallback, dataCallback );
+	 *	new CKEDITOR.plugins.autocomplete( editor, {
+	 *  	textTestCallback: textTestCallback,
+	 *  	dataCallback: dataCallback
+	 *  } );
 	 * ```
 	 *
 	 * # Changing the behavior of the autocomplete class by subclassing it
@@ -131,9 +134,9 @@
 	 *				this.element.setStyle( 'width', container.getSize( 'width' ) + 'px' );
 	 *			};
 	 *
-	 *			function CustomAutocomplete( editor, textTestCallback, dataCallback ) {
+	 *			function CustomAutocomplete( editor, configDefinition ) {
 	 *				// Call the parent class constructor.
-	 *				Autocomplete.call( this, editor, textTestCallback, dataCallback );
+	 *				Autocomplete.call( this, editor, configDefinition );
 	 *			}
 	 *			// Inherit the autocomplete methods.
 	 *			CustomAutocomplete.prototype = CKEDITOR.tools.prototypedCopy( Autocomplete.prototype );
@@ -148,15 +151,9 @@
 	 *	} );
 	 * ```
 	 * @param {CKEDITOR.editor} editor The editor to watch.
-	 * @param {CKEDITOR.plugins.autocomplete.configDefinition} config Configuration object keeping information
-	 * how to instantiate autocomplete plugin.
+	 * @param {CKEDITOR.plugins.autocomplete.configDefinition} config Configuration object for this autocomplete instance.
 	 */
 	function Autocomplete( editor, config ) {
-		var configKeystrokes = editor.config.autocomplete_commitKeystrokes || CKEDITOR.config.autocomplete_commitKeystrokes;
-
-		/**
-		 * The editor instance to which autocomplete is attached to.
-		 *
 		var configKeystrokes = editor.config.autocomplete_commitKeystrokes || CKEDITOR.config.autocomplete_commitKeystrokes;
 
 		/**
@@ -170,9 +167,9 @@
 		/**
 		 * See {@link CKEDITOR.plugins.autocomplete.configDefinition#throttle}.
 		 *
-		 * @property {Number} [throttle=0]
+		 * @property {Number} [throttle]
 		 */
-		this.throttle = config.throttle || 0;
+		this.throttle = config.throttle || 20;
 
 		/**
 		 * The autocomplete view instance.
@@ -1253,14 +1250,17 @@
 	 * Simple usage:
 	 *
 	 * ```javascript
-	 * var definition = { dataCallback: dataCallback, textTestCallback: textTestCallback, throttle: 200 };
+ 	 * var definition = {
+	 *	 dataCallback: dataCallback,
+	 *	 textTestCallback: textTestCallback,
+	 *	 throttle: 200
+	 * };
 	 * ```
 	 *
 	 * @class CKEDITOR.plugins.autocomplete.configDefinition
 	 * @abstract
 	 * @since 4.10.0
 	 */
-
 
 	/**
 	 * Callback executed to get suggestion data based on search query. The returned data will be
@@ -1333,12 +1333,9 @@
 	 */
 
 	/**
-	 * Indicates throttle threshold mitigating text checks.
+	 * Indicates throttle threshold expressed in milliseconds mitigating text checks.
 	 *
-	 * Higher levels of throttle threshold will create visible delay for autocomplete view
-	 * but also save the number of {@link #dataCallback} calls.
-	 *
-	 * @property {Number} [throttle=0]
+	 * @property {Number} [throttle=20]
 	 */
 
 	/**

--- a/plugins/autocomplete/plugin.js
+++ b/plugins/autocomplete/plugin.js
@@ -92,9 +92,9 @@
 	 *
 	 *	// Finally, instantiate the autocomplete class.
 	 *	new CKEDITOR.plugins.autocomplete( editor, {
-	 *  	textTestCallback: textTestCallback,
-	 *  	dataCallback: dataCallback
-	 *  } );
+	 *		textTestCallback: textTestCallback,
+	 *		dataCallback: dataCallback
+	 *	} );
 	 * ```
 	 *
 	 * # Changing the behavior of the autocomplete class by subclassing it

--- a/plugins/autocomplete/plugin.js
+++ b/plugins/autocomplete/plugin.js
@@ -1333,7 +1333,7 @@
 	 */
 
 	/**
-	 * Indicates throttle threshold expressed in milliseconds mitigating text checks.
+	 * Indicates throttle threshold expressed in milliseconds reducing text checks frequency.
 	 *
 	 * @property {Number} [throttle=20]
 	 */

--- a/plugins/textwatcher/plugin.js
+++ b/plugins/textwatcher/plugin.js
@@ -67,12 +67,13 @@
 	 * @param {CKEDITOR.editor} editor The editor instance to watch in.
 	 * @param {Function} callback Callback executed when the text watcher
 	 * thinks that something might have changed.
+	 * @param {Number} [throttle=0] Throttle inverval, see {@link #throttle}.
 	 * @param {CKEDITOR.dom.range} callback.range The range representing the caret position.
 	 * @param {Object} [callback.return=null] Matching text data (`null` if nothing matches).
 	 * @param {String} callback.return.text The matching text.
 	 * @param {CKEDITOR.dom.range} callback.return.range Range in the DOM for the text that matches.
 	 */
-	function TextWatcher( editor, callback ) {
+	function TextWatcher( editor, callback, throttle ) {
 		/**
 		 * The editor instance which the text watcher watches.
 		 *
@@ -131,6 +132,26 @@
 		 * @private
 		 */
 		this._listeners = [];
+
+		/**
+		 * Indicates throttle threshold mitigating text checks.
+		 *
+		 * Higher levels of throttle threshold will create delay for text watcher checks
+		 * but also improve its performance.
+		 *
+		 * See {@link CKEDITOR.tools#throttle throttle} feature for more information.
+		 *
+		 * @readonly
+		 * @property {Number} [throttle=0]
+		 */
+		this.throttle = throttle || 0;
+
+		/**
+		 * {@link CKEDITOR.tools#throttle Throttle buffer} used to mitigate text checks.
+		 *
+		 * @private
+		 */
+		this._buffer = CKEDITOR.tools.throttle( this.throttle, check, this );
 
 		/**
 		 * Event fired when the text is no longer matching.
@@ -215,18 +236,7 @@
 				return;
 			}
 
-			var matched = this.callback( selectionRange );
-
-			if ( matched ) {
-				if ( matched.text == this.lastMatched ) {
-					return;
-				}
-
-				this.lastMatched = matched.text;
-				this.fire( 'matched', matched );
-			} else if ( this.lastMatched ) {
-				this.unmatch();
-			}
+			this._buffer.input( selectionRange );
 		},
 
 		/**
@@ -260,6 +270,21 @@
 			this._listeners = [];
 		}
 	};
+
+	function check( selectionRange ) {
+		var matched = this.callback( selectionRange );
+
+		if ( matched ) {
+			if ( matched.text == this.lastMatched ) {
+				return;
+			}
+
+			this.lastMatched = matched.text;
+			this.fire( 'matched', matched );
+		} else if ( this.lastMatched ) {
+			this.unmatch();
+		}
+	}
 
 	CKEDITOR.event.implementOn( TextWatcher.prototype );
 

--- a/plugins/textwatcher/plugin.js
+++ b/plugins/textwatcher/plugin.js
@@ -151,7 +151,7 @@
 		 *
 		 * @private
 		 */
-		this._buffer = CKEDITOR.tools.throttle( this.throttle, check, this );
+		this._buffer = CKEDITOR.tools.throttle( this.throttle, matchTextTestCallback, this );
 
 		/**
 		 * Event fired when the text is no longer matching.
@@ -167,6 +167,21 @@
 		 *
 		 * @event unmatched
 		 */
+
+		function matchTextTestCallback( selectionRange ) {
+			var matched = this.callback( selectionRange );
+
+			if ( matched ) {
+				if ( matched.text == this.lastMatched ) {
+					return;
+				}
+
+				this.lastMatched = matched.text;
+				this.fire( 'matched', matched );
+			} else if ( this.lastMatched ) {
+				this.unmatch();
+			}
+		}
 	}
 
 	TextWatcher.prototype = {
@@ -270,21 +285,6 @@
 			this._listeners = [];
 		}
 	};
-
-	function check( selectionRange ) {
-		var matched = this.callback( selectionRange );
-
-		if ( matched ) {
-			if ( matched.text == this.lastMatched ) {
-				return;
-			}
-
-			this.lastMatched = matched.text;
-			this.fire( 'matched', matched );
-		} else if ( this.lastMatched ) {
-			this.unmatch();
-		}
-	}
 
 	CKEDITOR.event.implementOn( TextWatcher.prototype );
 

--- a/plugins/textwatcher/plugin.js
+++ b/plugins/textwatcher/plugin.js
@@ -151,7 +151,7 @@
 		 *
 		 * @private
 		 */
-		this._buffer = CKEDITOR.tools.throttle( this.throttle, matchTextTestCallback, this );
+		this._buffer = CKEDITOR.tools.throttle( this.throttle, testTextMatch, this );
 
 		/**
 		 * Event fired when the text is no longer matching.
@@ -168,7 +168,7 @@
 		 * @event unmatched
 		 */
 
-		function matchTextTestCallback( selectionRange ) {
+		function testTextMatch( selectionRange ) {
 			var matched = this.callback( selectionRange );
 
 			if ( matched ) {

--- a/tests/plugins/autocomplete/autocomplete.js
+++ b/tests/plugins/autocomplete/autocomplete.js
@@ -5,7 +5,11 @@
 	'use strict';
 
 	bender.editors = {
-		standard: {},
+		standard: {
+			config: {
+				allowedContent: 'strong'
+			}
+		},
 		arrayKeystrokes: {
 			config: {
 				autocomplete_commitKeystrokes: [ 16 ] // SHIFT

--- a/tests/plugins/autocomplete/autocomplete.js
+++ b/tests/plugins/autocomplete/autocomplete.js
@@ -289,8 +289,11 @@
 			var editor = this.editors.standard,
 				ac = new CKEDITOR.plugins.autocomplete( editor, {
 					dataCallback: dataCallback,
-					textTestCallback: function() {
-						return { text: CKEDITOR.tools.getUniqueId() };
+					textTestCallback: function( selectionRange ) {
+						return {
+							text: CKEDITOR.tools.getUniqueId(),
+							range: selectionRange
+						};
 					},
 					throttle: 100
 				} ),
@@ -361,8 +364,8 @@
 			var editor = this.editors.standard,
 				editable = editor.editable(),
 				lastRangeRect = { left: 10, top: 10, height: 10 },
-				ac = new CKEDITOR.plugins.autocomplete( editor,
-					function() {
+				ac = new CKEDITOR.plugins.autocomplete( editor, {
+					textTestCallback: function() {
 						var range = editor.createRange(),
 							invalidRect = { top: 0, left: 0, height: 5 };
 
@@ -370,7 +373,8 @@
 
 						return { text: '@Annabelle', range: range };
 					},
-					dataCallback );
+					dataCallback: dataCallback
+				} );
 
 			this.editorBots.standard.setHtmlWithSelection( '@Annabelle^' );
 

--- a/tests/plugins/autocomplete/autocomplete.js
+++ b/tests/plugins/autocomplete/autocomplete.js
@@ -22,6 +22,11 @@
 		}
 	};
 
+	var configDefinition = {
+		textTestCallback: textTestCallback,
+		dataCallback: dataCallback
+	};
+
 	bender.test( {
 
 		'test API exists': function() {
@@ -32,7 +37,7 @@
 
 		'test esc key closes view': function() {
 			var editor = this.editors.standard,
-				ac = new CKEDITOR.plugins.autocomplete( editor, matchTestCallback, dataCallback );
+				ac = new CKEDITOR.plugins.autocomplete( editor, configDefinition );
 
 			this.editorBots.standard.setHtmlWithSelection( '' );
 
@@ -49,7 +54,7 @@
 
 		'test autocomplete starts with the first item selected': function() {
 			var editor = this.editors.standard,
-				ac = new CKEDITOR.plugins.autocomplete( editor, matchTestCallback, dataCallback );
+				ac = new CKEDITOR.plugins.autocomplete( editor, configDefinition );
 
 			this.editorBots.standard.setHtmlWithSelection( '' );
 
@@ -64,7 +69,7 @@
 		'test arrow down selects next item': function() {
 			var editor = this.editors.standard,
 				editable = editor.editable(),
-				ac = new CKEDITOR.plugins.autocomplete( editor, matchTestCallback, dataCallback );
+				ac = new CKEDITOR.plugins.autocomplete( editor, configDefinition );
 
 			this.editorBots.standard.setHtmlWithSelection( '' );
 
@@ -91,7 +96,7 @@
 		'test arrow up selects previous item': function() {
 			var editor = this.editors.standard,
 				editable = editor.editable(),
-				ac = new CKEDITOR.plugins.autocomplete( editor, matchTestCallback, dataCallback );
+				ac = new CKEDITOR.plugins.autocomplete( editor, configDefinition );
 
 			this.editorBots.standard.setHtmlWithSelection( '' );
 
@@ -123,7 +128,7 @@
 		'test enter inserts match': function() {
 			var editor = this.editors.standard,
 				editable = editor.editable(),
-				ac = new CKEDITOR.plugins.autocomplete( editor, matchTestCallback, dataCallback );
+				ac = new CKEDITOR.plugins.autocomplete( editor, configDefinition );
 
 			this.editorBots.standard.setHtmlWithSelection( '' );
 
@@ -139,7 +144,7 @@
 		'test tab inserts match': function() {
 			var editor = this.editors.standard,
 				editable = editor.editable(),
-				ac = new CKEDITOR.plugins.autocomplete( editor, matchTestCallback, dataCallback );
+				ac = new CKEDITOR.plugins.autocomplete( editor, configDefinition );
 
 			this.editorBots.standard.setHtmlWithSelection( '' );
 
@@ -155,7 +160,7 @@
 		'test custom autocomplete.commitKeystrokes value': function() {
 			var editor = this.editors.standard,
 				editable = editor.editable(),
-				ac = new CKEDITOR.plugins.autocomplete( editor, matchTestCallback, dataCallback );
+				ac = new CKEDITOR.plugins.autocomplete( editor, configDefinition );
 
 			this.editorBots.standard.setHtmlWithSelection( '' );
 
@@ -176,7 +181,7 @@
 		'test custom config.autocomplete_commitKeystrokes (array format)': function() {
 			var editor = this.editors.arrayKeystrokes,
 				editable = editor.editable(),
-				ac = new CKEDITOR.plugins.autocomplete( editor, matchTestCallback, dataCallback );
+				ac = new CKEDITOR.plugins.autocomplete( editor, configDefinition );
 
 			this.editorBots.arrayKeystrokes.setHtmlWithSelection( '' );
 
@@ -195,7 +200,7 @@
 		'test custom config.autocomplete_commitKeystrokes (primitive number)': function() {
 			var editor = this.editors.singleKeystroke,
 				editable = editor.editable(),
-				ac = new CKEDITOR.plugins.autocomplete( editor, matchTestCallback, dataCallback );
+				ac = new CKEDITOR.plugins.autocomplete( editor, configDefinition );
 
 			this.editorBots.singleKeystroke.setHtmlWithSelection( '' );
 
@@ -213,7 +218,7 @@
 
 		'test click inserts match': function() {
 			var editor = this.editors.standard,
-				ac = new CKEDITOR.plugins.autocomplete( editor, matchTestCallback, dataCallback );
+				ac = new CKEDITOR.plugins.autocomplete( editor, configDefinition );
 
 			this.editorBots.standard.setHtmlWithSelection( '' );
 
@@ -234,7 +239,7 @@
 				assert.ignore();
 			}
 
-			var ac = new CKEDITOR.plugins.autocomplete( editor, matchTestCallback, dataCallback );
+			var ac = new CKEDITOR.plugins.autocomplete( editor, configDefinition );
 
 			this.editorBots.standard.setHtmlWithSelection( '' );
 
@@ -367,7 +372,7 @@
 		}
 	}
 
-	function matchTestCallback( selectionRange ) {
+	function textTestCallback( selectionRange ) {
 		return { text: 'text', range: selectionRange };
 	}
 

--- a/tests/plugins/autocomplete/manual/__template__.html
+++ b/tests/plugins/autocomplete/manual/__template__.html
@@ -20,7 +20,10 @@
 		extraPlugins: 'textmatch',
 		on: {
 			instanceReady: function( evt ) {
-				new CKEDITOR.plugins.autocomplete( evt.editor, autocompleteUtils.getTextTestCallback(), autocompleteUtils.getDataCallback() );
+				new CKEDITOR.plugins.autocomplete( evt.editor, {
+					textTestCallback: autocompleteUtils.getTextTestCallback(),
+					dataCallback: autocompleteUtils.getDataCallback()
+				} );
 			}
 		}
 	} );

--- a/tests/plugins/autocomplete/manual/outputtemplate.html
+++ b/tests/plugins/autocomplete/manual/outputtemplate.html
@@ -9,30 +9,12 @@
 		width: 600,
 		on: {
 			instanceReady: function( evt ) {
-				var template = '<strong>{name}</strong>';
-				new CKEDITOR.plugins.autocomplete( evt.editor, getTextTestCallback(), dataCallback, null, template );
+				new CKEDITOR.plugins.autocomplete( evt.editor, {
+					textTestCallback: autocompleteUtils.getTextTestCallback(),
+					dataCallback: autocompleteUtils.getDataCallback(),
+					outputTemplate: '<strong>{name}</strong>'
+				} );
 			}
 		}
 	} );
-
-	function getTextTestCallback() {
-		return function( range ) {
-			return CKEDITOR.plugins.textMatch.match( range, matchCallback );
-		};
-	}
-
-	function matchCallback( text, offset ) {
-		var left = text.slice( 0, offset ),
-			match = left.match( new RegExp( '@\\w*$' ) );
-
-		if ( !match ) {
-			return null;
-		}
-
-		return { start: match.index, end: offset };
-	}
-
-	function dataCallback( query, range, callback ) {
-		callback( [ { id: 1, name: '@anna' } ] );
-	}
 </script>

--- a/tests/plugins/autocomplete/manual/outputtemplate.md
+++ b/tests/plugins/autocomplete/manual/outputtemplate.md
@@ -1,6 +1,7 @@
 @bender-tags: 4.10.0, bug, 1987
 @bender-ui: collapsed
 @bender-ckeditor-plugins: wysiwygarea, toolbar, basicstyles, autocomplete, textmatch
+@bender-include: _helpers/utils.js
 
 1. Focus the editor.
 1. Type `@`.

--- a/tests/plugins/autocomplete/manual/throttle.html
+++ b/tests/plugins/autocomplete/manual/throttle.html
@@ -10,43 +10,11 @@
 		on: {
 			instanceReady: function( evt ) {
 				new CKEDITOR.plugins.autocomplete( evt.editor, {
-					textTestCallback: getTextTestCallback(),
-					dataCallback: dataCallback,
+					textTestCallback: autocompleteUtils.getTextTestCallback(),
+					dataCallback: autocompleteUtils.getDataCallback(),
 					throttle: 3000
 				} );
 			}
 		}
 	} );
-
-	function getTextTestCallback() {
-		return function( range ) {
-			return CKEDITOR.plugins.textMatch.match( range, matchCallback );
-		};
-	}
-
-	function matchCallback( text, offset ) {
-		var left = text.slice( 0, offset ),
-			match = left.match( new RegExp( '@\\w*$' ) );
-
-		if ( !match ) {
-			return null;
-		}
-
-		return { start: match.index, end: offset };
-	}
-
-	function dataCallback( query, range, callback ) {
-		var data = [
-			{ id: 1, name: '@jack' },
-			{ id: 2, name: '@thomas' },
-			{ id: 3, name: '@anna' }
-		];
-
-		callback(
-			data.filter( function( item ) {
-				return item.name.indexOf( query ) === 0;
-			} )
-		);
-	}
-
 </script>

--- a/tests/plugins/autocomplete/manual/throttle.html
+++ b/tests/plugins/autocomplete/manual/throttle.html
@@ -1,0 +1,52 @@
+<div id="editor1" ></div>
+<script>
+
+	if( CKEDITOR.env.ie && CKEDITOR.env.version == 8 ) {
+		bender.ignore();
+	}
+
+	CKEDITOR.replace( 'editor1', {
+		width: 600,
+		on: {
+			instanceReady: function( evt ) {
+				new CKEDITOR.plugins.autocomplete( evt.editor, {
+					textTestCallback: getTextTestCallback(),
+					dataCallback: dataCallback,
+					throttle: 3000
+				} );
+			}
+		}
+	} );
+
+	function getTextTestCallback() {
+		return function( range ) {
+			return CKEDITOR.plugins.textMatch.match( range, matchCallback );
+		};
+	}
+
+	function matchCallback( text, offset ) {
+		var left = text.slice( 0, offset ),
+			match = left.match( new RegExp( '@\\w*$' ) );
+
+		if ( !match ) {
+			return null;
+		}
+
+		return { start: match.index, end: offset };
+	}
+
+	function dataCallback( query, range, callback ) {
+		var data = [
+			{ id: 1, name: '@jack' },
+			{ id: 2, name: '@thomas' },
+			{ id: 3, name: '@anna' }
+		];
+
+		callback(
+			data.filter( function( item ) {
+				return item.name.indexOf( query ) === 0;
+			} )
+		);
+	}
+
+</script>

--- a/tests/plugins/autocomplete/manual/throttle.md
+++ b/tests/plugins/autocomplete/manual/throttle.md
@@ -1,0 +1,17 @@
+@bender-tags: 4.10.0, bug, 1997
+@bender-ui: collapsed
+@bender-ckeditor-plugins: wysiwygarea, toolbar, basicstyles, autocomplete, textmatch
+
+1. Focus the editor.
+1. Type `@`.
+1. Wait until dropdown appear.
+1. Immediately type `a`.
+
+## Expected
+
+1. After `@` character dropdown should contain `'@anna', '@thomas', '@jack'` items and appear immediately.
+1. After `a` character dropdown should contain only `'@anna'` item and appear after 3000ms.
+
+## Unexpected
+
+Dropdown or items appears in invalid order or after invalid time intervals.

--- a/tests/plugins/autocomplete/manual/throttle.md
+++ b/tests/plugins/autocomplete/manual/throttle.md
@@ -1,6 +1,7 @@
 @bender-tags: 4.10.0, bug, 1997
 @bender-ui: collapsed
 @bender-ckeditor-plugins: wysiwygarea, toolbar, basicstyles, autocomplete, textmatch
+@bender-include: _helpers/utils.js
 
 1. Focus the editor.
 1. Type `@`.
@@ -9,7 +10,7 @@
 
 ## Expected
 
-1. After `@` character dropdown should contain `'@anna', '@thomas', '@jack'` items and appear immediately.
+1. After `@` character dropdown should contain multiple items and appear immediately.
 1. After `a` character dropdown should contain only `'@anna'` item and appear after 3000ms.
 
 ## Unexpected

--- a/tests/plugins/autocomplete/manual/throttle.md
+++ b/tests/plugins/autocomplete/manual/throttle.md
@@ -3,7 +3,8 @@
 @bender-ckeditor-plugins: wysiwygarea, toolbar, basicstyles, autocomplete, textmatch
 @bender-include: _helpers/utils.js
 
-1. Focus the editor.
+1. Read expected section before starting the test.
+1. Focus the editor using mouse.
 1. Type `@`.
 1. Wait until dropdown appear.
 1. Immediately type `a`.

--- a/tests/plugins/autocomplete/manual/viewposition.html
+++ b/tests/plugins/autocomplete/manual/viewposition.html
@@ -36,7 +36,10 @@
 		extraAllowedContent: 'p(filler)',
 		on: {
 			instanceReady: function( evt ) {
-				new CKEDITOR.plugins.autocomplete( evt.editor, autocompleteUtils.getTextTestCallback(), autocompleteUtils.getDataCallback() );
+				new CKEDITOR.plugins.autocomplete( evt.editor, {
+					textTestCallback: autocompleteUtils.getTextTestCallback(),
+					dataCallback: autocompleteUtils.getDataCallback()
+				} );
 			}
 		}
 	};

--- a/tests/plugins/autocomplete/manual/viewstart.html
+++ b/tests/plugins/autocomplete/manual/viewstart.html
@@ -11,10 +11,10 @@
 					{ id: 1, name: '@foo bar' }
 				];
 
-				new CKEDITOR.plugins.autocomplete( evt.editor,
-					autocompleteUtils.getTextTestCallback( { regex: '@[a-zA-Z ]*$' } ),
-					autocompleteUtils.getDataCallback( { data: data } )
-				);
+				new CKEDITOR.plugins.autocomplete( evt.editor, {
+					textTestCallback: autocompleteUtils.getTextTestCallback( { regex: '@[a-zA-Z ]*$' } ),
+					dataCallback: autocompleteUtils.getDataCallback( { data: data } )
+				});
 			}
 		}
 	} );

--- a/tests/plugins/autocomplete/manual/viewtemplate.html
+++ b/tests/plugins/autocomplete/manual/viewtemplate.html
@@ -9,42 +9,12 @@
 		width: 600,
 		on: {
 			instanceReady: function( evt ) {
-				var template = '<li data-id="{id}">item: <strong>{name}</strong></li>';
-				new CKEDITOR.plugins.autocomplete( evt.editor, getTextTestCallback(), dataCallback, template );
+				new CKEDITOR.plugins.autocomplete( evt.editor, {
+					textTestCallback: autocompleteUtils.getTextTestCallback(),
+					dataCallback: autocompleteUtils.getDataCallback(),
+					itemTemplate: '<li data-id="{id}">item: <strong>{name}</strong></li>'
+				} );
 			}
 		}
 	} );
-
-	function getTextTestCallback() {
-		return function( range ) {
-			return CKEDITOR.plugins.textMatch.match( range, matchCallback );
-		};
-	}
-
-	function matchCallback( text, offset ) {
-		var left = text.slice( 0, offset ),
-			match = left.match( new RegExp( '@\\w*$' ) );
-
-		if ( !match ) {
-			return null;
-		}
-
-		return {
-			start: match.index,
-			end: offset
-		};
-	}
-
-	function dataCallback( query, range, callback ) {
-		callback( [ {
-				id: 1,
-				name: 'anna'
-			},
-			{
-				id: 2,
-				name: 'john'
-			}
-		] );
-	}
-
 </script>

--- a/tests/plugins/autocomplete/manual/viewtemplate.md
+++ b/tests/plugins/autocomplete/manual/viewtemplate.md
@@ -1,6 +1,7 @@
 @bender-tags: 4.10.0, bug, 1987
 @bender-ui: collapsed
 @bender-ckeditor-plugins: wysiwygarea, toolbar, basicstyles, autocomplete, textmatch
+@bender-include: _helpers/utils.js
 
 1. Focus the editor.
 1. Type `@`.

--- a/tests/plugins/textwatcher/manual/throttle.html
+++ b/tests/plugins/textwatcher/manual/throttle.html
@@ -1,0 +1,26 @@
+<style>
+#logger {
+	height: 200px;
+	overflow-y: auto;
+}
+</style>
+<strong>Logger: </strong>
+<ul id="logger"></ul>
+<div id="editor1" ></div>
+
+<script>
+	var logger = document.getElementById( 'logger' ),
+		editor = CKEDITOR.replace( 'editor1', {
+		on: {
+			instanceReady: function() {
+				var textWatcher = new CKEDITOR.plugins.textWatcher( editor, function( selectionRange ) {
+					var match = document.createElement( 'li' );
+					match.innerText = selectionRange.startContainer.getText();
+					logger.appendChild( match );
+				}, 2000 );
+
+				textWatcher.attach();
+			}
+		}
+	} );
+</script>

--- a/tests/plugins/textwatcher/manual/throttle.html
+++ b/tests/plugins/textwatcher/manual/throttle.html
@@ -3,35 +3,57 @@
 	height: 200px;
 	overflow-y: auto;
 }
+
+#performance-msg {
+	position: absolute;
+	top: 20px;
+	border: 2px solid orange;
+	color: orange;
+	background: #111;
+	padding: 0.3em;
+	right: 150px;
+	display: none;
+}
 </style>
+<div id="performance-msg">
+	Your browser does not have
+	<var>performance.now()</var>
+	function. So you have to feel out the timings :(
+</div>
 <strong>Logger: </strong>
 <ul id="logger"></ul>
 <div id="editor1" ></div>
 
 <script>
 	var logger = document.getElementById( 'logger' ),
+		hasPerformance = window.performance && window.performance.now,
 		editor = CKEDITOR.replace( 'editor1', {
 		on: {
 			instanceReady: function() {
-				var counter = 0,
-					counterInterval = 100,
-
+				var lastTime = null,
 					textWatcher = new CKEDITOR.plugins.textWatcher( editor, function( selectionRange ) {
-					var matchEl = document.createElement( 'li' );
+						var now = hasPerformance ? performance.now() : null,
+							matchEl = document.createElement( 'li' );
 
-					matchEl.innerText = 'Time: ' + counter + 'ms, Text: ' + selectionRange.startContainer.getText();
-					logger.appendChild( matchEl );
+						if ( lastTime === null ) {
+							lastTime = now;
+						}
 
-					if ( counter == 0 ) {
-						setInterval( function() {
-							counter += counterInterval;
-						}, counterInterval );
-					}
+						matchEl.innerText = hasPerformance ? 'Delta: ' + ( now - lastTime ) + 'ms, ' : '';
+						matchEl.innerText += 'Text: ' + selectionRange.startContainer.getText();
+						logger.appendChild( matchEl );
 
-				}, 2000 );
+						lastTime = now;
+
+						// Throttling set slightly higher than expected due to https://github.com/ckeditor/ckeditor-dev/pull/2001#discussion_r194047585.
+					}, 2002 );
 
 				textWatcher.attach();
 			}
 		}
 	} );
+
+	if ( !hasPerformance ) {
+		CKEDITOR.document.getById( 'performance-msg' ).setStyle( 'display', 'block' );
+	}
 </script>

--- a/tests/plugins/textwatcher/manual/throttle.html
+++ b/tests/plugins/textwatcher/manual/throttle.html
@@ -13,10 +13,21 @@
 		editor = CKEDITOR.replace( 'editor1', {
 		on: {
 			instanceReady: function() {
-				var textWatcher = new CKEDITOR.plugins.textWatcher( editor, function( selectionRange ) {
-					var match = document.createElement( 'li' );
-					match.innerText = selectionRange.startContainer.getText();
-					logger.appendChild( match );
+				var counter = 0,
+					counterInterval = 100,
+
+					textWatcher = new CKEDITOR.plugins.textWatcher( editor, function( selectionRange ) {
+					var matchEl = document.createElement( 'li' );
+
+					matchEl.innerText = 'Time: ' + counter + 'ms, Text: ' + selectionRange.startContainer.getText();
+					logger.appendChild( matchEl );
+
+					if ( counter == 0 ) {
+						setInterval( function() {
+							counter += counterInterval;
+						}, counterInterval );
+					}
+
 				}, 2000 );
 
 				textWatcher.attach();

--- a/tests/plugins/textwatcher/manual/throttle.md
+++ b/tests/plugins/textwatcher/manual/throttle.md
@@ -1,0 +1,18 @@
+@bender-tags: 4.10.0, feature, 1997
+@bender-ui: collapsed
+@bender-ckeditor-plugins: wysiwygarea, toolbar, basicstyles, textwatcher
+
+1. Focus the editor.
+1. Start typing `a` constantly.
+1. Check log above the editor. 
+
+## Expected
+
+Typed text should be logged:
+1. Immediately after first typed character.
+1. After 2000ms intervals.
+
+
+## Unexpected
+
+Typed text is logged immediately or in invalid interval times.

--- a/tests/plugins/textwatcher/manual/throttle.md
+++ b/tests/plugins/textwatcher/manual/throttle.md
@@ -10,9 +10,11 @@
 
 Typed text should be logged:
 1. Immediately after first typed character.
-1. After 2000ms intervals.
-
+1. Not more often than once every 2000ms.
 
 ## Unexpected
 
 Typed text is logged immediately or in invalid interval times.
+
+
+***Other details*** Measured time by logger can have slight error +/- 100ms.

--- a/tests/plugins/textwatcher/manual/throttle.md
+++ b/tests/plugins/textwatcher/manual/throttle.md
@@ -16,5 +16,4 @@ Typed text should be logged:
 
 Typed text is logged immediately or in invalid interval times.
 
-
 ***Other details*** Measured time by logger can have slight error +/- 100ms.

--- a/tests/plugins/textwatcher/manual/throttle.md
+++ b/tests/plugins/textwatcher/manual/throttle.md
@@ -4,16 +4,15 @@
 
 1. Focus the editor.
 1. Start typing `a` constantly.
-1. Check log above the editor. 
+1. Check log above the editor.
 
 ## Expected
 
 Typed text should be logged:
+
 1. Immediately after first typed character.
 1. Not more often than once every 2000ms.
 
 ## Unexpected
 
 Typed text is logged immediately or in invalid interval times.
-
-***Other details*** Measured time by logger can have slight error +/- 100ms.

--- a/tests/plugins/textwatcher/textwatcher.js
+++ b/tests/plugins/textwatcher/textwatcher.js
@@ -202,12 +202,43 @@
 			textMatcher.check( {} );
 
 			assert.isTrue( spy.calledOnce );
+		},
+
+		// (#1997)
+		'test throttle': function() {
+			var editor = this.editor, bot = this.editorBot,
+				textWatcher = attachTextWatcher( editor, function() {
+					return {
+						text: 'test'
+					};
+				}, 100 ),
+				callbackSpy = sinon.spy( textWatcher, 'callback' );
+
+			bot.setHtmlWithSelection( 'Lorem ipsum dolor ^sit amet, consectetur.' );
+
+			textWatcher.lastMatched = 'changed first time';
+			textWatcher.check( {} );
+			assert.isTrue( callbackSpy.calledOnce );
+
+			textWatcher.lastMatched = 'changed second time';
+			textWatcher.check( {} );
+			assert.isTrue( callbackSpy.calledOnce );
+
+			setTimeout( function() {
+				resume( function() {
+					textWatcher.lastMatched = 'changed third time';
+					textWatcher.check( {} );
+					assert.isTrue( callbackSpy.calledTwice );
+				} );
+			}, 100 );
+
+			wait();
 		}
 
 	} );
 
-	function attachTextWatcher( editor, callback ) {
-		return new CKEDITOR.plugins.textWatcher( editor, callback || function() {} ).attach();
+	function attachTextWatcher( editor, callback, throttle ) {
+		return new CKEDITOR.plugins.textWatcher( editor, callback || function() {}, throttle ).attach();
 	}
 
 	function getKeyEvent( keyName, keyCode ) {


### PR DESCRIPTION
## What is the purpose of this pull request?

New feature

## Does your PR contain necessary tests?

All patches which change the editor code must include tests. You can always read more
on [PR testing](https://docs.ckeditor.com/ckeditor4/docs/#!/guide/dev_contributing_code-section-tests),
[how to set the testing environment](https://docs.ckeditor.com/ckeditor4/docs/#!/guide/dev_tests) and
[how to create tests](https://docs.ckeditor.com/ckeditor4/docs/#!/guide/dev_tests-section-creating-your-own-test)
in the official CKEditor documentation.

### This PR contains

- [x] Unit tests
- [x] Manual tests

## What changes did you make?

Implemented throttle feature inside `textwatcher` / `autocomplete` plugins. Refactored `autocomplete` constructor to use `CKEDITOR.plugins.autocomplete.configDefinition` abstract class.

Based on #1993 (PR #1996).

Closes #1997 
