### PR TITLE
Added an explicit information that find/findOne selector is a CSS selector

### DIFF
--- a/core/dom/document.js
+++ b/core/dom/document.js
@@ -284,7 +284,7 @@ CKEDITOR.tools.extend( CKEDITOR.dom.document.prototype, {
 	 * **Note:** The returned list is not a live collection (like the result of native `querySelectorAll`).
 	 *
 	 * @since 4.3
-	 * @param {String} selector
+	 * @param {String} selector A valid [CSS selector](https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_Selectors).
 	 * @returns {CKEDITOR.dom.nodeList}
 	 */
 	find: function( selector ) {
@@ -296,7 +296,7 @@ CKEDITOR.tools.extend( CKEDITOR.dom.document.prototype, {
 	 * the specified `selector`.
 	 *
 	 * @since 4.3
-	 * @param {String} selector
+	 * @param {String} selector A valid [CSS selector](https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_Selectors).
 	 * @returns {CKEDITOR.dom.element}
 	 */
 	findOne: function( selector ) {

--- a/core/dom/element.js
+++ b/core/dom/element.js
@@ -2021,7 +2021,7 @@ CKEDITOR.dom.element.clearMarkers = function( database, element, removeFromDatab
 		 *
 		 *	* Not available in IE7.
 		 *	* Returned list is not a live collection (like a result of native `querySelectorAll`).
-		 *	* Unlike native `querySelectorAll` this method ensures selector contextualization. This is:
+		 *	* Unlike the native `querySelectorAll` this method ensures selector contextualization. This is:
 		 *
 		 *			HTML:		'<body><div><i>foo</i></div></body>'
 		 *			Native:		div.querySelectorAll( 'body i' ) // ->		[ <i>foo</i> ]
@@ -2044,12 +2044,12 @@ CKEDITOR.dom.element.clearMarkers = function( database, element, removeFromDatab
 		},
 
 		/**
-		 * Returns the first element within this element that matches specified `selector`.
+		 * Returns the first element within this element that matches the specified `selector`.
 		 *
 		 * **Notes:**
 		 *
 		 *	* Not available in IE7.
-		 *	* Unlike native `querySelector` this method ensures selector contextualization. This is:
+		 *	* Unlike the native `querySelector` this method ensures selector contextualization. This is:
 		 *
 		 *			HTML:		'<body><div><i>foo</i></div></body>'
 		 *			Native:		div.querySelector( 'body i' ) // ->			<i>foo</i>

--- a/core/dom/element.js
+++ b/core/dom/element.js
@@ -2029,7 +2029,7 @@ CKEDITOR.dom.element.clearMarkers = function( database, element, removeFromDatab
 		 *						div.find( 'i' ) // ->						[ <i>foo</i> ]
 		 *
 		 * @since 4.3
-		 * @param {String} selector
+		 * @param {String} selector A valid [CSS selector](https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_Selectors).
 		 * @returns {CKEDITOR.dom.nodeList}
 		 */
 		find: function( selector ) {
@@ -2044,12 +2044,12 @@ CKEDITOR.dom.element.clearMarkers = function( database, element, removeFromDatab
 		},
 
 		/**
-		 * Returns first element within this element that matches specified `selector`.
+		 * Returns the first element within this element that matches specified `selector`.
 		 *
 		 * **Notes:**
 		 *
 		 *	* Not available in IE7.
-		 *	* Unlike native `querySelectorAll` this method ensures selector contextualization. This is:
+		 *	* Unlike native `querySelector` this method ensures selector contextualization. This is:
 		 *
 		 *			HTML:		'<body><div><i>foo</i></div></body>'
 		 *			Native:		div.querySelector( 'body i' ) // ->			<i>foo</i>
@@ -2057,7 +2057,7 @@ CKEDITOR.dom.element.clearMarkers = function( database, element, removeFromDatab
 		 *						div.findOne( 'i' ) // ->					<i>foo</i>
 		 *
 		 * @since 4.3
-		 * @param {String} selector
+		 * @param {String} selector A valid [CSS selector](https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_Selectors).
 		 * @returns {CKEDITOR.dom.element}
 		 */
 		findOne: function( selector ) {

--- a/core/dom/range.js
+++ b/core/dom/range.js
@@ -3117,7 +3117,7 @@ CKEDITOR.dom.range = function( root ) {
 		 *
 		 * @since 4.5.11
 		 * @private
-		 * @param {String} query
+		 * @param {String} query A valid [CSS selector](https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_Selectors).
 		 * @param {Boolean} [includeNonEditables=false] Whether elements with `contenteditable` set to `false` should
 		 * be included.
 		 * @returns {CKEDITOR.dom.element[]}


### PR DESCRIPTION
## What is the purpose of this pull request?

Task

## Does your PR contain necessary tests?

All patches which change the editor code must include tests. You can always read more
on [PR testing](https://docs.ckeditor.com/ckeditor4/docs/#!/guide/dev_contributing_code-section-tests),
[how to set the testing environment](https://docs.ckeditor.com/ckeditor4/docs/#!/guide/dev_tests) and
[how to create tests](https://docs.ckeditor.com/ckeditor4/docs/#!/guide/dev_tests-section-creating-your-own-test)
in the official CKEditor documentation.

### This PR contains

- [ ] Unit tests
- [ ] Manual tests

Skipped tests, this is doc only change.

## What changes did you make?

Added an explicit information that selector is a CSS selector.

During the process I was thinking about higher DRY factor, however both methods have such documentation that it differs in details here and there, thus rendering `@inheritdoc` unfeasible.

Closes ckeditor/ckeditor-docs#43.