### PR TITLE
Optionally keep richcombo value on selection

### DIFF
--- a/plugins/richcombo/plugin.js
+++ b/plugins/richcombo/plugin.js
@@ -74,7 +74,8 @@ CKEDITOR.plugins.add( 'richcombo', {
 				canGroup: false,
 				title: definition.label,
 				modes: { wysiwyg: 1 },
-				editorFocus: 1
+				editorFocus: 1,
+				clearOnBlur: true
 			} );
 
 			// We don't want the panel definition in this object.
@@ -169,7 +170,7 @@ CKEDITOR.plugins.add( 'richcombo', {
 					if ( editor.readOnly && !this.readOnly )
 						state = CKEDITOR.TRISTATE_DISABLED;
 
-					this.setState( state );
+					this.clearOnBlur && this.setState( state );
 					this.setValue( '' );
 
 					// Let plugin to disable button.


### PR DESCRIPTION
## What is the purpose of this pull request?

New feature as requested in #2186 

## Does your PR contain necessary tests?

No. I don't know how to trigger the event directly from a test and the plugin testing is too sparse right to adjust existing tests.

### This PR contains

- [ ] Unit tests
- [ ] Manual tests

## What changes did you make?

The default behavior of richcombo is to reset value on events like mode or selection change happen. This is not desirable in every case, i.e. if the richcombo is a filter for another list. The new clearOnBlur can be set to false to inhibit the value reset part.

