### PR TITLE
Fixed: Holding and releasing mouse button is not inserting autocomplete item

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -7,6 +7,7 @@ Fixed Issues:
 
 * [#2114](https://github.com/ckeditor/ckeditor-dev/issues/2114): [Autocomplete](https://ckeditor.com/cke4/addon/autocomplete) cannot be initialized before [`instanceReady`](https://docs.ckeditor.com/ckeditor4/latest/api/CKEDITOR_editor.html#event-instanceReady).
 * [#2169](https://github.com/ckeditor/ckeditor-dev/issues/2169): [Edge] Fixed: Error thrown when pasting into editor.
+* [#2107](https://github.com/ckeditor/ckeditor-dev/issues/2107): [Autocomplete](https://ckeditor.com/cke4/addon/autocomplete): holding and releasing mouse button is not inserting autocomplete item.
 
 ## CKEditor 4.10
 

--- a/plugins/autocomplete/plugin.js
+++ b/plugins/autocomplete/plugin.js
@@ -286,7 +286,7 @@
 				this.viewRepositionListener();
 			}, this ) );
 
-			// Don't let browser to focus dropdown element.
+			// Don't let browser to focus dropdown element (#2107).
 			this._listeners.push( this.view.element.on( 'mousedown', function( e ) {
 				e.data.preventDefault();
 			}, null, null, 9999 ) );

--- a/plugins/autocomplete/plugin.js
+++ b/plugins/autocomplete/plugin.js
@@ -286,6 +286,11 @@
 				this.viewRepositionListener();
 			}, this ) );
 
+			// Don't let browser to focus dropdown element.
+			this._listeners.push( this.view.element.on( 'mousedown', function( e ) {
+				e.data.preventDefault();
+			}, null, null, 9999 ) );
+
 			// Attach if editor is already initialized.
 			if ( editable ) {
 				onContentDom.call( this );

--- a/plugins/autocomplete/plugin.js
+++ b/plugins/autocomplete/plugin.js
@@ -354,7 +354,6 @@
 
 			this._listeners = [];
 
-			this.view.deregisterAllFocusables();
 			this.view.element.remove();
 		},
 
@@ -594,7 +593,7 @@
 		 * @readonly
 		 * @property {CKEDITOR.template}
 		 */
-		this.itemTemplate = new CKEDITOR.template( '<li data-id="{id}" tabindex="-1">{name}</li>' );
+		this.itemTemplate = new CKEDITOR.template( '<li data-id="{id}">{name}</li>' );
 
 		/**
 		 * The editor instance.
@@ -603,14 +602,6 @@
 		 * @property {CKEDITOR.editor}
 		 */
 		this.editor = editor;
-
-		/**
-		 * Focusable elements in this view.
-		 * See {@link #registerAllFocusables}, {@link #deregisterAllFocusables} and {@link CKEDITOR.focusManager}.
-		 *
-		 * @since 4.11.0
-		 */
-		this.focusables = {};
 
 		/**
 		 * The ID of the selected item.
@@ -668,7 +659,6 @@
 		appendItems: function( itemsFragment ) {
 			this.element.setHtml( '' );
 			this.element.append( itemsFragment );
-			this.registerAllFocusables();
 		},
 
 		/**
@@ -711,7 +701,6 @@
 		 */
 		close: function() {
 			this.element.removeClass( 'cke_autocomplete_opened' );
-			this.deregisterAllFocusables();
 		},
 
 		/**
@@ -722,6 +711,7 @@
 		 */
 		createElement: function() {
 			var el = new CKEDITOR.dom.element( 'ul', this.document );
+
 			el.addClass( 'cke_autocomplete_panel' );
 			// Below float panels and context menu, but above maximized editor (-5).
 			el.setStyle( 'z-index', this.editor.config.baseFloatZIndex - 3 );
@@ -738,35 +728,6 @@
 		createItem: function( item ) {
 			var encodedItem = encodeItem( item );
 			return CKEDITOR.dom.element.createFromHtml( this.itemTemplate.output( encodedItem ), this.document );
-		},
-
-		/**
-		 * Unregisters Views all focusables from editor's focus manager.
-		 * See {@link #focusables}, {@link #deregisterFocusable}.
-		 *
-		 * @since 4.11.0
-		 */
-		deregisterAllFocusables: function() {
-			var children = this.element.getChildren().toArray();
-			CKEDITOR.tools.array.forEach( children, function( item ) {
-				this.deregisterFocusable( item );
-			}, this );
-		},
-
-		/**
-		 * Unregisters an element from editor's focus manager.
-		 * See {@link #focusables}.
-		 *
-		 * @since 4.11.0
-		 * @param {CKEDITOR.dom.element} element An element to be registered.
-		 */
-		deregisterFocusable: function( element ) {
-			var id = element.getUniqueId();
-			// Don't remove same item many times. Currently we are removing items both on `destroy` and on `close`.
-			if ( id in this.focusables ) {
-				this.editor.focusManager.remove( element );
-				delete this.focusables[ id ];
-			}
 		},
 
 		/**
@@ -841,33 +802,6 @@
 		 */
 		open: function() {
 			this.element.addClass( 'cke_autocomplete_opened' );
-		},
-
-		/**
-		 * Register Views all items as focusables in editor's focus manager.
-		 * See {@link #focusables}, {@link #registerFocusable}.
-		 *
-		 * @since 4.11.0
-		 */
-		registerAllFocusables: function() {
-			var children = this.element.getChildren().toArray();
-
-			CKEDITOR.tools.array.forEach( children, function( item ) {
-				this.registerFocusable( item );
-			}, this );
-		},
-
-		/**
-		 * Registers a new focusable element in the editor's focus manager so the instance
-		 * does not blur once the child of the balloon panel gains focus.
-		 * See {@link #focusables}.
-		 *
-		 * @since 4.11.0
-		 * @param {CKEDITOR.dom.element} element An element to be registered.
-		 */
-		registerFocusable: function( element ) {
-			this.editor.focusManager.add( element );
-			this.focusables[ element.getUniqueId() ] = element;
 		},
 
 		/**

--- a/tests/plugins/autocomplete/focus.js
+++ b/tests/plugins/autocomplete/focus.js
@@ -1,0 +1,103 @@
+/* bender-tags: editor */
+/* bender-ckeditor-plugins: autocomplete */
+
+( function() {
+	'use strict';
+
+	var configDefinition = {
+		textTestCallback: textTestCallback,
+		dataCallback: dataCallback
+	};
+
+	bender.editor = {};
+
+	bender.test( {
+		setUp: function() {
+			if ( CKEDITOR.env.ie && CKEDITOR.env.version == 8 ) {
+				assert.ignore();
+			}
+		},
+
+		tearDown: function() {
+			for ( var key in this._stubs ) {
+				this._stubs[ key ].restore();
+			}
+		},
+
+		_stubs: {},
+
+		'test dropdown items registered as focusables and removed on destroy': function() {
+			var editor = this.editor,
+				ac = new CKEDITOR.plugins.autocomplete( editor, configDefinition ),
+				registeredFocusables = {},
+				items;
+
+			this._stubs = {
+				add: sinon.stub( editor.focusManager, 'add', registerFocusableMock ),
+				remove: sinon.stub( editor.focusManager, 'remove', unregisterFocusableMock )
+			};
+
+			this.editorBot.setHtmlWithSelection( '' );
+
+			editor.editable().fire( 'keyup', new CKEDITOR.dom.event( {} ) );
+
+			items = ac.view.element.getChildren().toArray();
+
+			CKEDITOR.tools.array.forEach( items, function( item ) {
+				assert.isTrue( item.getUniqueId() in ac.view.focusables, 'Item is focusables list' );
+				assert.isTrue( item.getUniqueId() in registeredFocusables, 'Item is registered in focusManager' );
+			} );
+
+			ac.destroy();
+
+			CKEDITOR.tools.array.forEach( items, function( item ) {
+				assert.isFalse( item.getUniqueId() in ac.view.focusables, 'Item is removed from focusables list' );
+				assert.isFalse( item.getUniqueId() in registeredFocusables, 'Item is removed from focusManager' );
+			} );
+
+			function registerFocusableMock( item ) {
+				registeredFocusables[ item.getUniqueId() ] = true;
+			}
+			function unregisterFocusableMock( item ) {
+				delete registeredFocusables[ item.getUniqueId() ];
+			}
+		},
+
+		'test focusing dropdown doesn\'t blur editor': function() {
+			var editor = this.editor,
+				ac = new CKEDITOR.plugins.autocomplete( editor, configDefinition ),
+				blurSpy = sinon.spy(),
+				item;
+
+			this.editorBot.setHtmlWithSelection( '' );
+
+			editor.focus();
+			editor.on( 'blur', blurSpy, null, null, 10000 );
+
+			editor.editable().fire( 'keyup', new CKEDITOR.dom.event( {} ) );
+			item = ac.view.element.getChildren().getItem( 0 );
+
+			item.once( 'focus', function() {
+				// Blur is delayed by 200ms, asserts needs to be delayed more.
+				setTimeout( function() {
+					resume( function() {
+						assert.isFalse( blurSpy.called, 'Editor should remain focused, when dropdown is focused.' );
+					} );
+				}, 210 );
+			} );
+
+			setTimeout( function() {
+				item.focus();
+			} );
+			wait();
+		}
+	} );
+
+	function textTestCallback( selectionRange ) {
+		return { text: 'text', range: selectionRange };
+	}
+
+	function dataCallback( matchInfo, callback ) {
+		return callback( [ { id: 1, name: 'first' }, { id: 2, name: 'second' } ] );
+	}
+} )();

--- a/tests/plugins/autocomplete/focus.js
+++ b/tests/plugins/autocomplete/focus.js
@@ -18,78 +18,21 @@
 			}
 		},
 
-		tearDown: function() {
-			for ( var key in this._stubs ) {
-				this._stubs[ key ].restore();
-			}
-		},
-
-		_stubs: {},
-
-		'test dropdown items registered as focusables and removed on destroy': function() {
+		'test preventDefault is called on mousedown': function() {
 			var editor = this.editor,
 				ac = new CKEDITOR.plugins.autocomplete( editor, configDefinition ),
-				registeredFocusables = {},
-				items;
-
-			this._stubs = {
-				add: sinon.stub( editor.focusManager, 'add', registerFocusableMock ),
-				remove: sinon.stub( editor.focusManager, 'remove', unregisterFocusableMock )
-			};
+				spy = sinon.spy(),
+				data = {
+					preventDefault: spy
+				};
 
 			this.editorBot.setHtmlWithSelection( '' );
 
 			editor.editable().fire( 'keyup', new CKEDITOR.dom.event( {} ) );
 
-			items = ac.view.element.getChildren().toArray();
+			ac.view.element.fire( 'mousedown', data );
 
-			CKEDITOR.tools.array.forEach( items, function( item ) {
-				assert.isTrue( item.getUniqueId() in ac.view.focusables, 'Item is focusables list' );
-				assert.isTrue( item.getUniqueId() in registeredFocusables, 'Item is registered in focusManager' );
-			} );
-
-			ac.destroy();
-
-			CKEDITOR.tools.array.forEach( items, function( item ) {
-				assert.isFalse( item.getUniqueId() in ac.view.focusables, 'Item is removed from focusables list' );
-				assert.isFalse( item.getUniqueId() in registeredFocusables, 'Item is removed from focusManager' );
-			} );
-
-			function registerFocusableMock( item ) {
-				registeredFocusables[ item.getUniqueId() ] = true;
-			}
-			function unregisterFocusableMock( item ) {
-				delete registeredFocusables[ item.getUniqueId() ];
-			}
-		},
-
-		'test focusing dropdown doesn\'t blur editor': function() {
-			var editor = this.editor,
-				ac = new CKEDITOR.plugins.autocomplete( editor, configDefinition ),
-				blurSpy = sinon.spy(),
-				item;
-
-			this.editorBot.setHtmlWithSelection( '' );
-
-			editor.focus();
-			editor.on( 'blur', blurSpy, null, null, 10000 );
-
-			editor.editable().fire( 'keyup', new CKEDITOR.dom.event( {} ) );
-			item = ac.view.element.getChildren().getItem( 0 );
-
-			item.once( 'focus', function() {
-				// Blur is delayed by 200ms, asserts needs to be delayed more.
-				setTimeout( function() {
-					resume( function() {
-						assert.isFalse( blurSpy.called, 'Editor should remain focused, when dropdown is focused.' );
-					} );
-				}, 210 );
-			} );
-
-			setTimeout( function() {
-				item.focus();
-			} );
-			wait();
+			assert.isTrue( spy.called, 'preventDefault called' );
 		}
 	} );
 

--- a/tests/plugins/autocomplete/manual/holdmousebutton.html
+++ b/tests/plugins/autocomplete/manual/holdmousebutton.html
@@ -1,0 +1,43 @@
+<h2>Classic editor</h2>
+<div id="classic">
+	<p>Sample text.</p>
+	<p>Sample text.</p>
+	<p>Sample text.</p>
+</div>
+
+<h2>Divarea editor</h2>
+<div id="divarea">
+	<p>Sample text.</p>
+	<p>Sample text.</p>
+	<p>Sample text.</p>
+</div>
+
+<h2>Inline editor</h2>
+<div id="inline" contenteditable="true">
+	<p>Sample text.</p>
+	<p>Sample text.</p>
+	<p>Sample text.</p>
+</div>
+
+<script>
+
+	if ( autocompleteUtils.isUnsupportedEnvironment() ) {
+		bender.ignore();
+	}
+
+	var config = {
+		width: 600,
+		on: {
+			instanceReady: function( evt ) {
+				new CKEDITOR.plugins.autocomplete( evt.editor, {
+					textTestCallback: autocompleteUtils.getTextTestCallback(),
+					dataCallback: autocompleteUtils.getDataCallback()
+				} );
+			}
+		}
+	};
+
+	CKEDITOR.replace( 'classic', config );
+	CKEDITOR.replace( 'divarea', CKEDITOR.tools.extend( config, { extraPlugins: 'divarea' } ) );
+	CKEDITOR.inline( 'inline', config );
+</script>

--- a/tests/plugins/autocomplete/manual/holdmousebutton.md
+++ b/tests/plugins/autocomplete/manual/holdmousebutton.md
@@ -1,0 +1,19 @@
+@bender-tags: 4.10.0, bug, 2107
+@bender-ui: collapsed
+@bender-ckeditor-plugins: wysiwygarea, toolbar, basicstyles, autocomplete, textmatch
+@bender-include: _helpers/utils.js
+
+----
+
+## For each editor
+
+1. Focus editor and type `@`.
+1. Click and hold mouse button on first dropdown. Release it after 2 seconds.
+
+### Expected
+
+Item is inserted into editor.
+
+### Unexpected
+
+Dropdown disappears without inserting item into editor.

--- a/tests/plugins/autocomplete/manual/holdmousebutton.md
+++ b/tests/plugins/autocomplete/manual/holdmousebutton.md
@@ -1,4 +1,4 @@
-@bender-tags: 4.10.0, bug, 2107
+@bender-tags: 4.11.0, bug, 2107
 @bender-ui: collapsed
 @bender-ckeditor-plugins: wysiwygarea, toolbar, basicstyles, autocomplete, textmatch
 @bender-include: _helpers/utils.js

--- a/tests/plugins/autocomplete/manual/holdmousebutton.md
+++ b/tests/plugins/autocomplete/manual/holdmousebutton.md
@@ -1,4 +1,4 @@
-@bender-tags: 4.11.0, bug, 2107
+@bender-tags: 4.10.1, bug, 2107
 @bender-ui: collapsed
 @bender-ckeditor-plugins: wysiwygarea, toolbar, basicstyles, autocomplete, textmatch
 @bender-include: _helpers/utils.js

--- a/tests/plugins/autocomplete/view.js
+++ b/tests/plugins/autocomplete/view.js
@@ -193,7 +193,10 @@
 	}
 
 	function assertItemElement( item, itemElement ) {
-		assert.areEqual( '<li data-id="' + item.id + '" tabindex="-1">' + item.name + '</li>', itemElement.$.outerHTML );
+		assert.areEqual( '<li data-id="' + item.id + '" tabindex="-1">' + item.name + '</li>',
+			// We need to sort attributes because of Edge, but 'compatHtml' wraps 'li' with an 'ul' element.
+			bender.tools.compatHtml( itemElement.$.outerHTML, false, true ).replace( '<ul>', '' ).replace( '</ul>', '' )
+		);
 	}
 
 	function getCaretRect( editor, caretPosition, offset ) {

--- a/tests/plugins/autocomplete/view.js
+++ b/tests/plugins/autocomplete/view.js
@@ -193,7 +193,7 @@
 	}
 
 	function assertItemElement( item, itemElement ) {
-		assert.areEqual( '<li data-id="' + item.id + '">' + item.name + '</li>', itemElement.$.outerHTML );
+		assert.areEqual( '<li data-id="' + item.id + '" tabindex="-1">' + item.name + '</li>', itemElement.$.outerHTML );
 	}
 
 	function getCaretRect( editor, caretPosition, offset ) {

--- a/tests/plugins/autocomplete/view.js
+++ b/tests/plugins/autocomplete/view.js
@@ -193,10 +193,7 @@
 	}
 
 	function assertItemElement( item, itemElement ) {
-		assert.areEqual( '<li data-id="' + item.id + '" tabindex="-1">' + item.name + '</li>',
-			// We need to sort attributes because of Edge, but 'compatHtml' wraps 'li' with an 'ul' element.
-			bender.tools.compatHtml( itemElement.$.outerHTML, false, true ).replace( '<ul>', '' ).replace( '</ul>', '' )
-		);
+		assert.areEqual( '<li data-id="' + item.id + '">' + item.name + '</li>', itemElement.$.outerHTML );
 	}
 
 	function getCaretRect( editor, caretPosition, offset ) {


### PR DESCRIPTION
## What is the purpose of this pull request?

Bug fix

## Does your PR contain necessary tests?

All patches which change the editor code must include tests. You can always read more
on [PR testing](https://docs.ckeditor.com/ckeditor4/docs/#!/guide/dev_contributing_code-section-tests),
[how to set the testing environment](https://docs.ckeditor.com/ckeditor4/docs/#!/guide/dev_tests) and
[how to create tests](https://docs.ckeditor.com/ckeditor4/docs/#!/guide/dev_tests-section-creating-your-own-test)
in the official CKEditor documentation.

### This PR contains

- [X] Unit tests
- [X] Manual tests

## What changes did you make?

I've registered autocomplete items in focusManager, so focusing them wont trigger editor blur event which was cause for hiding dropdown. Note `tabindex` is required for items to be focusable.

Closes #2107.