### PR TITLE
Update changelog entry for replaced dialog in find plugin

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -3,10 +3,6 @@
 
 ## CKEditor 4.10
 
-**Important Notes:**
-
-* [#850](https://github.com/ckeditor/ckeditor-dev/issues/850): Replaced `replace` dialog from [Find / Replace](https://ckeditor.com/cke4/addon/find) plugin with `tabId` option in `find` command.
-
 New Features:
 
 * [#1761](https://github.com/ckeditor/ckeditor-dev/issues/1761): [Autolink](https://ckeditor.com/cke4/addon/autolink) plugin supports email links.
@@ -24,6 +20,7 @@ Fixed Issues:
 
 API Changes:
 
+* [#850](https://github.com/ckeditor/ckeditor-dev/issues/850): Backward incompatibility: Replaced `replace` dialog from [Find / Replace](https://ckeditor.com/cke4/addon/find) plugin with `tabId` option in `find` command.
 * [#1582](https://github.com/ckeditor/ckeditor-dev/issues/1582): The [`CKEDITOR.editor.addCommand`](https://docs.ckeditor.com/ckeditor4/latest/api/CKEDITOR_editor.html#method-addCommand) can accept [`CKEDITOR.command`](https://docs.ckeditor.com/ckeditor4/latest/api/CKEDITOR_command.html) instance as parameter.
 * [#1712](https://github.com/ckeditor/ckeditor-dev/issues/1712): [`extraPlugins`](https://docs.ckeditor.com/ckeditor4/latest/api/CKEDITOR_config.html#cfg-extraPlugins), [`removePlugins`](https://docs.ckeditor.com/ckeditor4/latest/api/CKEDITOR_config.html#cfg-removePlugins) and [`plugins`](https://docs.ckeditor.com/ckeditor4/latest/api/CKEDITOR_config.html#cfg-plugins) configuration options allow whitespace.
 * [#1724](https://github.com/ckeditor/ckeditor-dev/issues/1724): Added option to [`getClientRect`](https://docs.ckeditor.com/ckeditor4/latest/api/CKEDITOR_dom_element.html#method-getClientRect) function allowing to retrieve an absolute bounding rectangle of the element i.e. position relative to the upper-left corner of the topmost viewport.


### PR DESCRIPTION
## What is the purpose of this pull request?

Changelog entry

## Does your PR contain necessary tests?

All patches which change the editor code must include tests. You can always read more
on [PR testing](https://docs.ckeditor.com/ckeditor4/docs/#!/guide/dev_contributing_code-section-tests),
[how to set the testing environment](https://docs.ckeditor.com/ckeditor4/docs/#!/guide/dev_tests) and
[how to create tests](https://docs.ckeditor.com/ckeditor4/docs/#!/guide/dev_tests-section-creating-your-own-test)
in the official CKEditor documentation.

### This PR contains

- [ ] Unit tests
- [ ] Manual tests

**NOPE**, no tests.

## What changes did you make?

Moved changelog entry for replaced `replace` dialog into API category with "Backward Incompatiblity" note.