### PR TITLE
Fixed failing tests on vertical screens

### DIFF
--- a/tests/core/tools/absoluterectposition.html
+++ b/tests/core/tools/absoluterectposition.html
@@ -5,4 +5,4 @@
 	<textarea id="inline"></textarea>
 </div>
 
-<div style="height:2000px"></div>
+<div style="height:5000px"></div>

--- a/tests/core/tools/absoluterectposition.html
+++ b/tests/core/tools/absoluterectposition.html
@@ -1,8 +1,0 @@
-<div id="test_container_classic" style="margin:99px;position:absolute">
-	<textarea id="classic"></textarea>
-</div>
-<div id="test_container_inline" style="margin:99px;position:absolute">
-	<textarea id="inline"></textarea>
-</div>
-
-<div style="height:5000px"></div>

--- a/tests/core/tools/absoluterectposition.js
+++ b/tests/core/tools/absoluterectposition.js
@@ -54,7 +54,6 @@
 			assertRect( editor.name === 'classic', 100 );
 
 			function assertRect( classic, scroll ) {
-				var actual;
 				// `getAbsoluteRectPosition` on classic editor adds its parent offset position which is also affected by scroll
 				// we need to include that in our test so inline and classic have different expected results.
 				for ( key in rect ) {
@@ -65,9 +64,8 @@
 					} else {
 						expected = rect[ key ];
 					}
-					// Firefox might return subpixel values.
-					actual = CKEDITOR.env.gecko ? Math.round( absoluteRect[ key ] ) : absoluteRect[ key ];
-					assert.areEqual( expected, actual, 'Rect[ ' + key + ' ]' );
+					// Round values, as there is no need to compare pixels as floats.
+					assert.areEqual( expected, Math.round( absoluteRect[ key ] ), 'Rect[ ' + key + ' ]' );
 				}
 			}
 		}

--- a/tests/core/tools/absoluterectposition.js
+++ b/tests/core/tools/absoluterectposition.js
@@ -54,6 +54,7 @@
 			assertRect( editor.name === 'classic', 100 );
 
 			function assertRect( classic, scroll ) {
+				var actual;
 				// `getAbsoluteRectPosition` on classic editor adds its parent offset position which is also affected by scroll
 				// we need to include that in our test so inline and classic have different expected results.
 				for ( key in rect ) {
@@ -64,7 +65,9 @@
 					} else {
 						expected = rect[ key ];
 					}
-					assert.areEqual( expected, absoluteRect[ key ], 'Rect[ ' + key + ' ]' );
+					// Firefox might return subpixel values.
+					actual = CKEDITOR.env.gecko ? Math.round( absoluteRect[ key ] ) : absoluteRect[ key ];
+					assert.areEqual( expected, actual, 'Rect[ ' + key + ' ]' );
 				}
 			}
 		}

--- a/tests/core/tools/absoluterectposition.js
+++ b/tests/core/tools/absoluterectposition.js
@@ -1,34 +1,17 @@
 /* bender-tags: editor, tools */
-/* bender-ckeditor-plugins: toolbar */
 
 ( function() {
 	'use strict';
-	bender.editors = {
-		inline: {
-			name: 'inline',
-			creator: 'inline'
-		},
-		classic: {
-			name: 'classic',
-			// Toolbar height affects absolute rects in built classic editor, this should make it consistent (#2092).
-			config: {
-				toolbar: [ '' ]
-			}
-		}
-	};
 
-	var tests = bender.tools.createTestsForEditors( CKEDITOR.tools.objectKeys( bender.editors ), {
-		tearDown: function() {
-			window.scrollBy( 0, -window.scrollY );
+	var tests = {
+		setUp: function() {
+			CKEDITOR.document.getBody().setStyle( 'height', '5000px' );
 		},
-		'test getting absolute rect': function( editor ) {
-			var container = CKEDITOR.document.findOne( '#test_container_' + editor.name ).getClientRect( true ),
-				offset = {
-					x: container.left - 99,
-					y: container.top - 99
-				},
-				inline = editor.name === 'inline' ? 0 : 9,
-				rect = {
+		tearDown: function() {
+			window.scrollBy( 0, -CKEDITOR.document.getWindow().getScrollPosition().y );
+		},
+		'test absolute rect inline': function() {
+			var rect = {
 					bottom: 10,
 					height: 10,
 					left: 0,
@@ -38,38 +21,96 @@
 					x: 0,
 					y: 0
 				},
-				absoluteRect = CKEDITOR.tools.getAbsoluteRectPosition( editor.window, rect ),
-				key,
-				expected;
+				expected = CKEDITOR.tools.copy( rect ),
+				// Mimic inline editor, as it is outside of an iframe.
+				mockedWindow = {
+					getFrame: function() {
+						return null;
+					}
+				},
+				absoluteRect = CKEDITOR.tools.getAbsoluteRectPosition( mockedWindow, rect );
 
-			if ( CKEDITOR.env.ie ) {
-				delete rect.x;
-				delete rect.y;
-			}
-			assertRect( editor.name === 'classic', 0 );
+			assertRect( absoluteRect, expected );
 
 			window.scrollBy( 0, 100 );
+			// We are adjusting the rect, as an element would move when scrolling.
+			updateVerticalRectParts( rect, -100 );
+			absoluteRect = CKEDITOR.tools.getAbsoluteRectPosition( mockedWindow, rect );
 
-			absoluteRect = CKEDITOR.tools.getAbsoluteRectPosition( editor.window, rect );
-			assertRect( editor.name === 'classic', 100 );
-
-			function assertRect( classic, scroll ) {
-				// `getAbsoluteRectPosition` on classic editor adds its parent offset position which is also affected by scroll
-				// we need to include that in our test so inline and classic have different expected results.
-				for ( key in rect ) {
-					if ( key in { left: '', right: '', x: '' } ) {
-						expected = rect[ key ] + ( classic ? 100 + offset.x : 0 );
-					} else if ( key in { top: '', bottom: '', y: '' } ) {
-						expected = rect[ key ] + ( classic ? 100 + offset.y : scroll ) + inline;
-					} else {
-						expected = rect[ key ];
+			assertRect( absoluteRect, expected );
+		},
+		'test absolute rect classic': function() {
+			var rect = {
+					bottom: 10,
+					height: 10,
+					left: 0,
+					right: 10,
+					top: 0,
+					width: 10,
+					x: 0,
+					y: 0
+				},
+				expected = {
+					bottom: 119,
+					height: 10,
+					left: 100,
+					right: 110,
+					top: 109,
+					width: 10,
+					x: 100,
+					y: 109
+				},
+				frameRect = {
+					bottom: 309,
+					height: 200,
+					left: 100,
+					right: 400,
+					top: 109,
+					width: 300,
+					x: 100,
+					y: 109
+				},
+				// Mimic classic editor, as it would be inside an iframe.
+				mockedWindow = {
+					getFrame: function() {
+						return {
+							getClientRect: function() {
+								return frameRect;
+							},
+							getWindow: function() {
+								return {
+									getFrame: function() {}
+								};
+							}
+						};
 					}
-					// Round values, as there is no need to compare pixels as floats.
-					assert.areEqual( expected, Math.round( absoluteRect[ key ] ), 'Rect[ ' + key + ' ]' );
-				}
-			}
+				},
+				absoluteRect = CKEDITOR.tools.getAbsoluteRectPosition( mockedWindow, rect );
+
+			assertRect( absoluteRect, expected );
+
+			window.scrollBy( 0, 100 );
+			// We need to change frameRect as it would be scrolled.
+			updateVerticalRectParts( frameRect, -100 );
+			absoluteRect = CKEDITOR.tools.getAbsoluteRectPosition( mockedWindow, rect );
+
+			assertRect( absoluteRect, expected );
 		}
-	} );
+	};
 
 	bender.test( tests );
+
+	function updateVerticalRectParts( rect, value ) {
+		CKEDITOR.tools.array.forEach( [ 'top', 'bottom', 'y' ], function( key ) {
+			if ( key in rect ) {
+				rect[ key ] += value;
+			}
+		} );
+	}
+
+	function assertRect( actual, expected ) {
+		for ( var key in expected ) {
+			assert.areEqual( expected[ key ], actual[ key ] );
+		}
+	}
 } )();

--- a/tests/plugins/balloonpanel/_helpers/tools.js
+++ b/tests/plugins/balloonpanel/_helpers/tools.js
@@ -25,25 +25,38 @@ var balloonTestsTools = {
 		}
 	},
 
-	assertMoveTo: function( moveMethod, expectedX, expectedY, maxX, maxY, shouldRound ) {
-		var actualX = moveMethod.args[ 0 ][ 1 ],
-			actualY = moveMethod.args[ 0 ][ 0 ];
+	/**
+	 * Asserts balloon toolbar move method. If `options.maxX` or `options.maxY` is passed will use `assertInRange`, otherwise will use `areEqual`.
+	 *
+	 * @param {Object} options
+	 * @param {Number} options.expectedX Expected X value.
+	 * @param {Number} options.expectedY Expected Y value.
+	 * @param {Number} [options.maxX] Maximum expected X value.
+	 * @param {Number} [options.maxY] Maximum expected Y value.
+	 * @param {Object} options.moveMethod Spied `move` method.
+	 */
+	assertMoveTo: function( options ) {
+		//moveMethod, expectedX, expectedY, maxX, maxY, shouldRound
+		var actualX = options.moveMethod.args[ 0 ][ 1 ],
+			actualY = options.moveMethod.args[ 0 ][ 0 ],
+			maxX = options.maxX,
+			maxY = options.maxY;
 
 		// Round values, as there is no need to compare pixels as floats.
-		if ( shouldRound ) {
+		if ( options.shouldRound ) {
 			actualX = Math.round( actualX );
 			actualY = Math.round( actualY );
 		}
 
-		if ( maxX !== undefined || maxY !== undefined ) {
-			maxX = maxX !== undefined ? maxX : expectedX;
-			maxY = maxY !== undefined ? maxY : expectedY;
+		if ( maxX || maxY ) {
+			maxX = maxX || options.expectedX;
+			maxY = maxY || options.expectedY;
 
-			this.assertInRange( expectedX, maxX, actualX, 'balloon move() x argument is not in range' );
-			this.assertInRange( expectedY, maxY, actualY, 'balloon move() y argument is not in range' );
+			this.assertInRange( options.expectedX, maxX, actualX, 'balloon move() x argument is not in range' );
+			this.assertInRange( options.expectedY, maxY, actualY, 'balloon move() y argument is not in range' );
 		} else {
-			assert.areEqual( expectedX, actualX, 'invalid balloon move() x value' );
-			assert.areEqual( expectedY, actualY, 'invalid balloon move() y value' );
+			assert.areEqual( options.expectedX, actualX, 'invalid balloon move() x value' );
+			assert.areEqual( options.expectedY, actualY, 'invalid balloon move() y value' );
 		}
 	},
 

--- a/tests/plugins/balloonpanel/_helpers/tools.js
+++ b/tests/plugins/balloonpanel/_helpers/tools.js
@@ -25,13 +25,15 @@ var balloonTestsTools = {
 		}
 	},
 
-	assertMoveTo: function( moveMethod, expectedX, expectedY, maxX, maxY ) {
+	assertMoveTo: function( moveMethod, expectedX, expectedY, maxX, maxY, shouldRound ) {
 		var actualX = moveMethod.args[ 0 ][ 1 ],
 			actualY = moveMethod.args[ 0 ][ 0 ];
 
 		// Round values, as there is no need to compare pixels as floats.
-		actualX = Math.round( actualX );
-		actualY = Math.round( actualY );
+		if ( shouldRound ) {
+			actualX = Math.round( actualX );
+			actualY = Math.round( actualY );
+		}
 
 		if ( maxX !== undefined || maxY !== undefined ) {
 			maxX = maxX !== undefined ? maxX : expectedX;

--- a/tests/plugins/balloonpanel/_helpers/tools.js
+++ b/tests/plugins/balloonpanel/_helpers/tools.js
@@ -29,6 +29,12 @@ var balloonTestsTools = {
 		var actualX = moveMethod.args[ 0 ][ 1 ],
 			actualY = moveMethod.args[ 0 ][ 0 ];
 
+		// Firefox might return subpixel values.
+		if ( CKEDITOR.env.gecko ) {
+			actualX = Math.round( actualX );
+			actualY = Math.round( actualY );
+		}
+
 		if ( maxX !== undefined || maxY !== undefined ) {
 			maxX = maxX !== undefined ? maxX : expectedX;
 			maxY = maxY !== undefined ? maxY : expectedY;

--- a/tests/plugins/balloonpanel/_helpers/tools.js
+++ b/tests/plugins/balloonpanel/_helpers/tools.js
@@ -29,11 +29,9 @@ var balloonTestsTools = {
 		var actualX = moveMethod.args[ 0 ][ 1 ],
 			actualY = moveMethod.args[ 0 ][ 0 ];
 
-		// Firefox might return subpixel values.
-		if ( CKEDITOR.env.gecko ) {
-			actualX = Math.round( actualX );
-			actualY = Math.round( actualY );
-		}
+		// Round values, as there is no need to compare pixels as floats.
+		actualX = Math.round( actualX );
+		actualY = Math.round( actualY );
 
 		if ( maxX !== undefined || maxY !== undefined ) {
 			maxX = maxX !== undefined ? maxX : expectedX;

--- a/tests/plugins/balloonpanel/positioning.inline.js
+++ b/tests/plugins/balloonpanel/positioning.inline.js
@@ -80,8 +80,14 @@
 			var moveSpy = spy( this.balloon, 'move' );
 			balloonTestsTools.attachBalloon( this.balloon, 'center' );
 
-			balloonTestsTools.assertMoveTo( moveSpy, screenSize.width - balloonSize.width - 40, screenSize.height,
-				screenSize.width - balloonSize.width, screenSize.height * 2, true );
+			balloonTestsTools.assertMoveTo( {
+				moveMethod: moveSpy,
+				expectedX: screenSize.width - balloonSize.width - 40,
+				expectedY: screenSize.height,
+				maxX: screenSize.width - balloonSize.width,
+				maxY: screenSize.height * 2,
+				shouldRound: true
+			} );
 			moveSpy.restore();
 		},
 
@@ -91,8 +97,14 @@
 			balloonTestsTools.attachBalloon( this.balloon, 'center' );
 
 			// Should appear on the right-hand side.
-			balloonTestsTools.assertMoveTo( moveSpy, screenSize.width * 1.5, screenSize.height * 1.5 - balloonSize.height / 2,
-				screenSize.width * 2, screenSize.height * 1.5, true );
+			balloonTestsTools.assertMoveTo( {
+				moveMethod: moveSpy,
+				expectedX: screenSize.width * 1.5,
+				expectedY: screenSize.height * 1.5 - balloonSize.height / 2,
+				maxX: screenSize.width * 2,
+				maxY: screenSize.height * 1.5,
+				shouldRound: true
+			} );
 			moveSpy.restore();
 		},
 
@@ -102,8 +114,14 @@
 			balloonTestsTools.attachBalloon( this.balloon, 'center' );
 
 			// Should appear on the right-hand side.
-			balloonTestsTools.assertMoveTo( moveSpy, screenSize.width * 1.5 - balloonSize.width, screenSize.height * 2 + 20,
-				screenSize.width * 1.5 + balloonSize.width, screenSize.height * 2 + 21, true );
+			balloonTestsTools.assertMoveTo( {
+				moveMethod: moveSpy,
+				expectedX: screenSize.width * 1.5 - balloonSize.width,
+				expectedY: screenSize.height * 2 + 20,
+				maxX: screenSize.width * 1.5 + balloonSize.width,
+				maxY: screenSize.height * 2 + 21,
+				shouldRound: true
+			} );
 			moveSpy.restore();
 		},
 

--- a/tests/plugins/balloonpanel/positioning.inline.js
+++ b/tests/plugins/balloonpanel/positioning.inline.js
@@ -80,7 +80,8 @@
 			var moveSpy = spy( this.balloon, 'move' );
 			balloonTestsTools.attachBalloon( this.balloon, 'center' );
 
-			balloonTestsTools.assertMoveTo( moveSpy, screenSize.width - balloonSize.width - 40, screenSize.height, screenSize.width - balloonSize.width, screenSize.height * 2 );
+			balloonTestsTools.assertMoveTo( moveSpy, screenSize.width - balloonSize.width - 40, screenSize.height,
+				screenSize.width - balloonSize.width, screenSize.height * 2, true );
 			moveSpy.restore();
 		},
 
@@ -90,7 +91,8 @@
 			balloonTestsTools.attachBalloon( this.balloon, 'center' );
 
 			// Should appear on the right-hand side.
-			balloonTestsTools.assertMoveTo( moveSpy, screenSize.width * 1.5, screenSize.height * 1.5 - balloonSize.height / 2, screenSize.width * 2, screenSize.height * 1.5 );
+			balloonTestsTools.assertMoveTo( moveSpy, screenSize.width * 1.5, screenSize.height * 1.5 - balloonSize.height / 2,
+				screenSize.width * 2, screenSize.height * 1.5, true );
 			moveSpy.restore();
 		},
 
@@ -100,7 +102,8 @@
 			balloonTestsTools.attachBalloon( this.balloon, 'center' );
 
 			// Should appear on the right-hand side.
-			balloonTestsTools.assertMoveTo( moveSpy, screenSize.width * 1.5 - balloonSize.width, screenSize.height * 2 + 20, screenSize.width * 1.5 + balloonSize.width, screenSize.height * 2 + 21 );
+			balloonTestsTools.assertMoveTo( moveSpy, screenSize.width * 1.5 - balloonSize.width, screenSize.height * 2 + 20,
+				screenSize.width * 1.5 + balloonSize.width, screenSize.height * 2 + 21, true );
 			moveSpy.restore();
 		},
 

--- a/tests/plugins/balloonpanel/positioning.inline.js
+++ b/tests/plugins/balloonpanel/positioning.inline.js
@@ -42,10 +42,10 @@
 
 	// Some init logic, we need to properly place elements according to the screen size.
 
-	// Make body as big as 3 screens.
+	// Make body big enough so scrollbars are visibly on any screen resolution.
 	CKEDITOR.document.getBody().setStyles( {
-		height: screenSize.height * 3 + 'px',
-		width: screenSize.width * 3 + 'px'
+		height: screenSize.height * 10 + 'px',
+		width: screenSize.width * 10 + 'px'
 	} );
 
 	// Set reference element size.

--- a/tests/plugins/balloonpanel/positioning.js
+++ b/tests/plugins/balloonpanel/positioning.js
@@ -116,7 +116,11 @@
 				var moveSpy = spy( this.balloon, 'move' );
 				balloonTestsTools.attachBalloon( this.balloon, this.markerElement );
 
-				balloonTestsTools.assertMoveTo( moveSpy, 180, 346.84375 );
+				balloonTestsTools.assertMoveTo( {
+					moveMethod: moveSpy,
+					expectedX: 180,
+					expectedY: 346.84375
+				} );
 
 				moveSpy.restore();
 			},
@@ -127,7 +131,11 @@
 				var moveSpy = spy( this.balloon, 'move' );
 				balloonTestsTools.attachBalloon( this.balloon, this.markerElement );
 
-				balloonTestsTools.assertMoveTo( moveSpy, 92.5, 422 );
+				balloonTestsTools.assertMoveTo( {
+					moveMethod: moveSpy,
+					expectedX: 92.5,
+					expectedY: 422
+				} );
 
 				moveSpy.restore();
 			},
@@ -138,7 +146,11 @@
 				var moveSpy = spy( this.balloon, 'move' );
 				balloonTestsTools.attachBalloon( this.balloon, this.markerElement );
 
-				balloonTestsTools.assertMoveTo( moveSpy, 21, 391.84375 );
+				balloonTestsTools.assertMoveTo( {
+					moveMethod: moveSpy,
+					expectedX: 21,
+					expectedY: 391.84375
+				} );
 
 				moveSpy.restore();
 			},
@@ -149,7 +161,11 @@
 				var moveSpy = spy( this.balloon, 'move' );
 				balloonTestsTools.attachBalloon( this.balloon, this.markerElement );
 
-				balloonTestsTools.assertMoveTo( moveSpy, 92.5, 363 );
+				balloonTestsTools.assertMoveTo( {
+					moveMethod: moveSpy,
+					expectedX: 92.5,
+					expectedY: 363
+				} );
 
 				moveSpy.restore();
 			},
@@ -161,7 +177,11 @@
 				balloonTestsTools.attachBalloon( this.balloon, this.markerElement );
 
 				// Most likely we'll have to work on this case, since balloon is cropped.
-				balloonTestsTools.assertMoveTo( moveSpy, -25.5, 379.34375 );
+				balloonTestsTools.assertMoveTo( {
+					moveMethod: moveSpy,
+					expectedX: -25.5,
+					expectedY: 379.34375
+				} );
 
 				moveSpy.restore();
 			},
@@ -172,7 +192,11 @@
 				var moveSpy = spy( this.balloon, 'move' );
 				balloonTestsTools.attachBalloon( this.balloon, this.markerElement );
 
-				balloonTestsTools.assertMoveTo( moveSpy, 228.5, 422 );
+				balloonTestsTools.assertMoveTo( {
+					moveMethod: moveSpy,
+					expectedX: 228.5,
+					expectedY: 422
+				} );
 
 				moveSpy.restore();
 			}


### PR DESCRIPTION
## What is the purpose of this pull request?

Failing tests

## Does your PR contain necessary tests?

All patches which change the editor code must include tests. You can always read more
on [PR testing](https://ckeditor.com/docs/ckeditor4/latest/guide/dev_contributing_code.html#tests),
[how to set the testing environment](https://ckeditor.com/docs/ckeditor4/latest/guide/dev_tests.html) and
[how to create tests](https://ckeditor.com/docs/ckeditor4/latest/guide/dev_tests.html#creating-your-own-test)
in the official CKEditor documentation.

### This PR contains

- [ ] Unit tests
- [ ] Manual tests

## What changes did you make?

`tests/core/tools/absoluterectposition`
- Firefox returned float numbers, as they were differing by less than one pixel I've rounded them
- Space filler had 2000px height, as it wasn't enough to make scrollbars visible in vertical monitors I've increased it's size to 5000px.

`tests/plugins/balloonpanel/positioning.inline`
- Firefox returned float numbers, as they were differing by less than one pixel I've rounded them
Closes #2347 