### PR TITLE
Force removal of enterkey plugin in test

### DIFF
--- a/tests/plugins/tableselection/manual/nativeenterkey.html
+++ b/tests/plugins/tableselection/manual/nativeenterkey.html
@@ -122,16 +122,13 @@
 	}
 
 	CKEDITOR.replace( 'editor1', {
-		height: 250,
-		removedPlugins: 'enterkey'
+		height: 250
 	} );
 	CKEDITOR.replace( 'editor2', {
 		extraPlugins: 'divarea',
-		height: 250,
-		removedPlugins: 'enterkey'
+		height: 250
 	} );
 	CKEDITOR.inline( 'editor3', {
-		height: 250,
-		removedPlugins: 'enterkey'
+		height: 250
 	} );
 </script>

--- a/tests/plugins/tableselection/manual/nativeenterkey.md
+++ b/tests/plugins/tableselection/manual/nativeenterkey.md
@@ -1,6 +1,7 @@
 @bender-ui: collapsed
 @bender-tags: bug, 4.10.1, 1816, tableselection
 @bender-ckeditor-plugins: wysiwygarea, toolbar, sourcearea, table, tableselection, clipboard, floatingspace, basicstyles, list, undo, elementspath
+@bender-ckeditor-remove-plugins: enterkey
 
 ## Enter event **without** enterkey plugin:
 1. Select few cells to have activated tableselection.


### PR DESCRIPTION
## What is the purpose of this pull request?

Failing test

## What changes did you make?

I've fixed the typo that prevented removal of `enterkey` plugin in `tests/plugins/tableselection/manual/nativeenterkey`.
