### PR TITLE
Excluded movement keys from textwatcher

### DIFF
--- a/plugins/textwatcher/plugin.js
+++ b/plugins/textwatcher/plugin.js
@@ -114,7 +114,13 @@
 			16, // Shift
 			17, // Ctrl
 			18, // Alt
-			91 // Cmd
+			91, // Cmd
+			35, // End
+			36, // Home
+			37, // Left
+			38, // Up
+			39, // Right
+			40 // Down
 		];
 
 		/**

--- a/tests/plugins/textwatcher/manual/movementkeys.html
+++ b/tests/plugins/textwatcher/manual/movementkeys.html
@@ -1,0 +1,31 @@
+<style>
+#logger {
+	height: 80px;
+	overflow-y: auto;
+	color: red;
+}
+</style>
+<strong>Logger: </strong>
+<ul id="logger"></ul>
+<div id="editor1" >
+	<p>@</p>
+	<p>@</p>
+	<p>@</p>
+</div>
+
+<script>
+	var logger = document.getElementById( 'logger' ),
+		editor = CKEDITOR.replace( 'editor1', {
+			on: {
+				instanceReady: function() {
+					var textWatcher = new CKEDITOR.plugins.textWatcher( editor, function( selectionRange ) {
+						var match = document.createElement( 'li' );
+						match.innerText = 'Check logged! The test failed!';
+						logger.appendChild( match );
+					} );
+
+					textWatcher.attach();
+				}
+			}
+		} );
+</script>

--- a/tests/plugins/textwatcher/manual/movementkeys.md
+++ b/tests/plugins/textwatcher/manual/movementkeys.md
@@ -8,11 +8,11 @@
 
 **Movement keys:** 
 
-* `arrowLeft` 
-* `arrowRight` 
-* `arrowUp` 
-* `arrowDown` 
-* `end` 
+* `arrowLeft`
+* `arrowRight`
+* `arrowUp`
+* `arrowDown`
+* `end`
 * `home`
 
 ## Expected

--- a/tests/plugins/textwatcher/manual/movementkeys.md
+++ b/tests/plugins/textwatcher/manual/movementkeys.md
@@ -1,0 +1,26 @@
+@bender-tags: 4.10.0, bug, 2018
+@bender-ui: collapsed
+@bender-ckeditor-plugins: wysiwygarea, toolbar, basicstyles, textwatcher
+
+1. Focus the editor.
+1. Use all of the listed movement keys to change cursor position inside editor between `@` characters. Repeat with modifier keys `cmd`, `ctrl`, `option` e.g. `ctrl+leftArrow`.
+1. See history output (above the editor).
+
+**Movement keys:** 
+
+* `arrowLeft` 
+* `arrowRight` 
+* `arrowUp` 
+* `arrowDown` 
+* `end` 
+* `home`
+
+## Expected
+
+No `textwatcher` checks logged inside history output.
+
+## Unexpected
+
+Any `textwatcher` check logged into history output.
+
+***Other details*** If you use different keys than listed above the editor you may see logged checks inside history output.

--- a/tests/plugins/textwatcher/textwatcher.js
+++ b/tests/plugins/textwatcher/textwatcher.js
@@ -133,6 +133,12 @@
 			textMatcher.check( getKeyEvent( keyName, 17 ) ); // Ctrl
 			textMatcher.check( getKeyEvent( keyName, 18 ) ); // Alt
 			textMatcher.check( getKeyEvent( keyName, 91 ) ); // Cmd
+			textMatcher.check( getKeyEvent( keyName, 35 ) ); // End
+			textMatcher.check( getKeyEvent( keyName, 36 ) ); // Home
+			textMatcher.check( getKeyEvent( keyName, 37 ) ); // Left
+			textMatcher.check( getKeyEvent( keyName, 38 ) ); // Up
+			textMatcher.check( getKeyEvent( keyName, 39 ) ); // Right
+			textMatcher.check( getKeyEvent( keyName, 40 ) ); // Down
 
 			assert.isTrue( callbackSpy.notCalled );
 		},


### PR DESCRIPTION
## What is the purpose of this pull request?

Bug fix

## Does your PR contain necessary tests?

All patches which change the editor code must include tests. You can always read more
on [PR testing](https://docs.ckeditor.com/ckeditor4/docs/#!/guide/dev_contributing_code-section-tests),
[how to set the testing environment](https://docs.ckeditor.com/ckeditor4/docs/#!/guide/dev_tests) and
[how to create tests](https://docs.ckeditor.com/ckeditor4/docs/#!/guide/dev_tests-section-creating-your-own-test)
in the official CKEditor documentation.

### This PR contains

- [x] Unit tests
- [x] Manual tests

## What changes did you make?

Movement keys i.e end, home, arrows are no longer included into `textwatcher` checks.

Closes #2018