### PR TITLE
Fixed issue with invalid commands state refresh

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -6,6 +6,7 @@
 Fixed Issues:
 
 * [#1181](https://github.com/ckeditor/ckeditor-dev/issues/1181): [Chrome] Fixed: Opening context menu in readonly editor results in error.
+* [#2276](https://github.com/ckeditor/ckeditor-dev/issues/2276): [iOS] Fixed: [Button](https://ckeditor.com/cke4/addon/button) state doesn't refresh properly.
 
 ## CKEditor 4.10.1
 
@@ -32,7 +33,6 @@ Fixed Issues:
 * [#1115](https://github.com/ckeditor/ckeditor-dev/issues/1115): Fixed: `<font>` tag is not preserved, when proper config is provided and style is applied by [Font](https://ckeditor.com/cke4/addon/font) plugin.
 * [#727](https://github.com/ckeditor/ckeditor-dev/issues/727): Fixed: custom styles might be invisible in [Styles Combo](https://ckeditor.com/cke4/addon/stylescombo) plugin.
 * [#988](https://github.com/ckeditor/ckeditor-dev/issues/988): Fixed: ACF - enabled custom elements prefixed with `object`, `embed`, `param` are removed from editor's content.
-* [#2276](https://github.com/ckeditor/ckeditor-dev/issues/2276): [iOS] Fixed: [Button](https://ckeditor.com/cke4/addon/button) state doesn't refresh properly.
 
 API Changes:
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -32,6 +32,7 @@ Fixed Issues:
 * [#1115](https://github.com/ckeditor/ckeditor-dev/issues/1115): Fixed: `<font>` tag is not preserved, when proper config is provided and style is applied by [Font](https://ckeditor.com/cke4/addon/font) plugin.
 * [#727](https://github.com/ckeditor/ckeditor-dev/issues/727): Fixed: custom styles might be invisible in [Styles Combo](https://ckeditor.com/cke4/addon/stylescombo) plugin.
 * [#988](https://github.com/ckeditor/ckeditor-dev/issues/988): Fixed: ACF - enabled custom elements prefixed with `object`, `embed`, `param` are removed from editor's content.
+* [#2276](https://github.com/ckeditor/ckeditor-dev/issues/2276): [iOS] Fixed: [Button](https://ckeditor.com/cke4/addon/button) state doesn't refresh properly.
 
 API Changes:
 

--- a/core/selection.js
+++ b/core/selection.js
@@ -920,9 +920,11 @@
 
 			// We check the selection change:
 			// 1. Upon "selectionchange" event from the editable element. (which might be faked event fired by our code)
-			// 2. After the accomplish of keyboard and mouse events.
+			// 2. After the accomplish of keyboard, mouse and touch (#2276) events.
 			editable.attachListener( editable, 'selectionchange', checkSelectionChange, editor );
 			editable.attachListener( editable, 'keyup', checkSelectionChangeTimeout, editor );
+			editable.attachListener( editable, 'touchstart', checkSelectionChangeTimeout, editor );
+			editable.attachListener( editable, 'touchend', checkSelectionChangeTimeout, editor );
 
 			if ( CKEDITOR.env.ie ) {
 				// https://dev.ckeditor.com/ticket/14407 - Don't even let anything happen if the selection is in a non-editable element.

--- a/tests/core/selection/editor.js
+++ b/tests/core/selection/editor.js
@@ -149,6 +149,14 @@ bender.test( {
 		}, 200 );
 	},
 
+	// (#2276)
+	'test "selectionCheck" fires properly': function() {
+		testSelectionCheck( this.editors.editor, 'touchstart', 'Fire touchstart.' );
+		testSelectionCheck( this.editors.editor, 'touchend', 'Fire touchend.' );
+		testSelectionCheck( this.editors.editor, 'keyup', 'Fire keyup.' );
+		testSelectionCheck( this.editors.editor, 'mouseup', 'Fire mouseup.' );
+	},
+
 	'test "selectionChange" not fired when editor selection is locked': function() {
 		var ed = this.editors.editor, editable = ed.editable();
 
@@ -735,3 +743,18 @@ bender.test( {
 	}
 
 } );
+
+function testSelectionCheck( editor, event, msg ) {
+	var onSelectionChange = sinon.spy();
+
+	bender.tools.setHtmlWithSelection( editor, '<p>[test]</p>' );
+
+	editor.on( 'selectionCheck', onSelectionChange );
+	editor.editable().fire( event );
+
+	// selection change has a 200ms delay.
+	wait( function() {
+		editor.removeListener( 'selectionCheck', onSelectionChange );
+		assert.isTrue( onSelectionChange.calledOnce, msg );
+	}, 200 );
+}

--- a/tests/core/selection/editor.js
+++ b/tests/core/selection/editor.js
@@ -150,11 +150,11 @@ bender.test( {
 	},
 
 	// (#2276)
-	'test "selectionCheck" fires properly': function() {
-		testSelectionCheck( this.editors.editor, 'touchstart', 'Fire touchstart.' );
-		testSelectionCheck( this.editors.editor, 'touchend', 'Fire touchend.' );
-		testSelectionCheck( this.editors.editor, 'keyup', 'Fire keyup.' );
-		testSelectionCheck( this.editors.editor, 'mouseup', 'Fire mouseup.' );
+	'test "selectionCheck" fires for mouse, key and touch events': function() {
+		testSelectionCheck( this.editors.editor, 'touchstart' );
+		testSelectionCheck( this.editors.editor, 'touchend' );
+		testSelectionCheck( this.editors.editor, 'keyup' );
+		testSelectionCheck( this.editors.editor, 'mouseup' );
 	},
 
 	'test "selectionChange" not fired when editor selection is locked': function() {
@@ -744,7 +744,7 @@ bender.test( {
 
 } );
 
-function testSelectionCheck( editor, event, msg ) {
+function testSelectionCheck( editor, event ) {
 	var onSelectionChange = sinon.spy();
 
 	bender.tools.setHtmlWithSelection( editor, '<p>[test]</p>' );
@@ -755,6 +755,6 @@ function testSelectionCheck( editor, event, msg ) {
 	// selection change has a 200ms delay.
 	wait( function() {
 		editor.removeListener( 'selectionCheck', onSelectionChange );
-		assert.isTrue( onSelectionChange.calledOnce, msg );
+		assert.isTrue( onSelectionChange.calledOnce, 'selectionCheck not fired on ' + event );
 	}, 200 );
 }

--- a/tests/core/selection/manual/commandsrefresh.html
+++ b/tests/core/selection/manual/commandsrefresh.html
@@ -1,0 +1,9 @@
+<div id="editor">
+	<p>
+	Hello <a href="http://example.com">World!</a>
+	</p>
+</div>
+
+<script>
+	CKEDITOR.replace( 'editor' );
+</script>

--- a/tests/core/selection/manual/commandsrefresh.md
+++ b/tests/core/selection/manual/commandsrefresh.md
@@ -1,0 +1,15 @@
+@bender-tags: selection, 4.10.1, bug, 2276
+@bender-ui: collapsed
+@bender-ckeditor-plugins: wysiwygarea, link, toolbar
+
+1. Set cursor position inside a link.
+1. Move cursor position inside a text.
+1. Repeat couple of times.
+
+## Expected
+
+`Unlink` button is disabled for a plain text and enabled for a link.
+
+## Unexpected
+
+`Unlink` button changes its status incorrectly.

--- a/tests/core/selection/manual/commandsrefresh.md
+++ b/tests/core/selection/manual/commandsrefresh.md
@@ -2,6 +2,8 @@
 @bender-ui: collapsed
 @bender-ckeditor-plugins: wysiwygarea, link, toolbar
 
+Pay attention to `unlink` button state when performing test steps:
+
 1. Set cursor position inside a link.
 1. Move cursor position inside a text.
 1. Repeat couple of times.

--- a/tests/core/selection/manual/commandsrefresh.md
+++ b/tests/core/selection/manual/commandsrefresh.md
@@ -1,4 +1,4 @@
-@bender-tags: selection, 4.10.1, bug, 2276
+@bender-tags: selection, 4.10.2, bug, 2276
 @bender-ui: collapsed
 @bender-ckeditor-plugins: wysiwygarea, link, toolbar
 


### PR DESCRIPTION
## What is the purpose of this pull request?

Bug fix

## Does your PR contain necessary tests?

All patches which change the editor code must include tests. You can always read more
on [PR testing](https://docs.ckeditor.com/ckeditor4/docs/#!/guide/dev_contributing_code-section-tests),
[how to set the testing environment](https://docs.ckeditor.com/ckeditor4/docs/#!/guide/dev_tests) and
[how to create tests](https://docs.ckeditor.com/ckeditor4/docs/#!/guide/dev_tests-section-creating-your-own-test)
in the official CKEditor documentation.

### This PR contains

- [x] Unit tests
- [x] Manual tests

## What changes did you make?

A selection wasn't refreshed for touch events and in the result, commands weren't correctly refreshed on iOS. I added appropriate event listeners for `selection`.

**Note:** Unit and manual tests are enabled on each browser for simplicity and future changes.

Closes #2276
