### PR TITLE
Fixed custom color name not being used as a label in Color Button plugin

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -11,6 +11,7 @@ Fixed Issues:
 * [#2167](https://github.com/ckeditor/ckeditor-dev/issues/2167): Fixed: Matching in [Emoji](https://ckeditor.com/cke4/addon/emoji) plugin is not case insensitive.
 * [#1084](https://github.com/ckeditor/ckeditor-dev/issues/1084) Fixed: Using the "Automatic" option with [Color Button](https://ckeditor.com/cke4/addon/colorbutton) on a text with color already defined sets an invalid color value.
 * [#1348](https://github.com/ckeditor/ckeditor-dev/issues/1348): Fixed: [Enhanced Image](https://ckeditor.com/cke4/addon/image2) plugin aspect ratio locking uses old width and height on image URL change.
+* [#2271](https://github.com/ckeditor/ckeditor-dev/issues/2271): Fixed: Custom color name not used as a label in [Color Button](https://ckeditor.com/cke4/addon/image2) plugin. Thanks to [Eric Geloen](https://github.com/egeloen).
 * [#966](https://github.com/ckeditor/ckeditor-dev/issues/966): Fixed: Executing [`editor.destroy()`](https://docs.ckeditor.com/ckeditor4/latest/api/CKEDITOR_editor.html#destroy) during [file upload](https://docs.ckeditor.com/ckeditor4/latest/api/CKEDITOR_fileTools_uploadWidgetDefinition.html#onUploading) throws error. Thanks to [Maksim Makarevich](https://github.com/MaksimMakarevich)!
 
 ## CKEditor 4.10

--- a/plugins/colorbutton/plugin.js
+++ b/plugins/colorbutton/plugin.js
@@ -264,15 +264,21 @@ CKEDITOR.plugins.add( 'colorbutton', {
 
 				var parts = colors[ i ].split( '/' ),
 					colorName = parts[ 0 ],
-					colorCode = parts[ 1 ] || colorName;
+					colorCode = parts[ 1 ] || colorName,
+					colorLabel;
 
 				// The data can be only a color code (without #) or colorName + color code
 				// If only a color code is provided, then the colorName is the color with the hash
 				// Convert the color from RGB to RRGGBB for better compatibility with IE and <font>. See https://dev.ckeditor.com/ticket/5676
-				if ( !parts[ 1 ] )
+				// Additionally, if the data is a single color code then let's try to translate it or fallback on the
+				// color code. If the data is a color name/code, then use directly the color name provided.
+				if ( !parts[ 1 ] ) {
 					colorName = '#' + colorName.replace( /^(.)(.)(.)$/, '$1$1$2$2$3$3' );
+					colorLabel = editor.lang.colorbutton.colors[ colorCode ] || colorCode;
+				} else {
+					colorLabel = colorName;
+				}
 
-				var colorLabel = editor.lang.colorbutton.colors[ colorCode ] || colorCode;
 				output.push( '<td>' +
 					'<a class="cke_colorbox" _cke_focus=1 hidefocus=true' +
 						' title="', colorLabel, '"' +

--- a/tests/plugins/colorbutton/config.js
+++ b/tests/plugins/colorbutton/config.js
@@ -34,20 +34,18 @@
 		'test config.colorButton_colors labels': function() {
 			var editor = this.editors.colorLabels,
 				bgColorBtn = editor.ui.get( 'BGColor' ),
-				expectedLabels = [ 'FontColor1', 'FontColor2', 'Red' ];
+				expectedLabels = [ 'FontColor1', 'FontColor2', 'Red' ],
+				colorOptions;
 
-			resume( function() {
-				var colorOptions = bgColorBtn._.panel.getBlock( bgColorBtn._.id ).element.find( 'a.cke_colorbox' );
-
-				CKEDITOR.tools.array.map( colorOptions.toArray(), function( el, index ) {
-					assert.areSame( expectedLabels[ index ], colorOptions.getItem( index ).getAttribute( 'title' ), 'Title for color at index ' + index );
-				} );
-			} );
-
-			bender.tools.selection.setWithHtml( editor, '<h1 style="background: #999999">{Moo}</h1>' );
+			// Editor needs a focus, otherwise IE/Edge throws permission error.
+			editor.focus();
 			bgColorBtn.click( editor );
 
-			wait();
+			colorOptions = bgColorBtn._.panel.getBlock( bgColorBtn._.id ).element.find( 'a.cke_colorbox' );
+
+			CKEDITOR.tools.array.map( colorOptions.toArray(), function( el, index ) {
+				assert.areSame( expectedLabels[ index ], colorOptions.getItem( index ).getAttribute( 'title' ), 'Title for color at index ' + index );
+			} );
 		}
 	} );
 } )();

--- a/tests/plugins/colorbutton/config.js
+++ b/tests/plugins/colorbutton/config.js
@@ -4,10 +4,22 @@
 ( function() {
 	'use strict';
 
-	bender.editor = {
-		config: {
-			colorButton_normalizeBackground: false,
-			extraAllowedContent: 'span{background}'
+	bender.editors = {
+		normalizeBackground: {
+			creator: 'inline',
+			name: 'normalizeBackground',
+			config: {
+				colorButton_normalizeBackground: false,
+				extraAllowedContent: 'span{background}'
+			}
+		},
+		colorLabels: {
+			creator: 'inline',
+			name: 'colorLabels',
+			config: {
+				colorButton_colors: 'FontColor1/FF9900,FontColor2/0066CC,F00',
+				language: 'en'
+			}
 		}
 	};
 
@@ -15,7 +27,27 @@
 		'test config.normalizeBackground': function() {
 			var input = '<p><span style="background:#ff0000">foo</span><span style="background:yellow">bar</span></p>';
 
-			assert.areSame( input, this.editor.dataProcessor.toHtml( input ) );
+			assert.areSame( input, this.editors.normalizeBackground.dataProcessor.toHtml( input ) );
+		},
+
+		// (#2271)
+		'test config.colorButton_colors labels': function() {
+			var editor = this.editors.colorLabels,
+				bgColorBtn = editor.ui.get( 'BGColor' ),
+				expectedLabels = [ 'FontColor1', 'FontColor2', 'Red' ];
+
+			resume( function() {
+				var colorOptions = bgColorBtn._.panel.getBlock( bgColorBtn._.id ).element.find( 'a.cke_colorbox' );
+
+				CKEDITOR.tools.array.map( colorOptions.toArray(), function( el, index ) {
+					assert.areSame( expectedLabels[ index ], colorOptions.getItem( index ).getAttribute( 'title' ), 'Title for color at index ' + index );
+				} );
+			} );
+
+			bender.tools.selection.setWithHtml( editor, '<h1 style="background: #999999">{Moo}</h1>' );
+			bgColorBtn.click( editor );
+
+			wait();
 		}
 	} );
 } )();

--- a/tests/plugins/colorbutton/manual/customlabel.html
+++ b/tests/plugins/colorbutton/manual/customlabel.html
@@ -1,0 +1,14 @@
+<textarea cols="80" id="editor1" name="editor1" rows="10">
+	<p>Editor content.</p>
+</textarea>
+
+<script>
+	if ( bender.tools.env.mobile ) {
+		bender.ignore();
+	}
+
+	CKEDITOR.replace( 'editor1', {
+		colorButton_colors: 'FontColor1/FF9900,FontColor2/0066CC,F00',
+		toolbar: [ [ 'BGColor' ] ]
+	} );
+</script>

--- a/tests/plugins/colorbutton/manual/customlabel.md
+++ b/tests/plugins/colorbutton/manual/customlabel.md
@@ -2,8 +2,8 @@
 @bender-ui: collapsed
 @bender-ckeditor-plugins: wysiwygarea, toolbar, colorbutton
 
-1. Click the background color button.
-1. Focus the orange color.
+1. Click "Background Color" button.
+1. Move the cursor over the orange color button.
 1. Wait until the title/label appears.
 
 ### Expected

--- a/tests/plugins/colorbutton/manual/customlabel.md
+++ b/tests/plugins/colorbutton/manual/customlabel.md
@@ -1,0 +1,15 @@
+@bender-tags: bug, 2271, 4.10.1
+@bender-ui: collapsed
+@bender-ckeditor-plugins: wysiwygarea, toolbar, colorbutton
+
+1. Click the background color button.
+1. Focus the orange color.
+1. Wait until the title/label appears.
+
+### Expected
+
+The tooltip is "FontColor1".
+
+### Unexpected
+
+The tooltip is "FF9900".


### PR DESCRIPTION
## What is the purpose of this pull request?

Bug fix

## Does your PR contain necessary tests?

All patches which change the editor code must include tests. You can always read more
on [PR testing](https://docs.ckeditor.com/ckeditor4/docs/#!/guide/dev_contributing_code-section-tests),
[how to set the testing environment](https://docs.ckeditor.com/ckeditor4/docs/#!/guide/dev_tests) and
[how to create tests](https://docs.ckeditor.com/ckeditor4/docs/#!/guide/dev_tests-section-creating-your-own-test)
in the official CKEditor documentation.

### This PR contains

- [x] Unit tests
- [x] Manual tests

## What changes did you make?

There was a bug in how custom color labels are fetched. Community PR was good in that regard, I have added manual and unit tests for this case.

Closes #2271.

Follow-up of a #253.