### PR TITLE
Fix docs for CKEDITOR.dialog.addIframe

### DIFF
--- a/plugins/iframedialog/plugin.js
+++ b/plugins/iframedialog/plugin.js
@@ -17,6 +17,7 @@ CKEDITOR.plugins.add( 'iframedialog', {
 		 * @member CKEDITOR.dialog
 		 * @param {String} name Name of the dialog.
 		 * @param {String} title Title of the dialog.
+		 * @param {String} src URL address of the dialog.
 		 * @param {Number} minWidth Minimum width of the dialog.
 		 * @param {Number} minHeight Minimum height of the dialog.
 		 * @param {Function} [onContentLoad] Function called when the iframe has been loaded.


### PR DESCRIPTION
## What is the purpose of this pull request?

Other, docs fix

## Does your PR contain necessary tests?

Not sure if changing method docs warrants test?

### This PR contains

- [ ] Unit tests
- [ ] Manual tests

## What changes did you make?

The `src` parameter for `CKEDITOR.dialog.addIframe` was missing (and currently still is eg. from [the documentation](https://docs.ckeditor.com/ckeditor4/latest/api/CKEDITOR_dialog.html#static-method-addIframe)). I hope this fixes it.