### PR TITLE
Improved IE 10 and IE 11 version detection

### DIFF
--- a/core/env.js
+++ b/core/env.js
@@ -193,7 +193,17 @@ if ( !CKEDITOR.env ) {
 			if ( edge ) {
 				version = parseFloat( edge[ 1 ] );
 			} else if ( env.quirks || !document.documentMode ) {
-				version = parseFloat( agent.match( /msie (\d+)/ )[ 1 ] );
+				// documentMode can be undefined for IE10 and IE11
+				// so lets do this a bit more thoroughly
+				var msie = agent.indexOf('msie '); // IE10 or older
+				if (msie > -1) {
+					version = parseInt(agent.substring(msie + 5, agent.indexOf('.', msie)), 10);
+				}
+				var trident = agent.indexOf('trident/'); // IE11
+				if (trident > -1) {
+                    var rv = agent.indexOf('rv:');
+                    version = parseInt(agent.substring(rv + 3, agent.indexOf('.', rv)), 10);
+                }
 			} else {
 				version = document.documentMode;
 			}


### PR DESCRIPTION
In IE 10 and IE 11, there are cases observed where document.documentMode may be undefined and the user agent does not match what CKEditor expects for detection.  For example, in IE11, the user agent may be "Mozilla/5.0 (Windows NT 6.3); Trident/7.0; rv:11.0) like Gecko) and documentMode can be undefined.  In this case, CKEditor will error out on line 196 with:

"SCRIPT5007: Unable to get property '1' of undefined or null reference"

The code added here does a slower but more rigorous check of the user agent.  For IE10 or IE11, if documentMode is undefined, the version is extracted from the user agent and set properly.  This makes it possible for CKEditor 4.10 to support IE11 (at least in the cases that we tested).

## What is the purpose of this pull request?

<!-- Bug fix / New feature / Typo fix / Other, please explain  -->

## Does your PR contain necessary tests?

All patches which change the editor code must include tests. You can always read more
on [PR testing](https://docs.ckeditor.com/ckeditor4/docs/#!/guide/dev_contributing_code-section-tests),
[how to set the testing environment](https://docs.ckeditor.com/ckeditor4/docs/#!/guide/dev_tests) and
[how to create tests](https://docs.ckeditor.com/ckeditor4/docs/#!/guide/dev_tests-section-creating-your-own-test)
in the official CKEditor documentation.

### This PR contains

- [ ] Unit tests
- [ ] Manual tests

## What changes did you make?

*Give an overview…*
