### PR TITLE
Fix error with dragged text inside editor

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -9,6 +9,7 @@ Fixed Issues:
 * [#2403](https://github.com/ckeditor/ckeditor-dev/issues/2403): Fixed: Styling inline editor initialized inside a table with [Table Selection](https://ckeditor.com/cke4/addon/tabletools) plugin is causing style leaks.
 * [#2514](https://github.com/ckeditor/ckeditor-dev/issues/2403): Fixed: Pasting table data into inline editor initialized inside a table with [Table Selection](https://ckeditor.com/cke4/addon/tabletools) plugin inserts pasted content into a wrapping table.
 * [#2451](https://github.com/ckeditor/ckeditor-dev/issues/2451): Fixed: The [Remove Format](https://ckeditor.com/cke4/addon/removeformat) changes selection.
+* [#724](https://github.com/ckeditor/ckeditor-dev/issues/724): Fixed: Dragged text was removed from editor and error appeared in the console.
 
 Other Changes:
 

--- a/plugins/clipboard/plugin.js
+++ b/plugins/clipboard/plugin.js
@@ -1916,12 +1916,6 @@
 		 * @param {CKEDITOR.editor} editor
 		 */
 		internalDrop: function( dragRange, dropRange, dataTransfer, editor ) {
-			function compareRanges( range1, range2 ) {
-				return range1.startContainer.equals( range2.startContainer ) &&
-					range1.endContainer && range2.endContainer &&
-					range1.endContainer.equals( range2.endContainer );
-			}
-
 			var clipboard = CKEDITOR.plugins.clipboard,
 				editable = editor.editable(),
 				dragBookmark, dropBookmark, isDropRangeAffected;
@@ -1938,11 +1932,6 @@
 					clipboard.dragStartContainerChildCount,
 					clipboard.dragEndContainerChildCount
 				);
-			}
-
-			if ( compareRanges( dragRange, dropRange ) ) {
-				firePasteEvents( editor, { dataTransfer: dataTransfer, method: 'drop', range: dragRange }, 1 );
-				return editor.fire( 'unlockSnapshot' );
 			}
 
 			// Because we manipulate multiple ranges we need to do it carefully,
@@ -1985,8 +1974,14 @@
 			editable.extractHtmlFromRange( dragRange, 1 );
 
 			// ...and paste content into the drop position.
-			dropRange = editor.createRange();
-			dropRange.moveToBookmark( dropBookmark );
+			if ( editable.contains( dropBookmark.startNode ) ) {
+				// Move range only when bookmarks are still in editable
+				dropRange = editor.createRange();
+				dropRange.moveToBookmark( dropBookmark );
+			} else {
+				// If there is no saved bookmarks paste content inside current selection
+				dropRange = editor.getSelection().getRanges()[ 0 ];
+			}
 
 			// We do not select drop range, because of may be in the place we can not set the selection
 			// (e.g. between blocks, in case of block widget D&D). We put range to the paste event instead.

--- a/plugins/clipboard/plugin.js
+++ b/plugins/clipboard/plugin.js
@@ -1974,6 +1974,7 @@
 			editable.extractHtmlFromRange( dragRange, 1 );
 
 			// ...and paste content into the drop position.
+			// #724
 			if ( editable.contains( dropBookmark.startNode ) ) {
 				// Move range only when bookmarks are still in editable
 				dropRange = editor.createRange();

--- a/plugins/clipboard/plugin.js
+++ b/plugins/clipboard/plugin.js
@@ -1916,6 +1916,12 @@
 		 * @param {CKEDITOR.editor} editor
 		 */
 		internalDrop: function( dragRange, dropRange, dataTransfer, editor ) {
+			function compareRanges( range1, range2 ) {
+				return range1.startContainer.equals( range2.startContainer ) &&
+					range1.endContainer && range2.endContainer &&
+					range1.endContainer.equals( range2.endContainer );
+			}
+
 			var clipboard = CKEDITOR.plugins.clipboard,
 				editable = editor.editable(),
 				dragBookmark, dropBookmark, isDropRangeAffected;
@@ -1932,6 +1938,11 @@
 					clipboard.dragStartContainerChildCount,
 					clipboard.dragEndContainerChildCount
 				);
+			}
+
+			if ( compareRanges( dragRange, dropRange ) ) {
+				firePasteEvents( editor, { dataTransfer: dataTransfer, method: 'drop', range: dragRange }, 1 );
+				return editor.fire( 'unlockSnapshot' );
 			}
 
 			// Because we manipulate multiple ranges we need to do it carefully,

--- a/tests/plugins/clipboard/drop.js
+++ b/tests/plugins/clipboard/drop.js
@@ -657,6 +657,34 @@ var testsForMultipleEditor = {
 			}, function() {
 				assert.areSame( '<p class="p">^foo</p>', bender.tools.getHtmlWithSelection( editor ), 'after drop' );
 			} );
+		},
+
+		// #724
+		'test drop inside dragged range': function( editor, bot ) {
+			var evt = bender.tools.mockDropEvent();
+
+			bot.setHtmlWithSelection( '<p><strong>[foo]</strong></p>' );
+			editor.resetUndo();
+
+			drag( editor, evt );
+
+			drop( editor, evt, {
+				dropContainer: editor.editable().findOne( 'strong' ).getChild( 0 ),
+				dropOffset: 0,
+				expectedTransferType: CKEDITOR.DATA_TRANSFER_INTERNAL,
+				expectedText: 'foo',
+				expectedHtml: '<strong>foo</strong>',
+				expectedDataType: 'html',
+				expectedDataValue: '<strong>foo</strong>',
+				expectedBeforePasteEventCount: 1,
+				expectedPasteEventCount: 1,
+				expectedDropPrevented: false
+			}, function() {
+				return true;
+			}, function() {
+				assert.areSame( '<p><strong>foo^</strong></p>', bender.tools.getHtmlWithSelection( editor ), 'after drop' );
+			} );
+
 		}
 	},
 	testsForOneEditor = {

--- a/tests/plugins/clipboard/manual/draganddroperror.html
+++ b/tests/plugins/clipboard/manual/draganddroperror.html
@@ -1,0 +1,27 @@
+<h2>Classic editor</h2>
+<textarea cols="80" id="classic" name="classic" rows="10">
+	<p><strong>test</strong></p>
+</textarea>
+<h2>Divarea editor</h2>
+<div id="divarea">
+	<p><strong>test</strong></p>
+</div>
+<h2>Inline editor</h2>
+<div id="inline" contenteditable="true" style="margin: 15px;">
+	<p><strong>test</strong></p>
+</div>
+
+<script>
+	// Ignore on mobiles due to browser dev console requirement.
+	if ( bender.tools.env.mobile ) {
+		bender.ignore();
+	}
+
+	CKEDITOR.replace( 'classic' );
+	CKEDITOR.replace( 'divarea', {
+		extraPlugins: 'divarea'
+	} );
+	CKEDITOR.inline( 'inline', {
+		extraPlugins: 'floatingspace'
+	} );
+</script>

--- a/tests/plugins/clipboard/manual/draganddroperror.md
+++ b/tests/plugins/clipboard/manual/draganddroperror.md
@@ -1,0 +1,17 @@
+@bender-tags: bug, 4.10.1, 724
+@bender-ui: collapsed
+@bender-ckeditor-plugins: wysiwygarea, toolbar, undo, sourcearea, elementspath, clipboard, basicstyles
+
+## Please note tat bug exist on Windows only, that's why you should perform a test under Windows, if it's possible.
+
+1. Open console
+2. Select text
+3. Drag selected text to the bottom of editable (<a href="https://user-images.githubusercontent.com/20988892/28924759-10f4f568-7863-11e7-80bc-d3e3bf14211d.gif" target="_blank">link</a>)
+
+## Expected:
+* text is preserved in current position or is apend at the end of line if was selected partially
+* there is no error in console
+
+## Unexpected:
+* there is error in console
+* selected text disappear

--- a/tests/plugins/clipboard/manual/draganddroperror.md
+++ b/tests/plugins/clipboard/manual/draganddroperror.md
@@ -1,4 +1,4 @@
-@bender-tags: bug, 4.10.1, 724
+@bender-tags: bug, 4.11.2, 724
 @bender-ui: collapsed
 @bender-ckeditor-plugins: wysiwygarea, toolbar, undo, sourcearea, elementspath, clipboard, basicstyles
 


### PR DESCRIPTION
## What is the purpose of this pull request?

Bug fix

## Does your PR contain necessary tests?

All patches which change the editor code must include tests. You can always read more
on [PR testing](https://ckeditor.com/docs/ckeditor4/latest/guide/dev_contributing_code.html#tests),
[how to set the testing environment](https://ckeditor.com/docs/ckeditor4/latest/guide/dev_tests.html) and
[how to create tests](https://ckeditor.com/docs/ckeditor4/latest/guide/dev_tests.html#creating-your-own-test)
in the official CKEditor documentation.

### This PR contains

- [x] Unit tests
- [x] Manual tests

## What changes did you make?
* Fix error when dragged text land within self. What result error with removed bookmarks during this operation.

Close #724