### PR TITLE
[Edge] Fixed: 'Permission denied' is thrown when opening panel instance

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -12,6 +12,7 @@ Fixed Issues:
 * [#1264](https://github.com/ckeditor/ckeditor-dev/issues/1264) Fixed: Right-click doesn't clear selection created with [Table Selection](https://ckeditor.com/cke4/addon/tableselection) plugin.
 * [#2380](https://github.com/ckeditor/ckeditor-dev/issues/2380) Fixed: Styling HTML comments in top level element result with extra paragraphs.
 * [#2294](https://github.com/ckeditor/ckeditor-dev/issues/2294) Fixed: Pasting content from MS Outlook and then bolding it results with an error.
+* [#2035](https://github.com/ckeditor/ckeditor-dev/issues/2035) [Edge] Fixed: `Permission denied` is thrown when opening [Panel](https://ckeditor.com/cke4/addon/panel) instance.
 
 API Changes:
 

--- a/plugins/panel/plugin.js
+++ b/plugins/panel/plugin.js
@@ -169,7 +169,7 @@
 				// trigger iframe's 'load' event.
 				var src =
 					CKEDITOR.env.air ? 'javascript:void(0)' : // jshint ignore:line
-					CKEDITOR.env.ie ? 'javascript:void(function(){' + encodeURIComponent( // jshint ignore:line
+					( CKEDITOR.env.ie && !CKEDITOR.env.edge ) ? 'javascript:void(function(){' + encodeURIComponent( // jshint ignore:line
 						'document.open();' +
 						// In IE, the document domain must be set any time we call document.open().
 						'(' + CKEDITOR.tools.fixDomain + ')();' +

--- a/tests/plugins/panel/manual/edgepermissiondenied.html
+++ b/tests/plugins/panel/manual/edgepermissiondenied.html
@@ -1,0 +1,8 @@
+<textarea id="editor"></textarea>
+
+<script>
+	if ( !CKEDITOR.env.edge ) {
+		bender.ignore();
+	}
+	CKEDITOR.replace( 'editor' );
+</script>

--- a/tests/plugins/panel/manual/edgepermissiondenied.md
+++ b/tests/plugins/panel/manual/edgepermissiondenied.md
@@ -1,0 +1,14 @@
+@bender-tags: 4.10.2, bug, 2035
+@bender-ui: collapsed
+@bender-ckeditor-plugins: wysiwygarea,toolbar,stylescombo
+
+1. Open console.
+1. Press styles combo button.
+
+## Expected
+
+Nothing is logged in console.
+
+## Unexpected
+
+`Permission denied` is thrown in console.

--- a/tests/plugins/panel/panel.js
+++ b/tests/plugins/panel/panel.js
@@ -18,7 +18,7 @@
 					forceIFrame: true
 				} ),
 				html = panel.render( editor ),
-				src = html.match( /src="[^"]*"/i )[ 0 ];
+				src = html.match( /src="([^"]*)"/i )[ 1 ];
 
 			src = src.substring( 5, src.length - 1 );
 

--- a/tests/plugins/panel/panel.js
+++ b/tests/plugins/panel/panel.js
@@ -1,0 +1,28 @@
+/* bender-tags: editor */
+/* bender-ckeditor-plugins: panel */
+
+( function() {
+	'use sctrict';
+
+	bender.editor = {};
+
+	bender.test( {
+		// #2035
+		'test panel src is empty': function() {
+			if ( !CKEDITOR.env.edge ) {
+				assert.ignore();
+			}
+
+			var editor = this.editor,
+				panel = new CKEDITOR.ui.panel( CKEDITOR.document, {
+					forceIFrame: true
+				} ),
+				html = panel.render( editor ),
+				src = html.match( /src="[^"]*"/i )[ 0 ];
+
+			src = src.substring( 5, src.length - 1 );
+
+			assert.areSame( '', src, 'Frame source should be empty.' );
+		}
+	} );
+} )();


### PR DESCRIPTION
## What is the purpose of this pull request?

Bug fix

## Does your PR contain necessary tests?

All patches which change the editor code must include tests. You can always read more
on [PR testing](https://ckeditor.com/docs/ckeditor4/latest/guide/dev_contributing_code.html#tests),
[how to set the testing environment](https://ckeditor.com/docs/ckeditor4/latest/guide/dev_tests.html) and
[how to create tests](https://ckeditor.com/docs/ckeditor4/latest/guide/dev_tests.html#creating-your-own-test)
in the official CKEditor documentation.

### This PR contains

- [X] Unit tests
- [X] Manual tests

## What changes did you make?

Edge throws 'permission denied' when trying to append an iframe with `src` attribute containing some javascript. This happens within `panel` plugin, excluded Edge from check, so `src` should be empty. After some testing it looks like nothing is broken.

Closes #2035 