### PR TITLE
Autocomplete dropdown mouseover no longer throws an error

### DIFF
--- a/plugins/autocomplete/plugin.js
+++ b/plugins/autocomplete/plugin.js
@@ -673,9 +673,9 @@
 				if ( this.element.contains( target ) ) {
 
 					// Find node containing data-id attribute inside target node tree (#2187).
-					target = target.getParents().filter( function( element ) {
+					target = target.getAscendant( function( element ) {
 						return element.hasAttribute( 'data-id' );
-					} )[ 0 ];
+					}, true );
 
 					if ( !target ) {
 						return;

--- a/plugins/autocomplete/plugin.js
+++ b/plugins/autocomplete/plugin.js
@@ -671,6 +671,16 @@
 				var target = evt.data.getTarget();
 
 				if ( this.element.contains( target ) ) {
+
+					// Find node containing data-id attribute inside target node tree (#2187).
+					target = target.getParents().filter( function( element ) {
+						return element.hasAttribute( 'data-id' );
+					} )[ 0 ];
+
+					if ( !target ) {
+						return;
+					}
+
 					var itemId = target.data( 'id' );
 
 					this.fire( 'change-selectedItemId', itemId );

--- a/tests/plugins/autocomplete/autocomplete.js
+++ b/tests/plugins/autocomplete/autocomplete.js
@@ -98,6 +98,35 @@
 			ac.destroy();
 		},
 
+		// (#2187)
+		'test mouseover finds correct target': function() {
+			var editor = this.editors.standard,
+				ac = new CKEDITOR.plugins.autocomplete( editor, {
+					dataCallback: dataCallback,
+					textTestCallback: textTestCallback,
+					itemTemplate: '<li data-id="{id}"><b>{name}</b></li>'
+				} );
+
+			this.editorBots.standard.setHtmlWithSelection( '' );
+
+			editor.editable().fire( 'keyup', new CKEDITOR.dom.event( {} ) );
+
+			var firstElement = ac.view.getItemById( 1 );
+			assertViewOpened( ac, true );
+			assert.isTrue( firstElement.hasClass( 'cke_autocomplete_selected' ) );
+
+			var listItem = ac.view.element.getLast(),
+				target = listItem.findOne( 'b' );
+
+			ac.view.element.fire( 'mouseover', new CKEDITOR.dom.event( { target: target.$ } ) );
+
+			assertViewOpened( ac, true );
+			assert.isFalse( firstElement.hasClass( 'cke_autocomplete_selected' ) );
+			assert.isTrue( listItem.hasClass( 'cke_autocomplete_selected' ) );
+
+			ac.destroy();
+		},
+
 		// (#1984)
 		'test view is not opened after unmatch': function() {
 			var editor = this.editors.standard,

--- a/tests/plugins/autocomplete/manual/mouseover.html
+++ b/tests/plugins/autocomplete/manual/mouseover.html
@@ -1,0 +1,37 @@
+<div id="editor1" ></div>
+
+<script>
+
+	if ( autocompleteUtils.isUnsupportedEnvironment() || CKEDITOR.env.mobile ) {
+		bender.ignore();
+	}
+
+	CKEDITOR.replace( 'editor1', {
+		width: 600,
+		on: {
+			instanceReady: function( evt ) {
+
+				// Default autocomplete instance.
+				new CKEDITOR.plugins.autocomplete( evt.editor, {
+					textTestCallback: autocompleteUtils.getTextTestCallback(),
+					dataCallback: autocompleteUtils.getDataCallback()
+				} );
+
+				var DATA = [
+					{ id: 1, name: '#john' },
+					{ id: 2, name: '#thomas' },
+					{ id: 3, name: '#anna' },
+					{ id: 4, name: '#cris' },
+					{ id: 5, name: '#julia' }
+				];
+
+				// Autocomplete instance with custom template.
+				new CKEDITOR.plugins.autocomplete( evt.editor, {
+					textTestCallback: autocompleteUtils.getTextTestCallback( { regex: '#\\w*$' } ),
+					dataCallback: autocompleteUtils.getDataCallback( { data: DATA } ),
+					itemTemplate: '<li data-id="{id}"><b>{name}</b></li>'
+				} );
+			}
+		}
+	} );
+</script>

--- a/tests/plugins/autocomplete/manual/mouseover.md
+++ b/tests/plugins/autocomplete/manual/mouseover.md
@@ -5,10 +5,10 @@
 
 1. Open a console.
 1. Focus the editor.
-1. Type `@` character.
+1. Type `@` character to open autocomplete with default template.
 1. Move mouse over the last dropdown item.
 1. Press enter.
-1. Repeat with `#` character.
+1. Repeat with `#` character to open autocomplete with custom template.
 
 
 ## Expected

--- a/tests/plugins/autocomplete/manual/mouseover.md
+++ b/tests/plugins/autocomplete/manual/mouseover.md
@@ -1,18 +1,24 @@
-@bender-tags: 4.10.0, bug, 2031
+@bender-tags: 4.10.0, bug, 2031, 2187
 @bender-ui: collapsed
-@bender-ckeditor-plugins: wysiwygarea, toolbar, basicstyles, autocomplete
+@bender-ckeditor-plugins: wysiwygarea, toolbar, basicstyles, autocomplete, textmatch
 @bender-include: _helpers/utils.js
 
+1. Open a console.
 1. Focus the editor.
-1. Type `@`.
+1. Type `@` character.
 1. Move mouse over the last dropdown item.
 1. Press enter.
+1. Repeat with `#` character.
 
 
 ## Expected
 
-Selection changes when moving mouse over dropdown items. The last selected item is inserted on `enter` key.
+* No errors inside console.
+* Selection changes when moving mouse over dropdown items.
+* The last selected item is inserted on `enter` key.
 
 ## Unexpected
 
-First item is preselected regardless of mouse hover. The first item is inserted on `enter` key.
+* Any errors inside console.
+* First item is preselected regardless of mouse hover.
+* The first item is inserted on `enter` key.


### PR DESCRIPTION
## What is the purpose of this pull request?

Bug fix

## Does your PR contain necessary tests?

All patches which change the editor code must include tests. You can always read more
on [PR testing](https://docs.ckeditor.com/ckeditor4/docs/#!/guide/dev_contributing_code-section-tests),
[how to set the testing environment](https://docs.ckeditor.com/ckeditor4/docs/#!/guide/dev_tests) and
[how to create tests](https://docs.ckeditor.com/ckeditor4/docs/#!/guide/dev_tests-section-creating-your-own-test)
in the official CKEditor documentation.

### This PR contains

- [x] Unit tests
- [x] Manual tests

## What changes did you make?

On mouseover correct element is found by `data-id` attribute inside event's target node tree.

Closes #2187
