### PR TITLE
Bumped MatJax references version

### DIFF
--- a/bender.ci.js
+++ b/bender.ci.js
@@ -4,6 +4,6 @@
 var config = require( './bender' );
 
 config.startBrowser = process.env.BROWSER || 'Chrome';
-config.mathJaxLibPath = 'https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.0/MathJax.js?config=TeX-AMS_HTML';
+config.mathJaxLibPath = 'https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.4/MathJax.js?config=TeX-AMS_HTML';
 
 module.exports = config;

--- a/plugins/mathjax/dev/mathjax.html
+++ b/plugins/mathjax/dev/mathjax.html
@@ -18,7 +18,7 @@ For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-oss-license
 	<meta name="ckeditor-sample-isnew" content="1">
 	<script>
 		CKEDITOR.disableAutoInline = true;
-		document.domain = 'ckeditor.dev';
+		document.domain = 'ckeditor.test';
 	</script>
 </head>
 <body>
@@ -78,7 +78,7 @@ For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-oss-license
 			extraPlugins: 'mathjax',
 			height: 350,
 			allowedContent: true,
-			// mathJaxLib: 'https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.0/MathJax.js?config=TeX-AMS_HTML',
+			// mathJaxLib: 'https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.4/MathJax.js?config=TeX-AMS_HTML',
 			mathJaxClass: 'mjx'
 		} );
 
@@ -86,7 +86,7 @@ For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-oss-license
 			extraPlugins: 'mathjax',
 			height: 350,
 			allowedContent: true,
-			// mathJaxLib: 'https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.0/MathJax.js?config=TeX-AMS_HTML',
+			// mathJaxLib: 'https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.4/MathJax.js?config=TeX-AMS_HTML',
 			mathJaxClass: 'mjx'
 		} );
 
@@ -94,7 +94,7 @@ For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-oss-license
 			extraPlugins: 'mathjax,divarea',
 			height: 350,
 			allowedContent: true,
-			// mathJaxLib: 'https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.0/MathJax.js?config=TeX-AMS_HTML',
+			// mathJaxLib: 'https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.4/MathJax.js?config=TeX-AMS_HTML',
 			mathJaxClass: 'mjx'
 		} );
 

--- a/plugins/mathjax/plugin.js
+++ b/plugins/mathjax/plugin.js
@@ -11,7 +11,9 @@
 
 ( function() {
 	CKEDITOR.plugins.add( 'mathjax', {
+		// jscs:disable maximumLineLength
 		lang: 'af,ar,az,bg,ca,cs,cy,da,de,de-ch,el,en,en-au,en-gb,eo,es,es-mx,eu,fa,fi,fr,gl,he,hr,hu,id,it,ja,km,ko,ku,lt,nb,nl,no,oc,pl,pt,pt-br,ro,ru,sk,sl,sq,sv,tr,tt,ug,uk,vi,zh,zh-cn', // %REMOVE_LINE_CORE%
+		// jscs:enable maximumLineLength
 		requires: 'widget,dialog',
 		icons: 'mathjax',
 		hidpi: true, // %REMOVE_LINE_CORE%
@@ -441,7 +443,7 @@
  * Read more in the [documentation](#!/guide/dev_mathjax)
  * and see the [SDK sample](https://sdk.ckeditor.com/samples/mathjax.html).
  *
- *		config.mathJaxLib = '//cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.0/MathJax.js?config=TeX-AMS_HTML';
+ *		config.mathJaxLib = '//cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.4/MathJax.js?config=TeX-AMS_HTML';
  *
  * **Note:** Since CKEditor 4.5 this option does not have a default value, so it must
  * be set in order to enable the MathJax plugin.


### PR DESCRIPTION
nit## What is the purpose of this pull request?

Task

## Does your PR contain necessary tests?

All patches which change the editor code must include tests. You can always read more
on [PR testing](https://docs.ckeditor.com/ckeditor4/docs/#!/guide/dev_contributing_code-section-tests),
[how to set the testing environment](https://docs.ckeditor.com/ckeditor4/docs/#!/guide/dev_tests) and
[how to create tests](https://docs.ckeditor.com/ckeditor4/docs/#!/guide/dev_tests-section-creating-your-own-test)
in the official CKEditor documentation.

### This PR contains

- [ ] Unit tests
- [ ] Manual tests

No unit/manual tests were affected by this change.

## What changes did you make?

See #2159 for description.

Along with that I had to adjust `plugins/mathjax/dev/mathjax.html` as it used old domain. Also a linter exception was required in the plugin.js.

Closes #2159.