### PR TITLE
Fixed textmatch failing manual test

### DIFF
--- a/tests/plugins/textmatch/manual/fillingcharsequence.html
+++ b/tests/plugins/textmatch/manual/fillingcharsequence.html
@@ -12,7 +12,7 @@
 		}
 	} );
 
-	function dataCallback( query, range, callback ) {
+	function dataCallback( matchInfo, callback ) {
 		callback( [ { id: 1, name: '@foo' } ] );
 	}
 


### PR DESCRIPTION
## What is the purpose of this pull request?

Test fix

## What changes did you make?

Fixed `textmatch` failing  manual test by updating dataCallback API.
