### PR TITLE
Autocomplete dropdown position is now static when typing text

### DIFF
--- a/plugins/autocomplete/plugin.js
+++ b/plugins/autocomplete/plugin.js
@@ -908,8 +908,6 @@
 		 * @param {CKEDITOR.dom.range} range The range of text match.
 		 */
 		updatePosition: function( range ) {
-			range = range.clone();
-
 			this.setPosition( this.getViewPosition( range ) );
 		}
 	};

--- a/plugins/autocomplete/plugin.js
+++ b/plugins/autocomplete/plugin.js
@@ -672,21 +672,21 @@
 		},
 
 		/**
-		 * Returns the view position relative to the panel's offset parent.
+		 * Returns the view position based on a given `range`.
 		 *
 		 * Indicates the start position of the autocomplete dropdown.
 		 * The value returned by this function is passed to the {@link #setPosition} method
 		 * by the {@link #updatePosition} method.
 		 *
 		 * @param {CKEDITOR.dom.range} range The range of text match.
-		 * @returns {Object} Represents the position of the caret.
+		 * @returns {Object} Represents the position of the caret. The value is relative to the panel's offset parent.
 		 * @returns {Number} rect.left
 		 * @returns {Number} rect.top
 		 * @returns {Number} rect.bottom
 		 */
 		getViewPosition: function( range ) {
 			// Use the last rect so the view will be
-			// correctly positioned with a word splitted into few lines.
+			// correctly positioned with a word split into few lines.
 			var rects = range.getClientRects(),
 				viewPositionRect = rects[ rects.length - 1 ],
 				offset,

--- a/plugins/autocomplete/plugin.js
+++ b/plugins/autocomplete/plugin.js
@@ -685,7 +685,10 @@
 		 * @returns {Number} rect.bottom
 		 */
 		getViewPosition: function( range ) {
-			var viewPositionRect = range.getClientRects()[ 0 ],
+			// Use the last rect so the view will be
+			// correctly positioned with a word splitted into few lines.
+			var rects = range.getClientRects(),
+				viewPositionRect = rects[ rects.length - 1 ],
 				offset,
 				editable = this.editor.editable();
 
@@ -906,7 +909,6 @@
 		 */
 		updatePosition: function( range ) {
 			range = range.clone();
-			range.collapse( true );
 
 			this.setPosition( this.getViewPosition( range ) );
 		}

--- a/plugins/autocomplete/plugin.js
+++ b/plugins/autocomplete/plugin.js
@@ -117,8 +117,8 @@
 	 *			// Change the positioning of the panel, so it is stretched
 	 *			// to 100% of the editor container width and is positioned
 	 *			// relative to the editor container.
-	 *			CustomView.prototype.updatePosition = function() {
-	 *				var caretRect = this.getCaretRect(),
+	 *			CustomView.prototype.updatePosition = function( range ) {
+	 *				var caretRect = this.getViewStartPosition( range ),
 	 *					container = this.editor.container;
 	 *
 	 *				this.setPosition( {
@@ -672,18 +672,20 @@
 		},
 
 		/**
-		 * Returns the caret position relative to the panel's offset parent.
+		 * Returns the view position relative to the panel's offset parent.
+		 *
+		 * Indicates the start position of the autocomplete dropdown.
 		 * The value returned by this function is passed to the {@link #setPosition} method
 		 * by the {@link #updatePosition} method.
 		 *
+		 * @param {CKEDITOR.dom.range} range The range of text match.
 		 * @returns {Object} Represents the position of the caret.
 		 * @returns {Number} rect.left
 		 * @returns {Number} rect.top
 		 * @returns {Number} rect.bottom
 		 */
-		getCaretRect: function( range ) {
-			var caretClientRect = range
-				.getClientRects()[ 0 ],
+		getViewStartPosition: function( range ) {
+			var viewPositionRect = range.getClientRects()[ 0 ],
 				offset,
 				editable = this.editor.editable();
 
@@ -706,9 +708,9 @@
 			offset.y -= offsetCorrection.y;
 
 			return {
-				top: ( caretClientRect.top + offset.y ),
-				bottom: ( caretClientRect.top + caretClientRect.height + offset.y ),
-				left: ( caretClientRect.left + offset.x )
+				top: ( viewPositionRect.top + offset.y ),
+				bottom: ( viewPositionRect.top + viewPositionRect.height + offset.y ),
+				left: ( viewPositionRect.left + offset.x )
 			};
 		},
 
@@ -904,7 +906,7 @@
 			range = range.clone();
 			range.collapse( true );
 
-			this.setPosition( this.getCaretRect( range ) );
+			this.setPosition( this.getViewStartPosition( range ) );
 		}
 	};
 

--- a/plugins/autocomplete/plugin.js
+++ b/plugins/autocomplete/plugin.js
@@ -404,7 +404,7 @@
 				this.model.setActive( true );
 				this.view.open();
 				this.model.selectFirst();
-				this.view.updatePosition();
+				this.view.updatePosition( this.model.range );
 			}
 		},
 
@@ -416,7 +416,7 @@
 		 */
 		onChange: function() {
 			if ( this.model.isActive ) {
-				this.view.updatePosition();
+				this.view.updatePosition( this.model.range );
 			}
 		},
 
@@ -681,9 +681,8 @@
 		 * @returns {Number} rect.top
 		 * @returns {Number} rect.bottom
 		 */
-		getCaretRect: function() {
-			var caretClientRect = this.editor.getSelection()
-				.getRanges()[ 0 ]
+		getCaretRect: function( range ) {
+			var caretClientRect = range
 				.getClientRects()[ 0 ],
 				offset,
 				editable = this.editor.editable();
@@ -901,8 +900,11 @@
 		 * {@link #setPosition} to move the panel to the best position close
 		 * to the caret.
 		 */
-		updatePosition: function() {
-			this.setPosition( this.getCaretRect() );
+		updatePosition: function( range ) {
+			range = range.clone();
+			range.collapse( true );
+
+			this.setPosition( this.getCaretRect( range ) );
 		}
 	};
 

--- a/plugins/autocomplete/plugin.js
+++ b/plugins/autocomplete/plugin.js
@@ -118,7 +118,7 @@
 	 *			// to 100% of the editor container width and is positioned
 	 *			// relative to the editor container.
 	 *			CustomView.prototype.updatePosition = function( range ) {
-	 *				var caretRect = this.getViewStartPosition( range ),
+	 *				var caretRect = this.getViewPosition( range ),
 	 *					container = this.editor.container;
 	 *
 	 *				this.setPosition( {
@@ -684,7 +684,7 @@
 		 * @returns {Number} rect.top
 		 * @returns {Number} rect.bottom
 		 */
-		getViewStartPosition: function( range ) {
+		getViewPosition: function( range ) {
 			var viewPositionRect = range.getClientRects()[ 0 ],
 				offset,
 				editable = this.editor.editable();
@@ -901,12 +901,14 @@
 		 * By default this method finds the position of the caret and uses
 		 * {@link #setPosition} to move the panel to the best position close
 		 * to the caret.
+		 *
+		 * @param {CKEDITOR.dom.range} range The range of text match.
 		 */
 		updatePosition: function( range ) {
 			range = range.clone();
 			range.collapse( true );
 
-			this.setPosition( this.getViewStartPosition( range ) );
+			this.setPosition( this.getViewPosition( range ) );
 		}
 	};
 

--- a/plugins/autocomplete/samples/customview.html
+++ b/plugins/autocomplete/samples/customview.html
@@ -104,7 +104,7 @@ For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-oss-license
 				// to 100% of the editor container width and is positioned
 				// according to the editor container.
 				CustomView.prototype.updatePosition = function( range ) {
-					var caretRect = this.getViewStartPosition( range ),
+					var caretRect = this.getViewPosition( range ),
 						container = this.editor.container;
 
 					this.setPosition( {

--- a/plugins/autocomplete/samples/customview.html
+++ b/plugins/autocomplete/samples/customview.html
@@ -103,8 +103,8 @@ For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-oss-license
 				// Change the positioning of the panel, so it is stretched
 				// to 100% of the editor container width and is positioned
 				// according to the editor container.
-				CustomView.prototype.updatePosition = function() {
-					var caretRect = this.getCaretRect(),
+				CustomView.prototype.updatePosition = function( range ) {
+					var caretRect = this.getViewStartPosition( range ),
 						container = this.editor.container;
 
 					this.setPosition( {

--- a/tests/plugins/autocomplete/autocomplete.js
+++ b/tests/plugins/autocomplete/autocomplete.js
@@ -325,13 +325,13 @@
 		'test view position starts from the beginning of the match': function() {
 			var editor = this.editors.standard,
 				editable = editor.editable(),
-				expectedRect = { left: 10, top: 10, height: 10 },
+				lastRangeRect = { left: 10, top: 10, height: 10 },
 				ac = new CKEDITOR.plugins.autocomplete( editor,
 					function() {
 						var range = editor.createRange(),
-							invalidRect = { top: 999, left: 999, height: 10 };
+							invalidRect = { top: 0, left: 0, height: 5 };
 
-						sinon.stub( range, 'getClientRects' ).returns( [ invalidRect, invalidRect, expectedRect ] );
+						sinon.stub( range, 'getClientRects' ).returns( [ invalidRect, invalidRect, lastRangeRect ] );
 
 						return { text: '@Annabelle', range: range };
 					},
@@ -345,13 +345,13 @@
 				offset = 3;
 
 			assert.isNumberInRange( viewRect.left,
-				expectedRect.left - offset,
-				expectedRect.left + offset,
+				lastRangeRect.left - offset,
+				lastRangeRect.left + offset,
 				'Horizontal position.' );
 
 			assert.isNumberInRange( viewRect.top,
-				expectedRect.top + expectedRect.height - offset,
-				expectedRect.top + expectedRect.height + offset,
+				lastRangeRect.top + lastRangeRect.height - offset,
+				lastRangeRect.top + lastRangeRect.height + offset,
 				'Vertical position.' );
 
 			ac.destroy();

--- a/tests/plugins/autocomplete/manual/_helpers/utils.js
+++ b/tests/plugins/autocomplete/manual/_helpers/utils.js
@@ -16,14 +16,15 @@
 	];
 
 	window.autocompleteUtils = {
-		getTextTestCallback: function() {
+		getTextTestCallback: function( config ) {
+			config = config || {};
 			return function( range ) {
 				return CKEDITOR.plugins.textMatch.match( range, matchCallback );
 			};
 
 			function matchCallback( text, offset ) {
 				var left = text.slice( 0, offset ),
-					match = left.match( new RegExp( '@\\w*$' ) );
+					match = left.match( new RegExp( config.regex || '@\\w*$' ) );
 
 				if ( !match ) {
 					return null;
@@ -34,9 +35,12 @@
 		},
 
 		getDataCallback: function( config ) {
+			var dataSource = config.data || DATA;
+
 			config = config || {};
+
 			return function( query, range, callback ) {
-				var data = DATA.filter( function( item ) {
+				var data = dataSource.filter( function( item ) {
 					return item.name.indexOf( query.toLowerCase() ) == 0;
 				} );
 

--- a/tests/plugins/autocomplete/manual/viewstart.html
+++ b/tests/plugins/autocomplete/manual/viewstart.html
@@ -8,8 +8,7 @@
 		on: {
 			instanceReady: function( evt ) {
 				var data = [
-					{ id: 1, name: '@anna' },
-					{ id: 2, name: '@foo bar' }
+					{ id: 1, name: '@foo bar' }
 				];
 
 				new CKEDITOR.plugins.autocomplete( evt.editor,

--- a/tests/plugins/autocomplete/manual/viewstart.html
+++ b/tests/plugins/autocomplete/manual/viewstart.html
@@ -1,0 +1,22 @@
+<div id="editor">
+		Adipisicing aliquid dolorem repudiandae voluptate nihil. Eos est iste fugit doloribus dolore.
+</div>
+
+<script>
+	CKEDITOR.replace( 'editor', {
+		width: 600,
+		on: {
+			instanceReady: function( evt ) {
+				var data = [
+					{ id: 1, name: '@anna' },
+					{ id: 2, name: '@foo bar' }
+				];
+
+				new CKEDITOR.plugins.autocomplete( evt.editor,
+					autocompleteUtils.getTextTestCallback( { regex: '@[a-zA-Z ]*$' } ),
+					autocompleteUtils.getDataCallback( { data: data } )
+				);
+			}
+		}
+	} );
+</script>

--- a/tests/plugins/autocomplete/manual/viewstart.md
+++ b/tests/plugins/autocomplete/manual/viewstart.md
@@ -1,0 +1,14 @@
+@bender-tags: 4.10.0, bug, 1970
+@bender-ui: collapsed
+@bender-ckeditor-plugins: wysiwygarea, toolbar, basicstyles, autocomplete, textmatch
+
+1. Focus the editor.
+1. Type `@anna`.
+
+## Expected
+
+View should be placed at the beginning of the typed text.
+
+## Unexpected
+
+View is placed at the end of the typed text.

--- a/tests/plugins/autocomplete/manual/viewstart.md
+++ b/tests/plugins/autocomplete/manual/viewstart.md
@@ -1,6 +1,7 @@
 @bender-tags: 4.10.0, bug, 1970
 @bender-ui: collapsed
 @bender-ckeditor-plugins: wysiwygarea, toolbar, basicstyles, autocomplete, textmatch
+@bender-include: _helpers/utils.js
 
 1. Focus the editor.
 1. Type `@anna`.

--- a/tests/plugins/autocomplete/manual/viewstart.md
+++ b/tests/plugins/autocomplete/manual/viewstart.md
@@ -6,7 +6,7 @@
 # Single word
 
 1. Focus the editor.
-1. Type `@anna`.
+1. Type `@foo`.
 
 ## Expected
 

--- a/tests/plugins/autocomplete/manual/viewstart.md
+++ b/tests/plugins/autocomplete/manual/viewstart.md
@@ -3,13 +3,37 @@
 @bender-ckeditor-plugins: wysiwygarea, toolbar, basicstyles, autocomplete, textmatch
 @bender-include: _helpers/utils.js
 
+# Single word
+
 1. Focus the editor.
 1. Type `@anna`.
 
 ## Expected
 
-View should be placed at the beginning of the typed text.
+View should be placed at the beginning of the word.
 
 ## Unexpected
 
-View is placed at the end of the typed text.
+View is placed at the end of the word.
+
+# Splitted word
+
+1. Focus the editor.
+1. Type `@foo bar` where both words are in different lines e.g.
+
+```
++-----------------------+
+|                       |
+|      text start - @foo|
+| bar█ - caret position |
+|                       |
++-----------------------+
+```
+
+## Expected
+
+View should be placed at the beginning of the second word.
+
+## Unexpected
+
+View is placed at the end of the second word.

--- a/tests/plugins/autocomplete/view.js
+++ b/tests/plugins/autocomplete/view.js
@@ -217,7 +217,7 @@
 
 		view.append();
 
-		var caretRect = view.getCaretRect();
+		var caretRect = view.getViewStartPosition( editor.getSelection().getRanges()[ 0 ] );
 
 		getClientRectsStub.restore();
 		offsetStub.restore();

--- a/tests/plugins/autocomplete/view.js
+++ b/tests/plugins/autocomplete/view.js
@@ -217,7 +217,7 @@
 
 		view.append();
 
-		var caretRect = view.getViewStartPosition( editor.getSelection().getRanges()[ 0 ] );
+		var caretRect = view.getViewPosition( editor.getSelection().getRanges()[ 0 ] );
 
 		getClientRectsStub.restore();
 		offsetStub.restore();


### PR DESCRIPTION
## What is the purpose of this pull request?

Bug fix

## Does your PR contain necessary tests?

All patches which change the editor code must include tests. You can always read more
on [PR testing](https://docs.ckeditor.com/ckeditor4/docs/#!/guide/dev_contributing_code-section-tests),
[how to set the testing environment](https://docs.ckeditor.com/ckeditor4/docs/#!/guide/dev_tests) and
[how to create tests](https://docs.ckeditor.com/ckeditor4/docs/#!/guide/dev_tests-section-creating-your-own-test)
in the official CKEditor documentation.

### This PR contains

- [x] Unit tests (existing unit tests for view positioning)
- [x] Manual tests

## What changes did you make?

Refactored `autocomplete.view.getCaretRect` function to use the beginning of a typed word as a view starting position.

I tried to write some more integration test for text typing. However, I wasn't able to reproduce changing selection on typing. If you think we need additional integration test besides existing unit tests and manual test I will spend some more time on it. Any hints are welcome :)

Closes #1970
