### PR TITLE
Fixed: Right click on empty paragraph inside table removes table selection on Firefox

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -20,6 +20,7 @@ Fixed Issues:
 * [#1184](https://github.com/ckeditor/ckeditor-dev/issues/1184): [IE8-11] Fixed: Copying and pasting data in [read-only mode](https://docs.ckeditor.com/ckeditor4/latest/api/CKEDITOR_editor.html#property-readOnly) throws an error.
 * [#1916](https://github.com/ckeditor/ckeditor-dev/issues/1916): [IE9-11] Fixed: Pressing <kbd>Delete</kbd> key in [read-only mode](https://docs.ckeditor.com/ckeditor4/latest/api/CKEDITOR_editor.html#property-readOnly) throws an error.
 * [#2254](https://github.com/ckeditor/ckeditor-dev/issues/2254): Fixed: [Image](https://ckeditor.com/cke4/addon/image) ratio locking is too precise for resized images. Thanks to [Jonathan Gilbert](https://github.com/logiclrd)!
+* [#2003](https://github.com/ckeditor/ckeditor-dev/issues/2003): Fixed: Right-clicking on multiple selected cells containing empty paragraphs removes the selection on Firefox.
 
 API Changes:
 

--- a/core/editable.js
+++ b/core/editable.js
@@ -1148,7 +1148,7 @@
 						if ( ev.data.$.button == 2 ) {
 							var target = ev.data.getTarget();
 
-							if ( !target.getOuterHtml().replace( emptyParagraphRegexp, '' ) ) {
+							if ( !target.getAscendant( 'table' ) && !target.getOuterHtml().replace( emptyParagraphRegexp, '' ) ) {
 								var range = editor.createRange();
 								range.moveToElementEditStart( target );
 								range.select( true );

--- a/tests/plugins/tableselection/manual/firefoxrightclick.html
+++ b/tests/plugins/tableselection/manual/firefoxrightclick.html
@@ -1,0 +1,30 @@
+<textarea id="editor">
+	<table border="1" style="width:500px">
+		<tbody>
+		<tr>
+			<td>
+				<p>&nbsp;</p>
+			</td>
+			<td>
+				<p>&nbsp;</p>
+			</td>
+		</tr>
+		<tr>
+			<td>
+				<p>&nbsp;</p>
+			</td>
+			<td>
+				<p>&nbsp;</p>
+			</td>
+		</tr>
+		</tbody>
+	</table>
+</textarea>
+
+<script>
+	if ( !CKEDITOR.env.gecko ) {
+		bender.ignore();
+	}
+
+	CKEDITOR.replace( 'editor' );
+</script>

--- a/tests/plugins/tableselection/manual/firefoxrightclick.md
+++ b/tests/plugins/tableselection/manual/firefoxrightclick.md
@@ -1,0 +1,18 @@
+@bender-ui: collapsed
+@bender-tags: bug, 4.10.0, 2003
+@bender-ckeditor-plugins: wysiwygarea, toolbar, tableselection
+
+# Test steps:
+
+1. Select all table cells.
+1. Right click inside one of table cell.
+1. Choose cell properties from context menu.
+1. Change background color.
+
+## Expected:
+
+All selected cells has changed background colour.
+
+## Unexpected:
+
+Only cell that was right clicked has changed background colour.

--- a/tests/plugins/tableselection/manual/firefoxrightclick.md
+++ b/tests/plugins/tableselection/manual/firefoxrightclick.md
@@ -1,5 +1,5 @@
 @bender-ui: collapsed
-@bender-tags: bug, 4.10.0, 2003
+@bender-tags: bug, 4.10.1, 2003
 @bender-ckeditor-plugins: wysiwygarea, toolbar, tableselection
 
 # Test steps:

--- a/tests/plugins/tableselection/manual/firefoxrightclick.md
+++ b/tests/plugins/tableselection/manual/firefoxrightclick.md
@@ -2,17 +2,14 @@
 @bender-tags: bug, 4.10.1, 2003
 @bender-ckeditor-plugins: wysiwygarea, toolbar, tableselection
 
-# Test steps:
-
 1. Select all table cells.
-1. Right click inside one of table cell.
-1. Choose cell properties from context menu.
-1. Change background color.
+1. Press and hold right click inside table cell.
+1. Release right click inside table cell, but outside of context menu.
 
 ## Expected:
 
-All selected cells has changed background colour.
+All cells are selected.
 
 ## Unexpected:
 
-Only cell that was right clicked has changed background colour.
+Only cell that was right clicked is selected.

--- a/tests/plugins/tableselection/tableselection.html
+++ b/tests/plugins/tableselection/tableselection.html
@@ -51,5 +51,27 @@
 	</table>
 </div>
 
+<div id="emptyParagraph">
+	<table border="1" style="width:500px">
+		<tbody>
+		<tr>
+			<td>
+				<p>&nbsp;</p>
+			</td>
+			<td>
+				<p>&nbsp;</p>
+			</td>
+		</tr>
+		<tr>
+			<td>
+				<p>&nbsp;</p>
+			</td>
+			<td>
+				<p>&nbsp;</p>
+			</td>
+		</tr>
+		</tbody>
+	</table>
+</div>
 
 <iframe id="focusIframe"></iframe>

--- a/tests/plugins/tableselection/tableselection.js
+++ b/tests/plugins/tableselection/tableselection.js
@@ -79,7 +79,7 @@
 			assert.areSame( 2, ranges.length, 'Range count' );
 			assert.isTrue( ranges[ 0 ].getEnclosedNode().equals( contentCells.getItem( 1 ) ), 'Range[ 0 ] encloses correct element' );
 			assert.isTrue( ranges[ 1 ].getEnclosedNode().equals( contentCells.getItem( 4 ) ), 'Range[ 1 ] encloses correct element' );
-			assert.areSame( 1,  editor.getSelection().isFake, 'Selection remains faked' );
+			assert.areSame( 1, editor.getSelection().isFake, 'Selection remains faked' );
 		},
 
 		'test simulating merge cells from context menu ': function( editor ) {
@@ -144,6 +144,42 @@
 
 			mockMouseSelection( editor, [ cells.getItem( 1 ), cells.getItem( 3 ), cells.getItem( 8 ) ], function() {
 				assert.pass();
+			} );
+		},
+
+		// (#2003)
+		'test': function( editor, bot ) {
+			if ( !CKEDITOR.env.gecko ) {
+				assert.ignore();
+			}
+			bot.setData( CKEDITOR.document.getById( 'emptyParagraph' ).getHtml(), function() {
+				var cells = editor.editable().find( 'td' ).toArray(),
+					ranges = CKEDITOR.tools.array.map( cells, function( cell ) {
+						var range = editor.createRange(),
+							row = cell.getParent(),
+							index = cell.getIndex();
+
+						range.setStart( row, index );
+						range.setEnd( row, index + 1 );
+
+						return range;
+					} ),
+					paragraph = cells[ 0 ].findOne( 'p' ),
+					selection = editor.getSelection();
+
+				selection.selectRanges( ranges );
+				ranges = selection.getRanges();
+
+				editor.editable().fire( 'mouseup', {
+					getTarget: function() {
+						return paragraph;
+					},
+					$: {
+						button: 2
+					}
+				} );
+
+				assert.areSame( ranges, editor.getSelection().getRanges(), 'Selected ranges should be unchanged' );
 			} );
 		}
 	};

--- a/tests/plugins/tableselection/tableselection.js
+++ b/tests/plugins/tableselection/tableselection.js
@@ -148,22 +148,13 @@
 		},
 
 		// (#2003)
-		'test': function( editor, bot ) {
+		'test right-click in cell with empty paragraph': function( editor, bot ) {
 			if ( !CKEDITOR.env.gecko ) {
 				assert.ignore();
 			}
 			bot.setData( CKEDITOR.document.getById( 'emptyParagraph' ).getHtml(), function() {
 				var cells = editor.editable().find( 'td' ).toArray(),
-					ranges = CKEDITOR.tools.array.map( cells, function( cell ) {
-						var range = editor.createRange(),
-							row = cell.getParent(),
-							index = cell.getIndex();
-
-						range.setStart( row, index );
-						range.setEnd( row, index + 1 );
-
-						return range;
-					} ),
+					ranges = tableSelectionHelpers.getRangesForCells( editor, [ 0, 1, 2, 3 ] ),
 					paragraph = cells[ 0 ].findOne( 'p' ),
 					selection = editor.getSelection();
 


### PR DESCRIPTION
## What is the purpose of this pull request?

Bug fix

## Does your PR contain necessary tests?

All patches which change the editor code must include tests. You can always read more
on [PR testing](https://docs.ckeditor.com/ckeditor4/docs/#!/guide/dev_contributing_code-section-tests),
[how to set the testing environment](https://docs.ckeditor.com/ckeditor4/docs/#!/guide/dev_tests) and
[how to create tests](https://docs.ckeditor.com/ckeditor4/docs/#!/guide/dev_tests-section-creating-your-own-test)
in the official CKEditor documentation.

### This PR contains

- [X] Unit tests
- [X] Manual tests

## What changes did you make?

I've removed part of legacy code which produced this issue.

Notes:
-This bug is only reproducible in Firefox on Windows.

-Original bug can be found here:
https://dev.ckeditor.com/ticket/5845
As I'm not able to reproduce it after this change I believe nothing is broken anymore. Also after browsing commit history I didn't find any tests for that old issue.

Closes #2003 

