### PR TITLE
Using 'Automatic' color on text with already applied color creates 'span.style=color:null'

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -9,6 +9,8 @@ Fixed Issues:
 * [#2169](https://github.com/ckeditor/ckeditor-dev/issues/2169): [Edge] Fixed: Error thrown when pasting into editor.
 * [#2107](https://github.com/ckeditor/ckeditor-dev/issues/2107): Fixed: [Autocomplete](https://ckeditor.com/cke4/addon/autocomplete): holding and releasing mouse button is not inserting autocomplete item.
 * [#2167](https://github.com/ckeditor/ckeditor-dev/issues/2167): Fixed: Matching in [Emoji](https://ckeditor.com/cke4/addon/emoji) plugin is not case insensitive.
+* [#1084](https://github.com/ckeditor/ckeditor-dev/issues/1084) Fixed: Using `Automatic` color with color button on text with already defined color creates span with `style="color:null"`.
+
 
 ## CKEditor 4.10
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -9,7 +9,7 @@ Fixed Issues:
 * [#2169](https://github.com/ckeditor/ckeditor-dev/issues/2169): [Edge] Fixed: Error thrown when pasting into editor.
 * [#2107](https://github.com/ckeditor/ckeditor-dev/issues/2107): Fixed: [Autocomplete](https://ckeditor.com/cke4/addon/autocomplete): holding and releasing mouse button is not inserting autocomplete item.
 * [#2167](https://github.com/ckeditor/ckeditor-dev/issues/2167): Fixed: Matching in [Emoji](https://ckeditor.com/cke4/addon/emoji) plugin is not case insensitive.
-* [#1084](https://github.com/ckeditor/ckeditor-dev/issues/1084) Fixed: Using `Automatic` color with color button on text with already defined color creates span with `style="color:null"`.
+* [#1084](https://github.com/ckeditor/ckeditor-dev/issues/1084) Fixed: Using `Automatic` color with color button on text with already defined color creates span with wrong color.
 
 
 ## CKEditor 4.10

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -9,8 +9,7 @@ Fixed Issues:
 * [#2169](https://github.com/ckeditor/ckeditor-dev/issues/2169): [Edge] Fixed: Error thrown when pasting into editor.
 * [#2107](https://github.com/ckeditor/ckeditor-dev/issues/2107): Fixed: [Autocomplete](https://ckeditor.com/cke4/addon/autocomplete): holding and releasing mouse button is not inserting autocomplete item.
 * [#2167](https://github.com/ckeditor/ckeditor-dev/issues/2167): Fixed: Matching in [Emoji](https://ckeditor.com/cke4/addon/emoji) plugin is not case insensitive.
-* [#1084](https://github.com/ckeditor/ckeditor-dev/issues/1084) Fixed: Using `Automatic` color with color button on text with already defined color creates span with wrong color.
-
+* [#1084](https://github.com/ckeditor/ckeditor-dev/issues/1084) Fixed: Using the "Automatic" option with color button on a text with color already defined sets an invalid color value.
 
 ## CKEditor 4.10
 

--- a/plugins/colorbutton/plugin.js
+++ b/plugins/colorbutton/plugin.js
@@ -210,14 +210,14 @@ CKEDITOR.plugins.add( 'colorbutton', {
 				if ( color == '?' ) {
 					editor.getColorFromDialog( function( color ) {
 						if ( color ) {
-							return applyOrRemoveColor( color );
+							return setColor( color );
 						}
 					} );
 				} else {
-					return applyOrRemoveColor( color );
+					return setColor( color );
 				}
 
-				function applyOrRemoveColor( color ) {
+				function setColor( color ) {
 					// Clean up any conflicting style within the range.
 					editor.removeStyle( new CKEDITOR.style( config[ 'colorButton_' + type + 'Style' ], { color: 'inherit' } ) );
 					var colorStyle = config[ 'colorButton_' + type + 'Style' ];

--- a/plugins/colorbutton/plugin.js
+++ b/plugins/colorbutton/plugin.js
@@ -210,14 +210,14 @@ CKEDITOR.plugins.add( 'colorbutton', {
 				if ( color == '?' ) {
 					editor.getColorFromDialog( function( color ) {
 						if ( color ) {
-							return applyColor( color );
+							return applyOrRemoveColor( color );
 						}
 					} );
 				} else {
-					return applyColor( color );
+					return applyOrRemoveColor( color );
 				}
 
-				function applyColor( color ) {
+				function applyOrRemoveColor( color ) {
 					// Clean up any conflicting style within the range.
 					editor.removeStyle( new CKEDITOR.style( config[ 'colorButton_' + type + 'Style' ], { color: 'inherit' } ) );
 					var colorStyle = config[ 'colorButton_' + type + 'Style' ];
@@ -233,7 +233,7 @@ CKEDITOR.plugins.add( 'colorbutton', {
 					};
 
 					editor.focus();
-					editor.applyStyle( new CKEDITOR.style( colorStyle, { color: color } ) );
+					editor[ ( color ? 'apply' : 'remove' ) + 'Style' ]( new CKEDITOR.style( colorStyle, { color: color } ) );
 					editor.fire( 'saveSnapshot' );
 				}
 

--- a/plugins/colorbutton/plugin.js
+++ b/plugins/colorbutton/plugin.js
@@ -220,7 +220,7 @@ CKEDITOR.plugins.add( 'colorbutton', {
 				function setColor( color ) {
 					var colorStyle = config[ 'colorButton_' + type + 'Style' ];
 					// Clean up any conflicting style within the range.
-					editor.removeStyle( new CKEDITOR.style( config[ 'colorButton_' + type + 'Style' ], { color: 'inherit' } ) );
+					editor.removeStyle( new CKEDITOR.style( colorStyle, { color: 'inherit' } ) );
 
 					colorStyle.childRule = type == 'back' ?
 					function( element ) {

--- a/plugins/colorbutton/plugin.js
+++ b/plugins/colorbutton/plugin.js
@@ -218,9 +218,9 @@ CKEDITOR.plugins.add( 'colorbutton', {
 				}
 
 				function setColor( color ) {
+					var colorStyle = config[ 'colorButton_' + type + 'Style' ];
 					// Clean up any conflicting style within the range.
 					editor.removeStyle( new CKEDITOR.style( config[ 'colorButton_' + type + 'Style' ], { color: 'inherit' } ) );
-					var colorStyle = config[ 'colorButton_' + type + 'Style' ];
 
 					colorStyle.childRule = type == 'back' ?
 					function( element ) {
@@ -233,7 +233,9 @@ CKEDITOR.plugins.add( 'colorbutton', {
 					};
 
 					editor.focus();
-					editor[ ( color ? 'apply' : 'remove' ) + 'Style' ]( new CKEDITOR.style( colorStyle, { color: color } ) );
+					if ( color ) {
+						editor.applyStyle( new CKEDITOR.style( colorStyle, { color: color } ) );
+					}
 					editor.fire( 'saveSnapshot' );
 				}
 

--- a/tests/plugins/colorbutton/colorbutton.js
+++ b/tests/plugins/colorbutton/colorbutton.js
@@ -164,6 +164,32 @@
 
 				wait();
 			} );
-		}
+		},
+
+		// (#1084)
+		'test changing text color to automatic': testAutomaticColor(),
+
+		// (#1084)
+		'test changing background color to automatic': testAutomaticColor( true )
 	} );
+
+	function testAutomaticColor( background ) {
+		return function() {
+			var editor = this.editor,
+				bot = this.editorBot,
+				colorBtn = editor.ui.get( background ? 'BGColor' : 'TextColor' );
+
+			bot.setHtmlWithSelection( 'Foo [<span style="' + ( background ? 'background-' : '' ) + 'color:red">bar</span>]' );
+
+			colorBtn.click( editor );
+
+			setTimeout( function() {
+				resume();
+				colorBtn._.panel.getBlock( colorBtn._.id ).element.findOne( '.cke_colorauto' ).$.click();
+
+				assert.areEqual( '<p>Foo bar</p>', editor.getData() );
+			}, 0 );
+			wait();
+		};
+	}
 } )();

--- a/tests/plugins/colorbutton/colorbutton.js
+++ b/tests/plugins/colorbutton/colorbutton.js
@@ -181,14 +181,15 @@
 
 			bot.setHtmlWithSelection( 'Foo [<span style="' + ( background ? 'background-' : '' ) + 'color:red">bar</span>]' );
 
-			colorBtn.click( editor );
-
-			setTimeout( function() {
+			editor.once( 'panelShow', function() {
 				resume();
 				colorBtn._.panel.getBlock( colorBtn._.id ).element.findOne( '.cke_colorauto' ).$.click();
 
 				assert.areEqual( '<p>Foo bar</p>', editor.getData() );
-			}, 0 );
+			} );
+
+			colorBtn.click( editor );
+
 			wait();
 		};
 	}

--- a/tests/plugins/colorbutton/colorbutton.js
+++ b/tests/plugins/colorbutton/colorbutton.js
@@ -173,13 +173,13 @@
 		'test changing background color to automatic': testAutomaticColor( true )
 	} );
 
-	function testAutomaticColor( background ) {
+	function testAutomaticColor( isBackgroundColor ) {
 		return function() {
 			var editor = this.editor,
 				bot = this.editorBot,
-				colorBtn = editor.ui.get( background ? 'BGColor' : 'TextColor' );
+				colorBtn = editor.ui.get( isBackgroundColor ? 'BGColor' : 'TextColor' );
 
-			bot.setHtmlWithSelection( 'Foo [<span style="' + ( background ? 'background-' : '' ) + 'color:red">bar</span>]' );
+			bot.setHtmlWithSelection( 'Foo [<span style="' + ( isBackgroundColor ? 'background-' : '' ) + 'color:red">bar</span>]' );
 
 			editor.once( 'panelShow', function() {
 				resume();

--- a/tests/plugins/colorbutton/colorbutton.js
+++ b/tests/plugins/colorbutton/colorbutton.js
@@ -182,10 +182,11 @@
 			bot.setHtmlWithSelection( 'Foo [<span style="' + ( isBackgroundColor ? 'background-' : '' ) + 'color:red">bar</span>]' );
 
 			editor.once( 'panelShow', function() {
-				resume();
-				colorBtn._.panel.getBlock( colorBtn._.id ).element.findOne( '.cke_colorauto' ).$.click();
+				resume( function() {
+					colorBtn._.panel.getBlock( colorBtn._.id ).element.findOne( '.cke_colorauto' ).$.click();
 
-				assert.areEqual( '<p>Foo bar</p>', editor.getData() );
+					assert.areEqual( '<p>Foo bar</p>', editor.getData() );
+				} );
 			} );
 
 			colorBtn.click( editor );

--- a/tests/plugins/colorbutton/manual/automaticcolor.html
+++ b/tests/plugins/colorbutton/manual/automaticcolor.html
@@ -1,0 +1,5 @@
+<textarea id="classic">Test text</textarea>
+
+<script>
+	CKEDITOR.replace( 'classic' );
+</script>

--- a/tests/plugins/colorbutton/manual/automaticcolor.md
+++ b/tests/plugins/colorbutton/manual/automaticcolor.md
@@ -1,0 +1,23 @@
+@bender-tags: bug, 4.10.1, 1084
+@bender-ckeditor-plugins: wysiwygarea, toolbar, colorbutton, sourcearea
+
+Do following steps for both text color button and background color button.
+
+1. Select word 'text'.
+1. Press text color button.
+1. Set any of colors other than automatic.
+1. Select word 'text' again.
+1. Press text color button again.
+1. Set color to 'automatic'.
+1. Press source button.
+
+## Expected
+
+Html in source mode matches following:
+`<p>Test text</p>`
+
+## Unexpected
+
+Html in source mode has span with color undefined, eg.:
+
+`<p>Test <span style="color:undefined">text</span></p>`

--- a/tests/plugins/colorbutton/manual/automaticcolor.md
+++ b/tests/plugins/colorbutton/manual/automaticcolor.md
@@ -1,5 +1,6 @@
 @bender-tags: bug, 4.10.1, 1084
 @bender-ckeditor-plugins: wysiwygarea, toolbar, colorbutton, sourcearea
+@bender-ui: collapsed
 
 Do following steps for both text color button and background color button.
 
@@ -18,6 +19,6 @@ Html in source mode matches following:
 
 ## Unexpected
 
-Html in source mode has span with color undefined, eg.:
+Html in source mode has span with color `null`, eg.:
 
-`<p>Test <span style="color:undefined">text</span></p>`
+`<p>Test <span style="color:null">text</span></p>`

--- a/tests/plugins/colorbutton/manual/automaticcolor.md
+++ b/tests/plugins/colorbutton/manual/automaticcolor.md
@@ -7,7 +7,6 @@ Do following steps for both text color button and background color button.
 1. Select word 'text'.
 1. Press text color button.
 1. Set any of colors other than automatic.
-1. Select word 'text' again.
 1. Press text color button again.
 1. Set color to 'automatic'.
 1. Press source button.


### PR DESCRIPTION
## What is the purpose of this pull request?

Bug fix

## Does your PR contain necessary tests?

All patches which change the editor code must include tests. You can always read more
on [PR testing](https://docs.ckeditor.com/ckeditor4/docs/#!/guide/dev_contributing_code-section-tests),
[how to set the testing environment](https://docs.ckeditor.com/ckeditor4/docs/#!/guide/dev_tests) and
[how to create tests](https://docs.ckeditor.com/ckeditor4/docs/#!/guide/dev_tests-section-creating-your-own-test)
in the official CKEditor documentation.

### This PR contains

- [X] Unit tests
- [X] Manual tests

## What changes did you make?

Before changes method applyColor still tried to apply style with undefined colour. After changes it is renamed to applyOrRemoveColor and it will remove styles when no colour is passed.

Closes #1084.