### PR TITLE
Attaching autocomplete before instanceReady event

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -3,11 +3,15 @@
 
 ## CKEditor 4.10.1
 
+Fixed Issues:
+
+* [#2114](https://github.com/ckeditor/ckeditor-dev/issues/2114): [Autocomplete](https://ckeditor.com/cke4/addon/autocomplete) cannot be initialized before [`instanceReady`](https://docs.ckeditor.com/ckeditor4/latest/api/CKEDITOR_editor.html#event-instanceReady).
+
 ## CKEditor 4.10
 
 New Features:
 
-* [#1751](https://github.com/ckeditor/ckeditor-dev/issues/1751): Introduced the **Autocomplete** feature that consists of the following plugins: 
+* [#1751](https://github.com/ckeditor/ckeditor-dev/issues/1751): Introduced the **Autocomplete** feature that consists of the following plugins:
 	* [Autocomplete](https://ckeditor.com/cke4/addon/autocomplete) &ndash; Provides contextual completion feature for custom text matches based on user input.
 	* [Text Watcher](https://ckeditor.com/cke4/addon/textWatcher) &ndash; Checks whether an editor's text change matches the chosen criteria.
 	* [Text Match](https://ckeditor.com/cke4/addon/textMatch) &ndash; Allows to search [`CKEDITOR.dom.range`](https://docs.ckeditor.com/ckeditor4/latest/api/CKEDITOR_dom_range.html) for matching text.

--- a/plugins/autocomplete/plugin.js
+++ b/plugins/autocomplete/plugin.js
@@ -231,7 +231,14 @@
 			this.view.itemTemplate = new CKEDITOR.template( config.itemTemplate );
 		}
 
-		this.attach();
+		// Attach autocomplete when editor instance is ready (#2114).
+		if ( this.editor.status === 'ready' ) {
+			this.attach();
+		} else {
+			this.editor.on( 'instanceReady', function() {
+				this.attach();
+			}, this );
+		}
 	}
 
 	Autocomplete.prototype = {

--- a/tests/plugins/autocomplete/autocomplete.html
+++ b/tests/plugins/autocomplete/autocomplete.html
@@ -1,0 +1,1 @@
+<div id="init"></div>

--- a/tests/plugins/autocomplete/autocomplete.js
+++ b/tests/plugins/autocomplete/autocomplete.js
@@ -1,5 +1,5 @@
 /* bender-tags: editor */
-/* bender-ckeditor-plugins: autocomplete */
+/* bender-ckeditor-plugins: autocomplete,wysiwygarea */
 
 ( function() {
 	'use strict';
@@ -543,6 +543,26 @@
 			assert.areEqual( 1, ac.view.selectedItemId, 'View selected item id' );
 
 			ac.destroy();
+		},
+
+		// (#2114)
+		'test initialize autocomplete before instanceReady': function() {
+			var editor = CKEDITOR.replace( 'init' ),
+				ac;
+
+			editor.once( 'pluginsLoaded', function() {
+				ac = new CKEDITOR.plugins.autocomplete( editor, configDefinition );
+			} );
+
+			editor.on( 'instanceReady', function() {
+				resume( function() {
+					bender.tools.setHtmlWithSelection( editor, '' );
+					editor.editable().fire( 'keyup', new CKEDITOR.dom.event( {} ) );
+					assertViewOpened( ac, true );
+				} );
+			} );
+
+			wait();
 		}
 	} );
 

--- a/tests/plugins/autocomplete/manual/init.html
+++ b/tests/plugins/autocomplete/manual/init.html
@@ -1,0 +1,14 @@
+<div id="editor"></div>
+
+<script>
+	CKEDITOR.replace( 'editor', {
+		on: {
+			pluginsLoaded: function( evt ) {
+				new CKEDITOR.plugins.autocomplete( evt.editor, {
+					textTestCallback: autocompleteUtils.getTextTestCallback(),
+					dataCallback: autocompleteUtils.getDataCallback(),
+				} );
+			}
+		}
+	} );
+</script>

--- a/tests/plugins/autocomplete/manual/init.html
+++ b/tests/plugins/autocomplete/manual/init.html
@@ -1,6 +1,11 @@
 <div id="editor"></div>
 
 <script>
+
+	if ( autocompleteUtils.isUnsupportedEnvironment() ) {
+		bender.ignore();
+	}
+
 	CKEDITOR.replace( 'editor', {
 		on: {
 			pluginsLoaded: function( evt ) {

--- a/tests/plugins/autocomplete/manual/init.md
+++ b/tests/plugins/autocomplete/manual/init.md
@@ -1,18 +1,15 @@
-@bender-tags: 4.10.0, bug, 2114
+@bender-tags: 4.10.1, bug, 2114
 @bender-ui: collapsed
 @bender-ckeditor-plugins: wysiwygarea, toolbar, basicstyles, autocomplete, textmatch
 @bender-include: _helpers/utils.js
 
-1. Open console.
 1. Focus the editor.
 1. Type `@`
 
 ## Expected
 
-* No console errors.
-* Autocomplete dropdown showed up.
+Autocomplete dropdown showed up.
 
 ## Unexpected
 
-* Console errors refering to `Autocomplete.attach` function.
-* Autocomplete dropdown didn't show up.
+Editor is not loaded / Autocomplete dropdown didn't show up.

--- a/tests/plugins/autocomplete/manual/init.md
+++ b/tests/plugins/autocomplete/manual/init.md
@@ -1,0 +1,18 @@
+@bender-tags: 4.10.0, bug, 2114
+@bender-ui: collapsed
+@bender-ckeditor-plugins: wysiwygarea, toolbar, basicstyles, autocomplete, textmatch
+@bender-include: _helpers/utils.js
+
+1. Open console.
+1. Focus the editor.
+1. Type `@`
+
+## Expected
+
+* No console errors.
+* Autocomplete dropdown showed up.
+
+## Unexpected
+
+* Console errors refering to `Autocomplete.attach` function.
+* Autocomplete dropdown didn't show up.


### PR DESCRIPTION
## What is the purpose of this pull request?

Bug fix

## Does your PR contain necessary tests?

All patches which change the editor code must include tests. You can always read more
on [PR testing](https://docs.ckeditor.com/ckeditor4/docs/#!/guide/dev_contributing_code-section-tests),
[how to set the testing environment](https://docs.ckeditor.com/ckeditor4/docs/#!/guide/dev_tests) and
[how to create tests](https://docs.ckeditor.com/ckeditor4/docs/#!/guide/dev_tests-section-creating-your-own-test)
in the official CKEditor documentation.

### This PR contains

- [x] Unit tests
- [x] Manual tests

## What changes did you make?

Autocomplete recognizes editors state when attaching into an editor.

Closes #2114
