### PR TITLE
Move plugins conflict detection helper

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -29,7 +29,7 @@ Fixed Issues:
 
 API Changes:
 
-* [#2249](https://github.com/ckeditor/ckeditor-dev/issues/1791): Added [`CKEDITOR.tools.detectPluginsConflict`](https://ckeditor.com/docs/ckeditor4/latest/api/CKEDITOR_tools.html#method-detectPluginsConflict) function finding conflicts between provided plugins.
+* [#2249](https://github.com/ckeditor/ckeditor-dev/issues/1791): Added [`editor.plugins.detectPluginsConflict`](https://ckeditor.com/docs/ckeditor4/latest/CKEDITOR_editor_plugins.html#method-detectPluginsConflict) function finding conflicts between provided plugins.
 
 ## CKEditor 4.10
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -29,7 +29,7 @@ Fixed Issues:
 
 API Changes:
 
-* [#2249](https://github.com/ckeditor/ckeditor-dev/issues/1791): Added [`editor.plugins.detectPluginsConflict`](https://ckeditor.com/docs/ckeditor4/latest/CKEDITOR_editor_plugins.html#method-detectPluginsConflict) function finding conflicts between provided plugins.
+* [#2249](https://github.com/ckeditor/ckeditor-dev/issues/1791): Added [`editor.plugins.detectConflict`](https://ckeditor.com/docs/ckeditor4/latest/CKEDITOR_editor_plugins.html#method-detectConflict) function finding conflicts between provided plugins.
 
 ## CKEditor 4.10
 

--- a/core/editor.js
+++ b/core/editor.js
@@ -742,7 +742,7 @@
 		 *		}
 		 *
 		 * @readonly
-		 * @property {Object}
+		 * @property {CKEDITOR.editor.plugins}
 		 */
 		plugins: {
 			/**

--- a/core/editor.js
+++ b/core/editor.js
@@ -524,21 +524,7 @@
 			// The list of URLs to language files.
 			var languageFiles = [];
 
-			/**
-			 * An object that contains references to all plugins used by this
-			 * editor instance.
-			 *
-			 *		alert( editor.plugins.dialog.path ); // e.g. 'http://example.com/ckeditor/plugins/dialog/'
-			 *
-			 *		// Check if a plugin is available.
-			 *		if ( editor.plugins.image ) {
-			 *			...
-			 *		}
-			 *
-			 * @readonly
-			 * @property {Object}
-			 */
-			editor.plugins = plugins;
+			CKEDITOR.tools.extend( editor.plugins, plugins );
 
 			// Loop through all plugins, to build the list of language
 			// files to get loaded.
@@ -744,6 +730,55 @@
 	}
 
 	CKEDITOR.tools.extend( CKEDITOR.editor.prototype, {
+		/**
+		 * An object that contains references to all plugins used by this
+		 * editor instance.
+		 *
+		 *		alert( editor.plugins.dialog.path ); // e.g. 'http://example.com/ckeditor/plugins/dialog/'
+		 *
+		 *		// Check if a plugin is available.
+		 *		if ( editor.plugins.image ) {
+		 *			...
+		 *		}
+		 *
+		 * @readonly
+		 * @property {Object}
+		 */
+		plugins: {
+			/**
+			 * Checks for conflicting plugins with the given one.
+			 *
+			 * If conflict occurs this function will send {@link CKEDITOR#warn console warning}
+			 * with `editor-plugin-conflict` error code. Order of a `conflicted` names is respected
+			 * where the first conflicted plugin has the highest priority and will be used in a warning
+			 * message.
+			 *
+			 * ```javascript
+			 * editor.plugins.detectPluginsConflict( 'image', [ 'image2', 'easyimage' ] );
+			 * ```
+			 *
+			 * @since 4.10.1
+			 * @param {String} plugin Current plugin name.
+			 * @param {String[]} conflicted Names of plugins that are conflicted with a current plugin.
+			 * @return {Boolean} Returns true, if there is some conflict. Returns false otherwise.
+			 */
+			detectPluginsConflict: function( plugin, conflicted ) {
+				for ( var i = 0; i < conflicted.length; i++ ) {
+					var pluginName = conflicted[ i ];
+
+					if ( this[ pluginName ] ) {
+						CKEDITOR.warn( 'editor-plugin-conflict', {
+							plugin: plugin,
+							replacedWith: pluginName
+						} );
+
+						return true;
+					}
+				}
+
+				return false;
+			}
+		},
 		/**
 		 * Adds a command definition to the editor instance. Commands added with
 		 * this function can be executed later with the {@link #execCommand} method.

--- a/core/editor.js
+++ b/core/editor.js
@@ -754,7 +754,7 @@
 			 * message.
 			 *
 			 * ```javascript
-			 * editor.plugins.detectPluginsConflict( 'image', [ 'image2', 'easyimage' ] );
+			 * editor.plugins.detectConflict( 'image', [ 'image2', 'easyimage' ] );
 			 * ```
 			 *
 			 * @member CKEDITOR.editor.plugins
@@ -763,7 +763,7 @@
 			 * @param {String[]} conflicted Names of plugins that are conflicted with a current plugin.
 			 * @return {Boolean} Returns true, if there is some conflict. Returns false otherwise.
 			 */
-			detectPluginsConflict: function( plugin, conflicted ) {
+			detectConflict: function( plugin, conflicted ) {
 				for ( var i = 0; i < conflicted.length; i++ ) {
 					var pluginName = conflicted[ i ];
 

--- a/core/editor.js
+++ b/core/editor.js
@@ -757,6 +757,7 @@
 			 * editor.plugins.detectPluginsConflict( 'image', [ 'image2', 'easyimage' ] );
 			 * ```
 			 *
+			 * @member CKEDITOR.editor.plugins
 			 * @since 4.10.1
 			 * @param {String} plugin Current plugin name.
 			 * @param {String[]} conflicted Names of plugins that are conflicted with a current plugin.

--- a/core/editor.js
+++ b/core/editor.js
@@ -524,7 +524,7 @@
 			// The list of URLs to language files.
 			var languageFiles = [];
 
-			CKEDITOR.tools.extend( editor.plugins, plugins );
+			editor.plugins = CKEDITOR.tools.extend( {}, editor.plugins, plugins );
 
 			// Loop through all plugins, to build the list of language
 			// files to get loaded.

--- a/core/plugins.js
+++ b/core/plugins.js
@@ -117,3 +117,16 @@ CKEDITOR.plugins.setLang = function( pluginName, languageCode, languageEntries )
 
 	pluginLangEntries[ languageCode ] = languageEntries;
 };
+
+/**
+ * Virtual class that illustrates the API of {@link CKEDITOR.editor} instance plugins dictionary.
+ *
+ * Such object contains references to all plugins used by a related editor instance.
+ *
+ * See {@link CKEDITOR.editor#property-plugins} for example use.
+ *
+ * This class is not really a part of the API, so its constructor can not be called.
+ *
+ * @abstract
+ * @class CKEDITOR.editor.plugins
+ */

--- a/core/tools.js
+++ b/core/tools.js
@@ -2298,41 +2298,6 @@
 
 				appendParentFramePosition( frame.getWindow().getFrame() );
 			}
-		},
-
-		/**
-		 * Checks for conflicting plugins with the given one.
-		 *
-		 * If conflict occurs this function will send {@link CKEDITOR#warn console warning}
-		 * with `editor-plugin-conflict` error code. Order of a `conflicted` names is respected
-		 * where the first conflicted plugin has the highest priority and will be used in a warning
-		 * message.
-		 *
-		 * ```javascript
-		 * CKEDITOR.tools.detectPluginsConflict( editor, 'image', [ 'image2', 'easyimage' ] );
-		 * ```
-		 *
-		 * @since 4.10.1
-		 * @param {CKEDITOR.editor} editor Editor searched for conflicting plugins.
-		 * @param {String} plugin Current plugin name.
-		 * @param {String[]} conflicted Names of plugins that are conflicted with a current plugin.
-		 * @return {Boolean} Returns true, if there is some conflict. Returns false otherwise.
-		 */
-		detectPluginsConflict: function( editor, plugin, conflicted ) {
-			for ( var i = 0; i < conflicted.length; i++ ) {
-				var pluginName = conflicted[ i ];
-
-				if ( editor.plugins[ pluginName ] ) {
-					CKEDITOR.warn( 'editor-plugin-conflict', {
-						plugin: plugin,
-						replacedWith: pluginName
-					} );
-
-					return true;
-				}
-			}
-
-			return false;
 		}
 	};
 

--- a/plugins/image/plugin.js
+++ b/plugins/image/plugin.js
@@ -21,7 +21,7 @@
 
 			// Abort when Easyimage or Image2 are to be loaded since this plugins
 			// share the same functionality (#1791).
-			if ( CKEDITOR.tools.detectPluginsConflict( editor, pluginName, [ 'easyimage', 'image2' ] ) ) {
+			if ( editor.plugins.detectPluginsConflict( pluginName, [ 'easyimage', 'image2' ] ) ) {
 				return;
 			}
 

--- a/plugins/image/plugin.js
+++ b/plugins/image/plugin.js
@@ -21,7 +21,7 @@
 
 			// Abort when Easyimage or Image2 are to be loaded since this plugins
 			// share the same functionality (#1791).
-			if ( editor.plugins.detectPluginsConflict( pluginName, [ 'easyimage', 'image2' ] ) ) {
+			if ( editor.plugins.detectConflict( pluginName, [ 'easyimage', 'image2' ] ) ) {
 				return;
 			}
 

--- a/plugins/image2/plugin.js
+++ b/plugins/image2/plugin.js
@@ -70,7 +70,7 @@
 		init: function( editor ) {
 			// Abort when Easyimage is to be loaded since this plugins
 			// share the same functionality (#1791).
-			if ( editor.plugins.detectPluginsConflict( 'image2', [ 'easyimage' ] ) ) {
+			if ( editor.plugins.detectConflict( 'image2', [ 'easyimage' ] ) ) {
 				return;
 			}
 

--- a/plugins/image2/plugin.js
+++ b/plugins/image2/plugin.js
@@ -70,7 +70,7 @@
 		init: function( editor ) {
 			// Abort when Easyimage is to be loaded since this plugins
 			// share the same functionality (#1791).
-			if ( CKEDITOR.tools.detectPluginsConflict( editor, 'image2', [ 'easyimage' ] ) ) {
+			if ( editor.plugins.detectPluginsConflict( 'image2', [ 'easyimage' ] ) ) {
 				return;
 			}
 

--- a/tests/core/plugins/plugins.js
+++ b/tests/core/plugins/plugins.js
@@ -68,5 +68,40 @@ bender.test(
 		} );
 
 		wait();
+	},
+
+	// (#1791)
+	'test detect plugins conflict - with conflicting plugins': function() {
+		var editor = {
+				plugins: {
+					'plugin1': 1,
+					'plugin2': 2
+				}
+			},
+			spy = sinon.spy( CKEDITOR, 'warn' ),
+
+			result = CKEDITOR.editor.prototype.plugins.detectPluginsConflict.call( editor.plugins,
+				'plugin', [ 'plugin1', 'plugin2' ] );
+
+		spy.restore();
+
+		assert.isTrue( result, 'Conflicts detected.' );
+		assert.isTrue( spy.calledWith( 'editor-plugin-conflict', { plugin: 'plugin', replacedWith: 'plugin1' } ) );
+	},
+
+	// (#1791)
+	'test detect plugins conflict - without conflicting plugins': function() {
+		var editor = {
+				plugins: {}
+			},
+			spy = sinon.spy( CKEDITOR, 'warn' ),
+
+			result = CKEDITOR.editor.prototype.plugins.detectPluginsConflict.call( editor.plugins,
+				'plugin', [ 'plugin1', 'plugin2' ] );
+
+		spy.restore();
+
+		assert.isFalse( result, 'Conflicts not detected.' );
+		assert.isFalse( spy.called );
 	}
 } );

--- a/tests/core/plugins/plugins.js
+++ b/tests/core/plugins/plugins.js
@@ -80,7 +80,7 @@ bender.test(
 			},
 			spy = sinon.spy( CKEDITOR, 'warn' ),
 
-			result = CKEDITOR.editor.prototype.plugins.detectPluginsConflict.call( editor.plugins,
+			result = CKEDITOR.editor.prototype.plugins.detectConflict.call( editor.plugins,
 				'plugin', [ 'plugin1', 'plugin2' ] );
 
 		spy.restore();
@@ -96,7 +96,7 @@ bender.test(
 			},
 			spy = sinon.spy( CKEDITOR, 'warn' ),
 
-			result = CKEDITOR.editor.prototype.plugins.detectPluginsConflict.call( editor.plugins,
+			result = CKEDITOR.editor.prototype.plugins.detectConflict.call( editor.plugins,
 				'plugin', [ 'plugin1', 'plugin2' ] );
 
 		spy.restore();

--- a/tests/core/tools.js
+++ b/tests/core/tools.js
@@ -952,40 +952,6 @@
 			CKEDITOR.tools.array.forEach( testCases, function( test ) {
 				assert.areSame( test.base64, CKEDITOR.tools.convertBytesToBase64( test.bytes ) );
 			} );
-		},
-
-		// (#1791)
-		'test detect plugins conflict - with conflicting plugins': function() {
-			var editor = {
-					plugins: {
-						'plugin1': 1,
-						'plugin2': 2
-					}
-				},
-				spy = sinon.spy( CKEDITOR, 'warn' ),
-
-				result = CKEDITOR.tools.detectPluginsConflict( editor, 'plugin', [ 'plugin1', 'plugin2' ] );
-
-			spy.restore();
-
-			assert.isTrue( result, 'Conflicts detected.' );
-			assert.isTrue( spy.calledWith( 'editor-plugin-conflict', { plugin: 'plugin', replacedWith: 'plugin1' } ) );
-		},
-
-		// (#1791)
-		'test detect plugins conflict - without conflicting plugins': function() {
-			var editor = {
-					plugins: {}
-				},
-				spy = sinon.spy( CKEDITOR, 'warn' ),
-
-				result = CKEDITOR.tools.detectPluginsConflict( editor, 'plugin', [ 'plugin1', 'plugin2' ] );
-
-			spy.restore();
-
-			assert.isFalse( result, 'Conflicts not detected.' );
-			assert.isFalse( spy.called );
 		}
-
 	} );
 } )();


### PR DESCRIPTION
## What is the purpose of this pull request?

Task

## Does your PR contain necessary tests?

All patches which change the editor code must include tests. You can always read more
on [PR testing](https://ckeditor.com/docs/ckeditor4/latest/guide/dev_contributing_code.html#tests),
[how to set the testing environment](https://ckeditor.com/docs/ckeditor4/latest/guide/dev_tests.html) and
[how to create tests](https://ckeditor.com/docs/ckeditor4/latest/guide/dev_tests.html#creating-your-own-test)
in the official CKEditor documentation.

### This PR contains

- [x] Unit tests
- [x] Manual tests

## What changes did you make?

Moved `detectPluginConflict` from `CKEDITOR.tools` to `CKEDITOR.editor.prototype.plugins`. Updated tests accordingly.

Closes #2341.
