### PR TITLE
Ignore mobile unfriendly manual tests for plugins

### DIFF
--- a/tests/plugins/image/manual/easyimage.html
+++ b/tests/plugins/image/manual/easyimage.html
@@ -1,7 +1,7 @@
 <div id="editor"></div>
 
 <script>
-	if ( easyImageTools.isUnsupportedEnvironment() ) {
+	if ( easyImageTools.isUnsupportedEnvironment() || bender.tools.env.mobile ) {
 		bender.ignore();
 	}
 

--- a/tests/plugins/image/manual/easyimageimage2.html
+++ b/tests/plugins/image/manual/easyimageimage2.html
@@ -1,7 +1,7 @@
 <div id="editor"></div>
 
 <script>
-	if ( easyImageTools.isUnsupportedEnvironment() ) {
+	if ( easyImageTools.isUnsupportedEnvironment() || bender.tools.env.mobile ) {
 		bender.ignore();
 	}
 

--- a/tests/plugins/image/manual/image2.html
+++ b/tests/plugins/image/manual/image2.html
@@ -1,5 +1,9 @@
 <div id="editor"></div>
 
 <script>
+	if ( bender.tools.env.mobile ) {
+		bender.ignore();
+	}
+
 	CKEDITOR.replace( 'editor' );
 </script>

--- a/tests/plugins/image2/manual/easyimage.html
+++ b/tests/plugins/image2/manual/easyimage.html
@@ -1,7 +1,7 @@
 <div id="editor"></div>
 
 <script>
-	if ( easyImageTools.isUnsupportedEnvironment() ) {
+	if ( easyImageTools.isUnsupportedEnvironment() || bender.tools.env.mobile ) {
 		bender.ignore();
 	}
 


### PR DESCRIPTION
## What is the purpose of this pull request?

Failing test fix

## Does your PR contain necessary tests?

All patches which change the editor code must include tests. You can always read more
on [PR testing](https://ckeditor.com/docs/ckeditor4/latest/guide/dev_contributing_code.html#tests),
[how to set the testing environment](https://ckeditor.com/docs/ckeditor4/latest/guide/dev_tests.html) and
[how to create tests](https://ckeditor.com/docs/ckeditor4/latest/guide/dev_tests.html#creating-your-own-test)
in the official CKEditor documentation.

### This PR contains

- [ ] Unit tests
- [ ] Manual tests

## What changes did you make?

Ignores manual tests that rely on the console in mobile env.

Closes #2361.