### PR TITLE
Fixed: Emoji shows suggestion box when colon preceded with other character than white space

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -14,6 +14,7 @@ Fixed Issues:
 * [#2271](https://github.com/ckeditor/ckeditor-dev/issues/2271): Fixed: Custom color name not used as a label in [Color Button](https://ckeditor.com/cke4/addon/image2) plugin. Thanks to [Eric Geloen](https://github.com/egeloen).
 * [#966](https://github.com/ckeditor/ckeditor-dev/issues/966): Fixed: Executing [`editor.destroy()`](https://docs.ckeditor.com/ckeditor4/latest/api/CKEDITOR_editor.html#destroy) during [file upload](https://docs.ckeditor.com/ckeditor4/latest/api/CKEDITOR_fileTools_uploadWidgetDefinition.html#onUploading) throws error. Thanks to [Maksim Makarevich](https://github.com/MaksimMakarevich)!
 * [#1719](https://github.com/ckeditor/ckeditor-dev/issues/1719): Fixed: <kbd>Ctrl</kbd>/<kbd>Cmd</kbd> + <kbd>A</kbd> focuses inline editor if starting and ending with a list. Thanks to [theNailz](https://github.com/theNailz)!
+* [#2195](https://github.com/ckeditor/ckeditor-dev/issues/2195): Fixed: [Emoji](https://ckeditor.com/cke4/addon/emoji) shows suggestion box when colon preceded with other character than white space.
 
 ## CKEditor 4.10
 

--- a/plugins/emoji/plugin.js
+++ b/plugins/emoji/plugin.js
@@ -67,14 +67,15 @@
 
 				function matchCallback( text, offset ) {
 					var left = text.slice( 0, offset ),
-						// Positive lookbehind for space, as emoji should be started with space or newline (#2195).
-						match = left.match( new RegExp( '(?<=\\s\|^):\\S{' + charactersToStart + '}\\S*$' ) );
+						// Emoji should be started with space or newline, but space shouldn't leak to output, hence it is in non captured group (#2195).
+						match = left.match( new RegExp( '(?:\\s\|^)(:\\S{' + charactersToStart + '}\\S*)$' ) );
 
 					if ( !match ) {
 						return null;
 					}
 
-					return { start: match.index, end: offset };
+					// In case of space preceding colon we need to return index of capturing grup.
+					return { start: text.indexOf( match[ 1 ] ), end: offset };
 				}
 
 				function dataCallback( matchInfo, callback ) {

--- a/plugins/emoji/plugin.js
+++ b/plugins/emoji/plugin.js
@@ -67,15 +67,10 @@
 
 				function matchCallback( text, offset ) {
 					var left = text.slice( 0, offset ),
-						match = left.match( new RegExp( ':\\S{' + charactersToStart + '}\\S*$' ) );
+						// Positive lookbehind for space, as emoji should be started with space or newline (#2195).
+						match = left.match( new RegExp( '(?<=\\s\|^):\\S{' + charactersToStart + '}\\S*$' ) );
 
 					if ( !match ) {
-						return null;
-					}
-
-					// Do not proceed if a query is a part of word.
-					var prevChar = text[ match.index - 1];
-					if ( prevChar !== undefined && !prevChar.match( /\s+/ ) ) {
 						return null;
 					}
 

--- a/plugins/emoji/plugin.js
+++ b/plugins/emoji/plugin.js
@@ -73,6 +73,12 @@
 						return null;
 					}
 
+					// Do not proceed if a query is a part of word.
+					var prevChar = text[ match.index - 1];
+					if ( prevChar !== undefined && !prevChar.match( /\s+/ ) ) {
+						return null;
+					}
+
 					return { start: match.index, end: offset };
 				}
 

--- a/tests/plugins/emoji/basic.js
+++ b/tests/plugins/emoji/basic.js
@@ -87,10 +87,14 @@
 
 			for ( var key in this.editorBots ) {
 				var editor = this.editorBots[ key ].editor,
+					autocomplete;
+
+				if ( editor._.emoji ) {
 					autocomplete = editor._.emoji.autocomplete;
 
-				emojiTools.clearAutocompleteModel( autocomplete );
-				autocomplete.close();
+					emojiTools.clearAutocompleteModel( autocomplete );
+					autocomplete.close();
+				}
 			}
 		},
 

--- a/tests/plugins/emoji/basic.js
+++ b/tests/plugins/emoji/basic.js
@@ -168,6 +168,26 @@
 				editable.fire( 'keyup', new CKEDITOR.dom.event( {} ) );
 				wait();
 			} );
+		},
+
+		// (#2195)
+		'test emoji suggestion box should appear at the beginning of new line': function( editor, bot ) {
+			emojiTools.runAfterInstanceReady( editor, bot, function( editor, bot ) {
+				var autocomplete = editor._.emoji.autocomplete,
+					editable = editor.editable();
+
+				bot.setHtmlWithSelection( '<p>foo</p><p>:bug^</p>' );
+
+				// Delay assertions because of autocomplete throttle.
+				setTimeout( function() {
+					resume( function() {
+						objectAssert.areEqual( { id: ':bug:', symbol: '🐛' }, autocomplete.model.data[ 0 ], 'Emoji result contains wrong result' );
+					} );
+				}, 50 );
+
+				editable.fire( 'keyup', new CKEDITOR.dom.event( {} ) );
+				wait();
+			} );
 		}
 	};
 

--- a/tests/plugins/emoji/basic.js
+++ b/tests/plugins/emoji/basic.js
@@ -146,7 +146,7 @@
 		},
 
 		// (#2195)
-		'test emoji suggestion box shouldn\'t appear inside text: function( editor, bot )': function( editor, bot ) {
+		'test emoji suggestion box shouldn\'t appear inside text': function( editor, bot ) {
 			emojiTools.runAfterInstanceReady( editor, bot, function( editor, bot ) {
 				var autocomplete = editor._.emoji.autocomplete;
 

--- a/tests/plugins/emoji/basic.js
+++ b/tests/plugins/emoji/basic.js
@@ -143,6 +143,19 @@
 					wait();
 				} );
 			} );
+		},
+
+		// (#2195)
+		'test emoji suggestion box shouldn\'t appear inside text: function( editor, bot )': function( editor, bot ) {
+			emojiTools.runAfterInstanceReady( editor, bot, function( editor, bot ) {
+				var autocomplete = editor._.emoji.autocomplete;
+
+				bot.setHtmlWithSelection( '<p>foo:bug^</p>' );
+
+				editor.editable().fire( 'keyup', new CKEDITOR.dom.event( {} ) );
+				emojiTools.assertIsNullOrUndefined( autocomplete.model.query );
+				emojiTools.assertIsNullOrUndefined( autocomplete.model.data );
+			} );
 		}
 	};
 

--- a/tests/plugins/emoji/basic.js
+++ b/tests/plugins/emoji/basic.js
@@ -148,13 +148,21 @@
 		// (#2195)
 		'test emoji suggestion box shouldn\'t appear inside text': function( editor, bot ) {
 			emojiTools.runAfterInstanceReady( editor, bot, function( editor, bot ) {
-				var autocomplete = editor._.emoji.autocomplete;
+				var autocomplete = editor._.emoji.autocomplete,
+					editable = editor.editable();
 
 				bot.setHtmlWithSelection( '<p>foo:bug^</p>' );
 
-				editor.editable().fire( 'keyup', new CKEDITOR.dom.event( {} ) );
-				emojiTools.assertIsNullOrUndefined( autocomplete.model.query );
-				emojiTools.assertIsNullOrUndefined( autocomplete.model.data );
+				// Delay assertions because of autocomplete throttle.
+				setTimeout( function() {
+					resume( function() {
+						emojiTools.assertIsNullOrUndefined( autocomplete.model.query );
+						emojiTools.assertIsNullOrUndefined( autocomplete.model.data );
+					} );
+				}, 50 );
+
+				editable.fire( 'keyup', new CKEDITOR.dom.event( {} ) );
+				wait();
 			} );
 		}
 	};

--- a/tests/plugins/emoji/basic.js
+++ b/tests/plugins/emoji/basic.js
@@ -39,7 +39,7 @@
 			emojiTools.runAfterInstanceReady( editor, bot, function( editor, bot ) {
 				var autocomplete = editor._.emoji.autocomplete;
 
-				bot.setHtmlWithSelection( '<p>foo:da^</p>' );
+				bot.setHtmlWithSelection( '<p>foo :da^</p>' );
 				editor.editable().fire( 'keyup', new CKEDITOR.dom.event( {} ) );
 
 				// Asserted data might not be initialised yet or reset to null value with `onTextUnmatch` method.
@@ -49,7 +49,7 @@
 				// Handle throttle in autocomplete which by defualt is 20ms;
 				setTimeout( function() {
 					resume( function() {
-						bot.setHtmlWithSelection( '<p>foo:dagg^</p>' );
+						bot.setHtmlWithSelection( '<p>foo :dagg^</p>' );
 						editor.editable().fire( 'keyup', new CKEDITOR.dom.event( {} ) );
 						assert.areSame( ':dagg', autocomplete.model.query, 'Model keeps wrong querry.' );
 						assert.areSame( 1, autocomplete.model.data.length, 'Emoji result contains more than one result.' );
@@ -105,7 +105,7 @@
 			emojiTools.runAfterInstanceReady( editor, bot, function( editor, bot ) {
 				var autocomplete = editor._.emoji.autocomplete;
 
-				bot.setHtmlWithSelection( '<p>foo:bug^</p>' );
+				bot.setHtmlWithSelection( '<p>foo :bug^</p>' );
 				editor.editable().fire( 'keyup', new CKEDITOR.dom.event( {} ) );
 				assert.areSame( ':bug', autocomplete.model.query, 'Model keeps wrong querry.' );
 				assert.areSame( 1, autocomplete.model.data.length, 'Emoji result contains more than one result.' );
@@ -116,7 +116,7 @@
 		'test emoji are not actived when too few letters are written': function( editor, bot ) {
 			emojiTools.runAfterInstanceReady( editor, bot, function( editor, bot ) {
 				var autocomplete = editor._.emoji.autocomplete;
-				bot.setHtmlWithSelection( '<p>foo:b^</p>' );
+				bot.setHtmlWithSelection( '<p>foo :b^</p>' );
 				editor.editable().fire( 'keyup', new CKEDITOR.dom.event( {} ) );
 
 				// Asserted data might not be initialised yet or reset to null value with `onTextUnmatch` method.
@@ -135,7 +135,7 @@
 				CKEDITOR.tools.array.forEach( queries, function( query, index ) {
 					setTimeout( function() {
 						resume();
-						bot.setHtmlWithSelection( '<p>foo' + query + '^</p>' );
+						bot.setHtmlWithSelection( '<p>foo ' + query + '^</p>' );
 						editor.editable().fire( 'keyup', new CKEDITOR.dom.event( {} ) );
 
 						objectAssert.areEqual( { id: ':ok_hand:', symbol: '👌' }, autocomplete.model.data[ 0 ], 'Emoji result contains wrong result' );

--- a/tests/plugins/emoji/manual/spacerequired.html
+++ b/tests/plugins/emoji/manual/spacerequired.html
@@ -1,8 +1,10 @@
 <textarea id="classic">
 	<p>Foo</p>
+	<p></p>
 </textarea>
 <div id="inline" contenteditable="true">
 	<p>Foo</p>
+	<p></p>
 </div>
 
 <script>

--- a/tests/plugins/emoji/manual/spacerequired.html
+++ b/tests/plugins/emoji/manual/spacerequired.html
@@ -1,0 +1,13 @@
+<textarea id="classic">
+	<p>Foo</p>
+	<p>Bar</p>
+</textarea>
+<div id="inline" contenteditable="true">
+	<p>Foo</p>
+	<p>Bar</p>
+</div>
+
+<script>
+	CKEDITOR.replace( 'classic' );
+	CKEDITOR.inline( 'inline' );
+</script>

--- a/tests/plugins/emoji/manual/spacerequired.html
+++ b/tests/plugins/emoji/manual/spacerequired.html
@@ -1,10 +1,8 @@
 <textarea id="classic">
 	<p>Foo</p>
-	<p>Bar</p>
 </textarea>
 <div id="inline" contenteditable="true">
 	<p>Foo</p>
-	<p>Bar</p>
 </div>
 
 <script>

--- a/tests/plugins/emoji/manual/spacerequired.md
+++ b/tests/plugins/emoji/manual/spacerequired.md
@@ -5,27 +5,22 @@
 
 ## For both editors:
 
-1. Place caret at the end of line.
+1. Place caret at the end of first line.
 
 1. Type ':bu' without space before.
 
 1. Type ' :bu' with space.
 
+1. Place caret at the end of second line and repeat step 2.
+
 ### Expected
 
-When there is no space:
-
-- Nothing happens.
-
-When there is space:
-
-- Emoji suggestion box appears.
+- Nothing happens when there is no preceding space.
+- When there is preceding space or it is beginning of line emoji suggestion box appears.
 
 ### Unexpected
 
-When there is no space:
-
-- Emoji suggestion box appears.
+- Emoji suggestion box appears when there is no preceding space.
 
 ----
 ## Example emoji to use in tests:

--- a/tests/plugins/emoji/manual/spacerequired.md
+++ b/tests/plugins/emoji/manual/spacerequired.md
@@ -1,0 +1,40 @@
+@bender-tags: 4.10.1, bug, emoji, 2195
+@bender-ckeditor-plugins: wysiwygarea, sourcearea, emoji
+@bender-ui: collapsed
+@bender-include: ../_helpers/tools.js
+
+## For both editors:
+
+1. Place caret at the end of first line.
+
+1. Type `:bu`.
+
+	### Expected
+
+	Nothing happens.
+
+	### Unexpected
+
+	Emoji suggestion box appears.
+
+1. Place caret at the end of second line.
+
+1. Type `:bu`.
+
+	### Expected
+
+	Emoji suggestion box appears.
+
+	### Unexpected
+
+	Nothing happens
+
+----
+## Example emoji to use in tests:
+
+| name | symbol |
+| ---: | --- |
+| :bug: | 🐛 |
+| :winking_face: | 😉 |
+| :collision: | 💥 |
+| :unicorn_face: | 🦄 |

--- a/tests/plugins/emoji/manual/spacerequired.md
+++ b/tests/plugins/emoji/manual/spacerequired.md
@@ -5,29 +5,27 @@
 
 ## For both editors:
 
-1. Place caret at the end of first line.
+1. Place caret at the end of line.
 
-1. Type `:bu`.
+1. Type ':bu' without space before.
 
-	### Expected
+1. Type ' :bu' with space.
 
-	Nothing happens.
+### Expected
 
-	### Unexpected
+When there is no space:
 
-	Emoji suggestion box appears.
+- Nothing happens.
 
-1. Place caret at the end of second line.
+When there is space:
 
-1. Type `:bu`.
+- Emoji suggestion box appears.
 
-	### Expected
+### Unexpected
 
-	Emoji suggestion box appears.
+When there is no space:
 
-	### Unexpected
-
-	Nothing happens
+- Emoji suggestion box appears.
 
 ----
 ## Example emoji to use in tests:


### PR DESCRIPTION
## What is the purpose of this pull request?

Bug fix

## Does your PR contain necessary tests?

All patches which change the editor code must include tests. You can always read more
on [PR testing](https://docs.ckeditor.com/ckeditor4/docs/#!/guide/dev_contributing_code-section-tests),
[how to set the testing environment](https://docs.ckeditor.com/ckeditor4/docs/#!/guide/dev_tests) and
[how to create tests](https://docs.ckeditor.com/ckeditor4/docs/#!/guide/dev_tests-section-creating-your-own-test)
in the official CKEditor documentation.

### This PR contains

- [X] Unit tests
- [X] Manual tests

## What changes did you make?

Added check for last character before colon. If it's not white space then don't show drop down.

Closes #2195 