### PR TITLE
Corrected return type docs for the tools.keystrokeToString method

### DIFF
--- a/core/tools.js
+++ b/core/tools.js
@@ -1419,7 +1419,9 @@
 		 * @since 4.6.0
 		 * @param {Object} lang A language object with the key name translation.
 		 * @param {Number} keystroke The keystroke to convert.
-		 * @returns {{display: String, aria: String}} See {@link #keystrokeToArray}.
+		 * @returns {Object} See {@link #keystrokeToArray}.
+		 * @returns {String} return.display
+		 * @returns {String} return.aria
 		 */
 		keystrokeToString: function( lang, keystroke ) {
 			var ret = this.keystrokeToArray( lang, keystroke );


### PR DESCRIPTION
## What is the purpose of this pull request?

Task

## Does your PR contain necessary tests?

All patches which change the editor code must include tests. You can always read more
on [PR testing](https://docs.ckeditor.com/ckeditor4/docs/#!/guide/dev_contributing_code-section-tests),
[how to set the testing environment](https://docs.ckeditor.com/ckeditor4/docs/#!/guide/dev_tests) and
[how to create tests](https://docs.ckeditor.com/ckeditor4/docs/#!/guide/dev_tests-section-creating-your-own-test)
in the official CKEditor documentation.

### This PR contains

- [ ] Unit tests
- [ ] Manual tests

Just a API doc fix, skipping the tests.

## What changes did you make?

Just changed the return value docs for [tools.keystrokeToString](https://docs.ckeditor.com/ckeditor4/latest/api/CKEDITOR_tools.html#method-keystrokeToString).