### PR TITLE
Fix type error while opening context menu in readonly editor

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -3,6 +3,10 @@
 
 ## CKEditor 4.10.2
 
+Fixed Issues:
+
+* [#1181](https://github.com/ckeditor/ckeditor-dev/issues/1181): [Chrome] Fixed: Opening context menu in readonly editor results in error.
+
 ## CKEditor 4.10.1
 
 Fixed Issues:

--- a/plugins/contextmenu/plugin.js
+++ b/plugins/contextmenu/plugin.js
@@ -111,7 +111,9 @@ CKEDITOR.plugins.add( 'contextmenu', {
 				 * @param {Number} [offsetY]
 				 */
 				open: function( offsetParent, corner, offsetX, offsetY ) {
-					if ( this.editor.config.enableContextMenu === false ) {
+					// Do not open context menu if there is no selection in the editor (#1181).
+					if ( this.editor.config.enableContextMenu === false ||
+						this.editor.getSelection().getType() === CKEDITOR.SELECTION_NONE ) {
 						return;
 					}
 

--- a/plugins/contextmenu/plugin.js
+++ b/plugins/contextmenu/plugin.js
@@ -111,7 +111,7 @@ CKEDITOR.plugins.add( 'contextmenu', {
 				 * @param {Number} [offsetY]
 				 */
 				open: function( offsetParent, corner, offsetX, offsetY ) {
-					// Do not open context menu if there is no selection in the editor (#1181).
+					// Do not open context menu if it's disabled or there is no selection in the editor (#1181).
 					if ( this.editor.config.enableContextMenu === false ||
 						this.editor.getSelection().getType() === CKEDITOR.SELECTION_NONE ) {
 						return;

--- a/tests/_benderjs/ckeditor/static/bot.js
+++ b/tests/_benderjs/ckeditor/static/bot.js
@@ -232,7 +232,8 @@
 		 */
 		contextmenu: function( callback ) {
 			var editor = this.editor,
-				tc = this.testCase;
+				tc = this.testCase,
+				range;
 
 			editor.once( 'panelShow', function() {
 				// Make sure resume comes after wait.
@@ -244,6 +245,16 @@
 					);
 				} );
 			} );
+
+			// Force selection in the editor as opening menu
+			// by user always results in selection.
+			if ( editor.getSelection().getType() === CKEDITOR.SELECTION_NONE ) {
+				range = editor.createRange();
+
+				range.selectNodeContents( editor.editable() );
+				range.collapse( true );
+				range.select();
+			}
 
 			// Open context menu on editable element.
 			editor.contextMenu.open( editor.editable() );

--- a/tests/_benderjs/ckeditor/static/bot.js
+++ b/tests/_benderjs/ckeditor/static/bot.js
@@ -247,7 +247,7 @@
 			} );
 
 			// Force selection in the editor as opening menu
-			// by user always results in selection.
+			// by user always results in selection in non readonly editor.
 			if ( editor.getSelection().getType() === CKEDITOR.SELECTION_NONE ) {
 				range = editor.createRange();
 

--- a/tests/_benderjs/ckeditor/static/bot.js
+++ b/tests/_benderjs/ckeditor/static/bot.js
@@ -248,7 +248,7 @@
 
 			// Force selection in the editor as opening menu
 			// by user always results in selection in non readonly editor.
-			if ( editor.getSelection().getType() === CKEDITOR.SELECTION_NONE ) {
+			if ( !editor.readOnly && editor.getSelection().getType() === CKEDITOR.SELECTION_NONE ) {
 				range = editor.createRange();
 
 				range.selectNodeContents( editor.editable() );
@@ -259,7 +259,7 @@
 			// Open context menu on editable element.
 			editor.contextMenu.open( editor.editable() );
 
-			// combo panel opening is synchronous;
+			// Combo panel opening is asynchronous.
 			tc.wait();
 		},
 

--- a/tests/plugins/contextmenu/contextmenu.js
+++ b/tests/plugins/contextmenu/contextmenu.js
@@ -7,9 +7,6 @@
 	bender.editor = {};
 
 	bender.test( {
-		tearDown: function() {
-		},
-
 		'test opening context menu color': function() {
 			var ed1 = this.editor,
 				bot1 = this.editorBot;

--- a/tests/plugins/contextmenu/contextmenu.js
+++ b/tests/plugins/contextmenu/contextmenu.js
@@ -121,6 +121,22 @@
 					assert.isFalse( !!editor.getSelection().isFake, 'Fake selection is not set for nested editables' );
 				} );
 			} );
+		},
+
+		// (#1181)
+		'test open context menu when no selection in the editor': function() {
+			bender.editorBot.create( {
+				name: 'editor_noselection'
+			}, function( bot ) {
+				var editor = bot.editor;
+
+				editor.contextMenu.show = sinon.spy();
+
+				editor.getSelection().removeAllRanges();
+				editor.contextMenu.open( editor.editable() );
+
+				assert.isFalse( editor.contextMenu.show.called );
+			} );
 		}
 	} );
 } )();

--- a/tests/plugins/contextmenu/contextmenu.js
+++ b/tests/plugins/contextmenu/contextmenu.js
@@ -7,10 +7,14 @@
 	bender.editor = {};
 
 	bender.test( {
+		tearDown: function() {
+		},
+
 		'test opening context menu color': function() {
 			var ed1 = this.editor,
 				bot1 = this.editorBot;
 
+			ed1.focus();
 			bot1.contextmenu( function( menu1 ) {
 				// Check DOM focus and virtual editor focus.
 				assert.areSame( menu1._.panel._.iframe, CKEDITOR.document.getActive(), 'check DOM focus inside of panel' );
@@ -36,7 +40,7 @@
 				name: 'editor_nocontextmenu1'
 			}, function( bot ) {
 				bot.editor.contextMenu.show = sinon.spy();
-
+				bot.editor.focus();
 				bot.editor.contextMenu.open( bot.editor.editable() );
 
 				assert.isTrue( bot.editor.contextMenu.show.called );
@@ -51,7 +55,7 @@
 					}
 				}, function( bot ) {
 				bot.editor.contextMenu.show = sinon.spy();
-
+				bot.editor.focus();
 				bot.editor.contextMenu.open( bot.editor.editable() );
 
 				assert.isFalse( bot.editor.contextMenu.show.called );

--- a/tests/plugins/contextmenu/integration.js
+++ b/tests/plugins/contextmenu/integration.js
@@ -28,6 +28,7 @@
 					} );
 				} );
 
+				editor.focus();
 				editor.contextMenu.open( editor.editable() );
 
 				wait();
@@ -55,6 +56,7 @@
 					} );
 				} );
 
+				editor.focus();
 				editor.contextMenu.open( editor.editable() );
 
 				wait();
@@ -87,6 +89,7 @@
 					editor.contextMenu.open( editor.editable() );
 				} );
 
+				editor.focus();
 				editor.contextMenu.open( editor.editable() );
 
 				wait();
@@ -103,6 +106,7 @@
 					} );
 				} );
 
+				bot.editor.focus();
 				bot.editor.contextMenu.open( bot.editor.editable() );
 
 				wait();

--- a/tests/plugins/contextmenu/manual/readonly.html
+++ b/tests/plugins/contextmenu/manual/readonly.html
@@ -1,0 +1,13 @@
+<div id="editor">
+	<p>I am a sample content with <a href="https://ckeditor.com">link</a>.</p>
+</div>
+
+<script>
+	if ( CKEDITOR.env.mobile || !CKEDITOR.env.chrome ) {
+		bender.ignore();
+	}
+
+	CKEDITOR.replace( 'editor', {
+		readOnly: true
+	} );
+</script>

--- a/tests/plugins/contextmenu/manual/readonly.md
+++ b/tests/plugins/contextmenu/manual/readonly.md
@@ -11,6 +11,8 @@
 
 Context menu does not appear.
 
+In case of Chrome on macOS: right-clicking on link will select it and open the context menu.
+
 **Unexpected**
 
 There is an error inside the console:

--- a/tests/plugins/contextmenu/manual/readonly.md
+++ b/tests/plugins/contextmenu/manual/readonly.md
@@ -1,0 +1,20 @@
+@bender-ui: collapsed
+@bender-tags: bug, 4.10.1, 1181
+@bender-ckeditor-plugins: wysiwygarea, toolbar, contextmenu, link, clipboard
+
+**Test Scenario**
+
+1. Open console.
+2. Right click on the link without prior focusing the editor.
+
+**Expected**
+
+Context menu does not appear.
+
+**Unexpected**
+
+There is an error inside the console:
+
+```
+Uncaught TypeError: Cannot read property 'checkReadOnly' of undefined
+```

--- a/tests/plugins/contextmenu/manual/readonly.md
+++ b/tests/plugins/contextmenu/manual/readonly.md
@@ -1,19 +1,17 @@
 @bender-ui: collapsed
-@bender-tags: bug, 4.10.1, 1181
+@bender-tags: bug, 4.10.2, 1181
 @bender-ckeditor-plugins: wysiwygarea, toolbar, contextmenu, link, clipboard
-
-**Test Scenario**
 
 1. Open console.
 2. Right click on the link without prior focusing the editor.
 
-**Expected**
+## Expected
 
 Context menu does not appear.
 
 In case of Chrome on macOS: right-clicking on link will select it and open the context menu.
 
-**Unexpected**
+## Unexpected
 
 There is an error inside the console:
 


### PR DESCRIPTION
## What is the purpose of this pull request?

Bug fix

## Does your PR contain necessary tests?

All patches which change the editor code must include tests. You can always read more
on [PR testing](https://ckeditor.com/docs/ckeditor4/latest/guide/dev_contributing_code.html#tests),
[how to set the testing environment](https://ckeditor.com/docs/ckeditor4/latest/guide/dev_tests.html) and
[how to create tests](https://ckeditor.com/docs/ckeditor4/latest/guide/dev_tests.html#creating-your-own-test)
in the official CKEditor documentation.

### This PR contains

- [x] Unit tests
- [x] Manual tests

## What changes did you make?

I've added a simple check to open context menu only if there is selection inside the editor. In Chrome there is no selection inside the editor before the first focus. Unfortunately it required to update tests connected to context menu as many of them were fired on editor without the selection.

Closes #1181.