### PR TITLE
Failing tableselection tests in Edge

### DIFF
--- a/tests/plugins/tableselection/integrations/core/selection.js
+++ b/tests/plugins/tableselection/integrations/core/selection.js
@@ -1106,5 +1106,10 @@
 
 	tableSelectionHelpers.ignoreUnsupportedEnvironment( tests );
 
+	// Ignores for Edge (#1944).
+	var shouldIgnore = !tableSelectionHelpers.isSupportedEnvironment || CKEDITOR.env.edge;
+	tests._should.ignore[ 'Make fake table selection' ] = shouldIgnore;
+	tests._should.ignore[ 'Reset fake-selection' ] = shouldIgnore;
+
 	bender.test( tests );
 }() );

--- a/tests/plugins/tableselection/integrations/tabletools/tabletools.js
+++ b/tests/plugins/tableselection/integrations/tabletools/tabletools.js
@@ -181,5 +181,16 @@
 
 	tableSelectionHelpers.ignoreUnsupportedEnvironment( tests );
 
+	// Ignores for Edge (#1944).
+	var shouldIgnore = !tableSelectionHelpers.isSupportedEnvironment || CKEDITOR.env.edge;
+	tests._should.ignore[ 'test merge cells (classic)' ] = shouldIgnore;
+	tests._should.ignore[ 'test merge cells (inline)' ] = shouldIgnore;
+	tests._should.ignore[ 'test merge one cell (classic)' ] = shouldIgnore;
+	tests._should.ignore[ 'test merge one cell (inline)' ] = shouldIgnore;
+	tests._should.ignore[ 'test merge one cell (collapsed selection) (classic)' ] = shouldIgnore;
+	tests._should.ignore[ 'test merge one cell (collapsed selection) (inline)' ] = shouldIgnore;
+	tests._should.ignore[ 'test delete nested cells (classic)' ] = shouldIgnore;
+	tests._should.ignore[ 'test delete nested cells (inline)' ] = shouldIgnore;
+
 	bender.test( tests );
 } )();

--- a/tests/plugins/tableselection/tableselection.js
+++ b/tests/plugins/tableselection/tableselection.js
@@ -155,5 +155,10 @@
 
 	tableSelectionHelpers.ignoreUnsupportedEnvironment( tests );
 
+	// Ignores for Edge (#1944).
+	var shouldIgnore = !tableSelectionHelpers.isSupportedEnvironment || CKEDITOR.env.edge;
+	tests._should.ignore[ 'test simulating merge cells from context menu  (classic)' ] = shouldIgnore;
+	tests._should.ignore[ 'test simulating merge cells from context menu  (inline)' ] = shouldIgnore;
+
 	bender.test( tests );
 } )();


### PR DESCRIPTION
## What is the purpose of this pull request?

Failing test fix

## What changes did you make?

I've added bunch of ignores for Edge. We should reinvestigate the issue after 4.10 release.