### PR TITLE
Added a missing reference to classcheckinlexicalorder manual test

### DIFF
--- a/tests/core/filter/manual/classcheckinlexicalorder.md
+++ b/tests/core/filter/manual/classcheckinlexicalorder.md
@@ -1,4 +1,4 @@
-@bender-tags: style, bug, 4.10.1
+@bender-tags: 727, style, bug, 4.10.1
 @bender-ui: collapsed
 @bender-ckeditor-plugins: wysiwygarea,sourcearea,toolbar,undo,clipboard,stylescombo,floatingspace
 


### PR DESCRIPTION
## What is the purpose of this pull request?

Task

## Does your PR contain necessary tests?

All patches which change the editor code must include tests. You can always read more
on [PR testing](https://ckeditor.com/docs/ckeditor4/latest/guide/dev_contributing_code.html#tests),
[how to set the testing environment](https://ckeditor.com/docs/ckeditor4/latest/guide/dev_tests.html) and
[how to create tests](https://ckeditor.com/docs/ckeditor4/latest/guide/dev_tests.html#creating-your-own-test)
in the official CKEditor documentation.

### This PR contains

- [ ] Unit tests
- [x] Manual tests

## What changes did you make?

The test was missing ticket reference.