### PR TITLE
Remove link plugin dependancy from unnecessary tests

### DIFF
--- a/tests/plugins/autolink/autolink.js
+++ b/tests/plugins/autolink/autolink.js
@@ -1,7 +1,7 @@
 'use strict';
 
 /* bender-tags: editor */
-/* bender-ckeditor-plugins: autolink,clipboard */
+/* bender-ckeditor-plugins: autolink,clipboard,link */
 /* bender-include: ../clipboard/_helpers/pasting.js */
 /* global assertPasteEvent */
 
@@ -9,23 +9,22 @@ bender.editors = {
 	classic: {
 		config: {
 			allowedContent: true,
-			pasteFilter: null
+			pasteFilter: null,
+			removePlugins: 'link'
 		}
 	},
 	encodedDefault: {
 		config: {
 			allowedContent: true,
 			pasteFilter: null,
-			emailProtection: 'encode',
-			extraPlugins: 'link'
+			emailProtection: 'encode'
 		}
 	},
 	encodedCustom: {
 		config: {
 			allowedContent: true,
 			pasteFilter: null,
-			emailProtection: 'mt(NAME,DOMAIN,SUBJECT,BODY)',
-			extraPlugins: 'link'
+			emailProtection: 'mt(NAME,DOMAIN,SUBJECT,BODY)'
 		}
 	}
 };


### PR DESCRIPTION
## What is the purpose of this pull request?

Bug fix

## Does your PR contain necessary tests?

All patches which change the editor code must include tests. You can always read more
on [PR testing](https://docs.ckeditor.com/ckeditor4/docs/#!/guide/dev_contributing_code-section-tests),
[how to set the testing environment](https://docs.ckeditor.com/ckeditor4/docs/#!/guide/dev_tests) and
[how to create tests](https://docs.ckeditor.com/ckeditor4/docs/#!/guide/dev_tests-section-creating-your-own-test)
in the official CKEditor documentation.

### This PR contains

- [ ] Unit tests
- [ ] Manual tests

## What changes did you make?

- fix failing test for autolink. Remove dependancy where are not needed.

Close #2093 