### PR TITLE
Fixed opening autocomplete view on unmatch

### DIFF
--- a/plugins/autocomplete/plugin.js
+++ b/plugins/autocomplete/plugin.js
@@ -516,6 +516,10 @@
 		 * @param {CKEDITOR.eventInfo} evt
 		 */
 		onTextUnmatched: function() {
+			// Remove query and request id to avoid opening view for invalid callback (#1984).
+			this.model.query = null;
+			this.model.lastRequestId = null;
+
 			this.close();
 		}
 	};

--- a/tests/plugins/autocomplete/autocomplete.js
+++ b/tests/plugins/autocomplete/autocomplete.js
@@ -66,6 +66,7 @@
 			ac.destroy();
 		},
 
+		// (#2031)
 		'test mouseover changes selected item': function() {
 			var editor = this.editors.standard,
 				ac = new CKEDITOR.plugins.autocomplete( editor, configDefinition );
@@ -86,6 +87,37 @@
 			assert.isTrue( target.hasClass( 'cke_autocomplete_selected' ) );
 
 			ac.destroy();
+		},
+
+		// (#1984)
+		'test view is not opened after unmatch': function() {
+			var editor = this.editors.standard,
+				ac = new CKEDITOR.plugins.autocomplete( editor, matchTestCallback, function( query, range, callback ) {
+
+					setTimeout( function() {
+						callback( [ { id: 1, name: 'test' } ] );
+					}, 100 );
+
+				} );
+
+			this.editorBots.standard.setHtmlWithSelection( 'foo' );
+
+			editor.editable().fire( 'keyup', new CKEDITOR.dom.event( {} ) );
+
+			ac.textWatcher.fire( 'unmatched' );
+
+			setTimeout( function() {
+
+				resume( function() {
+					assertViewOpened( ac, false );
+					assert.isNull( ac.model.data );
+
+					ac.destroy();
+				} );
+
+			}, 150 );
+
+			wait();
 		},
 
 		'test arrow down selects next item': function() {

--- a/tests/plugins/autocomplete/autocomplete.js
+++ b/tests/plugins/autocomplete/autocomplete.js
@@ -92,12 +92,13 @@
 		// (#1984)
 		'test view is not opened after unmatch': function() {
 			var editor = this.editors.standard,
-				ac = new CKEDITOR.plugins.autocomplete( editor, matchTestCallback, function( query, range, callback ) {
-
-					setTimeout( function() {
-						callback( [ { id: 1, name: 'test' } ] );
-					}, 100 );
-
+				ac = new CKEDITOR.plugins.autocomplete( editor, {
+					textTestCallback: textTestCallback,
+					dataCallback: function( query, range, callback ) {
+						setTimeout( function() {
+							callback( [ { id: 1, name: 'test' } ] );
+						}, 100 );
+					}
 				} );
 
 			this.editorBots.standard.setHtmlWithSelection( 'foo' );

--- a/tests/plugins/autocomplete/manual/callbackcleaning.html
+++ b/tests/plugins/autocomplete/manual/callbackcleaning.html
@@ -1,8 +1,12 @@
 <div id="editor" ></div>
 
 <script>
-	CKEDITOR.replace( 'editor', {
 
+	if( CKEDITOR.env.ie && CKEDITOR.env.version == 8 ) {
+		bender.ignore();
+	}
+
+	CKEDITOR.replace( 'editor', {
 		on: {
 			instanceReady: function( evt ) {
 				new CKEDITOR.plugins.autocomplete( evt.editor,
@@ -12,4 +16,5 @@
 		}
 
 	} );
+
 </script>

--- a/tests/plugins/autocomplete/manual/callbackcleaning.html
+++ b/tests/plugins/autocomplete/manual/callbackcleaning.html
@@ -1,0 +1,15 @@
+<div id="editor" ></div>
+
+<script>
+	CKEDITOR.replace( 'editor', {
+
+		on: {
+			instanceReady: function( evt ) {
+				new CKEDITOR.plugins.autocomplete( evt.editor,
+					autocompleteUtils.getTextTestCallback(),
+					autocompleteUtils.getDataCallback( { async: 3000 } ) );
+			}
+		}
+
+	} );
+</script>

--- a/tests/plugins/autocomplete/manual/callbackcleaning.html
+++ b/tests/plugins/autocomplete/manual/callbackcleaning.html
@@ -9,9 +9,10 @@
 	CKEDITOR.replace( 'editor', {
 		on: {
 			instanceReady: function( evt ) {
-				new CKEDITOR.plugins.autocomplete( evt.editor,
-					autocompleteUtils.getTextTestCallback(),
-					autocompleteUtils.getDataCallback( { async: 3000 } ) );
+				new CKEDITOR.plugins.autocomplete( evt.editor, {
+					textTestCallback: autocompleteUtils.getTextTestCallback(),
+					dataCallback: autocompleteUtils.getDataCallback( { async: 3000 } )
+				} );
 			}
 		}
 

--- a/tests/plugins/autocomplete/manual/callbackcleaning.md
+++ b/tests/plugins/autocomplete/manual/callbackcleaning.md
@@ -1,0 +1,17 @@
+@bender-tags: 4.10.0, bug, 1984
+@bender-ui: collapsed
+@bender-ckeditor-plugins: wysiwygarea, toolbar, basicstyles, autocomplete, textmatch
+@bender-include: _helpers/utils.js
+
+1. Focus the editor.
+1. Type `@`.
+1. Immediately delete `@` using `backspace`key.
+1. Wait 3 seconds.
+
+## Expected
+
+Nothing happened.
+
+## Unexpedted
+
+After 3 seconds dropdown showed up.


### PR DESCRIPTION
## What is the purpose of this pull request?

Bug fix

## Does your PR contain necessary tests?

All patches which change the editor code must include tests. You can always read more
on [PR testing](https://docs.ckeditor.com/ckeditor4/docs/#!/guide/dev_contributing_code-section-tests),
[how to set the testing environment](https://docs.ckeditor.com/ckeditor4/docs/#!/guide/dev_tests) and
[how to create tests](https://docs.ckeditor.com/ckeditor4/docs/#!/guide/dev_tests-section-creating-your-own-test)
in the official CKEditor documentation.

### This PR contains

- [x] Unit tests
- [x] Manual tests

## What changes did you make?

Autocomplete query and id are removed on `unmatched` event so they invalidate old callback.

Because I have to add a similar manual test to existing tests I also did some refactoring to avoid code duplication.

Closes #1984