### PR TITLE
Fix enterkey integration test in built version

### DIFF
--- a/tests/plugins/tableselection/integrations/enterkey/enterkey.js
+++ b/tests/plugins/tableselection/integrations/enterkey/enterkey.js
@@ -27,7 +27,8 @@
 			name: 'editor1',
 			config: {
 				enterMode: CKEDITOR.ENTER_DIV,
-				shiftEnterMode: CKEDITOR.ENTER_BR
+				shiftEnterMode: CKEDITOR.ENTER_BR,
+				removePlugins: 'entities'
 			}
 		},
 		editor2: {
@@ -35,14 +36,16 @@
 			creator: 'inline',
 			config: {
 				enterMode: CKEDITOR.ENTER_BR,
-				shiftEnterMode: CKEDITOR.ENTER_DIV
+				shiftEnterMode: CKEDITOR.ENTER_DIV,
+				removePlugins: 'entities'
 			}
 		},
 		editor3: {
 			name: 'editor3',
 			config: {
 				enterMode: CKEDITOR.ENTER_P,
-				shiftEnterMode: CKEDITOR.ENTER_DIV
+				shiftEnterMode: CKEDITOR.ENTER_DIV,
+				removePlugins: 'entities'
 			}
 		},
 		editor4: {
@@ -50,7 +53,8 @@
 			creator: 'inline',
 			config: {
 				enterMode: CKEDITOR.ENTER_DIV,
-				shiftEnterMode: CKEDITOR.ENTER_P
+				shiftEnterMode: CKEDITOR.ENTER_P,
+				removePlugins: 'entities'
 			}
 		}
 	};


### PR DESCRIPTION
## What is the purpose of this pull request?

Failing test fix

## Does your PR contain necessary tests?

All patches which change the editor code must include tests. You can always read more
on [PR testing](https://ckeditor.com/docs/ckeditor4/latest/guide/dev_contributing_code.html#tests),
[how to set the testing environment](https://ckeditor.com/docs/ckeditor4/latest/guide/dev_tests.html) and
[how to create tests](https://ckeditor.com/docs/ckeditor4/latest/guide/dev_tests.html#creating-your-own-test)
in the official CKEditor documentation.

### This PR contains

- [ ] Unit tests
- [ ] Manual tests

## What changes did you make?

Fixed failing `tests/plugins/tableselection/integrations/enterkey/enterkey.js`. I've removed unnecessary `entities` plugin.

See #2343.
