### PR TITLE
Correct failing emoji test in presets.

### DIFF
--- a/tests/plugins/emoji/customemojilist.js
+++ b/tests/plugins/emoji/customemojilist.js
@@ -49,7 +49,7 @@
 		'test long ajax loading': function() {
 			var server = sinon.fakeServer.create();
 
-			server.respondWith( 'GET', 'http://random.url', [ 200, { 'Content-Type': 'application/json' }, '[{"id":":bug:","symbol":"🐛"}]' ] );
+			server.respondWith( 'GET', /^http:\/\/random\.url(?:\/?\?.*)?$/, [ 200, { 'Content-Type': 'application/json' }, '[{"id":":bug:","symbol":"🐛"}]' ] );
 
 			bender.editorBot.create( {
 				name: 'created1',


### PR DESCRIPTION
## What is the purpose of this pull request?

fialing test fix

## Does your PR contain necessary tests?

All patches which change the editor code must include tests. You can always read more
on [PR testing](https://docs.ckeditor.com/ckeditor4/docs/#!/guide/dev_contributing_code-section-tests),
[how to set the testing environment](https://docs.ckeditor.com/ckeditor4/docs/#!/guide/dev_tests) and
[how to create tests](https://docs.ckeditor.com/ckeditor4/docs/#!/guide/dev_tests-section-creating-your-own-test)
in the official CKEditor documentation.

### This PR contains

- [ ] Unit tests
- [ ] Manual tests

## What changes did you make?

- fix failing test: `/tests/plugins/emoji/customemojilist`, we need to stub XHR with regexp to consider cache buster in links.