### PR TITLE
Fixed failing tests for autocomplete and textwatcher

### DIFF
--- a/tests/plugins/autocomplete/autocomplete.js
+++ b/tests/plugins/autocomplete/autocomplete.js
@@ -1,5 +1,5 @@
 /* bender-tags: editor */
-/* bender-ckeditor-plugins: autocomplete */
+/* bender-ckeditor-plugins: autocomplete, toolbar, basicstyles */
 
 ( function() {
 	'use strict';
@@ -232,6 +232,8 @@
 			editable.fire( 'keydown', new CKEDITOR.dom.event( { keyCode: 9 } ) ); // TAB
 			assert.areEqual( '', editor.getData(), 'Tab caused insertion' );
 
+			// Model may be deactivated by the previous keydown.
+			ac.model.isActive = true;
 			editable.fire( 'keydown', new CKEDITOR.dom.event( { keyCode: 16 } ) ); // SHIFT
 
 			assert.areEqual( '<p>item1</p>', editor.getData() );
@@ -251,6 +253,8 @@
 			editable.fire( 'keydown', new CKEDITOR.dom.event( { keyCode: 9 } ) ); // TAB
 			assert.areEqual( '', editor.getData(), 'Tab caused insertion' );
 
+			// Model may be deactivated by the previous keydown.
+			ac.model.isActive = true;
 			editable.fire( 'keydown', new CKEDITOR.dom.event( { keyCode: 16 } ) ); // SHIFT
 
 			assert.areEqual( '<p>item1</p>', editor.getData() );
@@ -270,6 +274,8 @@
 			editable.fire( 'keydown', new CKEDITOR.dom.event( { keyCode: 9 } ) ); // TAB
 			assert.areEqual( '', editor.getData(), 'Tab caused insertion' );
 
+			// Model may be deactivated by the previous keydown.
+			ac.model.isActive = true;
 			editable.fire( 'keydown', new CKEDITOR.dom.event( { keyCode: 16 } ) ); // SHIFT
 
 			assert.areEqual( '<p>item1</p>', editor.getData() );
@@ -427,8 +433,9 @@
 				// Remove document position offset so it won't broke dashboard test (#2051).
 				getDocumentPositionStub = sinon.stub( CKEDITOR.dom.element.prototype, 'getDocumentPosition' )
 					.returns( { x: 0, y: 0 } ),
+				editorViewportRectStub = sinon.stub( CKEDITOR.dom.element.prototype, 'getClientRect' )
+					.returns( { top: 0, bottom: 200 } ),
 				lastRangeRect = { left: 10, top: 10, height: 10 },
-				offset = 3,
 				ac = new CKEDITOR.plugins.autocomplete( editor, {
 					textTestCallback: function() {
 						var range = editor.createRange(),
@@ -446,16 +453,10 @@
 			editable.fire( 'keyup', new CKEDITOR.dom.event( {} ) );
 
 			getDocumentPositionStub.restore();
+			editorViewportRectStub.restore();
 
-			assert.isNumberInRange( ac.view.element.getSize( 'left' ),
-				lastRangeRect.left - offset,
-				lastRangeRect.left + offset,
-				'Horizontal position.' );
-
-			assert.isNumberInRange( ac.view.element.getSize( 'top' ),
-				lastRangeRect.top + lastRangeRect.height - offset,
-				lastRangeRect.top + lastRangeRect.height + offset,
-				'Vertical position.' );
+			assert.areEqual( 10, ac.view.element.getSize( 'left' ), 'Horizontal position' );
+			assert.areEqual( 20, ac.view.element.getSize( 'top' ), 'Vertical position' );
 
 			ac.destroy();
 		},

--- a/tests/plugins/autocomplete/autocomplete.js
+++ b/tests/plugins/autocomplete/autocomplete.js
@@ -1,5 +1,5 @@
 /* bender-tags: editor */
-/* bender-ckeditor-plugins: autocomplete, toolbar, basicstyles */
+/* bender-ckeditor-plugins: autocomplete */
 
 ( function() {
 	'use strict';

--- a/tests/plugins/textwatcher/textwatcher.js
+++ b/tests/plugins/textwatcher/textwatcher.js
@@ -1,5 +1,5 @@
 /* bender-tags: editor */
-/* bender-ckeditor-plugins: textwatcher */
+/* bender-ckeditor-plugins: textwatcher,undo */
 
 ( function() {
 	'use strict';
@@ -28,7 +28,7 @@
 			editor.fire( 'setData', new CKEDITOR.dom.event( {} ) );
 			assert.isFalse( unmatchSpy.called, 'Unmatch called on setData' );
 
-			editor.fire( 'afterCommandExec', new CKEDITOR.dom.event( {} ) );
+			editor.fire( 'afterCommandExec', { command: new CKEDITOR.command( editor, {} ) } );
 			assert.isFalse( unmatchSpy.called, 'Unmatch called on afterCommandExec' );
 
 			assert.areEqual( 0, textwatcher._listeners.length, 'Listeners has not been emptied' );
@@ -47,7 +47,7 @@
 			var editor = this.editor,
 				spy = sinon.spy( attachTextWatcher( editor ), 'unmatch' );
 
-			editor.fire( 'afterCommandExec' );
+			editor.fire( 'afterCommandExec', { command: new CKEDITOR.command( editor, {} ) } );
 
 			assert.isTrue( spy.calledOnce );
 		},

--- a/tests/plugins/textwatcher/textwatcher.js
+++ b/tests/plugins/textwatcher/textwatcher.js
@@ -1,5 +1,5 @@
 /* bender-tags: editor */
-/* bender-ckeditor-plugins: textwatcher,undo */
+/* bender-ckeditor-plugins: textwatcher */
 
 ( function() {
 	'use strict';


### PR DESCRIPTION
## What is the purpose of this pull request?

Tests fix.

## What changes did you make?

*  easy fix for `textwatcher` by adding command into an event so `undo` plugin won't broke
* replaced `getClientRect` in `autocomplete` with stub so view positioning in test no longer depends on toolbar size
* with full built triggering `keydown` triggers `afterComandExec` event ( by `tableselection` ) and deactivates `autocompete` model. I'm manually activating model for next `keydown` event so the tests pass. Not best solution but I think the easiest and tests are still valid.

Closes #2132 ( emoji already fixed by @msamsel )
