### PR TITLE
Added items limit option for autocomplete plugin

### DIFF
--- a/plugins/autocomplete/plugin.js
+++ b/plugins/autocomplete/plugin.js
@@ -526,6 +526,8 @@
 	};
 
 	/**
+	 * Class representing the autocomplete view.
+	 *
 	 * In order to use a different view, implement a new view class and override
 	 * the {@link CKEDITOR.plugins.autocomplete#getView} method.
 	 *
@@ -944,6 +946,8 @@
 	CKEDITOR.event.implementOn( View.prototype );
 
 	/**
+	 * Class representing the autocomplete model.
+	 *
 	 * In case you want to modify model behavior, check out the
 	 * {@link CKEDITOR.plugins.autocomplete.view} documentation. It contains
 	 * examples of how to easily override the default behavior.

--- a/plugins/autocomplete/plugin.js
+++ b/plugins/autocomplete/plugin.js
@@ -526,7 +526,10 @@
 	};
 
 	/**
-	 * Class representing the autocomplete view.
+	 * Private class representing the autocomplete view.
+	 *
+	 * This class should not be used outside of the {@link CKEDITOR.plugins.autocomplete Autocomplete} plugin
+	 *  as API defined here may change at any time without notice.
 	 *
 	 * In order to use a different view, implement a new view class and override
 	 * the {@link CKEDITOR.plugins.autocomplete#getView} method.
@@ -553,6 +556,7 @@
 	 *
 	 * @class CKEDITOR.plugins.autocomplete.view
 	 * @since 4.10.0
+	 * @private
 	 * @mixins CKEDITOR.event
 	 * @constructor Creates the autocomplete view instance.
 	 * @param {CKEDITOR.editor} editor The editor instance.
@@ -942,7 +946,10 @@
 	CKEDITOR.event.implementOn( View.prototype );
 
 	/**
-	 * Class representing the autocomplete model.
+	 * Private class representing the autocomplete model.
+	 *
+	 * This class should not be used outside of the {@link CKEDITOR.plugins.autocomplete Autocomplete} plugin
+	 *  as API defined here may change at any time without notice.
 	 *
 	 * In case you want to modify model behavior, check out the
 	 * {@link CKEDITOR.plugins.autocomplete.view} documentation. It contains
@@ -952,6 +959,7 @@
 	 *
 	 * @class CKEDITOR.plugins.autocomplete.model
 	 * @since 4.10.0
+	 * @private
 	 * @mixins CKEDITOR.event
 	 * @constructor Creates the autocomplete model instance.
 	 * @param {Function} dataCallback See {@link CKEDITOR.plugins.autocomplete} arguments.

--- a/plugins/autocomplete/plugin.js
+++ b/plugins/autocomplete/plugin.js
@@ -1212,7 +1212,7 @@
 				if ( requestId == that.lastRequestId ) {
 					// Limit number of items (#2030).
 					if ( that.itemsLimit ) {
-						that.data = data.slice( 0, that.itemsLimit || undefined );
+						that.data = data.slice( 0, that.itemsLimit );
 					} else {
 						that.data = data;
 					}

--- a/plugins/autocomplete/plugin.js
+++ b/plugins/autocomplete/plugin.js
@@ -172,13 +172,6 @@
 		this.throttle = config.throttle !== undefined ? config.throttle : 20;
 
 		/**
-		 * See {@link CKEDITOR.plugins.autocomplete.configDefinition#itemsLimit}.
-		 *
-		 * @property {Number} [itemsLimit]
-		 */
-		this.itemsLimit = config.itemsLimit;
-
-		/**
 		 * The autocomplete view instance.
 		 *
 		 * @readonly
@@ -193,6 +186,7 @@
 		 * @property {CKEDITOR.plugins.autocomplete.model}
 		 */
 		this.model = this.getModel( config.dataCallback );
+		this.model.itemsLimit = config.itemsLimit;
 
 		/**
 		 * The autocomplete text watcher instance.
@@ -436,9 +430,7 @@
 		 */
 		onData: function( evt ) {
 			if ( this.model.hasData() ) {
-				// Limit number of items passed into view (#2030).
-				var items = evt.data.slice( 0, this.itemsLimit || undefined );
-				this.view.updateItems( items );
+				this.view.updateItems( evt.data );
 				this.open();
 			} else {
 				this.close();
@@ -983,6 +975,15 @@
 		this.isActive = false;
 
 		/**
+		 * Indicates the limit of items rendered in the dropdown.
+		 *
+		 * For false values i.e. `0` or `null` all items will be rendered.
+		 *
+		 * @property {Number} [itemsLimit=0]
+		 */
+		this.itemsLimit = 0;
+
+		/**
 		 * ID of the last request for data. Used by the {@link #setQuery} method.
 		 *
 		 * @readonly
@@ -1201,8 +1202,13 @@
 			this.dataCallback( query, range, function( data ) {
 				// Handle only the response for the most recent setQuery call.
 				if ( requestId == that.lastRequestId ) {
-					that.data = data;
-					that.fire( 'change-data', data );
+					// Limit number of items (#2030).
+					if ( that.itemsLimit ) {
+						that.data = data.slice( 0, that.itemsLimit || undefined );
+					} else {
+						that.data = data;
+					}
+					that.fire( 'change-data', that.data );
 				}
 			} );
 			// Note: don't put any code here because the callback passed to
@@ -1389,9 +1395,7 @@
 	 */
 
 	/**
-	 * Indicates the limit of items rendered in the dropdown.
-	 *
-	 * For false values i.e. `0` or `null` all items will be rendered.
+	 * Indicates the limit of items rendered in the dropdown. See {@link CKEDITOR.plugins.autocomplete.model#itemsLimit} for more information.
 	 *
 	 * @property {Number} [itemsLimit]
 	 */

--- a/plugins/autocomplete/plugin.js
+++ b/plugins/autocomplete/plugin.js
@@ -172,6 +172,13 @@
 		this.throttle = config.throttle !== undefined ? config.throttle : 20;
 
 		/**
+		 * See {@link CKEDITOR.plugins.autocomplete.configDefinition#itemsLimit}.
+		 *
+		 * @property {Number} [itemsLimit]
+		 */
+		this.itemsLimit = config.itemsLimit;
+
+		/**
 		 * The autocomplete view instance.
 		 *
 		 * @readonly
@@ -429,7 +436,9 @@
 		 */
 		onData: function( evt ) {
 			if ( this.model.hasData() ) {
-				this.view.updateItems( evt.data );
+				// Limit number of items passed into view (#2030).
+				var items = evt.data.slice( 0, this.itemsLimit || undefined );
+				this.view.updateItems( items );
 				this.open();
 			} else {
 				this.close();
@@ -1377,6 +1386,14 @@
 	 * Indicates throttle threshold expressed in milliseconds reducing text checks frequency.
 	 *
 	 * @property {Number} [throttle=20]
+	 */
+
+	/**
+	 * Indicates the limit of items rendered in the dropdown.
+	 *
+	 * For false values i.e. `0` or `null` all items will be rendered.
+	 *
+	 * @property {Number} [itemsLimit]
 	 */
 
 	/**

--- a/plugins/autocomplete/plugin.js
+++ b/plugins/autocomplete/plugin.js
@@ -526,11 +526,6 @@
 	};
 
 	/**
-	 * Private class representing the autocomplete view.
-	 *
-	 * This class should not be used outside of the {@link CKEDITOR.plugins.autocomplete Autocomplete} plugin
-	 *  as API defined here may change at any time without notice.
-	 *
 	 * In order to use a different view, implement a new view class and override
 	 * the {@link CKEDITOR.plugins.autocomplete#getView} method.
 	 *
@@ -553,6 +548,9 @@
 	 *		return view;
 	 *	};
 	 * ```
+	 *
+	 * **Note:** This class is marked as private meaning that it's API might be a subject of further changes in order to
+	 * provide further enhancements.
 	 *
 	 * @class CKEDITOR.plugins.autocomplete.view
 	 * @since 4.10.0
@@ -946,16 +944,14 @@
 	CKEDITOR.event.implementOn( View.prototype );
 
 	/**
-	 * Private class representing the autocomplete model.
-	 *
-	 * This class should not be used outside of the {@link CKEDITOR.plugins.autocomplete Autocomplete} plugin
-	 *  as API defined here may change at any time without notice.
-	 *
 	 * In case you want to modify model behavior, check out the
 	 * {@link CKEDITOR.plugins.autocomplete.view} documentation. It contains
 	 * examples of how to easily override the default behavior.
 	 *
 	 * Model instance is created by the {@link CKEDITOR.plugins.autocomplete#getModel} method.
+	 *
+	 * **Note:** This class is marked as private meaning that it's API might be a subject of further changes in order to
+	 * provide further enhancements.
 	 *
 	 * @class CKEDITOR.plugins.autocomplete.model
 	 * @since 4.10.0

--- a/tests/plugins/autocomplete/autocomplete.js
+++ b/tests/plugins/autocomplete/autocomplete.js
@@ -458,7 +458,8 @@
 		'test limit view items': function() {
 			var editor = this.editors.standard,
 				itemsCount = 1,
-				ac = new CKEDITOR.plugins.autocomplete( editor, CKEDITOR.tools.object.merge( configDefinition, { itemsLimit: itemsCount } ) );
+				ac = new CKEDITOR.plugins.autocomplete( editor,
+					CKEDITOR.tools.object.merge( configDefinition, { itemsLimit: itemsCount } ) );
 
 			this.editorBots.standard.setHtmlWithSelection( '' );
 
@@ -475,7 +476,8 @@
 			var editor = this.editors.standard,
 				editable = editor.editable(),
 				itemsCount = 1,
-				ac = new CKEDITOR.plugins.autocomplete( editor, CKEDITOR.tools.object.merge( configDefinition, { itemsLimit: itemsCount } ) );
+				ac = new CKEDITOR.plugins.autocomplete( editor,
+					CKEDITOR.tools.object.merge( configDefinition, { itemsLimit: itemsCount } ) );
 
 			this.editorBots.standard.setHtmlWithSelection( '' );
 

--- a/tests/plugins/autocomplete/autocomplete.js
+++ b/tests/plugins/autocomplete/autocomplete.js
@@ -468,6 +468,25 @@
 			assert.areEqual( itemsCount, ac.view.element.getChildCount() );
 
 			ac.destroy();
+		},
+
+		// (#2030)
+		'test cycle through limited items': function() {
+			var editor = this.editors.standard,
+				editable = editor.editable(),
+				itemsCount = 1,
+				ac = new CKEDITOR.plugins.autocomplete( editor, CKEDITOR.tools.object.merge( configDefinition, { itemsLimit: itemsCount } ) );
+
+			this.editorBots.standard.setHtmlWithSelection( '' );
+
+			editable.fire( 'keyup', new CKEDITOR.dom.event( {} ) );
+			editable.fire( 'keydown', new CKEDITOR.dom.event( { keyCode: 38 } ) ); // ARROW UP
+
+			assertViewOpened( ac, true );
+			assert.areEqual( 1, ac.model.selectedItemId, 'Model selected item id' );
+			assert.areEqual( 1, ac.view.selectedItemId, 'View selected item id' );
+
+			ac.destroy();
 		}
 	} );
 

--- a/tests/plugins/autocomplete/autocomplete.js
+++ b/tests/plugins/autocomplete/autocomplete.js
@@ -452,6 +452,22 @@
 				'Vertical position.' );
 
 			ac.destroy();
+		},
+
+		// (#2030)
+		'test limit view items': function() {
+			var editor = this.editors.standard,
+				itemsCount = 1,
+				ac = new CKEDITOR.plugins.autocomplete( editor, CKEDITOR.tools.object.merge( configDefinition, { itemsLimit: itemsCount } ) );
+
+			this.editorBots.standard.setHtmlWithSelection( '' );
+
+			editor.editable().fire( 'keyup', new CKEDITOR.dom.event( {} ) );
+
+			assertViewOpened( ac, true );
+			assert.areEqual( itemsCount, ac.view.element.getChildCount() );
+
+			ac.destroy();
 		}
 	} );
 

--- a/tests/plugins/autocomplete/autocomplete.js
+++ b/tests/plugins/autocomplete/autocomplete.js
@@ -482,7 +482,7 @@
 			this.editorBots.standard.setHtmlWithSelection( '' );
 
 			editable.fire( 'keyup', new CKEDITOR.dom.event( {} ) );
-			editable.fire( 'keydown', new CKEDITOR.dom.event( { keyCode: 38 } ) ); // ARROW UP
+			editable.fire( 'keydown', new CKEDITOR.dom.event( { keyCode: 40 } ) ); // ARROW DOWN
 
 			assertViewOpened( ac, true );
 			assert.areEqual( 1, ac.model.selectedItemId, 'Model selected item id' );

--- a/tests/plugins/autocomplete/manual/itemslimit.html
+++ b/tests/plugins/autocomplete/manual/itemslimit.html
@@ -1,0 +1,15 @@
+<div id="editor"></div>
+
+<script>
+	CKEDITOR.replace( 'editor', {
+		on: {
+			instanceReady: function( evt ) {
+				new CKEDITOR.plugins.autocomplete( evt.editor, {
+					textTestCallback: autocompleteUtils.getTextTestCallback(),
+					dataCallback: autocompleteUtils.getDataCallback(),
+					itemsLimit: 1
+				} );
+			}
+		}
+	} );
+</script>

--- a/tests/plugins/autocomplete/manual/itemslimit.html
+++ b/tests/plugins/autocomplete/manual/itemslimit.html
@@ -7,7 +7,7 @@
 				new CKEDITOR.plugins.autocomplete( evt.editor, {
 					textTestCallback: autocompleteUtils.getTextTestCallback(),
 					dataCallback: autocompleteUtils.getDataCallback(),
-					itemsLimit: 1
+					itemsLimit: 3
 				} );
 			}
 		}

--- a/tests/plugins/autocomplete/manual/itemslimit.md
+++ b/tests/plugins/autocomplete/manual/itemslimit.md
@@ -1,0 +1,15 @@
+@bender-tags: 4.10.0, feature, 2030
+@bender-ui: collapsed
+@bender-ckeditor-plugins: wysiwygarea, toolbar, basicstyles, autocomplete, textmatch
+@bender-include: _helpers/utils.js
+
+1. Focus the editor.
+1. Type `@`.
+
+## Expected
+
+Dropdown contains single item.
+
+## Unexpected
+
+Dropdown contains more than one item.

--- a/tests/plugins/autocomplete/manual/itemslimit.md
+++ b/tests/plugins/autocomplete/manual/itemslimit.md
@@ -11,8 +11,9 @@
 ## Expected
 
 * Dropdown contains 3 items.
-* The last dropdown item is selected after <kbd>ArrowUp</kbd> key.
+* The last dropdown item is focused.
 
 ## Unexpected
 
 * Dropdown contains more than 3 items.
+* Dropdown has invalid item focus.

--- a/tests/plugins/autocomplete/manual/itemslimit.md
+++ b/tests/plugins/autocomplete/manual/itemslimit.md
@@ -5,11 +5,14 @@
 
 1. Focus the editor.
 1. Type `@`.
+1. Wait until dropdown appear.
+1. Press <kbd>ArrowUp</kbd> key.
 
 ## Expected
 
-Dropdown contains single item.
+* Dropdown contains 3 items.
+* The last dropdown item is selected after <kbd>ArrowUp</kbd> key.
 
 ## Unexpected
 
-Dropdown contains more than one item.
+* Dropdown contains more than 3 items.


### PR DESCRIPTION
## What is the purpose of this pull request?

New feature

## Does your PR contain necessary tests?

All patches which change the editor code must include tests. You can always read more
on [PR testing](https://docs.ckeditor.com/ckeditor4/docs/#!/guide/dev_contributing_code-section-tests),
[how to set the testing environment](https://docs.ckeditor.com/ckeditor4/docs/#!/guide/dev_tests) and
[how to create tests](https://docs.ckeditor.com/ckeditor4/docs/#!/guide/dev_tests-section-creating-your-own-test)
in the official CKEditor documentation.

### This PR contains

- [x] Unit tests
- [x] Manual tests

## What changes did you make?

Added additional `itemsLimit` configuration property allowing to limit the number of rendered items inside autocomplete dropdown.

Closes #2030, #2099
