### PR TITLE
Edge 17 throws an error when pasting into editor

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -7,6 +7,10 @@ Fixed Issues:
 
 * [#2114](https://github.com/ckeditor/ckeditor-dev/issues/2114): [Autocomplete](https://ckeditor.com/cke4/addon/autocomplete) cannot be initialized before [`instanceReady`](https://docs.ckeditor.com/ckeditor4/latest/api/CKEDITOR_editor.html#event-instanceReady).
 
+Fixed Issues:
+
+* [#2169](https://github.com/ckeditor/ckeditor-dev/issues/2169): Fixed: MS Edge some times throws an error when pasting into editor.
+
 ## CKEditor 4.10
 
 New Features:

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -6,7 +6,7 @@
 Fixed Issues:
 
 * [#2114](https://github.com/ckeditor/ckeditor-dev/issues/2114): [Autocomplete](https://ckeditor.com/cke4/addon/autocomplete) cannot be initialized before [`instanceReady`](https://docs.ckeditor.com/ckeditor4/latest/api/CKEDITOR_editor.html#event-instanceReady).
-* [#2169](https://github.com/ckeditor/ckeditor-dev/issues/2169): Fixed: MS Edge some times throws an error when pasting into editor.
+* [#2169](https://github.com/ckeditor/ckeditor-dev/issues/2169): [Edge] Fixed: Error thrown when pasting into editor.
 
 ## CKEditor 4.10
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -6,9 +6,6 @@
 Fixed Issues:
 
 * [#2114](https://github.com/ckeditor/ckeditor-dev/issues/2114): [Autocomplete](https://ckeditor.com/cke4/addon/autocomplete) cannot be initialized before [`instanceReady`](https://docs.ckeditor.com/ckeditor4/latest/api/CKEDITOR_editor.html#event-instanceReady).
-
-Fixed Issues:
-
 * [#2169](https://github.com/ckeditor/ckeditor-dev/issues/2169): Fixed: MS Edge some times throws an error when pasting into editor.
 
 ## CKEditor 4.10

--- a/plugins/clipboard/plugin.js
+++ b/plugins/clipboard/plugin.js
@@ -2825,6 +2825,11 @@
 
 					fallbackDataTransfer._isCustomMimeTypeSupported = false;
 
+					// It looks like after our custom mime type test Edge 17 is denying access on nativeDataTransfer.
+					if ( CKEDITOR.env.edge && CKEDITOR.env.version > 16 ) {
+						return false;
+					}
+
 					try {
 						nativeDataTransfer.setData( testType, testValue );
 						fallbackDataTransfer._isCustomMimeTypeSupported = nativeDataTransfer.getData( testType ) === testValue;

--- a/plugins/clipboard/plugin.js
+++ b/plugins/clipboard/plugin.js
@@ -2825,7 +2825,8 @@
 
 					fallbackDataTransfer._isCustomMimeTypeSupported = false;
 
-					// It looks like after our custom mime type test Edge 17 is denying access on nativeDataTransfer.
+					// It looks like after our custom mime type test Edge 17 is denying access on nativeDataTransfer (#2169).
+					// Upstream issue: https://developer.microsoft.com/en-us/microsoft-edge/platform/issues/18089287/
 					if ( CKEDITOR.env.edge && CKEDITOR.env.version > 16 ) {
 						return true;
 					}

--- a/plugins/clipboard/plugin.js
+++ b/plugins/clipboard/plugin.js
@@ -2827,7 +2827,7 @@
 
 					// It looks like after our custom mime type test Edge 17 is denying access on nativeDataTransfer.
 					if ( CKEDITOR.env.edge && CKEDITOR.env.version > 16 ) {
-						return false;
+						return true;
 					}
 
 					try {

--- a/plugins/clipboard/plugin.js
+++ b/plugins/clipboard/plugin.js
@@ -2825,7 +2825,7 @@
 
 					fallbackDataTransfer._isCustomMimeTypeSupported = false;
 
-					// It looks like after our custom mime type test Edge 17 is denying access on nativeDataTransfer (#2169).
+					// It looks like after our custom MIME type test Edge 17 is denying access on nativeDataTransfer (#2169).
 					// Upstream issue: https://developer.microsoft.com/en-us/microsoft-edge/platform/issues/18089287/
 					if ( CKEDITOR.env.edge && CKEDITOR.env.version >= 17 ) {
 						return true;

--- a/plugins/clipboard/plugin.js
+++ b/plugins/clipboard/plugin.js
@@ -2827,7 +2827,7 @@
 
 					// It looks like after our custom mime type test Edge 17 is denying access on nativeDataTransfer (#2169).
 					// Upstream issue: https://developer.microsoft.com/en-us/microsoft-edge/platform/issues/18089287/
-					if ( CKEDITOR.env.edge && CKEDITOR.env.version > 16 ) {
+					if ( CKEDITOR.env.edge && CKEDITOR.env.version >= 17 ) {
 						return true;
 					}
 

--- a/tests/plugins/clipboard/manual/edgepasteimage.html
+++ b/tests/plugins/clipboard/manual/edgepasteimage.html
@@ -1,0 +1,8 @@
+<textarea id="editor"></textarea>
+
+<script>
+	if ( !CKEDITOR.env.edge || !CKEDITOR.env.version > 16 ) {
+		bender.ignore();
+	}
+	CKEDITOR.replace( 'editor' );
+</script>

--- a/tests/plugins/clipboard/manual/edgepasteimage.html
+++ b/tests/plugins/clipboard/manual/edgepasteimage.html
@@ -1,7 +1,7 @@
 <textarea id="editor"></textarea>
 
 <script>
-	if ( !CKEDITOR.env.edge || !CKEDITOR.env.version > 16 ) {
+	if ( !CKEDITOR.env.edge || !CKEDITOR.env.version >= 17 ) {
 		bender.ignore();
 	}
 	CKEDITOR.replace( 'editor' );

--- a/tests/plugins/clipboard/manual/edgepasteimage.md
+++ b/tests/plugins/clipboard/manual/edgepasteimage.md
@@ -1,0 +1,18 @@
+@bender-ui: collapsed
+@bender-tags: 4.10.1, bug
+@bender-ckeditor-plugins: wysiwygarea,toolbar,image,clipboard
+
+1. Open console.
+1. Select image with mouse and press `Ctrl+C`:
+
+<img src="../../image2/_assets/bar.png"></img>
+
+1. Focus editor and press `Ctrl+V`
+
+## Expected
+
+Image is pasted into editor.
+
+## Unexpected
+
+Image is not pasted into editor and or any errors are logged in console.


### PR DESCRIPTION
## What is the purpose of this pull request?

Fixes

## Does your PR contain necessary tests?

All patches which change the editor code must include tests. You can always read more
on [PR testing](https://docs.ckeditor.com/ckeditor4/docs/#!/guide/dev_contributing_code-section-tests),
[how to set the testing environment](https://docs.ckeditor.com/ckeditor4/docs/#!/guide/dev_tests) and
[how to create tests](https://docs.ckeditor.com/ckeditor4/docs/#!/guide/dev_tests-section-creating-your-own-test)
in the official CKEditor documentation.

### This PR contains

- [ ] Unit tests
- [X] Manual tests

## What changes did you make?

Testing for custom mime types (just by trying setData with such type) makes dataTransfer inaccessible in Edge, so as a workaround for upstream issue I've added if statement which will omit such test on Edge.

Note:
I have different error in console, than described in original issue, but with my fix it looks to work fine.

Closes #2169.