### PR TITLE
Fixed: Failing initialize_hidden unit test

### DIFF
--- a/tests/core/editor/initialize_hidden.js
+++ b/tests/core/editor/initialize_hidden.js
@@ -9,7 +9,7 @@ bender.test( {
 
 		// For Firefox 60.0.1+ this code is executed after 'instanceReady' event so listener won't be called.
 		// For that case just assert it right away.
-		if ( editor.instanceReady ) {
+		if ( editor.status === 'ready' ) {
 			this._assertEditor( editor );
 		} else {
 			CKEDITOR.on( 'instanceReady', function( evt ) {

--- a/tests/core/editor/initialize_hidden.js
+++ b/tests/core/editor/initialize_hidden.js
@@ -5,26 +5,38 @@ CKEDITOR.replaceClass = 'ckeditor';
 
 bender.test( {
 	'test auto initilization': function() {
-		CKEDITOR.on( 'instanceReady', function( evt ) {
-			if ( evt.editor.name == 'editor1' ) {
-				resume( function() {
-					assert.areEqual( '<p>ed1</p>', bender.tools.compatHtml( evt.editor.getData() ) );
-				} );
-			}
-		} );
+		var editor = CKEDITOR.instances.editor1;
 
-		wait();
+		// For Firefox 60.0.1+ this code is executed after 'instanceReady' event so listener won't be called.
+		// For that case just assert it right away.
+		if ( editor.instanceReady ) {
+			this._assertEditor( editor );
+		} else {
+			CKEDITOR.on( 'instanceReady', function( evt ) {
+				if ( evt.editor.name == editor.name ) {
+					resume( function() {
+						this._assertEditor( editor );
+					} );
+				}
+			} );
+
+			wait();
+		}
 	},
 
 	'test replace': function() {
 		CKEDITOR.replace( 'editor2', { on: {
 			instanceReady: function( evt ) {
 				resume( function() {
-					assert.areEqual( '<p>ed2</p>', bender.tools.compatHtml( evt.editor.getData() ) );
+					this._assertEditor( evt.editor );
 				} );
 			}
 		} } );
 
 		wait();
+	},
+
+	_assertEditor: function( editor ) {
+		assert.areEqual( '<p>ed' + editor.name[ editor.name.length - 1 ] + '</p>', bender.tools.compatHtml( editor.getData() ) );
 	}
 } );

--- a/tests/core/editor/initialize_hidden.js
+++ b/tests/core/editor/initialize_hidden.js
@@ -5,17 +5,18 @@ CKEDITOR.replaceClass = 'ckeditor';
 
 bender.test( {
 	'test auto initilization': function() {
-		var editor = CKEDITOR.instances.editor1;
+		var editor = CKEDITOR.instances.editor1,
+			expected = '<p>ed1</p>';
 
 		// For Firefox 60.0.1+ this code is executed after 'instanceReady' event so listener won't be called.
-		// For that case just assert it right away.
+		// For that case just assert it right away (#2019).
 		if ( editor.status === 'ready' ) {
-			this._assertEditor( editor );
+			this._assertEditor( expected, editor );
 		} else {
-			CKEDITOR.on( 'instanceReady', function( evt ) {
+			editor.once( 'instanceReady', function( evt ) {
 				if ( evt.editor.name == editor.name ) {
 					resume( function() {
-						this._assertEditor( editor );
+						this._assertEditor( expected, editor );
 					} );
 				}
 			} );
@@ -28,7 +29,7 @@ bender.test( {
 		CKEDITOR.replace( 'editor2', { on: {
 			instanceReady: function( evt ) {
 				resume( function() {
-					this._assertEditor( evt.editor );
+					this._assertEditor( '<p>ed2</p>', evt.editor );
 				} );
 			}
 		} } );
@@ -36,7 +37,7 @@ bender.test( {
 		wait();
 	},
 
-	_assertEditor: function( editor ) {
-		assert.areEqual( '<p>ed' + editor.name[ editor.name.length - 1 ] + '</p>', bender.tools.compatHtml( editor.getData() ) );
+	_assertEditor: function( expectedData, editor ) {
+		assert.areEqual( expectedData, bender.tools.compatHtml( editor.getData() ) );
 	}
 } );


### PR DESCRIPTION
## What is the purpose of this pull request?

Fixed failing test

## What changes did you make?

Due to race condition in Firefox bender added `instanceReady` listener with assertions after that event, so assertions were never fired. For that case I've added if statement which calls assertions right away if editor instance is ready.

Closes #2019 