### PR TITLE
Autocomplete selected item changes on mouseover

### DIFF
--- a/plugins/autocomplete/plugin.js
+++ b/plugins/autocomplete/plugin.js
@@ -240,7 +240,8 @@
 			this._listeners.push( this.textWatcher.on( 'matched', this.onTextMatched, this ) );
 			this._listeners.push( this.textWatcher.on( 'unmatched', this.onTextUnmatched, this ) );
 			this._listeners.push( this.model.on( 'change-data', this.onData, this ) );
-			this._listeners.push( this.model.on( 'change-selectedItemId', this.onSelectedItemId, this ) );
+			this._listeners.push( this.model.on( 'change-selectedItemId', this.onModelItemChange, this ) );
+			this._listeners.push( this.view.on( 'change-selectedItemId', this.onViewItemChange, this ) );
 			this._listeners.push( this.view.on( 'click-item', this.onItemClick, this ) );
 
 			// Update view position on viewport change.
@@ -467,11 +468,21 @@
 
 		/**
 		 * The function registered by the {@link #attach} method as the
+		 * {@link CKEDITOR.plugins.autocomplete.view#change-selectedItemId} event listener.
+		 *
+		 * @param {CKEDITOR.eventInfo} evt
+		 */
+		onViewItemChange: function( evt ) {
+			this.model.setItem( evt.data );
+		},
+
+		/**
+		 * The function registered by the {@link #attach} method as the
 		 * {@link CKEDITOR.plugins.autocomplete.model#change-selectedItemId} event listener.
 		 *
 		 * @param {CKEDITOR.eventInfo} evt
 		 */
-		onSelectedItemId: function( evt ) {
+		onModelItemChange: function( evt ) {
 			this.view.selectItem( evt.data );
 		},
 
@@ -608,6 +619,18 @@
 				if ( itemElement ) {
 					this.fire( 'click-item', itemElement.data( 'id' ) );
 				}
+			}, this );
+
+			this.element.on( 'mouseover', function( evt ) {
+				var target = evt.data.getTarget();
+
+				if ( this.element.contains( target ) ) {
+					var itemId = target.data( 'id' );
+
+					this.selectItem( itemId );
+					this.fire( 'change-selectedItemId', itemId );
+				}
+
 			}, this );
 		},
 
@@ -1017,17 +1040,26 @@
 		},
 
 		/**
+		 * Sets the {@link #selectedItemId} property.
+		 *
+		 * @param {Number/String} itemId
+		 */
+		setItem: function( itemId ) {
+			if ( this.getIndexById( itemId ) < 0 ) {
+				throw new Error( 'Item with given id does not exist' );
+			}
+
+			this.selectedItemId = itemId;
+		},
+
+		/**
 		 * Selects an item. Sets the {@link #selectedItemId} property and
 		 * fires the {@link #change-selectedItemId} event.
 		 *
 		 * @param {Number/String} itemId
 		 */
 		select: function( itemId ) {
-			if ( this.getIndexById( itemId ) < 0 ) {
-				throw new Error( 'Item with given id does not exist' );
-			}
-
-			this.selectedItemId = itemId;
+			this.setItem( itemId );
 			this.fire( 'change-selectedItemId', itemId );
 		},
 

--- a/tests/plugins/autocomplete/autocomplete.js
+++ b/tests/plugins/autocomplete/autocomplete.js
@@ -57,6 +57,28 @@
 			ac.destroy();
 		},
 
+		'test mouseover changes selected item': function() {
+			var editor = this.editors.standard,
+				ac = new CKEDITOR.plugins.autocomplete( editor, matchTestCallback, dataCallback );
+
+			this.editorBots.standard.setHtmlWithSelection( '' );
+
+			editor.editable().fire( 'keyup', new CKEDITOR.dom.event( {} ) );
+
+			var firstElement = ac.view.getItemById( 1 );
+			assertViewOpened( ac, true );
+			assert.isTrue( firstElement.hasClass( 'cke_autocomplete_selected' ) );
+
+			var target = ac.view.element.getLast();
+			ac.view.element.fire( 'mouseover', new CKEDITOR.dom.event( { target: target.$ } ) );
+
+			assertViewOpened( ac, true );
+			assert.isFalse( firstElement.hasClass( 'cke_autocomplete_selected' ) );
+			assert.isTrue( target.hasClass( 'cke_autocomplete_selected' ) );
+
+			ac.destroy();
+		},
+
 		'test arrow down selects next item': function() {
 			var editor = this.editors.standard,
 				editable = editor.editable(),

--- a/tests/plugins/autocomplete/manual/mouseover.md
+++ b/tests/plugins/autocomplete/manual/mouseover.md
@@ -1,0 +1,18 @@
+@bender-tags: 4.10.0, bug, 2031
+@bender-ui: collapsed
+@bender-ckeditor-plugins: wysiwygarea, toolbar, basicstyles, autocomplete
+@bender-include: _helpers/utils.js
+
+1. Focus the editor.
+1. Type `@`.
+1. Move mouse over the last dropdown item.
+1. Press enter.
+
+
+## Expected
+
+Selection changes when moving mouse over dropdown items. The last selected item is inserted on `enter` key.
+
+## Unexpected
+
+First item is preselected regardless of mouse hover. The first item is inserted on `enter` key.


### PR DESCRIPTION
## What is the purpose of this pull request?

Bug fix

## Does your PR contain necessary tests?

All patches which change the editor code must include tests. You can always read more
on [PR testing](https://docs.ckeditor.com/ckeditor4/docs/#!/guide/dev_contributing_code-section-tests),
[how to set the testing environment](https://docs.ckeditor.com/ckeditor4/docs/#!/guide/dev_tests) and
[how to create tests](https://docs.ckeditor.com/ckeditor4/docs/#!/guide/dev_tests-section-creating-your-own-test)
in the official CKEditor documentation.

### This PR contains

- [x] Unit tests
- [x] Manual tests

## What changes did you make?

Handled `mouseover` for items selection.

Closes #2031