### PR TITLE
Autocomplete dropdown is no longer selectable

### DIFF
--- a/plugins/autocomplete/plugin.js
+++ b/plugins/autocomplete/plugin.js
@@ -693,7 +693,7 @@
 		 * @returns {CKEDITOR.dom.element}
 		 */
 		createElement: function() {
-			var el = new CKEDITOR.dom.element( 'ul', this.document );
+			var el = CKEDITOR.dom.element.createFromHtml( '<ul onselectstart="return false;"></ul>' );
 
 			el.addClass( 'cke_autocomplete_panel' );
 			// Below float panels and context menu, but above maximized editor (-5).

--- a/tests/plugins/autocomplete/manual/dropdownselection.md
+++ b/tests/plugins/autocomplete/manual/dropdownselection.md
@@ -1,0 +1,16 @@
+@bender-tags: 4.10.0, feature, 2162
+@bender-ui: collapsed
+@bender-ckeditor-plugins: wysiwygarea, toolbar, basicstyles, autocomplete
+@bender-include: _helpers/utils.js
+
+1. Focus the editor.
+1. Type `@`.
+1. Select dropdown content using mouse.
+
+## Expected
+
+Nothing is selected.
+
+## Unexpected
+
+Dropdown items are selected.

--- a/tests/plugins/autocomplete/view.js
+++ b/tests/plugins/autocomplete/view.js
@@ -187,7 +187,7 @@
 
 	function assertViewElement( editor, element ) {
 		var zIndex = editor.config.baseFloatZIndex - 3,
-			expectedHtml = '<ul class="cke_autocomplete_panel" style="z-index: ' + zIndex + ';"></ul>';
+			expectedHtml = '<ul class="cke_autocomplete_panel" onselectstart="return false;" style="z-index: ' + zIndex + ';"></ul>';
 
 		assert.areEqual( expectedHtml, bender.tools.compatHtml( element.$.outerHTML, false, true ) );
 	}


### PR DESCRIPTION
## What is the purpose of this pull request?

Bug fix

## Does your PR contain necessary tests?

All patches which change the editor code must include tests. You can always read more
on [PR testing](https://docs.ckeditor.com/ckeditor4/docs/#!/guide/dev_contributing_code-section-tests),
[how to set the testing environment](https://docs.ckeditor.com/ckeditor4/docs/#!/guide/dev_tests) and
[how to create tests](https://docs.ckeditor.com/ckeditor4/docs/#!/guide/dev_tests-section-creating-your-own-test)
in the official CKEditor documentation.

### This PR contains

- [x] Unit tests
- [x] Manual tests

## What changes did you make?

Added `onselectstart=false` into dropdown element. It could be done by `user-select: none` CSS but it's not widely supported.

It's best to close #2107 issue before reviewing this one thus mentioned issue will improve manual testing.

Closes #2126
