### PR TITLE
Improve node validation for removed cells in table

### DIFF
--- a/plugins/tableselection/plugin.js
+++ b/plugins/tableselection/plugin.js
@@ -1046,8 +1046,9 @@
 				var node = range.getEnclosedNode();
 
 				// Set text only in case of table cells, otherwise remove whole element (#867).
-				if ( node && node.is( { td: 1, th: 1 } ) ) {
-					range.getEnclosedNode().setText( '' );
+				// Check if `node.is` is function, as returned node might be CKEDITOR.dom.text (#2089).
+				if ( node && typeof node.is === 'function' && node.is( { td: 1, th: 1 } ) ) {
+					node.setText( '' );
 				} else {
 					range.deleteContents();
 				}

--- a/tests/core/dom/range/misc.js
+++ b/tests/core/dom/range/misc.js
@@ -194,6 +194,16 @@
 			assert.isTrue( doc.getById( '_enclosed_i' ).equals( range.getEnclosedNode() ) );
 		},
 
+		// Test getEnclosedNode returns text node (#2089).
+		test_enclosed_node4: function() {
+			var range = new CKEDITOR.dom.range( doc );
+			range.setStart( doc.getById( '_enclosed_i' ).getFirst(), 0 );
+			range.setEnd( doc.getById( '_enclosed_i' ).getLast(), 8 );
+			// <p> Test <i>[enclosed]</i> node.</p>
+
+			assert.areSame( doc.getById( '_enclosed_i' ).getFirst(), range.getEnclosedNode() );
+		},
+
 		/* Start of https://dev.ckeditor.com/ticket/6735 */
 
 		'test checkReadOnly when both range boundaries are inside of read-only element': function() {


### PR DESCRIPTION
## What is the purpose of this pull request?

Other, please explain
task fix

## Does your PR contain necessary tests?

All patches which change the editor code must include tests. You can always read more
on [PR testing](https://docs.ckeditor.com/ckeditor4/docs/#!/guide/dev_contributing_code-section-tests),
[how to set the testing environment](https://docs.ckeditor.com/ckeditor4/docs/#!/guide/dev_tests) and
[how to create tests](https://docs.ckeditor.com/ckeditor4/docs/#!/guide/dev_tests-section-creating-your-own-test)
in the official CKEditor documentation.

### This PR contains

- [x] Unit tests
- [ ] Manual tests

## What changes did you make?

- improve `if` statement to validate that node contains `is` method. This prevent of throwing an error, whent node will be instance of `CKEDITOR.dom.text`.

Close: #2089 