### PR TITLE
Updated autocomplete dataCallback API

### DIFF
--- a/plugins/autocomplete/plugin.js
+++ b/plugins/autocomplete/plugin.js
@@ -368,7 +368,7 @@
 		 * initializing the autocomplete and can be overwritten in order to
 		 * return an instance of a different class than the default model.
 		 *
-		 * @param {Function} dataCallback See {@link CKEDITOR.plugins.autocomplete} arguments.
+		 * @param {Function} dataCallback See {@link CKEDITOR.plugins.autocomplete.configDefinition#dataCallback configDefinition.dataCallback}.
 		 * @returns {CKEDITOR.plugins.autocomplete.model} The model instance.
 		 */
 		getModel: function( dataCallback ) {
@@ -376,6 +376,7 @@
 
 			return new Model( function( matchInfo, callback ) {
 				return dataCallback.call( this, CKEDITOR.tools.extend( {
+					// Make sure autocomplete instance is available in the callback (#2108).
 					autocomplete: that
 				}, matchInfo ), callback );
 			} );
@@ -1431,10 +1432,7 @@
 	 */
 
 	/**
-	 * Abstract class describing the definition of a
-	 * {@link CKEDITOR.plugins.autocomplete.configDefinition#dataCallback config.dataCallback} arguments.
-	 *
-	 * It lists properties which can be used to produce more adequate suggestion data based on matched query.
+	 * Abstract class describing set of properties which can be used to produce more adequate suggestion data based on matched query.
 	 *
 	 * @class CKEDITOR.plugins.autocomplete.matchInfo
 	 * @abstract
@@ -1455,7 +1453,7 @@
 	 */
 
 	/**
-	 * The {@link CKEDITOR.plugins.autocomplete Autocomplete} instance.
+	 * The {@link CKEDITOR.plugins.autocomplete Autocomplete} instance that matched the query.
 	 *
 	 * @property {CKEDITOR.plugins.autocomplete} autocomplete
 	 */

--- a/plugins/autocomplete/plugin.js
+++ b/plugins/autocomplete/plugin.js
@@ -372,7 +372,13 @@
 		 * @returns {CKEDITOR.plugins.autocomplete.model} The model instance.
 		 */
 		getModel: function( dataCallback ) {
-			return new Model( dataCallback );
+			var that = this;
+
+			return new Model( function( options ) {
+				return dataCallback.call( this, CKEDITOR.tools.extend( {
+					autocomplete: that
+				}, options ) );
+			} );
 		},
 
 		/**
@@ -509,7 +515,7 @@
 		 */
 		onTextMatched: function( evt ) {
 			this.model.setActive( false );
-			this.model.setQuery( evt.data.text, evt.data.range, this );
+			this.model.setQuery( evt.data.text, evt.data.range );
 		},
 
 		/**
@@ -1200,9 +1206,8 @@
 		 *
 		 * @param {String} query
 		 * @param {CKEDITOR.dom.range} range
-		 * @param {CKEDITOR.plugins.autocomplete} autocomplete
 		 */
-		setQuery: function( query, range, autocomplete ) {
+		setQuery: function( query, range ) {
 			var that = this,
 				requestId = CKEDITOR.tools.getNextId();
 
@@ -1215,7 +1220,6 @@
 			this.dataCallback( {
 				query: query,
 				range: range,
-				autocomplete: autocomplete,
 				callback: function( data ) {
 					// Handle only the response for the most recent setQuery call.
 					if ( requestId == that.lastRequestId ) {

--- a/plugins/autocomplete/plugin.js
+++ b/plugins/autocomplete/plugin.js
@@ -509,7 +509,7 @@
 		 */
 		onTextMatched: function( evt ) {
 			this.model.setActive( false );
-			this.model.setQuery( evt.data.text, evt.data.range );
+			this.model.setQuery( evt.data.text, evt.data.range, this );
 		},
 
 		/**
@@ -1200,8 +1200,9 @@
 		 *
 		 * @param {String} query
 		 * @param {CKEDITOR.dom.range} range
+		 * @param {CKEDITOR.plugins.autocomplete} autocomplete
 		 */
-		setQuery: function( query, range ) {
+		setQuery: function( query, range, autocomplete ) {
 			var that = this,
 				requestId = CKEDITOR.tools.getNextId();
 
@@ -1214,7 +1215,7 @@
 			this.dataCallback( {
 				query: query,
 				range: range,
-				autocomplete: this,
+				autocomplete: autocomplete,
 				callback: function( data ) {
 					// Handle only the response for the most recent setQuery call.
 					if ( requestId == that.lastRequestId ) {
@@ -1421,7 +1422,7 @@
 
 	/**
 	 * Abstract class describing the definition of a
-	 *  {@link CKEDITOR.plugins.autocomplete.configDefinition#dataCallback config.dataCallback} arguments.
+	 * {@link CKEDITOR.plugins.autocomplete.configDefinition#dataCallback config.dataCallback} arguments.
 	 *
 	 * It lists properties which can be used to produce more adequate suggestion data based on matched query.
 	 *
@@ -1432,7 +1433,7 @@
 
 	/**
 	 * The query string that was accepted by the
-	 *  {@link CKEDITOR.plugins.autocomplete.configDefinition#textTestCallback config.textTestCallback}.
+	 * {@link CKEDITOR.plugins.autocomplete.configDefinition#textTestCallback config.textTestCallback}.
 	 *
 	 * @property {String} query
 	 */
@@ -1444,8 +1445,7 @@
 	 */
 
 	/**
-	 * The {@link CKEDITOR.plugins.autocomplete Autocomplete} instance which
-	 *  called {@link CKEDITOR.plugins.autocomplete.configDefinition#dataCallback config.dataCallback}.
+	 * The {@link CKEDITOR.plugins.autocomplete Autocomplete} instance.
 	 *
 	 * @property {CKEDITOR.plugins.autocomplete} autocomplete
 	 */

--- a/plugins/autocomplete/plugin.js
+++ b/plugins/autocomplete/plugin.js
@@ -77,17 +77,17 @@
 	 *	}
 	 *
 	 *	// Returns (through its callback) the suggestions for the current query.
-	 *	function dataCallback( query, range, callback ) {
+	 *	function dataCallback( options ) {
 	 *		// Simple search.
 	 *		// Filter the entire items array so only the items that start
 	 *		// with the query remain.
 	 *		var suggestions = itemsArray.filter( function( item ) {
-	 *			return item.name.toLowerCase().indexOf( query.toLowerCase() ) == 0;
+	 *			return item.name.toLowerCase().indexOf( options.query.toLowerCase() ) == 0;
 	 *		} );
 	 *
 	 *		// Note - the callback function can also be executed asynchronously
 	 *		// so dataCallback can do an XHR requests or use any other asynchronous API.
-	 *		callback( suggestions );
+	 *		options.callback( suggestions );
 	 *	}
 	 *
 	 *	// Finally, instantiate the autocomplete class.
@@ -1211,16 +1211,21 @@
 			this.data = null;
 			this.selectedItemId = null;
 
-			this.dataCallback( query, range, function( data ) {
-				// Handle only the response for the most recent setQuery call.
-				if ( requestId == that.lastRequestId ) {
-					// Limit number of items (#2030).
-					if ( that.itemsLimit ) {
-						that.data = data.slice( 0, that.itemsLimit );
-					} else {
-						that.data = data;
+			this.dataCallback( {
+				query: query,
+				range: range,
+				autocomplete: this,
+				callback: function( data ) {
+					// Handle only the response for the most recent setQuery call.
+					if ( requestId == that.lastRequestId ) {
+						// Limit number of items (#2030).
+						if ( that.itemsLimit ) {
+							that.data = data.slice( 0, that.itemsLimit );
+						} else {
+							that.data = data;
+						}
+						that.fire( 'change-data', that.data );
 					}
-					that.fire( 'change-data', that.data );
 				}
 			} );
 			// Note: don't put any code here because the callback passed to
@@ -1310,7 +1315,7 @@
 	}
 
 	/**
-	 * Abstract class describing the definition of a {@link https://ckeditor.com/cke4/addon/autocomplete Autocomplete} plugin configuration.
+	 * Abstract class describing the definition of a [Autocomplete](https://ckeditor.com/cke4/addon/autocomplete) plugin configuration.
 	 *
 	 * It lists properties used to define and create autocomplete configuration definition.
 	 *
@@ -1336,28 +1341,23 @@
 	 * ```javascript
 	 *	// Returns (through its callback) the suggestions for the current query.
 	 *	// Note: the itemsArray variable is our example "database".
-	 *	function dataCallback( query, range, callback ) {
+	 *	function dataCallback( options ) {
 	 *		// Simple search.
 	 *		// Filter the entire items array so only the items that start
 	 *		// with the query remain.
 	 *		var suggestions = itemsArray.filter( function( item ) {
-	 *			return item.name.indexOf( query ) === 0;
+	 *			return item.name.indexOf( options.query ) === 0;
 	 *		} );
 	 *
 	 *		// Note - the callback function can also be executed asynchronously
 	 *		// so dataCallback can do an XHR requests or use any other asynchronous API.
-	 *		callback( suggestions );
+	 *		options.callback( suggestions );
 	 *	}
 	 *
 	 * ```
 	 *
 	 * @method dataCallback
-	 * @param {String} query The query string that was accepted by the `textTestCallback`.
-	 * @param {CKEDITOR.dom.range} range The range in the DOM where the query text is.
-	 * @param {Function} callback The callback which should be executed with the matched data.
-	 * @param {CKEDITOR.plugins.autocomplete.model.item[]} callback.data The suggestion data that should be
-	 * displayed in the autocomplete view for a given query. The data items should implement the
-	 * {@link CKEDITOR.plugins.autocomplete.model.item} interface.
+	 * @param {CKEDITOR.plugins.autocomplete.dataCallbackDefinition} dataCallbackDefinition
 	 */
 
 	/**
@@ -1417,5 +1417,45 @@
 	/**
 	 * @inheritdoc CKEDITOR.plugins.autocomplete#outputTemplate
 	 * @property {String} [outputTemplate]
+	 */
+
+	/**
+	 * Abstract class describing the definition of a
+	 *  {@link CKEDITOR.plugins.autocomplete.configDefinition#dataCallback config.dataCallback} arguments.
+	 *
+	 * It lists properties which can be used to produce more adequate suggestion data based on matched query.
+	 *
+	 * @class CKEDITOR.plugins.autocomplete.dataCallbackDefinition
+	 * @abstract
+	 * @since 4.10.0
+	 */
+
+	/**
+	 * The query string that was accepted by the
+	 *  {@link CKEDITOR.plugins.autocomplete.configDefinition#textTestCallback config.textTestCallback}.
+	 *
+	 * @property {String} query
+	 */
+
+	/**
+	 * The range in the DOM indicating the position of the {@link #query}.
+	 *
+	 * @property {CKEDITOR.dom.range} range
+	 */
+
+	/**
+	 * The {@link CKEDITOR.plugins.autocomplete Autocomplete} instance which
+	 *  called {@link CKEDITOR.plugins.autocomplete.configDefinition#dataCallback config.dataCallback}.
+	 *
+	 * @property {CKEDITOR.plugins.autocomplete} autocomplete
+	 */
+
+	/**
+	 * The callback which should be executed with the matched data.
+	 *
+	 * @param {CKEDITOR.plugins.autocomplete.model.item[]} data The suggestion data that should be
+	 * displayed in the autocomplete view for a given query. The data items should implement the
+	 * {@link CKEDITOR.plugins.autocomplete.model.item} interface.
+	 * @property {Function} callback
 	 */
 } )();

--- a/plugins/emoji/plugin.js
+++ b/plugins/emoji/plugin.js
@@ -76,12 +76,12 @@
 					return { start: match.index, end: offset };
 				}
 
-				function dataCallback( query, range, callback ) {
+				function dataCallback( matchInfo, callback ) {
 					var data = CKEDITOR.tools.array.filter( emojiList, function( item ) {
-						return item.id.indexOf( query.slice( 1 ) ) !== -1;
+						return item.id.indexOf( matchInfo.query.slice( 1 ) ) !== -1;
 					} ).sort( function( a, b ) {
 						// Sort at the beginning emoji starts with given query.
-						var emojiName = query.substr( 1 ),
+						var emojiName = matchInfo.query.substr( 1 ),
 							isAStartWithEmojiName = a.id.substr( 1, emojiName.length ) === emojiName,
 							isBStartWithEmojiName = b.id.substr( 1, emojiName.length ) === emojiName;
 

--- a/plugins/mentions/plugin.js
+++ b/plugins/mentions/plugin.js
@@ -186,7 +186,9 @@
 	}
 
 	function getDataCallback( feed, mentions ) {
-		return function( query, range, callback ) {
+		return function( matchInfo, callback ) {
+			var query = matchInfo.query;
+
 			// We are removing marker here to give clean query result for the endpoint callback.
 			if ( mentions.marker ) {
 				query = query.substring( mentions.marker.length );

--- a/tests/plugins/autocomplete/autocomplete.js
+++ b/tests/plugins/autocomplete/autocomplete.js
@@ -94,9 +94,9 @@
 			var editor = this.editors.standard,
 				ac = new CKEDITOR.plugins.autocomplete( editor, {
 					textTestCallback: textTestCallback,
-					dataCallback: function( query, range, callback ) {
+					dataCallback: function( options ) {
 						setTimeout( function() {
-							callback( [ { id: 1, name: 'test' } ] );
+							options.callback( [ { id: 1, name: 'test' } ] );
 						}, 100 );
 					}
 				} );
@@ -376,8 +376,8 @@
 			var editor = this.editors.standard,
 				ac = new CKEDITOR.plugins.autocomplete( editor, {
 					textTestCallback: textTestCallback,
-					dataCallback: function( query, range, callback ) {
-						callback( [ { id: 1, name: 'anna' } ] );
+					dataCallback: function( options ) {
+						options.callback( [ { id: 1, name: 'anna' } ] );
 					},
 					itemTemplate: '<li data-id="{id}"><strong>{name}</strong></li>'
 				} );
@@ -398,8 +398,8 @@
 				editable = editor.editable(),
 				ac = new CKEDITOR.plugins.autocomplete( editor, {
 					textTestCallback: textTestCallback,
-					dataCallback: function( query, range, callback ) {
-						callback( [ { id: 1, name: 'anna' } ] );
+					dataCallback: function( options ) {
+						options.callback( [ { id: 1, name: 'anna' } ] );
 					},
 					outputTemplate: '<strong>{name}</strong>'
 				} );
@@ -505,8 +505,8 @@
 		return { text: 'text', range: selectionRange };
 	}
 
-	function dataCallback( query, range, callback ) {
-		return callback( [ { id: 1, name: 'item1' }, { id: 2, name: 'item2' }, { id: 3, name: 'item3' } ] );
+	function dataCallback( options ) {
+		return options.callback( [ { id: 1, name: 'item1' }, { id: 2, name: 'item2' }, { id: 3, name: 'item3' } ] );
 	}
 
 } )();

--- a/tests/plugins/autocomplete/autocomplete.js
+++ b/tests/plugins/autocomplete/autocomplete.js
@@ -471,6 +471,27 @@
 			ac.destroy();
 		},
 
+		// (#2108)
+		'test dataCallback API': function() {
+			var editor = this.editors.standard,
+				ac = new CKEDITOR.plugins.autocomplete( editor, {
+					textTestCallback: textTestCallback,
+					dataCallback: function( options ) {
+						assert.areSame( 'text', options.query, 'options.query' );
+						assert.isInstanceOf( CKEDITOR.dom.range, options.range, 'options.range' );
+						assert.areSame( ac, options.autocomplete, 'options.autocomplete' );
+
+						options.callback( [ { id: 1, name: 'textSample' } ] );
+					}
+				} );
+
+			this.editorBots.standard.setHtmlWithSelection( '<p>text^ bar</p>' );
+
+			editor.editable().fire( 'keyup', new CKEDITOR.dom.event( {} ) );
+
+			ac.destroy();
+		},
+
 		// (#2030)
 		'test cycle through limited items': function() {
 			var editor = this.editors.standard,

--- a/tests/plugins/autocomplete/autocomplete.js
+++ b/tests/plugins/autocomplete/autocomplete.js
@@ -94,9 +94,9 @@
 			var editor = this.editors.standard,
 				ac = new CKEDITOR.plugins.autocomplete( editor, {
 					textTestCallback: textTestCallback,
-					dataCallback: function( options ) {
+					dataCallback: function( matchInfo, callback ) {
 						setTimeout( function() {
-							options.callback( [ { id: 1, name: 'test' } ] );
+							callback( [ { id: 1, name: 'test' } ] );
 						}, 100 );
 					}
 				} );
@@ -376,8 +376,8 @@
 			var editor = this.editors.standard,
 				ac = new CKEDITOR.plugins.autocomplete( editor, {
 					textTestCallback: textTestCallback,
-					dataCallback: function( options ) {
-						options.callback( [ { id: 1, name: 'anna' } ] );
+					dataCallback: function( matchInfo, callback ) {
+						callback( [ { id: 1, name: 'anna' } ] );
 					},
 					itemTemplate: '<li data-id="{id}"><strong>{name}</strong></li>'
 				} );
@@ -398,8 +398,8 @@
 				editable = editor.editable(),
 				ac = new CKEDITOR.plugins.autocomplete( editor, {
 					textTestCallback: textTestCallback,
-					dataCallback: function( options ) {
-						options.callback( [ { id: 1, name: 'anna' } ] );
+					dataCallback: function( matchInfo, callback ) {
+						callback( [ { id: 1, name: 'anna' } ] );
 					},
 					outputTemplate: '<strong>{name}</strong>'
 				} );
@@ -476,12 +476,12 @@
 			var editor = this.editors.standard,
 				ac = new CKEDITOR.plugins.autocomplete( editor, {
 					textTestCallback: textTestCallback,
-					dataCallback: function( options ) {
-						assert.areSame( 'text', options.query, 'options.query' );
-						assert.isInstanceOf( CKEDITOR.dom.range, options.range, 'options.range' );
-						assert.areSame( ac, options.autocomplete, 'options.autocomplete' );
+					dataCallback: function( matchInfo, callback ) {
+						assert.areSame( 'text', matchInfo.query, 'matchInfo.query' );
+						assert.isInstanceOf( CKEDITOR.dom.range, matchInfo.range, 'matchInfo.range' );
+						assert.areSame( ac, matchInfo.autocomplete, 'matchInfo.autocomplete' );
 
-						options.callback( [ { id: 1, name: 'textSample' } ] );
+						callback( [ { id: 1, name: 'textSample' } ] );
 					}
 				} );
 
@@ -526,8 +526,8 @@
 		return { text: 'text', range: selectionRange };
 	}
 
-	function dataCallback( options ) {
-		return options.callback( [ { id: 1, name: 'item1' }, { id: 2, name: 'item2' }, { id: 3, name: 'item3' } ] );
+	function dataCallback( matchInfo, callback ) {
+		return callback( [ { id: 1, name: 'item1' }, { id: 2, name: 'item2' }, { id: 3, name: 'item3' } ] );
 	}
 
 } )();

--- a/tests/plugins/autocomplete/manual/_helpers/utils.js
+++ b/tests/plugins/autocomplete/manual/_helpers/utils.js
@@ -44,13 +44,13 @@
 
 			var dataSource = config.data || DATA;
 
-			return function( query, range, callback ) {
+			return function( options ) {
 				var data = dataSource.filter( function( item ) {
-					return item.name.indexOf( query.toLowerCase() ) == 0;
+					return item.name.indexOf( options.query.toLowerCase() ) == 0;
 				} );
 
 				setTimeout( function() {
-					callback( data );
+					options.callback( data );
 				}, config.async || 0 );
 			};
 		}

--- a/tests/plugins/autocomplete/manual/_helpers/utils.js
+++ b/tests/plugins/autocomplete/manual/_helpers/utils.js
@@ -44,13 +44,13 @@
 
 			var dataSource = config.data || DATA;
 
-			return function( options ) {
+			return function( matchInfo, callback ) {
 				var data = dataSource.filter( function( item ) {
-					return item.name.indexOf( options.query.toLowerCase() ) == 0;
+					return item.name.indexOf( matchInfo.query.toLowerCase() ) == 0;
 				} );
 
 				setTimeout( function() {
-					options.callback( data );
+					callback( data );
 				}, config.async || 0 );
 			};
 		}

--- a/tests/plugins/autocomplete/model.js
+++ b/tests/plugins/autocomplete/model.js
@@ -137,14 +137,14 @@
 					expectedRange = 'range',
 					expectedData = getData(),
 
-					model = new CKEDITOR.plugins.autocomplete.model( function( query, range, callback ) {
-						assert.areEqual( expectedQuery, query );
-						assert.areEqual( expectedRange, range );
+					model = new CKEDITOR.plugins.autocomplete.model( function( options ) {
+						assert.areEqual( expectedQuery, options.query );
+						assert.areEqual( expectedRange, options.range );
 						assert.isNull( model.data );
 
 						var spy = sinon.spy( model, 'fire' );
 
-						callback( expectedData );
+						options.callback( expectedData );
 
 						assert.areSame( expectedData, model.data );
 						assert.isTrue( spy.calledWith( 'change-data', expectedData ) );
@@ -161,16 +161,16 @@
 				expectedRange = 'range',
 				expectedData = getData(),
 
-				model = new CKEDITOR.plugins.autocomplete.model( function( query, range, callback ) {
-					assert.areEqual( expectedQuery, query );
-					assert.areEqual( expectedRange, range );
+				model = new CKEDITOR.plugins.autocomplete.model( function( options ) {
+					assert.areEqual( expectedQuery, options.query );
+					assert.areEqual( expectedRange, options.range );
 					assert.isNull( model.data );
 
 					var spy = sinon.spy( model, 'fire' );
 
 					setTimeout( function() {
 						resume( function() {
-							callback( expectedData );
+							options.callback( expectedData );
 
 							assert.areSame( expectedData, model.data );
 							assert.isTrue( spy.calledWith( 'change-data', expectedData ) );

--- a/tests/plugins/autocomplete/model.js
+++ b/tests/plugins/autocomplete/model.js
@@ -137,14 +137,14 @@
 					expectedRange = 'range',
 					expectedData = getData(),
 
-					model = new CKEDITOR.plugins.autocomplete.model( function( options ) {
-						assert.areEqual( expectedQuery, options.query );
-						assert.areEqual( expectedRange, options.range );
+					model = new CKEDITOR.plugins.autocomplete.model( function( matchInfo, callback ) {
+						assert.areEqual( expectedQuery, matchInfo.query );
+						assert.areEqual( expectedRange, matchInfo.range );
 						assert.isNull( model.data );
 
 						var spy = sinon.spy( model, 'fire' );
 
-						options.callback( expectedData );
+						callback( expectedData );
 
 						assert.areSame( expectedData, model.data );
 						assert.isTrue( spy.calledWith( 'change-data', expectedData ) );
@@ -161,16 +161,16 @@
 				expectedRange = 'range',
 				expectedData = getData(),
 
-				model = new CKEDITOR.plugins.autocomplete.model( function( options ) {
-					assert.areEqual( expectedQuery, options.query );
-					assert.areEqual( expectedRange, options.range );
+				model = new CKEDITOR.plugins.autocomplete.model( function( matchInfo, callback ) {
+					assert.areEqual( expectedQuery, matchInfo.query );
+					assert.areEqual( expectedRange, matchInfo.range );
 					assert.isNull( model.data );
 
 					var spy = sinon.spy( model, 'fire' );
 
 					setTimeout( function() {
 						resume( function() {
-							options.callback( expectedData );
+							callback( expectedData );
 
 							assert.areSame( expectedData, model.data );
 							assert.isTrue( spy.calledWith( 'change-data', expectedData ) );


### PR DESCRIPTION
## What is the purpose of this pull request?

New feature

## Does your PR contain necessary tests?

All patches which change the editor code must include tests. You can always read more
on [PR testing](https://docs.ckeditor.com/ckeditor4/docs/#!/guide/dev_contributing_code-section-tests),
[how to set the testing environment](https://docs.ckeditor.com/ckeditor4/docs/#!/guide/dev_tests) and
[how to create tests](https://docs.ckeditor.com/ckeditor4/docs/#!/guide/dev_tests-section-creating-your-own-test)
in the official CKEditor documentation.

### This PR contains

- [ ] Unit tests
- [ ] Manual tests

Tests are already available for `autocomplete` plugin.

## What changes did you make?

I updated dataCallback API to accept object instead of multiple parameters. Object exposes `autocomplete` instance.

Closes #2108