### PR TITLE
Selecting non-editable image in Edge

### DIFF
--- a/core/editable.js
+++ b/core/editable.js
@@ -1131,10 +1131,11 @@
 				}
 
 				// For some reason, after click event is done, IE Edge loses focus on the selected element. (https://dev.ckeditor.com/ticket/13386)
+				// Additional check for readonly disabled selecting of non-editable images (#2129).
 				if ( CKEDITOR.env.edge ) {
 					this.attachListener( this, 'mouseup', function( ev ) {
 						var selectedElement = ev.data.getTarget();
-						if ( selectedElement && selectedElement.is( 'img' ) ) {
+						if ( selectedElement && selectedElement.is( 'img' ) && !selectedElement.isReadOnly() ) {
 							editor.getSelection().selectElement( selectedElement );
 						}
 					} );

--- a/tests/core/editable/manual/noneditableimage.html
+++ b/tests/core/editable/manual/noneditableimage.html
@@ -1,0 +1,12 @@
+<div id="editor">
+	<p>Foo</p>
+	<div contenteditable="false">
+		<img src="../../../_assets/lena.jpg" alt="">
+	</div>
+</div>
+
+<script>
+	CKEDITOR.replace( 'editor', {
+		extraAllowedContent: 'div [contenteditable]'
+	} );
+</script>

--- a/tests/core/editable/manual/noneditableimage.md
+++ b/tests/core/editable/manual/noneditableimage.md
@@ -1,0 +1,14 @@
+@bender-tags: 4.10.0, bug, 2129
+@bender-ui: collapsed
+@bender-ckeditor-plugins: clipboard, image, wysiwygarea, elementspath
+
+1. Select "foo".
+2. Click on image.
+
+## Expected
+
+Selection doesn't change (you can check it on elements path).
+
+## Unexpected
+
+Image became selected.

--- a/tests/core/editable/misc.js
+++ b/tests/core/editable/misc.js
@@ -84,6 +84,8 @@ bender.test( {
 			var editor = bot.editor,
 				img = editor.editable().findOne( 'img' );
 
+			// For some reason Edge 42+ needs focus (#2129).
+			editor.focus();
 			editor.getSelection().selectElement( editor.editable().findOne( 'p' ) );
 
 			editor.editable().fire( 'mousedown', new CKEDITOR.dom.event( {


### PR DESCRIPTION
## What is the purpose of this pull request?

Bug fix

## Does your PR contain necessary tests?

All patches which change the editor code must include tests. You can always read more
on [PR testing](https://docs.ckeditor.com/ckeditor4/docs/#!/guide/dev_contributing_code-section-tests),
[how to set the testing environment](https://docs.ckeditor.com/ckeditor4/docs/#!/guide/dev_tests) and
[how to create tests](https://docs.ckeditor.com/ckeditor4/docs/#!/guide/dev_tests-section-creating-your-own-test)
in the official CKEditor documentation.

### This PR contains

- [x] Unit tests
- [x] Manual tests

## What changes did you make?

I've added `editor.focus()` to failing test.

BUT I also discovered that this test has been a false positive for 3 years 😱. Fix introduced in https://dev.ckeditor.com/ticket/13386 forced selection also of non-editable images, yet it was visible only via real interaction with the editor. I've fixed it as well, adding proper check. I've added also manual test for this case.

Closes #2129.