### PR TITLE
Mentions dropdown is now activated regardless of styling

### DIFF
--- a/plugins/textmatch/plugin.js
+++ b/plugins/textmatch/plugin.js
@@ -63,14 +63,23 @@
 	 */
 	CKEDITOR.plugins.textMatch.match = function( range, callback ) {
 		var textAndOffset = CKEDITOR.plugins.textMatch.getTextAndOffset( range ),
-			result = callback( textAndOffset.text, textAndOffset.offset );
+			fillingCharSequence = CKEDITOR.dom.selection.FILLING_CHAR_SEQUENCE,
+			fillingSequenceOffset = 0;
+
+		// Remove filling char sequence for clean query (#2038).
+		if ( textAndOffset.text.indexOf( fillingCharSequence ) == 0 ) {
+			textAndOffset.text = textAndOffset.text.replace( fillingCharSequence, '' );
+			textAndOffset.offset -= fillingSequenceOffset = 7;
+		}
+
+		var result = callback( textAndOffset.text, textAndOffset.offset );
 
 		if ( !result ) {
 			return null;
 		}
 
 		return {
-			range: CKEDITOR.plugins.textMatch.getRangeInText( range, result.start, result.end ),
+			range: CKEDITOR.plugins.textMatch.getRangeInText( range, result.start, result.end + fillingSequenceOffset ),
 			text: textAndOffset.text.slice( result.start, result.end )
 		};
 	};
@@ -207,6 +216,7 @@
 			elements = CKEDITOR.plugins.textMatch.getAdjacentTextNodes( range ),
 			startData = findElementAtOffset( elements, start ),
 			endData = findElementAtOffset( elements, end );
+
 
 		resultRange.setStart( startData.element, startData.offset );
 		resultRange.setEnd( endData.element, endData.offset );

--- a/plugins/textmatch/plugin.js
+++ b/plugins/textmatch/plugin.js
@@ -59,6 +59,8 @@
 	 *
 	 * @returns {Object/null} Object with information about matching text or `null`.
 	 * @returns {String} return.text The matching text.
+	 * The text doesn't reflect the range offsets. The range could contain additional,
+	 *  browser related characters like CKEDITOR.dom.selection.FILLING_CHAR_SEQUENCE.
 	 * @returns {CKEDITOR.dom.range} return.range Range in the DOM for the text that matches.
 	 */
 	CKEDITOR.plugins.textMatch.match = function( range, callback ) {

--- a/plugins/textmatch/plugin.js
+++ b/plugins/textmatch/plugin.js
@@ -66,10 +66,16 @@
 			fillingCharSequence = CKEDITOR.dom.selection.FILLING_CHAR_SEQUENCE,
 			fillingSequenceOffset = 0;
 
+		if ( !textAndOffset ) {
+			return;
+		}
+
 		// Remove filling char sequence for clean query (#2038).
 		if ( textAndOffset.text.indexOf( fillingCharSequence ) == 0 ) {
+			fillingSequenceOffset = fillingCharSequence.length;
+
 			textAndOffset.text = textAndOffset.text.replace( fillingCharSequence, '' );
-			textAndOffset.offset -= fillingSequenceOffset = 7;
+			textAndOffset.offset -= fillingSequenceOffset;
 		}
 
 		var result = callback( textAndOffset.text, textAndOffset.offset );
@@ -216,7 +222,6 @@
 			elements = CKEDITOR.plugins.textMatch.getAdjacentTextNodes( range ),
 			startData = findElementAtOffset( elements, start ),
 			endData = findElementAtOffset( elements, end );
-
 
 		resultRange.setStart( startData.element, startData.offset );
 		resultRange.setEnd( endData.element, endData.offset );

--- a/tests/plugins/textmatch/manual/fillingcharsequence.html
+++ b/tests/plugins/textmatch/manual/fillingcharsequence.html
@@ -1,0 +1,34 @@
+<div id="editor"></div>
+
+<script>
+	CKEDITOR.replace( 'editor', {
+		on: {
+			instanceReady: function( evt ) {
+				new CKEDITOR.plugins.autocomplete( evt.editor, textTestCallback, dataCallback );
+			}
+		}
+	} );
+
+	function dataCallback( query, range, callback ) {
+		callback( [ { id: 1, name: '@foo' } ] );
+	}
+
+	function textTestCallback( range ) {
+		return CKEDITOR.plugins.textMatch.match( range, matchCallback );
+	}
+
+	function matchCallback( text, offset ) {
+		var left = text.slice( 0, offset ),
+			match = left.match( new RegExp( '@\\w*$' ) );
+
+		if ( !match ) {
+			return null;
+		}
+
+		if ( text.indexOf( CKEDITOR.dom.selection.FILLING_CHAR_SEQUENCE ) == 0 ) {
+			return null;
+		}
+
+		return { start: match.index, end: offset };
+	}
+</script>

--- a/tests/plugins/textmatch/manual/fillingcharsequence.html
+++ b/tests/plugins/textmatch/manual/fillingcharsequence.html
@@ -4,7 +4,10 @@
 	CKEDITOR.replace( 'editor', {
 		on: {
 			instanceReady: function( evt ) {
-				new CKEDITOR.plugins.autocomplete( evt.editor, textTestCallback, dataCallback );
+				new CKEDITOR.plugins.autocomplete( evt.editor, {
+					textTestCallback: textTestCallback,
+					dataCallback: dataCallback
+				} );
 			}
 		}
 	} );

--- a/tests/plugins/textmatch/manual/fillingcharsequence.md
+++ b/tests/plugins/textmatch/manual/fillingcharsequence.md
@@ -6,6 +6,7 @@
 
 1. Open console.
 1. Focus the editor.
+1. Press `Bold` style button.
 1. Type `@`.
 1. Press `enter`.
 

--- a/tests/plugins/textmatch/manual/fillingcharsequence.md
+++ b/tests/plugins/textmatch/manual/fillingcharsequence.md
@@ -1,0 +1,24 @@
+@bender-tags: 4.10.0, bug, 2038
+@bender-ui: collapsed
+@bender-ckeditor-plugins: wysiwygarea, toolbar, basicstyles, textmatch, autocomplete
+
+# Phase 1
+
+1. Open console.
+1. Focus the editor.
+1. Type `@`.
+1. Press `enter`.
+
+Repeat test steps but use mouse instead of `enter` to accept dropdown option.
+
+## Expected
+
+`@foo` has been inserted into editor.
+
+## Unexpected
+
+Any of:
+
+* Dropdown didn't appear.
+* `@foo@` has been inserted into editor.
+* There are some errors inside console.

--- a/tests/plugins/textmatch/staticfunctions.js
+++ b/tests/plugins/textmatch/staticfunctions.js
@@ -119,8 +119,12 @@
 	};
 
 	tcs[ 'test textMatch' ] = function() {
-		var range = bender.tools.range.setWithHtml( rangeRoot, '<p>{}Hello</p>' ),
-			result = CKEDITOR.plugins.textMatch.match( range, function() {
+		var range = bender.tools.range.setWithHtml( rangeRoot, '<p>Hel{}lo</p>' ),
+			result = CKEDITOR.plugins.textMatch.match( range, function( text, offset ) {
+
+				assert.areEqual( 'Hello', text );
+				assert.areEqual( 3, offset );
+
 				return {
 					start: 0,
 					end: 3
@@ -131,6 +135,27 @@
 		assert.areSame( range.startContainer, result.range.startContainer );
 		assert.areSame( 0, result.range.startOffset );
 		assert.areSame( 3, result.range.endOffset );
+	};
+
+	// (#2038)
+	tcs[ 'test textMatch with filling char sequence' ] = function() {
+		var html = '<p>' + CKEDITOR.dom.selection.FILLING_CHAR_SEQUENCE + 'Hel{}lo</p>',
+			range = bender.tools.range.setWithHtml( rangeRoot, html ),
+			result = CKEDITOR.plugins.textMatch.match( range, function( text, offset ) {
+
+				assert.areEqual( 'Hello', text );
+				assert.areEqual( 3, offset );
+
+				return {
+					start: 0,
+					end: 3
+				};
+			} );
+
+		assert.areSame( 'Hel', result.text );
+		assert.areSame( range.startContainer, result.range.startContainer );
+		assert.areSame( 0, result.range.startOffset );
+		assert.areSame( 10, result.range.endOffset );
 	};
 
 	addTestCases( tcs, {


### PR DESCRIPTION
## What is the purpose of this pull request?

Bug fix

## Does your PR contain necessary tests?

All patches which change the editor code must include tests. You can always read more
on [PR testing](https://docs.ckeditor.com/ckeditor4/docs/#!/guide/dev_contributing_code-section-tests),
[how to set the testing environment](https://docs.ckeditor.com/ckeditor4/docs/#!/guide/dev_tests) and
[how to create tests](https://docs.ckeditor.com/ckeditor4/docs/#!/guide/dev_tests-section-creating-your-own-test)
in the official CKEditor documentation.

### This PR contains

- [x] Unit tests
- [x] Manual tests

## What changes did you make?

Previously I thought this issue should be fixed inside `textmatch` plugin but I think that we shouldn't mess with pattern matching which is delegated to the user implementation. The issue exists because we are using filling char sequence for styles on some browsers (probably to create clickable placeholder). I handled this issue inside mentions pattern matching.

However I was thinking about moving code checking if a query is a part of word into a helper function which could be used by a users for their custom autocomplete implementation.

Closes #2038