### PR TITLE
Use autocomplete's config templates in emoji plugin

### DIFF
--- a/plugins/emoji/plugin.js
+++ b/plugins/emoji/plugin.js
@@ -8,10 +8,15 @@
 ( function() {
 	'use strict';
 
+	var stylesLoaded = false;
+
 	CKEDITOR.plugins.add( 'emoji', {
 		requires: 'autocomplete,textmatch',
 		beforeInit: function() {
-			CKEDITOR.document.appendStyleSheet( this.path + 'skins/default.css' );
+			if ( !stylesLoaded ) {
+				CKEDITOR.document.appendStyleSheet( this.path + 'skins/default.css' );
+				stylesLoaded = true;
+			}
 		},
 
 		init: function( editor ) {

--- a/plugins/emoji/plugin.js
+++ b/plugins/emoji/plugin.js
@@ -10,6 +10,10 @@
 
 	CKEDITOR.plugins.add( 'emoji', {
 		requires: 'autocomplete,textmatch',
+		beforeInit: function() {
+			CKEDITOR.document.appendStyleSheet( this.path + 'skins/default.css' );
+		},
+
 		init: function( editor ) {
 			if ( CKEDITOR.env.ie && CKEDITOR.env.version < 9 ) {
 				return;
@@ -27,16 +31,12 @@
 				charactersToStart = editor.config.emoji_minChars || 2;
 
 			editor.on( 'instanceReady', function() {
-				var emoji = new CKEDITOR.plugins.autocomplete( editor, {
+				new CKEDITOR.plugins.autocomplete( editor, {
 					textTestCallback: getTextTestCallback(),
-					dataCallback: dataCallback
+					dataCallback: dataCallback,
+					itemTemplate: '<li data-id="{id}" class="cke_emoji_suggestion_item">{symbol} {id}</li>',
+					outputTemplate: '{symbol}'
 				} );
-
-				emoji.view.itemTemplate = new CKEDITOR.template( '<li data-id="{id}" style="overflow:hidden;text-overflow:ellipsis;white-space:nowrap;">{symbol} {id}</li>' );
-				emoji.getHtmlToInsert = function( item ) {
-					return item.symbol;
-				};
-
 			} );
 
 			editor.on( 'toHtml', function( evt ) {

--- a/plugins/emoji/skins/default.css
+++ b/plugins/emoji/skins/default.css
@@ -1,0 +1,5 @@
+.cke_emoji_suggestion_item {
+	overflow: hidden;
+	text-overflow: ellipsis;
+	white-space: nowrap;
+}


### PR DESCRIPTION
## What is the purpose of this pull request?

task

## Does your PR contain necessary tests?

All patches which change the editor code must include tests. You can always read more
on [PR testing](https://docs.ckeditor.com/ckeditor4/docs/#!/guide/dev_contributing_code-section-tests),
[how to set the testing environment](https://docs.ckeditor.com/ckeditor4/docs/#!/guide/dev_tests) and
[how to create tests](https://docs.ckeditor.com/ckeditor4/docs/#!/guide/dev_tests-section-creating-your-own-test)
in the official CKEditor documentation.

### This PR contains

- [ ] Unit tests
- [ ] Manual tests

## What changes did you make?

* update usage of autocomplete API in emoji plugin.
* remove inline style used in template.

Close #2032 
