### PR TITLE
Widget is accessible from dialog ok, show and hide events

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -12,6 +12,7 @@ New Features:
 * [#706](https://github.com/ckeditor/ckeditor-dev/issues/706): Added different cursor style when selecting cells for [Table Selection](https://ckeditor.com/cke4/addon/tableselection) plugin.
 * [#651](https://github.com/ckeditor/ckeditor-dev/issues/651): Text pasted using [Paste from Word](https://ckeditor.com/cke4/addon/pastefromword) preservers indentation in paragraphs.
 * [#1176](https://github.com/ckeditor/ckeditor-dev/pull/1176): The [Balloon Panel](https://ckeditor.com/cke4/addon/balloonpanel) can be attached to selection instead of element.
+* [#1044](https://github.com/ckeditor/ckeditor-dev/pull/1044): [Widget dialog](https://ckeditor.com/cke4/addon/widget) [`show`](https://ckeditor.com/docs/ckeditor4/latest/api/CKEDITOR_dialog.html#event-show), [`hide`](https://ckeditor.com/docs/ckeditor4/latest/api/CKEDITOR_dialog.html#event-hide), [`ok`](https://ckeditor.com/docs/ckeditor4/latest/api/CKEDITOR_dialog.html#event-ok) events contains information about a widget instance for which a dialog is launched.
 
 API Changes:
 

--- a/plugins/widget/plugin.js
+++ b/plugins/widget/plugin.js
@@ -1187,10 +1187,12 @@
 					}
 				}, null, null, 0 );
 
-				dialog.once( 'hide', function() {
+				dialog.once( 'hide', function( evt ) {
+					evt.data.widget = that;
+
 					showListener.removeListener();
 					okListener.removeListener();
-				} );
+				}, null, null, 0 );
 			} );
 
 			return true;

--- a/plugins/widget/plugin.js
+++ b/plugins/widget/plugin.js
@@ -1158,11 +1158,13 @@
 				if ( that.fire( 'dialog', dialog ) === false )
 					return;
 
-				showListener = dialog.on( 'show', function() {
+				showListener = dialog.on( 'show', function( evt ) {
+					evt.data.widget = that;
 					dialog.setupContent( that );
-				} );
+				}, null, null, 0 );
 
-				okListener = dialog.on( 'ok', function() {
+				okListener = dialog.on( 'ok', function( evt ) {
+					evt.data.widget = that;
 					// Commit dialog's fields, but prevent from
 					// firing data event for every field. Fire only one,
 					// bulk event at the end.
@@ -1183,7 +1185,7 @@
 						that.fire( 'data', that.data );
 						that.editor.fire( 'saveSnapshot' );
 					}
-				} );
+				}, null, null, 0 );
 
 				dialog.once( 'hide', function() {
 					showListener.removeListener();

--- a/tests/plugins/widget/editing.js
+++ b/tests/plugins/widget/editing.js
@@ -55,6 +55,30 @@
 							]
 						};
 					} );
+
+					evt.editor.widgets.add( 'dialogtest1', {
+						template: '<div>bar</div>',
+						dialog: 'dialogtest1'
+					} );
+
+					CKEDITOR.dialog.add( 'dialogtest1', function() {
+						return {
+							title: 'DialogTest1',
+							contents: [
+								{
+									id: 'info',
+									elements: []
+								}
+							],
+							onShow: dialogEventListener,
+							onOk: dialogEventListener,
+							onHide: dialogEventListener
+						};
+					} );
+
+					function dialogEventListener( evt ) {
+						assert.areEqual( 'dialogtest1', evt.data.widget.name );
+					}
 				}
 			}
 		}
@@ -327,6 +351,24 @@
 						assert.areNotSame( 'foofoo', value1, 'Cancelled dialog event prevented from default data loading' );
 						assert.isInstanceOf( CKEDITOR.dialog, dialogEventData, 'evt.data' );
 					} );
+				} );
+
+				wait( function() {
+					widget.edit();
+				} );
+			} );
+		},
+
+		// (#1044)
+		'test opening and hiding dialog events': function() {
+			var editor = this.editor;
+
+			this.editorBot.setData( '<p data-widget="dialogtest1" id="x">bar</p>', function() {
+				var widget = getWidgetById( editor, 'x' );
+
+				editor.once( 'dialogShow', function( evt ) {
+					evt.data.getButton( 'ok' ).click();
+					resume();
 				} );
 
 				wait( function() {
@@ -692,4 +734,5 @@
 			} );
 		}
 	} );
+	
 } )();

--- a/tests/plugins/widget/editing.js
+++ b/tests/plugins/widget/editing.js
@@ -77,7 +77,8 @@
 					} );
 
 					function dialogEventListener( evt ) {
-						assert.areEqual( 'dialogtest1', evt.data.widget.name );
+						assert.isNotUndefined( evt.data.widget, 'No widget passed for: ' + evt.name );
+						assert.areEqual( 'dialogtest1', evt.data.widget.name, 'Invalid widget for: ' + evt.name );
 					}
 				}
 			}

--- a/tests/plugins/widget/manual/dialogevents.html
+++ b/tests/plugins/widget/manual/dialogevents.html
@@ -1,0 +1,50 @@
+<div id="editor">
+	<p><span>Widget 1</span></p>
+	<p><span>Widget 2</span></p>
+</div>
+
+<script>
+
+	var editor = CKEDITOR.replace( 'editor', {
+		extraAllowedContent: 'span',
+		extraPlugins: 'spanwidget',
+		allowedContent: true,
+		on: {
+			instanceReady: function() {
+				CKEDITOR.dialog.add( 'spanwidget', function() {
+					return {
+						width: 200,
+						height: 200,
+						title: 'spanwidget',
+						contents: [
+							{
+								id: 'info',
+								elements: []
+							}
+						],
+						onOk: showNotification,
+						onShow: showNotification,
+						onHide: showNotification
+					}
+				} );
+			}
+		}
+	} );
+
+	CKEDITOR.plugins.add( 'spanwidget', {
+		requires: 'widget',
+		init: function ( editor )	{
+			editor.widgets.add( 'spanwidget', {
+				dialog: 'spanwidget',
+				upcast: function ( element ) {
+					return element.name == 'span';
+				}
+			} );
+		}
+	} );
+
+	function showNotification( evt ) {
+		editor.showNotification( evt.data.widget.element.getText() );
+	}
+
+</script>

--- a/tests/plugins/widget/manual/dialogevents.md
+++ b/tests/plugins/widget/manual/dialogevents.md
@@ -20,3 +20,5 @@ Repeat test steps for `Widget 2`.
 
 * Notification doesn't show up on widget opening and closing.
 * Notification message is not the same as widget content.
+
+**Note**: Clicking `OK` button triggers `ok` and `hide` events thus notification message will be doubled.

--- a/tests/plugins/widget/manual/dialogevents.md
+++ b/tests/plugins/widget/manual/dialogevents.md
@@ -1,0 +1,22 @@
+@bender-tags: widget, dialog, feature, 1044
+@bender-ui: collapsed
+@bender-ckeditor-plugins: wysiwygarea, toolbar, widget, dialog
+
+**Pay attention to notifications.**
+
+1. Double click on `Widget 1`.
+1. Wait until dialog show up.
+1. Click `OK` button.
+1. Repeat 1-3 for but instead of `OK` click `Close` button.
+
+Repeat test steps for `Widget 2`.
+
+## Expected
+
+* After opening and closing dialog notifications show up with widget content.
+* Make sure that notification message equals widget content.
+
+## Unexpected
+
+* Notification doesn't show up on widget opening and closing.
+* Notification message is not the same as widget content.


### PR DESCRIPTION
## What is the purpose of this pull request?

New feature

## Does your PR contain necessary tests?

All patches which change the editor code must include tests. You can always read more
on [PR testing](https://ckeditor.com/docs/ckeditor4/latest/guide/dev_contributing_code.html#tests),
[how to set the testing environment](https://ckeditor.com/docs/ckeditor4/latest/guide/dev_tests.html) and
[how to create tests](https://ckeditor.com/docs/ckeditor4/latest/guide/dev_tests.html#creating-your-own-test)
in the official CKEditor documentation.

### This PR contains

- [x] Unit tests
- [x] Manual tests

## What changes did you make?

Included widget into dialog events.

Closes #1044
