### PR TITLE
Fix for bleeding undo test

### DIFF
--- a/plugins/clipboard/plugin.js
+++ b/plugins/clipboard/plugin.js
@@ -603,9 +603,11 @@
 						if ( pasteButton ) {
 							var buttonElement = CKEDITOR.document.getById( pasteButton._.id );
 
-							buttonElement.on( 'touchend', function() {
-								editor._.forcePasteDialog = true;
-							} );
+							if ( buttonElement ) {
+								buttonElement.on( 'touchend', function() {
+									editor._.forcePasteDialog = true;
+								} );
+							}
 						}
 					} );
 				} );


### PR DESCRIPTION
## What is the purpose of this pull request?

Failing test fix

## What changes did you make?

http://tests.ckeditor.test:1030/tests/plugins/undo/change#tests%2Fplugins%2Fundo%2Fchange%20test%20no%20change%20event%20on%20create%20and%20destroy was bleeding with:

```javascript
Uncaught TypeError: Cannot read property 'on' of null
    at plugin.js:606
    at Object.forEach (tools.js:2094)
    at Editor.<anonymous> (plugin.js:600)
    at Editor.args.(anonymous function) (http://tests.ckeditor.test:1030/apps/ckeditor/core/event.js:202:16)
    at Editor.listenerFirer (event.js:144)
    at Editor.CKEDITOR.event.fire (event.js:290)
    at Editor.CKEDITOR.editor.fire (editor_basic.js:24)
    at Editor.fireOnce (event.js:334)
    at Editor.CKEDITOR.editor.fireOnce (editor_basic.js:31)
    at Editor.<anonymous> (themedui.js:360)
```

Error is connected with adding touch listener to paste button, as it's added after destroying the editor in the test. Simple adding checking if the button really exists fixes the issue.