### PR TITLE
Fixed failing test on Edge 42

### DIFF
--- a/tests/plugins/easyimage/uploadintegrations.js
+++ b/tests/plugins/easyimage/uploadintegrations.js
@@ -3,6 +3,8 @@
 /* bender-include: %BASE_PATH%/plugins/clipboard/_helpers/pasting.js, %BASE_PATH%/plugins/imagebase/features/_helpers/tools.js */
 /* bender-include: ./_helpers/tools.js */
 /* global imageBaseFeaturesTools, pasteFiles, assertPasteEvent, easyImageTools */
+/* bender-include: ../uploadfile/_helpers/waitForImage.js */
+/* global pasteFiles, waitForImage */
 
 ( function() {
 	'use strict';
@@ -145,7 +147,10 @@
 				assert.areSame( 'easyimage', widgets[ 0 ].name, 'Widget type' );
 				assert.areSame( bender.tools.pngBase64, widgets[ 0 ].parts.image.getAttribute( 'src' ), 'Image src attribute' );
 
-				assert.beautified.html( CKEDITOR.document.getById( 'expected-image-base64' ).getHtml(), editor.getData(), 'Editor data' );
+				// Assertion failed on Edge because it was fired before image 'load' event, on which easyimage plugin adds width #2057.
+				waitForImage( editor.editable().findOne( 'img' ), function() {
+					assert.beautified.html( CKEDITOR.document.getById( 'expected-image-base64' ).getHtml(), editor.getData(), 'Editor data' );
+				} );
 
 				this.listeners.push( widgets[ 0 ].once( 'uploadDone', function() {
 					resume( function() {

--- a/tests/plugins/easyimage/uploadintegrations.js
+++ b/tests/plugins/easyimage/uploadintegrations.js
@@ -178,7 +178,9 @@
 				assert.areSame( 'easyimage', widgets[ 1 ].name, 'Widget 1 type' );
 				assert.areSame( bender.tools.pngBase64, widgets[ 1 ].parts.image.getAttribute( 'src' ), 'Image 1 src attribute' );
 
-				assert.beautified.html( CKEDITOR.document.getById( 'expected-multiple-image-base64' ).getHtml(), editor.getData(), 'Editor data' );
+				waitForImage( editor.editable().findOne( 'img' ), function() {
+					assert.beautified.html( CKEDITOR.document.getById( 'expected-multiple-image-base64' ).getHtml(), editor.getData(), 'Editor data' );
+				} );
 			},
 
 			// #1529
@@ -213,7 +215,9 @@
 
 				assert.areSame( 1, widgets.length, 'Widget count' );
 
-				assert.beautified.html( CKEDITOR.document.getById( 'expected-mixed-content' ).getHtml(), editor.getData(), 'Editor data' );
+				waitForImage( editor.editable().findOne( 'img' ), function() {
+					assert.beautified.html( CKEDITOR.document.getById( 'expected-mixed-content' ).getHtml(), editor.getData(), 'Editor data' );
+				} );
 			},
 
 			'test pasting mixed HTML content image inline': function() {
@@ -227,7 +231,9 @@
 
 				assert.areSame( 1, widgets.length, 'Widget count' );
 
-				assert.beautified.html( CKEDITOR.document.getById( 'expected-mixed-content-inline-img' ).getHtml(), editor.getData(), 'Editor data' );
+				waitForImage( editor.editable().findOne( 'img' ), function() {
+					assert.beautified.html( CKEDITOR.document.getById( 'expected-mixed-content-inline-img' ).getHtml(), editor.getData(), 'Editor data' );
+				} );
 			},
 
 			'test downcast does not include progress bar': function() {

--- a/tests/plugins/easyimage/uploadintegrations.js
+++ b/tests/plugins/easyimage/uploadintegrations.js
@@ -2,9 +2,8 @@
 /* bender-ckeditor-plugins: sourcearea, wysiwygarea, easyimage */
 /* bender-include: %BASE_PATH%/plugins/clipboard/_helpers/pasting.js, %BASE_PATH%/plugins/imagebase/features/_helpers/tools.js */
 /* bender-include: ./_helpers/tools.js */
-/* global imageBaseFeaturesTools, pasteFiles, assertPasteEvent, easyImageTools */
 /* bender-include: ../uploadfile/_helpers/waitForImage.js */
-/* global pasteFiles, waitForImage */
+/* global imageBaseFeaturesTools, pasteFiles, assertPasteEvent, waitForImage, easyImageTools */
 
 ( function() {
 	'use strict';
@@ -147,7 +146,7 @@
 				assert.areSame( 'easyimage', widgets[ 0 ].name, 'Widget type' );
 				assert.areSame( bender.tools.pngBase64, widgets[ 0 ].parts.image.getAttribute( 'src' ), 'Image src attribute' );
 
-				// Assertion failed on Edge because it was fired before image 'load' event, on which easyimage plugin adds width #2057.
+				// Assertion failed on Edge because it was fired before image 'load' event, on which easyimage plugin adds width (#2057).
 				waitForImage( editor.editable().findOne( 'img' ), function() {
 					assert.beautified.html( CKEDITOR.document.getById( 'expected-image-base64' ).getHtml(), editor.getData(), 'Editor data' );
 				} );


### PR DESCRIPTION
## What is the purpose of this pull request?

Failing test

## What changes did you make?

I have fixed some race condition by calling assertion as a callback to method `waitForImage` which basically calls wait() and resumes on images `load` event.
Closes #2057 