### PR TITLE
Dropped unused numbered list types

### DIFF
--- a/dev/langtool/meta/ckeditor.plugin-liststyle/meta.txt
+++ b/dev/langtool/meta/ckeditor.plugin-liststyle/meta.txt
@@ -1,15 +1,11 @@
 # Copyright (c) 2003-2018, CKSource - Frederico Knabben. All rights reserved.
 # For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-oss-license
 
-armenian = Label for the Armenian numbering numbered list type option.
 bulletedTitle = Label for the Bulleted List Properties dialog window.
 circle = Label for the Circle bulleted list type option.
 decimal = Label for the Decimal numbering numbered list type option.
-decimalLeadingZero = Label for the Decimal leading zero numbered list type option.
 disc = Label for the Disc bulleted list type option.
-georgian = Label for the Georgian numbering numbered list type option.
 lowerAlpha = Label for the Lower Alpha numbered list type option.
-lowerGreek = Label for the Lower Greek numbered list type option.
 lowerRoman = Label for the Lower Roman numbered list type option.
 none =
 notset = Label for the <not set> list type option.

--- a/plugins/liststyle/dialogs/liststyle.js
+++ b/plugins/liststyle/dialogs/liststyle.js
@@ -91,15 +91,6 @@
 				[ lang.decimal, 'decimal' ]
 			];
 
-			if ( !CKEDITOR.env.ie || CKEDITOR.env.version > 7 ) {
-				listStyleOptions.concat( [
-					[ lang.armenian, 'armenian' ],
-					[ lang.decimalLeadingZero, 'decimal-leading-zero' ],
-					[ lang.georgian, 'georgian' ],
-					[ lang.lowerGreek, 'lower-greek' ]
-				] );
-			}
-
 			return {
 				title: lang.numberedTitle,
 				minWidth: 300,

--- a/plugins/liststyle/lang/af.js
+++ b/plugins/liststyle/lang/af.js
@@ -3,15 +3,11 @@ Copyright (c) 2003-2018, CKSource - Frederico Knabben. All rights reserved.
 For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-oss-license
 */
 CKEDITOR.plugins.setLang( 'liststyle', 'af', {
-	armenian: 'Armeense nommering',
 	bulletedTitle: 'Eienskappe van ongenommerde lys',
 	circle: 'Sirkel',
 	decimal: 'Desimale syfers (1, 2, 3, ens.)',
-	decimalLeadingZero: 'Desimale syfers met voorloopnul (01, 02, 03, ens.)',
 	disc: 'Skyf',
-	georgian: 'Georgiese nommering (an, ban, gan, ens.)',
 	lowerAlpha: 'Kleinletters (a, b, c, d, e, ens.)',
-	lowerGreek: 'Griekse kleinletters (alpha, beta, gamma, ens.)',
 	lowerRoman: 'Romeinse kleinletters (i, ii, iii, iv, v, ens.)',
 	none: 'Geen',
 	notset: '<nie ingestel nie>',

--- a/plugins/liststyle/lang/ar.js
+++ b/plugins/liststyle/lang/ar.js
@@ -3,15 +3,11 @@ Copyright (c) 2003-2018, CKSource - Frederico Knabben. All rights reserved.
 For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-oss-license
 */
 CKEDITOR.plugins.setLang( 'liststyle', 'ar', {
-	armenian: 'Armenian numbering',
 	bulletedTitle: 'Bulleted List Properties',
 	circle: 'Circle',
 	decimal: 'Decimal (1, 2, 3, etc.)',
-	decimalLeadingZero: 'Decimal leading zero (01, 02, 03, etc.)',
 	disc: 'Disc',
-	georgian: 'Georgian numbering (an, ban, gan, etc.)',
 	lowerAlpha: 'Lower Alpha (a, b, c, d, e, etc.)',
-	lowerGreek: 'Lower Greek (alpha, beta, gamma, etc.)',
 	lowerRoman: 'Lower Roman (i, ii, iii, iv, v, etc.)',
 	none: 'None',
 	notset: '<not set>',

--- a/plugins/liststyle/lang/az.js
+++ b/plugins/liststyle/lang/az.js
@@ -3,15 +3,11 @@ Copyright (c) 2003-2018, CKSource - Frederico Knabben. All rights reserved.
 For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-oss-license
 */
 CKEDITOR.plugins.setLang( 'liststyle', 'az', {
-	armenian: 'Erməni nömrələmə',
 	bulletedTitle: 'Markerlənmiş siyahının xüsusiyyətləri',
 	circle: 'Dəirəcik',
 	decimal: 'Rəqəm (1, 2, 3 və s.)',
-	decimalLeadingZero: 'Aparıcı sıfır olan rəqəm (01, 02, 03 və s.)',
 	disc: 'Disk',
-	georgian: 'Gürcü nömrələmə (an, ban, gan, və s.)',
 	lowerAlpha: 'Kiçik hərflər (a, b, c, d, e və s.)',
-	lowerGreek: 'Kiçik Yunan hərfləri (alfa, beta, qamma və s.)',
 	lowerRoman: 'Rum rəqəmləri (i, ii, iii, iv, v və s.)',
 	none: 'Yoxdur',
 	notset: '<seçilməmiş>',

--- a/plugins/liststyle/lang/bg.js
+++ b/plugins/liststyle/lang/bg.js
@@ -3,15 +3,11 @@ Copyright (c) 2003-2018, CKSource - Frederico Knabben. All rights reserved.
 For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-oss-license
 */
 CKEDITOR.plugins.setLang( 'liststyle', 'bg', {
-	armenian: 'Арменско номериране',
 	bulletedTitle: 'Свойства на точков списък',
 	circle: 'Кръг',
 	decimal: 'Числа (1, 2, 3 и т.н.)',
-	decimalLeadingZero: 'Числа с водеща нула (01, 02, 03 и т.н.)',
 	disc: 'Диск',
-	georgian: 'Грузинско номериране (an, ban, gan, и т.н.)',
 	lowerAlpha: 'Малки букви (а, б, в, г, д и т.н.)',
-	lowerGreek: 'Малки гръцки букви (алфа, бета, гама и т.н.)',
 	lowerRoman: 'Малки римски числа (i, ii, iii, iv, v и т.н.)',
 	none: 'Няма',
 	notset: '<не е указано>',

--- a/plugins/liststyle/lang/bn.js
+++ b/plugins/liststyle/lang/bn.js
@@ -3,15 +3,11 @@ Copyright (c) 2003-2018, CKSource - Frederico Knabben. All rights reserved.
 For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-oss-license
 */
 CKEDITOR.plugins.setLang( 'liststyle', 'bn', {
-	armenian: 'আর্মেনিয়ান সংখ্যাক্রমে বিন্যাস',
 	bulletedTitle: 'Bulleted List Properties',
 	circle: 'Circle',
 	decimal: 'Decimal (1, 2, 3, etc.)',
-	decimalLeadingZero: 'Decimal leading zero (01, 02, 03, etc.)',
 	disc: 'Disc',
-	georgian: 'Georgian numbering (an, ban, gan, etc.)',
 	lowerAlpha: 'Lower Alpha (a, b, c, d, e, etc.)',
-	lowerGreek: 'Lower Greek (alpha, beta, gamma, etc.)',
 	lowerRoman: 'Lower Roman (i, ii, iii, iv, v, etc.)',
 	none: 'None',
 	notset: '<not set>',

--- a/plugins/liststyle/lang/bs.js
+++ b/plugins/liststyle/lang/bs.js
@@ -3,15 +3,11 @@ Copyright (c) 2003-2018, CKSource - Frederico Knabben. All rights reserved.
 For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-oss-license
 */
 CKEDITOR.plugins.setLang( 'liststyle', 'bs', {
-	armenian: 'Armenian numbering',
 	bulletedTitle: 'Bulleted List Properties',
 	circle: 'Circle',
 	decimal: 'Decimal (1, 2, 3, etc.)',
-	decimalLeadingZero: 'Decimal leading zero (01, 02, 03, etc.)',
 	disc: 'Disc',
-	georgian: 'Georgian numbering (an, ban, gan, etc.)',
 	lowerAlpha: 'Lower Alpha (a, b, c, d, e, etc.)',
-	lowerGreek: 'Lower Greek (alpha, beta, gamma, etc.)',
 	lowerRoman: 'Lower Roman (i, ii, iii, iv, v, etc.)',
 	none: 'None',
 	notset: '<not set>',

--- a/plugins/liststyle/lang/ca.js
+++ b/plugins/liststyle/lang/ca.js
@@ -3,15 +3,11 @@ Copyright (c) 2003-2018, CKSource - Frederico Knabben. All rights reserved.
 For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-oss-license
 */
 CKEDITOR.plugins.setLang( 'liststyle', 'ca', {
-	armenian: 'Armenian numbering',
 	bulletedTitle: 'Bulleted List Properties',
 	circle: 'Circle',
 	decimal: 'Decimal (1, 2, 3, etc.)',
-	decimalLeadingZero: 'Decimal leading zero (01, 02, 03, etc.)',
 	disc: 'Disc',
-	georgian: 'Georgian numbering (an, ban, gan, etc.)',
 	lowerAlpha: 'Lower Alpha (a, b, c, d, e, etc.)',
-	lowerGreek: 'Lower Greek (alpha, beta, gamma, etc.)',
 	lowerRoman: 'Lower Roman (i, ii, iii, iv, v, etc.)',
 	none: 'None',
 	notset: '<not set>',

--- a/plugins/liststyle/lang/cs.js
+++ b/plugins/liststyle/lang/cs.js
@@ -3,15 +3,11 @@ Copyright (c) 2003-2018, CKSource - Frederico Knabben. All rights reserved.
 For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-oss-license
 */
 CKEDITOR.plugins.setLang( 'liststyle', 'cs', {
-	armenian: 'Arménské',
 	bulletedTitle: 'Vlastnosti odrážek',
 	circle: 'Kroužky',
 	decimal: 'Arabská čísla (1, 2, 3, atd.)',
-	decimalLeadingZero: 'Arabská čísla uvozená nulou (01, 02, 03, atd.)',
 	disc: 'Kolečka',
-	georgian: 'Gruzínské (an, ban, gan, atd.)',
 	lowerAlpha: 'Malá latinka (a, b, c, d, e, atd.)',
-	lowerGreek: 'Malé řecké (alpha, beta, gamma, atd.)',
 	lowerRoman: 'Malé římské (i, ii, iii, iv, v, atd.)',
 	none: 'Nic',
 	notset: '<nenastaveno>',

--- a/plugins/liststyle/lang/cy.js
+++ b/plugins/liststyle/lang/cy.js
@@ -3,15 +3,11 @@ Copyright (c) 2003-2018, CKSource - Frederico Knabben. All rights reserved.
 For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-oss-license
 */
 CKEDITOR.plugins.setLang( 'liststyle', 'cy', {
-	armenian: 'Rhifo Armeneg',
 	bulletedTitle: 'Priodweddau Rhestr Fwled',
 	circle: 'Cylch',
 	decimal: 'Degol (1, 2, 3, ayyb.)',
-	decimalLeadingZero: 'Degol â sero arweiniol (01, 02, 03, ayyb.)',
 	disc: 'Disg',
-	georgian: 'Rhifau Sioraidd (an, ban, gan, ayyb.)',
 	lowerAlpha: 'Alffa Is (a, b, c, d, e, ayyb.)',
-	lowerGreek: 'Groeg Is (alpha, beta, gamma, ayyb.)',
 	lowerRoman: 'Rhufeinig Is (i, ii, iii, iv, v, ayyb.)',
 	none: 'Dim',
 	notset: '<heb osod>',

--- a/plugins/liststyle/lang/da.js
+++ b/plugins/liststyle/lang/da.js
@@ -3,15 +3,11 @@ Copyright (c) 2003-2018, CKSource - Frederico Knabben. All rights reserved.
 For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-oss-license
 */
 CKEDITOR.plugins.setLang( 'liststyle', 'da', {
-	armenian: 'Armensk nummering',
 	bulletedTitle: 'Værdier for cirkelpunktopstilling',
 	circle: 'Cirkel',
 	decimal: 'Decimal (1, 2, 3, osv.)',
-	decimalLeadingZero: 'Decimaler med 0 først (01, 02, 03, etc.)',
 	disc: 'Værdier for diskpunktopstilling',
-	georgian: 'Georgiansk nummering (an, ban, gan, etc.)',
 	lowerAlpha: 'Små alfabet (a, b, c, d, e, etc.)',
-	lowerGreek: 'Små græsk (alpha, beta, gamma, etc.)',
 	lowerRoman: 'Små romerske (i, ii, iii, iv, v, etc.)',
 	none: 'Ingen',
 	notset: '<ikke defineret>',

--- a/plugins/liststyle/lang/de-ch.js
+++ b/plugins/liststyle/lang/de-ch.js
@@ -3,15 +3,11 @@ Copyright (c) 2003-2018, CKSource - Frederico Knabben. All rights reserved.
 For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-oss-license
 */
 CKEDITOR.plugins.setLang( 'liststyle', 'de-ch', {
-	armenian: 'Armenische Nummerierung',
 	bulletedTitle: 'Aufzählungslisteneigenschaften',
 	circle: 'Ring',
 	decimal: 'Dezimal (1, 2, 3, etc.)',
-	decimalLeadingZero: 'Dezimal mit führender Null (01, 02, 03, usw.)',
 	disc: 'Kreis',
-	georgian: 'Georgische Nummerierung (an, ban, gan, usw.)',
 	lowerAlpha: 'Klein Alpha (a, b, c, d, e, usw.)',
-	lowerGreek: 'Klein griechisch (alpha, beta, gamma, usw.)',
 	lowerRoman: 'Klein römisch (i, ii, iii, iv, v, usw.)',
 	none: 'Keine',
 	notset: '<nicht festgelegt>',

--- a/plugins/liststyle/lang/de.js
+++ b/plugins/liststyle/lang/de.js
@@ -3,15 +3,11 @@ Copyright (c) 2003-2018, CKSource - Frederico Knabben. All rights reserved.
 For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-oss-license
 */
 CKEDITOR.plugins.setLang( 'liststyle', 'de', {
-	armenian: 'Armenische Nummerierung',
 	bulletedTitle: 'Aufzählungslisteneigenschaften',
 	circle: 'Ring',
 	decimal: 'Dezimal (1, 2, 3, etc.)',
-	decimalLeadingZero: 'Dezimal mit führender Null (01, 02, 03, usw.)',
 	disc: 'Kreis',
-	georgian: 'Georgische Nummerierung (an, ban, gan, usw.)',
 	lowerAlpha: 'Klein Alpha (a, b, c, d, e, usw.)',
-	lowerGreek: 'Klein griechisch (alpha, beta, gamma, usw.)',
 	lowerRoman: 'Klein römisch (i, ii, iii, iv, v, usw.)',
 	none: 'Keine',
 	notset: '<nicht festgelegt>',

--- a/plugins/liststyle/lang/el.js
+++ b/plugins/liststyle/lang/el.js
@@ -3,15 +3,11 @@ Copyright (c) 2003-2018, CKSource - Frederico Knabben. All rights reserved.
 For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-oss-license
 */
 CKEDITOR.plugins.setLang( 'liststyle', 'el', {
-	armenian: 'Αρμενική αρίθμηση',
 	bulletedTitle: 'Ιδιότητες Λίστας Σημείων',
 	circle: 'Κύκλος',
 	decimal: 'Δεκαδική (1, 2, 3, κτλ)',
-	decimalLeadingZero: 'Δεκαδική με αρχικό μηδεν (01, 02, 03, κτλ)',
 	disc: 'Δίσκος',
-	georgian: 'Γεωργιανή αρίθμηση (ა, ბ, გ, κτλ)',
 	lowerAlpha: 'Μικρά Λατινικά (a, b, c, d, e, κτλ.)',
-	lowerGreek: 'Μικρά Ελληνικά (α, β, γ, κτλ)',
 	lowerRoman: 'Μικρά Ρωμαϊκά (i, ii, iii, iv, v, κτλ)',
 	none: 'Καμία',
 	notset: '<δεν έχει οριστεί>',

--- a/plugins/liststyle/lang/en-au.js
+++ b/plugins/liststyle/lang/en-au.js
@@ -3,15 +3,11 @@ Copyright (c) 2003-2018, CKSource - Frederico Knabben. All rights reserved.
 For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-oss-license
 */
 CKEDITOR.plugins.setLang( 'liststyle', 'en-au', {
-	armenian: 'Armenian numbering',
 	bulletedTitle: 'Bulleted List Properties',
 	circle: 'Circle',
 	decimal: 'Decimal (1, 2, 3, etc.)',
-	decimalLeadingZero: 'Decimal leading zero (01, 02, 03, etc.)',
 	disc: 'Disc',
-	georgian: 'Georgian numbering (an, ban, gan, etc.)',
 	lowerAlpha: 'Lower Alpha (a, b, c, d, e, etc.)',
-	lowerGreek: 'Lower Greek (alpha, beta, gamma, etc.)',
 	lowerRoman: 'Lower Roman (i, ii, iii, iv, v, etc.)',
 	none: 'None',
 	notset: '<not set>',

--- a/plugins/liststyle/lang/en-ca.js
+++ b/plugins/liststyle/lang/en-ca.js
@@ -3,15 +3,11 @@ Copyright (c) 2003-2018, CKSource - Frederico Knabben. All rights reserved.
 For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-oss-license
 */
 CKEDITOR.plugins.setLang( 'liststyle', 'en-ca', {
-	armenian: 'Armenian numbering',
 	bulletedTitle: 'Bulleted List Properties',
 	circle: 'Circle',
 	decimal: 'Decimal (1, 2, 3, etc.)',
-	decimalLeadingZero: 'Decimal leading zero (01, 02, 03, etc.)',
 	disc: 'Disc',
-	georgian: 'Georgian numbering (an, ban, gan, etc.)',
 	lowerAlpha: 'Lower Alpha (a, b, c, d, e, etc.)',
-	lowerGreek: 'Lower Greek (alpha, beta, gamma, etc.)',
 	lowerRoman: 'Lower Roman (i, ii, iii, iv, v, etc.)',
 	none: 'None',
 	notset: '<not set>',

--- a/plugins/liststyle/lang/en-gb.js
+++ b/plugins/liststyle/lang/en-gb.js
@@ -3,15 +3,11 @@ Copyright (c) 2003-2018, CKSource - Frederico Knabben. All rights reserved.
 For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-oss-license
 */
 CKEDITOR.plugins.setLang( 'liststyle', 'en-gb', {
-	armenian: 'Armenian numbering',
 	bulletedTitle: 'Bulleted List Properties',
 	circle: 'Circle',
 	decimal: 'Decimal (1, 2, 3, etc.)',
-	decimalLeadingZero: 'Decimal leading zero (01, 02, 03, etc.)',
 	disc: 'Disc',
-	georgian: 'Georgian numbering (an, ban, gan, etc.)',
 	lowerAlpha: 'Lower Alpha (a, b, c, d, e, etc.)',
-	lowerGreek: 'Lower Greek (alpha, beta, gamma, etc.)',
 	lowerRoman: 'Lower Roman (i, ii, iii, iv, v, etc.)',
 	none: 'None',
 	notset: '<not set>',

--- a/plugins/liststyle/lang/en.js
+++ b/plugins/liststyle/lang/en.js
@@ -3,15 +3,11 @@ Copyright (c) 2003-2018, CKSource - Frederico Knabben. All rights reserved.
 For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-oss-license
 */
 CKEDITOR.plugins.setLang( 'liststyle', 'en', {
-	armenian: 'Armenian numbering',
 	bulletedTitle: 'Bulleted List Properties',
 	circle: 'Circle',
 	decimal: 'Decimal (1, 2, 3, etc.)',
-	decimalLeadingZero: 'Decimal leading zero (01, 02, 03, etc.)',
 	disc: 'Disc',
-	georgian: 'Georgian numbering (an, ban, gan, etc.)',
 	lowerAlpha: 'Lower Alpha (a, b, c, d, e, etc.)',
-	lowerGreek: 'Lower Greek (alpha, beta, gamma, etc.)',
 	lowerRoman: 'Lower Roman (i, ii, iii, iv, v, etc.)',
 	none: 'None',
 	notset: '<not set>',

--- a/plugins/liststyle/lang/eo.js
+++ b/plugins/liststyle/lang/eo.js
@@ -3,15 +3,11 @@ Copyright (c) 2003-2018, CKSource - Frederico Knabben. All rights reserved.
 For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-oss-license
 */
 CKEDITOR.plugins.setLang( 'liststyle', 'eo', {
-	armenian: 'Armena nombrado',
 	bulletedTitle: 'Atributoj de Bula Listo',
 	circle: 'Cirklo',
 	decimal: 'Dekumaj Nombroj (1, 2, 3, ktp.)',
-	decimalLeadingZero: 'Dekumaj Nombroj malantaŭ nulo (01, 02, 03, ktp.)',
 	disc: 'Disko',
-	georgian: 'Gruza nombrado (an, ban, gan, ktp.)',
 	lowerAlpha: 'Minusklaj Literoj (a, b, c, d, e, ktp.)',
-	lowerGreek: 'Grekaj Minusklaj Literoj (alpha, beta, gamma, ktp.)',
 	lowerRoman: 'Minusklaj Romanaj Nombroj (i, ii, iii, iv, v, ktp.)',
 	none: 'Neniu',
 	notset: '<Defaŭlta>',

--- a/plugins/liststyle/lang/es-mx.js
+++ b/plugins/liststyle/lang/es-mx.js
@@ -3,15 +3,11 @@ Copyright (c) 2003-2018, CKSource - Frederico Knabben. All rights reserved.
 For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-oss-license
 */
 CKEDITOR.plugins.setLang( 'liststyle', 'es-mx', {
-	armenian: 'Numeración armenia',
 	bulletedTitle: 'Propiedades de la lista con viñetas',
 	circle: 'Círculo',
 	decimal: 'Decimal (1, 2, 3, etc.)',
-	decimalLeadingZero: 'Decimal con cero (01, 02, 03, etc.)',
 	disc: 'Desc',
-	georgian: 'Numeración gregoriana (an, ban, gan, etc.)',
 	lowerAlpha: 'Alfabeto minúscula (a, b, c, d, e, etc.)',
-	lowerGreek: 'Griego minúscula (alpha, beta, gamma, etc.)',
 	lowerRoman: 'Romano minúscula (i, ii, iii, iv, v, etc.)',
 	none: 'Ninguno',
 	notset: '<not set>',

--- a/plugins/liststyle/lang/es.js
+++ b/plugins/liststyle/lang/es.js
@@ -3,15 +3,11 @@ Copyright (c) 2003-2018, CKSource - Frederico Knabben. All rights reserved.
 For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-oss-license
 */
 CKEDITOR.plugins.setLang( 'liststyle', 'es', {
-	armenian: 'Numeración armenia',
 	bulletedTitle: 'Propiedades de viñetas',
 	circle: 'Círculo',
 	decimal: 'Decimal (1, 2, 3, etc.)',
-	decimalLeadingZero: 'Decimal con cero inicial (01, 02, 03, etc.)',
 	disc: 'Disco',
-	georgian: 'Numeración georgiana (an, ban, gan, etc.)',
 	lowerAlpha: 'Alfabeto en minúsculas (a, b, c, d, e, etc.)',
-	lowerGreek: 'Letras griegas (alpha, beta, gamma, etc.)',
 	lowerRoman: 'Números romanos en minúsculas (i, ii, iii, iv, v, etc.)',
 	none: 'Ninguno',
 	notset: '<sin establecer>',

--- a/plugins/liststyle/lang/et.js
+++ b/plugins/liststyle/lang/et.js
@@ -3,15 +3,11 @@ Copyright (c) 2003-2018, CKSource - Frederico Knabben. All rights reserved.
 For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-oss-license
 */
 CKEDITOR.plugins.setLang( 'liststyle', 'et', {
-	armenian: 'Armeenia numbrid',
 	bulletedTitle: 'Punktloendi omadused',
 	circle: 'Ring',
 	decimal: 'Numbrid (1, 2, 3, jne)',
-	decimalLeadingZero: 'Numbrid algusnulliga (01, 02, 03, jne)',
 	disc: 'Täpp',
-	georgian: 'Gruusia numbrid (an, ban, gan, jne)',
 	lowerAlpha: 'Väiketähed (a, b, c, d, e, jne)',
-	lowerGreek: 'Kreeka väiketähed (alpha, beta, gamma, jne)',
 	lowerRoman: 'Väiksed rooma numbrid (i, ii, iii, iv, v, jne)',
 	none: 'Puudub',
 	notset: '<pole määratud>',

--- a/plugins/liststyle/lang/eu.js
+++ b/plugins/liststyle/lang/eu.js
@@ -3,15 +3,11 @@ Copyright (c) 2003-2018, CKSource - Frederico Knabben. All rights reserved.
 For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-oss-license
 */
 CKEDITOR.plugins.setLang( 'liststyle', 'eu', {
-	armenian: 'Zenbakitze armeniarra',
 	bulletedTitle: 'Buletadun zerrendaren propietateak',
 	circle: 'Zirkulua',
 	decimal: 'Hamartarra (1, 2, 3...)',
-	decimalLeadingZero: 'Aurretik zeroa duen hamartarra (01, 02, 03...)',
 	disc: 'Diskoa',
-	georgian: 'Zenbakitze georgiarra (an, ban, gan...)',
 	lowerAlpha: 'Alfabetoa minuskulaz (a, b, c, d, e...)',
-	lowerGreek: 'Greziera minuskulaz (alpha, beta, gamma...)',
 	lowerRoman: 'Erromatarra minuskulaz (i, ii, iii, iv, v...)',
 	none: 'Bat ere ez',
 	notset: '<ezarri gabea>',

--- a/plugins/liststyle/lang/fa.js
+++ b/plugins/liststyle/lang/fa.js
@@ -3,15 +3,11 @@ Copyright (c) 2003-2018, CKSource - Frederico Knabben. All rights reserved.
 For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-oss-license
 */
 CKEDITOR.plugins.setLang( 'liststyle', 'fa', {
-	armenian: 'شماره‌گذاری ارمنی',
 	bulletedTitle: 'خصوصیات فهرست نقطه‌ای',
 	circle: 'دایره',
 	decimal: 'ده‌دهی (۱، ۲، ۳، ...)',
-	decimalLeadingZero: 'دهدهی همراه با صفر (۰۱، ۰۲، ۰۳، ...)',
 	disc: 'صفحه گرد',
-	georgian: 'شمارهگذاری گریگورین (an, ban, gan, etc.)',
 	lowerAlpha: 'پانویس الفبایی (a, b, c, d, e, etc.)',
-	lowerGreek: 'پانویس یونانی (alpha, beta, gamma, etc.)',
 	lowerRoman: 'پانویس رومی (i, ii, iii, iv, v, etc.)',
 	none: 'هیچ',
 	notset: '<تنظیم نشده>',

--- a/plugins/liststyle/lang/fi.js
+++ b/plugins/liststyle/lang/fi.js
@@ -3,15 +3,11 @@ Copyright (c) 2003-2018, CKSource - Frederico Knabben. All rights reserved.
 For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-oss-license
 */
 CKEDITOR.plugins.setLang( 'liststyle', 'fi', {
-	armenian: 'Armeenialainen numerointi',
 	bulletedTitle: 'Numeroimattoman listan ominaisuudet',
 	circle: 'Ympyrä',
 	decimal: 'Desimaalit (1, 2, 3, jne.)',
-	decimalLeadingZero: 'Desimaalit, alussa nolla (01, 02, 03, jne.)',
 	disc: 'Levy',
-	georgian: 'Georgialainen numerointi (an, ban, gan, etc.)',
 	lowerAlpha: 'Pienet aakkoset (a, b, c, d, e, jne.)',
-	lowerGreek: 'Pienet kreikkalaiset (alpha, beta, gamma, jne.)',
 	lowerRoman: 'Pienet roomalaiset (i, ii, iii, iv, v, jne.)',
 	none: 'Ei mikään',
 	notset: '<ei asetettu>',

--- a/plugins/liststyle/lang/fo.js
+++ b/plugins/liststyle/lang/fo.js
@@ -3,15 +3,11 @@ Copyright (c) 2003-2018, CKSource - Frederico Knabben. All rights reserved.
 For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-oss-license
 */
 CKEDITOR.plugins.setLang( 'liststyle', 'fo', {
-	armenian: 'Armensk talskipan',
 	bulletedTitle: 'Eginleikar fyri lista við prikkum',
 	circle: 'Sirkul',
 	decimal: 'Vanlig tøl (1, 2, 3, etc.)',
-	decimalLeadingZero: 'Tøl við null frammanfyri (01, 02, 03, etc.)',
 	disc: 'Disc',
-	georgian: 'Georgisk talskipan (an, ban, gan, osv.)',
 	lowerAlpha: 'Lítlir bókstavir (a, b, c, d, e, etc.)',
-	lowerGreek: 'Grikskt við lítlum (alpha, beta, gamma, etc.)',
 	lowerRoman: 'Lítil rómaratøl (i, ii, iii, iv, v, etc.)',
 	none: 'Einki',
 	notset: '<ikki sett>',

--- a/plugins/liststyle/lang/fr-ca.js
+++ b/plugins/liststyle/lang/fr-ca.js
@@ -3,15 +3,11 @@ Copyright (c) 2003-2018, CKSource - Frederico Knabben. All rights reserved.
 For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-oss-license
 */
 CKEDITOR.plugins.setLang( 'liststyle', 'fr-ca', {
-	armenian: 'Numération arménienne',
 	bulletedTitle: 'Propriété de liste à puce',
 	circle: 'Cercle',
 	decimal: 'Décimal (1, 2, 3, etc.)',
-	decimalLeadingZero: 'Décimal avec zéro (01, 02, 03, etc.)',
 	disc: 'Disque',
-	georgian: 'Numération géorgienne (an, ban, gan, etc.)',
 	lowerAlpha: 'Alphabétique minuscule (a, b, c, d, e, etc.)',
-	lowerGreek: 'Grecque minuscule (alpha, beta, gamma, etc.)',
 	lowerRoman: 'Romain minuscule (i, ii, iii, iv, v, etc.)',
 	none: 'Aucun',
 	notset: '<non défini>',

--- a/plugins/liststyle/lang/fr.js
+++ b/plugins/liststyle/lang/fr.js
@@ -3,15 +3,11 @@ Copyright (c) 2003-2018, CKSource - Frederico Knabben. All rights reserved.
 For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-oss-license
 */
 CKEDITOR.plugins.setLang( 'liststyle', 'fr', {
-	armenian: 'Numération arménienne',
 	bulletedTitle: 'Propriétés de la liste à puces',
 	circle: 'Cercle',
 	decimal: 'Décimal (1, 2, 3, etc.)',
-	decimalLeadingZero: 'Décimal précédé par un 0 (01, 02, 03, etc.)',
 	disc: 'Disque',
-	georgian: 'Numération géorgienne (an, ban, gan, etc.)',
 	lowerAlpha: 'Lettres minuscules (a, b, c, d, e, etc.)',
-	lowerGreek: 'Grec minuscule (alpha, bêta, gamma, etc.)',
 	lowerRoman: 'Chiffres romains minuscules (i, ii, iii, iv, v, etc.)',
 	none: 'Aucun',
 	notset: '<indéfini>',

--- a/plugins/liststyle/lang/gl.js
+++ b/plugins/liststyle/lang/gl.js
@@ -3,15 +3,11 @@ Copyright (c) 2003-2018, CKSource - Frederico Knabben. All rights reserved.
 For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-oss-license
 */
 CKEDITOR.plugins.setLang( 'liststyle', 'gl', {
-	armenian: 'Numeración armenia',
 	bulletedTitle: 'Propiedades da lista viñeteada',
 	circle: 'Circulo',
 	decimal: 'Decimal (1, 2, 3, etc.)',
-	decimalLeadingZero: 'Decimal con cero á esquerda (01, 02, 03, etc.)',
 	disc: 'Disc',
-	georgian: 'Numeración xeorxiana (an, ban, gan, etc.)',
 	lowerAlpha: 'Alfabeto en minúsculas (a, b, c, d, e, etc.)',
-	lowerGreek: 'Grego en minúsculas (alpha, beta, gamma, etc.)',
 	lowerRoman: 'Números romanos en minúsculas (i, ii, iii, iv, v, etc.)',
 	none: 'Ningún',
 	notset: '<sen estabelecer>',

--- a/plugins/liststyle/lang/gu.js
+++ b/plugins/liststyle/lang/gu.js
@@ -3,15 +3,11 @@ Copyright (c) 2003-2018, CKSource - Frederico Knabben. All rights reserved.
 For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-oss-license
 */
 CKEDITOR.plugins.setLang( 'liststyle', 'gu', {
-	armenian: 'અરમેનિયન આંકડા પદ્ધતિ',
 	bulletedTitle: 'બુલેટેડ લીસ્ટના ગુણ',
 	circle: 'વર્તુળ',
 	decimal: 'આંકડા (1, 2, 3, etc.)',
-	decimalLeadingZero: 'સુન્ય આગળ આંકડા (01, 02, 03, etc.)',
 	disc: 'ડિસ્ક',
-	georgian: 'ગેઓર્ગિયન આંકડા પદ્ધતિ (an, ban, gan, etc.)',
 	lowerAlpha: 'આલ્ફા નાના (a, b, c, d, e, etc.)',
-	lowerGreek: 'ગ્રીક નાના (alpha, beta, gamma, etc.)',
 	lowerRoman: 'રોમન નાના (i, ii, iii, iv, v, etc.)',
 	none: 'કસુ ',
 	notset: '<સેટ નથી>',

--- a/plugins/liststyle/lang/he.js
+++ b/plugins/liststyle/lang/he.js
@@ -3,15 +3,11 @@ Copyright (c) 2003-2018, CKSource - Frederico Knabben. All rights reserved.
 For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-oss-license
 */
 CKEDITOR.plugins.setLang( 'liststyle', 'he', {
-	armenian: 'ספרות ארמניות',
 	bulletedTitle: 'תכונות רשימת תבליטים',
 	circle: 'עיגול ריק',
 	decimal: 'ספרות (1, 2, 3 וכו\')',
-	decimalLeadingZero: 'ספרות עם 0 בהתחלה (01, 02, 03 וכו\')',
 	disc: 'עיגול מלא',
-	georgian: 'ספרות גיאורגיות (an, ban, gan וכו\')',
 	lowerAlpha: 'אותיות אנגליות קטנות (a, b, c, d, e וכו\')',
-	lowerGreek: 'אותיות יווניות קטנות (alpha, beta, gamma וכו\')',
 	lowerRoman: 'ספירה רומית באותיות קטנות (i, ii, iii, iv, v וכו\')',
 	none: 'ללא',
 	notset: '<לא נקבע>',

--- a/plugins/liststyle/lang/hi.js
+++ b/plugins/liststyle/lang/hi.js
@@ -3,15 +3,11 @@ Copyright (c) 2003-2018, CKSource - Frederico Knabben. All rights reserved.
 For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-oss-license
 */
 CKEDITOR.plugins.setLang( 'liststyle', 'hi', {
-	armenian: 'Armenian numbering',
 	bulletedTitle: 'Bulleted List Properties',
 	circle: 'Circle',
 	decimal: 'Decimal (1, 2, 3, etc.)',
-	decimalLeadingZero: 'Decimal leading zero (01, 02, 03, etc.)',
 	disc: 'Disc',
-	georgian: 'Georgian numbering (an, ban, gan, etc.)',
 	lowerAlpha: 'Lower Alpha (a, b, c, d, e, etc.)',
-	lowerGreek: 'Lower Greek (alpha, beta, gamma, etc.)',
 	lowerRoman: 'Lower Roman (i, ii, iii, iv, v, etc.)',
 	none: 'None',
 	notset: '<not set>',

--- a/plugins/liststyle/lang/hr.js
+++ b/plugins/liststyle/lang/hr.js
@@ -3,15 +3,11 @@ Copyright (c) 2003-2018, CKSource - Frederico Knabben. All rights reserved.
 For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-oss-license
 */
 CKEDITOR.plugins.setLang( 'liststyle', 'hr', {
-	armenian: 'Armenijska numeracija',
 	bulletedTitle: 'Svojstva liste',
 	circle: 'Krug',
 	decimal: 'Decimalna numeracija (1, 2, 3, itd.)',
-	decimalLeadingZero: 'Decimalna s vodećom nulom (01, 02, 03, itd)',
 	disc: 'Disk',
-	georgian: 'Gruzijska numeracija(an, ban, gan, etc.)',
 	lowerAlpha: 'Znakovi mala slova (a, b, c, d, e, itd.)',
-	lowerGreek: 'Grčka numeracija mala slova (alfa, beta, gama, itd).',
 	lowerRoman: 'Romanska numeracija mala slova (i, ii, iii, iv, v, itd.)',
 	none: 'Bez',
 	notset: '<nije određen>',

--- a/plugins/liststyle/lang/hu.js
+++ b/plugins/liststyle/lang/hu.js
@@ -3,15 +3,11 @@ Copyright (c) 2003-2018, CKSource - Frederico Knabben. All rights reserved.
 For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-oss-license
 */
 CKEDITOR.plugins.setLang( 'liststyle', 'hu', {
-	armenian: 'Örmény számozás',
 	bulletedTitle: 'Pontozott lista tulajdonságai',
 	circle: 'Kör',
 	decimal: 'Arab számozás (1, 2, 3, stb.)',
-	decimalLeadingZero: 'Számozás bevezető nullákkal (01, 02, 03, stb.)',
 	disc: 'Korong',
-	georgian: 'Grúz számozás (an, ban, gan, stb.)',
 	lowerAlpha: 'Kisbetűs (a, b, c, d, e, stb.)',
-	lowerGreek: 'Görög (alpha, beta, gamma, stb.)',
 	lowerRoman: 'Római kisbetűs (i, ii, iii, iv, v, stb.)',
 	none: 'Nincs',
 	notset: '<Nincs beállítva>',

--- a/plugins/liststyle/lang/id.js
+++ b/plugins/liststyle/lang/id.js
@@ -3,15 +3,11 @@ Copyright (c) 2003-2018, CKSource - Frederico Knabben. All rights reserved.
 For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-oss-license
 */
 CKEDITOR.plugins.setLang( 'liststyle', 'id', {
-	armenian: 'Armenian numbering', // MISSING
 	bulletedTitle: 'Bulleted List Properties', // MISSING
 	circle: 'Lingkaran',
 	decimal: 'Desimal (1, 2, 3, dst.)',
-	decimalLeadingZero: 'Desimal diawali angka nol (01, 02, 03, dst.)',
 	disc: 'Cakram',
-	georgian: 'Georgian numbering (an, ban, gan, etc.)', // MISSING
 	lowerAlpha: 'Huruf Kecil (a, b, c, d, e, dst.)',
-	lowerGreek: 'Lower Greek (alpha, beta, gamma, etc.)', // MISSING
 	lowerRoman: 'Angka Romawi (i, ii, iii, iv, v, dst.)',
 	none: 'Tidak ada',
 	notset: '<tidak diatur>',

--- a/plugins/liststyle/lang/is.js
+++ b/plugins/liststyle/lang/is.js
@@ -3,15 +3,11 @@ Copyright (c) 2003-2018, CKSource - Frederico Knabben. All rights reserved.
 For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-oss-license
 */
 CKEDITOR.plugins.setLang( 'liststyle', 'is', {
-	armenian: 'Armenian numbering',
 	bulletedTitle: 'Bulleted List Properties',
 	circle: 'Circle',
 	decimal: 'Decimal (1, 2, 3, etc.)',
-	decimalLeadingZero: 'Decimal leading zero (01, 02, 03, etc.)',
 	disc: 'Disc',
-	georgian: 'Georgian numbering (an, ban, gan, etc.)',
 	lowerAlpha: 'Lower Alpha (a, b, c, d, e, etc.)',
-	lowerGreek: 'Lower Greek (alpha, beta, gamma, etc.)',
 	lowerRoman: 'Lower Roman (i, ii, iii, iv, v, etc.)',
 	none: 'None',
 	notset: '<not set>',

--- a/plugins/liststyle/lang/it.js
+++ b/plugins/liststyle/lang/it.js
@@ -3,15 +3,11 @@ Copyright (c) 2003-2018, CKSource - Frederico Knabben. All rights reserved.
 For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-oss-license
 */
 CKEDITOR.plugins.setLang( 'liststyle', 'it', {
-	armenian: 'Numerazione Armena',
 	bulletedTitle: 'Proprietà liste puntate',
 	circle: 'Cerchio',
 	decimal: 'Decimale (1, 2, 3, ecc.)',
-	decimalLeadingZero: 'Decimale preceduto da 0 (01, 02, 03, ecc.)',
 	disc: 'Disco',
-	georgian: 'Numerazione Georgiana (an, ban, gan, ecc.)',
 	lowerAlpha: 'Alfabetico minuscolo (a, b, c, d, e, ecc.)',
-	lowerGreek: 'Greco minuscolo (alpha, beta, gamma, ecc.)',
 	lowerRoman: 'Numerazione Romana minuscola (i, ii, iii, iv, v, ecc.)',
 	none: 'Nessuno',
 	notset: '<non impostato>',

--- a/plugins/liststyle/lang/ja.js
+++ b/plugins/liststyle/lang/ja.js
@@ -3,15 +3,11 @@ Copyright (c) 2003-2018, CKSource - Frederico Knabben. All rights reserved.
 For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-oss-license
 */
 CKEDITOR.plugins.setLang( 'liststyle', 'ja', {
-	armenian: 'アルメニア数字',
 	bulletedTitle: '箇条書きのプロパティ',
 	circle: '白丸',
 	decimal: '数字 (1, 2, 3, etc.)',
-	decimalLeadingZero: '0付きの数字 (01, 02, 03, etc.)',
 	disc: '黒丸',
-	georgian: 'グルジア数字 (an, ban, gan, etc.)',
 	lowerAlpha: '小文字アルファベット (a, b, c, d, e, etc.)',
-	lowerGreek: '小文字ギリシャ文字 (alpha, beta, gamma, etc.)',
 	lowerRoman: '小文字ローマ数字 (i, ii, iii, iv, v, etc.)',
 	none: 'なし',
 	notset: '<なし>',

--- a/plugins/liststyle/lang/ka.js
+++ b/plugins/liststyle/lang/ka.js
@@ -3,15 +3,11 @@ Copyright (c) 2003-2018, CKSource - Frederico Knabben. All rights reserved.
 For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-oss-license
 */
 CKEDITOR.plugins.setLang( 'liststyle', 'ka', {
-	armenian: 'სომხური გადანომრვა',
 	bulletedTitle: 'ღილებიანი სიის პარამეტრები',
 	circle: 'წრეწირი',
 	decimal: 'რიცხვებით (1, 2, 3, ..)',
-	decimalLeadingZero: 'ნულით დაწყებული რიცხვებით (01, 02, 03, ..)',
 	disc: 'წრე',
-	georgian: 'ქართული გადანომრვა (ან, ბან, გან, ..)',
 	lowerAlpha: 'პატარა ლათინური ასოებით (a, b, c, d, e, ..)',
-	lowerGreek: 'პატარა ბერძნული ასოებით (ალფა, ბეტა, გამა, ..)',
 	lowerRoman: 'რომაული გადანომრვცა პატარა ციფრებით (i, ii, iii, iv, v, ..)',
 	none: 'არაფერი',
 	notset: '<არაფერი>',

--- a/plugins/liststyle/lang/km.js
+++ b/plugins/liststyle/lang/km.js
@@ -3,15 +3,11 @@ Copyright (c) 2003-2018, CKSource - Frederico Knabben. All rights reserved.
 For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-oss-license
 */
 CKEDITOR.plugins.setLang( 'liststyle', 'km', {
-	armenian: 'លេខ​អារមេនី',
 	bulletedTitle: 'លក្ខណៈ​សម្បត្តិ​បញ្ជី​ជា​ចំណុច',
 	circle: 'រង្វង់​មូល',
 	decimal: 'លេខ​ទសភាគ (1, 2, 3, ...)',
-	decimalLeadingZero: 'ទសភាគ​ចាប់​ផ្ដើម​ពី​សូន្យ (01, 02, 03, ...)',
 	disc: 'ថាស',
-	georgian: 'លេខ​ចចជា (an, ban, gan, ...)',
 	lowerAlpha: 'ព្យញ្ជនៈ​តូច (a, b, c, d, e, ...)',
-	lowerGreek: 'លេខ​ក្រិក​តូច (alpha, beta, gamma, ...)',
 	lowerRoman: 'លេខ​រ៉ូម៉ាំង​តូច (i, ii, iii, iv, v, ...)',
 	none: 'គ្មាន',
 	notset: '<not set>',

--- a/plugins/liststyle/lang/ko.js
+++ b/plugins/liststyle/lang/ko.js
@@ -3,15 +3,11 @@ Copyright (c) 2003-2018, CKSource - Frederico Knabben. All rights reserved.
 For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-oss-license
 */
 CKEDITOR.plugins.setLang( 'liststyle', 'ko', {
-	armenian: '아르메니아 숫자',
 	bulletedTitle: '순서 없는 목록 속성',
 	circle: '원',
 	decimal: '수 (1, 2, 3, 등)',
-	decimalLeadingZero: '0이 붙은 수 (01, 02, 03, 등)',
 	disc: '내림차순',
-	georgian: '그루지야 숫자 (an, ban, gan, 등)',
 	lowerAlpha: '영소문자 (a, b, c, d, e, 등)',
-	lowerGreek: '그리스 소문자 (alpha, beta, gamma, 등)',
 	lowerRoman: '로마 소문자 (i, ii, iii, iv, v, 등)',
 	none: '없음',
 	notset: '<설정 없음>',

--- a/plugins/liststyle/lang/ku.js
+++ b/plugins/liststyle/lang/ku.js
@@ -3,15 +3,11 @@ Copyright (c) 2003-2018, CKSource - Frederico Knabben. All rights reserved.
 For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-oss-license
 */
 CKEDITOR.plugins.setLang( 'liststyle', 'ku', {
-	armenian: 'ئاراستەی ژمارەی ئەرمەنی',
 	bulletedTitle: 'خاسیەتی لیستی خاڵی',
 	circle: 'بازنه',
 	decimal: 'ژمارە (1, 2, 3, وە هیتر.)',
-	decimalLeadingZero: 'ژمارە سفڕی لەپێشەوه (01, 02, 03, وە هیتر.)',
 	disc: 'پەپکە',
-	georgian: 'ئاراستەی ژمارەی جۆڕجی (an, ban, gan, وە هیتر.)',
 	lowerAlpha: 'ئەلفابێی بچووك (a, b, c, d, e, وە هیتر.)',
-	lowerGreek: 'یۆنانی بچووك (alpha, beta, gamma, وە هیتر.)',
 	lowerRoman: 'ژمارەی ڕۆمی بچووك (i, ii, iii, iv, v, وە هیتر.)',
 	none: 'هیچ',
 	notset: '<دانەندراوه>',

--- a/plugins/liststyle/lang/lt.js
+++ b/plugins/liststyle/lang/lt.js
@@ -3,15 +3,11 @@ Copyright (c) 2003-2018, CKSource - Frederico Knabben. All rights reserved.
 For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-oss-license
 */
 CKEDITOR.plugins.setLang( 'liststyle', 'lt', {
-	armenian: 'Armėniški skaitmenys',
 	bulletedTitle: 'Ženklelinio sąrašo nustatymai',
 	circle: 'Apskritimas',
 	decimal: 'Dešimtainis (1, 2, 3, t.t)',
-	decimalLeadingZero: 'Dešimtainis su nuliu priekyje (01, 02, 03, t.t)',
 	disc: 'Diskas',
-	georgian: 'Gruziniški skaitmenys (an, ban, gan, t.t)',
 	lowerAlpha: 'Mažosios Alpha (a, b, c, d, e, t.t)',
-	lowerGreek: 'Mažosios Graikų (alpha, beta, gamma, t.t)',
 	lowerRoman: 'Mažosios Romėnų (i, ii, iii, iv, v, t.t)',
 	none: 'Niekas',
 	notset: '<nenurodytas>',

--- a/plugins/liststyle/lang/lv.js
+++ b/plugins/liststyle/lang/lv.js
@@ -3,15 +3,11 @@ Copyright (c) 2003-2018, CKSource - Frederico Knabben. All rights reserved.
 For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-oss-license
 */
 CKEDITOR.plugins.setLang( 'liststyle', 'lv', {
-	armenian: 'Armēņu skaitļi',
 	bulletedTitle: 'Vienkārša saraksta uzstādījumi',
 	circle: 'Aplis',
 	decimal: 'Decimālie (1, 2, 3, utt)',
-	decimalLeadingZero: 'Decimālie ar nulli (01, 02, 03, utt)',
 	disc: 'Disks',
-	georgian: 'Gruzīņu skaitļi (an, ban, gan, utt)',
 	lowerAlpha: 'Mazie alfabēta (a, b, c, d, e, utt)',
-	lowerGreek: 'Mazie grieķu (alfa, beta, gamma, utt)',
 	lowerRoman: 'Mazie romāņu (i, ii, iii, iv, v, utt)',
 	none: 'Nekas',
 	notset: '<nav norādīts>',

--- a/plugins/liststyle/lang/mk.js
+++ b/plugins/liststyle/lang/mk.js
@@ -3,15 +3,11 @@ Copyright (c) 2003-2018, CKSource - Frederico Knabben. All rights reserved.
 For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-oss-license
 */
 CKEDITOR.plugins.setLang( 'liststyle', 'mk', {
-	armenian: 'Armenian numbering',
 	bulletedTitle: 'Bulleted List Properties',
 	circle: 'Circle',
 	decimal: 'Decimal (1, 2, 3, etc.)',
-	decimalLeadingZero: 'Decimal leading zero (01, 02, 03, etc.)',
 	disc: 'Disc',
-	georgian: 'Georgian numbering (an, ban, gan, etc.)',
 	lowerAlpha: 'Lower Alpha (a, b, c, d, e, etc.)',
-	lowerGreek: 'Lower Greek (alpha, beta, gamma, etc.)',
 	lowerRoman: 'Lower Roman (i, ii, iii, iv, v, etc.)',
 	none: 'None',
 	notset: '<not set>',

--- a/plugins/liststyle/lang/mn.js
+++ b/plugins/liststyle/lang/mn.js
@@ -3,15 +3,11 @@ Copyright (c) 2003-2018, CKSource - Frederico Knabben. All rights reserved.
 For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-oss-license
 */
 CKEDITOR.plugins.setLang( 'liststyle', 'mn', {
-	armenian: 'Armenian numbering',
 	bulletedTitle: 'Bulleted List Properties',
 	circle: 'Circle',
 	decimal: 'Decimal (1, 2, 3, etc.)',
-	decimalLeadingZero: 'Decimal leading zero (01, 02, 03, etc.)',
 	disc: 'Disc',
-	georgian: 'Georgian numbering (an, ban, gan, etc.)',
 	lowerAlpha: 'Lower Alpha (a, b, c, d, e, etc.)',
-	lowerGreek: 'Lower Greek (alpha, beta, gamma, etc.)',
 	lowerRoman: 'Lower Roman (i, ii, iii, iv, v, etc.)',
 	none: 'None',
 	notset: '<not set>',

--- a/plugins/liststyle/lang/ms.js
+++ b/plugins/liststyle/lang/ms.js
@@ -3,15 +3,11 @@ Copyright (c) 2003-2018, CKSource - Frederico Knabben. All rights reserved.
 For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-oss-license
 */
 CKEDITOR.plugins.setLang( 'liststyle', 'ms', {
-	armenian: 'Armenian numbering',
 	bulletedTitle: 'Bulleted List Properties',
 	circle: 'Circle',
 	decimal: 'Decimal (1, 2, 3, etc.)',
-	decimalLeadingZero: 'Decimal leading zero (01, 02, 03, etc.)',
 	disc: 'Disc',
-	georgian: 'Georgian numbering (an, ban, gan, etc.)',
 	lowerAlpha: 'Lower Alpha (a, b, c, d, e, etc.)',
-	lowerGreek: 'Lower Greek (alpha, beta, gamma, etc.)',
 	lowerRoman: 'Lower Roman (i, ii, iii, iv, v, etc.)',
 	none: 'None',
 	notset: '<not set>',

--- a/plugins/liststyle/lang/nb.js
+++ b/plugins/liststyle/lang/nb.js
@@ -3,15 +3,11 @@ Copyright (c) 2003-2018, CKSource - Frederico Knabben. All rights reserved.
 For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-oss-license
 */
 CKEDITOR.plugins.setLang( 'liststyle', 'nb', {
-	armenian: 'Armensk nummerering',
 	bulletedTitle: 'Egenskaper for punktliste',
 	circle: 'Sirkel',
 	decimal: 'Tall (1, 2, 3, osv.)',
-	decimalLeadingZero: 'Tall, med førstesiffer null (01, 02, 03, osv.)',
 	disc: 'Disk',
-	georgian: 'Georgisk nummerering (an, ban, gan, osv.)',
 	lowerAlpha: 'Alfabetisk, små (a, b, c, d, e, osv.)',
-	lowerGreek: 'Gresk, små (alpha, beta, gamma, osv.)',
 	lowerRoman: 'Romertall, små (i, ii, iii, iv, v, osv.)',
 	none: 'Ingen',
 	notset: '<ikke satt>',

--- a/plugins/liststyle/lang/nl.js
+++ b/plugins/liststyle/lang/nl.js
@@ -3,15 +3,11 @@ Copyright (c) 2003-2018, CKSource - Frederico Knabben. All rights reserved.
 For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-oss-license
 */
 CKEDITOR.plugins.setLang( 'liststyle', 'nl', {
-	armenian: 'Armeense nummering',
 	bulletedTitle: 'Eigenschappen lijst met opsommingstekens',
 	circle: 'Cirkel',
 	decimal: 'Cijfers (1, 2, 3, etc.)',
-	decimalLeadingZero: 'Cijfers beginnen met nul (01, 02, 03, etc.)',
 	disc: 'Schijf',
-	georgian: 'Georgische nummering (an, ban, gan, etc.)',
 	lowerAlpha: 'Kleine letters (a, b, c, d, e, etc.)',
-	lowerGreek: 'Grieks kleine letters (alpha, beta, gamma, etc.)',
 	lowerRoman: 'Romeins kleine letters (i, ii, iii, iv, v, etc.)',
 	none: 'Geen',
 	notset: '<niet gezet>',

--- a/plugins/liststyle/lang/no.js
+++ b/plugins/liststyle/lang/no.js
@@ -3,15 +3,11 @@ Copyright (c) 2003-2018, CKSource - Frederico Knabben. All rights reserved.
 For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-oss-license
 */
 CKEDITOR.plugins.setLang( 'liststyle', 'no', {
-	armenian: 'Armensk nummerering',
 	bulletedTitle: 'Egenskaper for punktmerket liste',
 	circle: 'Sirkel',
 	decimal: 'Tall (1, 2, 3, osv.)',
-	decimalLeadingZero: 'Tall, med førstesiffer null (01, 02, 03, osv.)',
 	disc: 'Disk',
-	georgian: 'Georgisk nummerering (an, ban, gan, osv.)',
 	lowerAlpha: 'Alfabetisk, små (a, b, c, d, e, osv.)',
-	lowerGreek: 'Gresk, små (alpha, beta, gamma, osv.)',
 	lowerRoman: 'Romertall, små (i, ii, iii, iv, v, osv.)',
 	none: 'Ingen',
 	notset: '<ikke satt>',

--- a/plugins/liststyle/lang/oc.js
+++ b/plugins/liststyle/lang/oc.js
@@ -3,15 +3,11 @@ Copyright (c) 2003-2018, CKSource - Frederico Knabben. All rights reserved.
 For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-oss-license
 */
 CKEDITOR.plugins.setLang( 'liststyle', 'oc', {
-	armenian: 'Numerotacion armènia',
 	bulletedTitle: 'Proprietats de la lista de piuses',
 	circle: 'Cercle',
 	decimal: 'Decimal (1, 2, 3, etc.)',
-	decimalLeadingZero: 'Decimal precedit per un 0 (01, 02, 03, etc.)',
 	disc: 'Disc',
-	georgian: 'Numeracion georgiana (an, ban, gan, etc.)',
 	lowerAlpha: 'Letras minusculas (a, b, c, d, e, etc.)',
-	lowerGreek: 'Grèc minuscula (alfa, bèta, gamma, etc.)',
 	lowerRoman: 'Chifras romanas minusculas (i, ii, iii, iv, v, etc.)',
 	none: 'Pas cap',
 	notset: '<indefinit>',

--- a/plugins/liststyle/lang/pl.js
+++ b/plugins/liststyle/lang/pl.js
@@ -3,15 +3,11 @@ Copyright (c) 2003-2018, CKSource - Frederico Knabben. All rights reserved.
 For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-oss-license
 */
 CKEDITOR.plugins.setLang( 'liststyle', 'pl', {
-	armenian: 'Numerowanie armeńskie',
 	bulletedTitle: 'Właściwości list wypunktowanych',
 	circle: 'Koło',
 	decimal: 'Liczby (1, 2, 3 itd.)',
-	decimalLeadingZero: 'Liczby z początkowym zerem (01, 02, 03 itd.)',
 	disc: 'Okrąg',
-	georgian: 'Numerowanie gruzińskie (an, ban, gan itd.)',
 	lowerAlpha: 'Małe litery (a, b, c, d, e itd.)',
-	lowerGreek: 'Małe litery greckie (alpha, beta, gamma itd.)',
 	lowerRoman: 'Małe cyfry rzymskie (i, ii, iii, iv, v itd.)',
 	none: 'Brak',
 	notset: '<nie ustawiono>',

--- a/plugins/liststyle/lang/pt-br.js
+++ b/plugins/liststyle/lang/pt-br.js
@@ -3,15 +3,11 @@ Copyright (c) 2003-2018, CKSource - Frederico Knabben. All rights reserved.
 For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-oss-license
 */
 CKEDITOR.plugins.setLang( 'liststyle', 'pt-br', {
-	armenian: 'Numeração Armêna',
 	bulletedTitle: 'Propriedades da Lista sem Numeros',
 	circle: 'Círculo',
 	decimal: 'Numeração Decimal (1, 2, 3, etc.)',
-	decimalLeadingZero: 'Numeração Decimal com zeros (01, 02, 03, etc.)',
 	disc: 'Disco',
-	georgian: 'Numeração da Geórgia (an, ban, gan, etc.)',
 	lowerAlpha: 'Numeração Alfabética minúscula (a, b, c, d, e, etc.)',
-	lowerGreek: 'Numeração Grega minúscula (alpha, beta, gamma, etc.)',
 	lowerRoman: 'Numeração Romana minúscula (i, ii, iii, iv, v, etc.)',
 	none: 'Nenhum',
 	notset: '<não definido>',

--- a/plugins/liststyle/lang/pt.js
+++ b/plugins/liststyle/lang/pt.js
@@ -3,15 +3,11 @@ Copyright (c) 2003-2018, CKSource - Frederico Knabben. All rights reserved.
 For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-oss-license
 */
 CKEDITOR.plugins.setLang( 'liststyle', 'pt', {
-	armenian: 'Numeração armênia',
 	bulletedTitle: 'Propriedades da lista não numerada',
 	circle: 'Círculo',
 	decimal: 'Decimal (1, 2, 3, etc.)',
-	decimalLeadingZero: 'Zero decimal à esquerda (01, 02, 03, etc.)',
 	disc: 'Disco',
-	georgian: 'Numeração georgiana (an, ban, gan, etc.)',
 	lowerAlpha: 'Minúsculas (a, b, c, d, e, etc.)',
-	lowerGreek: 'Grego em minúsculas (alpha, beta, gamma, etc.)',
 	lowerRoman: 'Romano em minúsculas (i, ii, iii, iv, v, etc.)',
 	none: 'Nenhum',
 	notset: '<not set>',

--- a/plugins/liststyle/lang/ro.js
+++ b/plugins/liststyle/lang/ro.js
@@ -3,15 +3,11 @@ Copyright (c) 2003-2018, CKSource - Frederico Knabben. All rights reserved.
 For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-oss-license
 */
 CKEDITOR.plugins.setLang( 'liststyle', 'ro', {
-	armenian: 'Numerotare armeniană',
 	bulletedTitle: 'Proprietățile listei cu simboluri',
 	circle: 'Cerc',
 	decimal: 'Decimale (1, 2, 3, etc.)',
-	decimalLeadingZero: 'Decimale cu zero în față (01, 02, 03, etc.)',
 	disc: 'Disc',
-	georgian: 'Numerotare georgiană (an, ban, gan, etc.)',
 	lowerAlpha: 'Litere mici (a, b, c, d, e, etc.)',
-	lowerGreek: 'Litere grecești mici (alpha, beta, gamma, etc.)',
 	lowerRoman: 'Cifre romane mici (i, ii, iii, iv, v, etc.)',
 	none: 'Nimic',
 	notset: '<nesetat>',

--- a/plugins/liststyle/lang/ru.js
+++ b/plugins/liststyle/lang/ru.js
@@ -3,15 +3,11 @@ Copyright (c) 2003-2018, CKSource - Frederico Knabben. All rights reserved.
 For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-oss-license
 */
 CKEDITOR.plugins.setLang( 'liststyle', 'ru', {
-	armenian: 'Армянская нумерация',
 	bulletedTitle: 'Свойства маркированного списка',
 	circle: 'Круг',
 	decimal: 'Десятичные (1, 2, 3, и т.д.)',
-	decimalLeadingZero: 'Десятичные с ведущим нулём (01, 02, 03, и т.д.)',
 	disc: 'Окружность',
-	georgian: 'Грузинская нумерация (ани, бани, гани, и т.д.)',
 	lowerAlpha: 'Строчные латинские (a, b, c, d, e, и т.д.)',
-	lowerGreek: 'Строчные греческие (альфа, бета, гамма, и т.д.)',
 	lowerRoman: 'Строчные римские (i, ii, iii, iv, v, и т.д.)',
 	none: 'Нет',
 	notset: '<не указано>',

--- a/plugins/liststyle/lang/si.js
+++ b/plugins/liststyle/lang/si.js
@@ -3,15 +3,11 @@ Copyright (c) 2003-2018, CKSource - Frederico Knabben. All rights reserved.
 For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-oss-license
 */
 CKEDITOR.plugins.setLang( 'liststyle', 'si', {
-	armenian: 'Armenian numbering', // MISSING
 	bulletedTitle: 'Bulleted List Properties', // MISSING
 	circle: 'Circle', // MISSING
 	decimal: 'Decimal (1, 2, 3, etc.)', // MISSING
-	decimalLeadingZero: 'Decimal leading zero (01, 02, 03, etc.)', // MISSING
 	disc: 'Disc', // MISSING
-	georgian: 'Georgian numbering (an, ban, gan, etc.)', // MISSING
 	lowerAlpha: 'Lower Alpha (a, b, c, d, e, etc.)', // MISSING
-	lowerGreek: 'Lower Greek (alpha, beta, gamma, etc.)', // MISSING
 	lowerRoman: 'Lower Roman (i, ii, iii, iv, v, etc.)', // MISSING
 	none: 'කිසිවක්ම නොවේ',
 	notset: '<යොදා >',

--- a/plugins/liststyle/lang/sk.js
+++ b/plugins/liststyle/lang/sk.js
@@ -3,15 +3,11 @@ Copyright (c) 2003-2018, CKSource - Frederico Knabben. All rights reserved.
 For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-oss-license
 */
 CKEDITOR.plugins.setLang( 'liststyle', 'sk', {
-	armenian: 'Arménske číslovanie',
 	bulletedTitle: 'Vlastnosti odrážkového zoznamu',
 	circle: 'Kruh',
 	decimal: 'Číselné (1, 2, 3, atď.)',
-	decimalLeadingZero: 'Číselné s nulou (01, 02, 03, atď.)',
 	disc: 'Disk',
-	georgian: 'Gruzínske číslovanie (an, ban, gan, atď.)',
 	lowerAlpha: 'Malé latinské (a, b, c, d, e, atď.)',
-	lowerGreek: 'Malé grécke (alfa, beta, gama, atď.)',
 	lowerRoman: 'Malé rímske (i, ii, iii, iv, v, atď.)',
 	none: 'Nič',
 	notset: '<nenastavené>',

--- a/plugins/liststyle/lang/sl.js
+++ b/plugins/liststyle/lang/sl.js
@@ -3,15 +3,11 @@ Copyright (c) 2003-2018, CKSource - Frederico Knabben. All rights reserved.
 For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-oss-license
 */
 CKEDITOR.plugins.setLang( 'liststyle', 'sl', {
-	armenian: 'Armenian numbering',
 	bulletedTitle: 'Bulleted List Properties',
 	circle: 'Circle',
 	decimal: 'Decimal (1, 2, 3, etc.)',
-	decimalLeadingZero: 'Decimal leading zero (01, 02, 03, etc.)',
 	disc: 'Disc',
-	georgian: 'Georgian numbering (an, ban, gan, etc.)',
 	lowerAlpha: 'Lower Alpha (a, b, c, d, e, etc.)',
-	lowerGreek: 'Lower Greek (alpha, beta, gamma, etc.)',
 	lowerRoman: 'Lower Roman (i, ii, iii, iv, v, etc.)',
 	none: 'None',
 	notset: '<not set>',

--- a/plugins/liststyle/lang/sq.js
+++ b/plugins/liststyle/lang/sq.js
@@ -3,15 +3,11 @@ Copyright (c) 2003-2018, CKSource - Frederico Knabben. All rights reserved.
 For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-oss-license
 */
 CKEDITOR.plugins.setLang( 'liststyle', 'sq', {
-	armenian: 'Numërim armenian',
 	bulletedTitle: 'Karakteristikat e Listës me Pulla',
 	circle: 'Rreth',
 	decimal: 'Decimal (1, 2, 3, etj.)',
-	decimalLeadingZero: 'Decimal me zerro udhëheqëse (01, 02, 03, etj.)',
 	disc: 'Disk',
-	georgian: 'Numërim gjeorgjian (an, ban, gan, etj.)',
 	lowerAlpha: 'Të vogla alfa (a, b, c, d, e, etj.)',
-	lowerGreek: 'Të vogla greke (alpha, beta, gamma, etj.)',
 	lowerRoman: 'Të vogla romake (i, ii, iii, iv, v, etj.)',
 	none: 'Asnjë',
 	notset: '<e pazgjedhur>',

--- a/plugins/liststyle/lang/sr-latn.js
+++ b/plugins/liststyle/lang/sr-latn.js
@@ -3,15 +3,11 @@ Copyright (c) 2003-2018, CKSource - Frederico Knabben. All rights reserved.
 For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-oss-license
 */
 CKEDITOR.plugins.setLang( 'liststyle', 'sr-latn', {
-	armenian: 'Armenian numbering',
 	bulletedTitle: 'Bulleted List Properties',
 	circle: 'Circle',
 	decimal: 'Decimal (1, 2, 3, etc.)',
-	decimalLeadingZero: 'Decimal leading zero (01, 02, 03, etc.)',
 	disc: 'Disc',
-	georgian: 'Georgian numbering (an, ban, gan, etc.)',
 	lowerAlpha: 'Lower Alpha (a, b, c, d, e, etc.)',
-	lowerGreek: 'Lower Greek (alpha, beta, gamma, etc.)',
 	lowerRoman: 'Lower Roman (i, ii, iii, iv, v, etc.)',
 	none: 'None',
 	notset: '<not set>',

--- a/plugins/liststyle/lang/sr.js
+++ b/plugins/liststyle/lang/sr.js
@@ -3,15 +3,11 @@ Copyright (c) 2003-2018, CKSource - Frederico Knabben. All rights reserved.
 For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-oss-license
 */
 CKEDITOR.plugins.setLang( 'liststyle', 'sr', {
-	armenian: 'Armenian numbering',
 	bulletedTitle: 'Bulleted List Properties',
 	circle: 'Circle',
 	decimal: 'Decimal (1, 2, 3, etc.)',
-	decimalLeadingZero: 'Decimal leading zero (01, 02, 03, etc.)',
 	disc: 'Disc',
-	georgian: 'Georgian numbering (an, ban, gan, etc.)',
 	lowerAlpha: 'Lower Alpha (a, b, c, d, e, etc.)',
-	lowerGreek: 'Lower Greek (alpha, beta, gamma, etc.)',
 	lowerRoman: 'Lower Roman (i, ii, iii, iv, v, etc.)',
 	none: 'None',
 	notset: '<not set>',

--- a/plugins/liststyle/lang/sv.js
+++ b/plugins/liststyle/lang/sv.js
@@ -3,15 +3,11 @@ Copyright (c) 2003-2018, CKSource - Frederico Knabben. All rights reserved.
 For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-oss-license
 */
 CKEDITOR.plugins.setLang( 'liststyle', 'sv', {
-	armenian: 'Armenisk numrering',
 	bulletedTitle: 'Egenskaper för punktlista',
 	circle: 'Cirkel',
 	decimal: 'Decimal (1, 2, 3, etc.)',
-	decimalLeadingZero: 'Decimal nolla (01, 02, 03, etc.)',
 	disc: 'Disk',
-	georgian: 'Georgisk numrering (an, ban, gan, etc.)',
 	lowerAlpha: 'Alpha gemener (a, b, c, d, e, etc.)',
-	lowerGreek: 'Grekiska gemener (alpha, beta, gamma, etc.)',
 	lowerRoman: 'Romerska gemener (i, ii, iii, iv, v, etc.)',
 	none: 'Ingen',
 	notset: '<ej angiven>',

--- a/plugins/liststyle/lang/th.js
+++ b/plugins/liststyle/lang/th.js
@@ -3,15 +3,11 @@ Copyright (c) 2003-2018, CKSource - Frederico Knabben. All rights reserved.
 For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-oss-license
 */
 CKEDITOR.plugins.setLang( 'liststyle', 'th', {
-	armenian: 'Armenian numbering',
 	bulletedTitle: 'Bulleted List Properties',
 	circle: 'Circle',
 	decimal: 'Decimal (1, 2, 3, etc.)',
-	decimalLeadingZero: 'Decimal leading zero (01, 02, 03, etc.)',
 	disc: 'Disc',
-	georgian: 'Georgian numbering (an, ban, gan, etc.)',
 	lowerAlpha: 'Lower Alpha (a, b, c, d, e, etc.)',
-	lowerGreek: 'Lower Greek (alpha, beta, gamma, etc.)',
 	lowerRoman: 'Lower Roman (i, ii, iii, iv, v, etc.)',
 	none: 'None',
 	notset: '<not set>',

--- a/plugins/liststyle/lang/tr.js
+++ b/plugins/liststyle/lang/tr.js
@@ -3,15 +3,11 @@ Copyright (c) 2003-2018, CKSource - Frederico Knabben. All rights reserved.
 For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-oss-license
 */
 CKEDITOR.plugins.setLang( 'liststyle', 'tr', {
-	armenian: 'Ermenice sayılandırma',
 	bulletedTitle: 'Simgeli Liste Özellikleri',
 	circle: 'Daire',
 	decimal: 'Ondalık (1, 2, 3, vs.)',
-	decimalLeadingZero: 'Başı sıfırlı ondalık (01, 02, 03, vs.)',
 	disc: 'Disk',
-	georgian: 'Gürcüce numaralandırma (an, ban, gan, vs.)',
 	lowerAlpha: 'Küçük Alpha (a, b, c, d, e, vs.)',
-	lowerGreek: 'Küçük Greek (alpha, beta, gamma, vs.)',
 	lowerRoman: 'Küçük Roman (i, ii, iii, iv, v, vs.)',
 	none: 'Yok',
 	notset: '<ayarlanmamış>',

--- a/plugins/liststyle/lang/tt.js
+++ b/plugins/liststyle/lang/tt.js
@@ -3,15 +3,11 @@ Copyright (c) 2003-2018, CKSource - Frederico Knabben. All rights reserved.
 For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-oss-license
 */
 CKEDITOR.plugins.setLang( 'liststyle', 'tt', {
-	armenian: 'Әрмән номерлавы',
 	bulletedTitle: 'Маркерлы тезмә үзлекләре',
 	circle: 'Түгәрәк',
 	decimal: 'Унарлы (1, 2, 3, ...)',
-	decimalLeadingZero: 'Ноль белән башланган унарлы (01, 02, 03, ...)',
 	disc: 'Диск',
-	georgian: 'Georgian numbering (an, ban, gan, etc.)', // MISSING
 	lowerAlpha: 'Lower Alpha (a, b, c, d, e, etc.)', // MISSING
-	lowerGreek: 'Lower Greek (alpha, beta, gamma, etc.)', // MISSING
 	lowerRoman: 'Lower Roman (i, ii, iii, iv, v, etc.)', // MISSING
 	none: 'Һичбер',
 	notset: '<билгеләнмәгән>',

--- a/plugins/liststyle/lang/ug.js
+++ b/plugins/liststyle/lang/ug.js
@@ -3,15 +3,11 @@ Copyright (c) 2003-2018, CKSource - Frederico Knabben. All rights reserved.
 For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-oss-license
 */
 CKEDITOR.plugins.setLang( 'liststyle', 'ug', {
-	armenian: 'قەدىمكى ئەرمىنىيە تەرتىپ نومۇرى شەكلى',
 	bulletedTitle: 'تۈر بەلگە تىزىم خاسلىقى',
 	circle: 'بوش چەمبەر',
 	decimal: 'سان (1, 2, 3 قاتارلىق)',
-	decimalLeadingZero: 'نۆلدىن باشلانغان سان بەلگە (01, 02, 03 قاتارلىق)',
 	disc: 'تولدۇرۇلغان چەمبەر',
-	georgian: 'قەدىمكى جورجىيە تەرتىپ نومۇرى شەكلى (an, ban, gan قاتارلىق)',
 	lowerAlpha: 'ئىنگلىزچە كىچىك ھەرپ (a, b, c, d, e قاتارلىق)',
-	lowerGreek: 'گرېكچە كىچىك ھەرپ (alpha, beta, gamma قاتارلىق)',
 	lowerRoman: 'كىچىك ھەرپلىك رىم رەقىمى (i, ii, iii, iv, v قاتارلىق)',
 	none: 'بەلگە يوق',
 	notset: '‹تەڭشەلمىگەن›',

--- a/plugins/liststyle/lang/uk.js
+++ b/plugins/liststyle/lang/uk.js
@@ -3,15 +3,11 @@ Copyright (c) 2003-2018, CKSource - Frederico Knabben. All rights reserved.
 For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-oss-license
 */
 CKEDITOR.plugins.setLang( 'liststyle', 'uk', {
-	armenian: 'Вірменська нумерація',
 	bulletedTitle: 'Опції маркованого списку',
 	circle: 'Кільце',
 	decimal: 'Десяткові (1, 2, 3 і т.д.)',
-	decimalLeadingZero: 'Десяткові з нулем (01, 02, 03 і т.д.)',
 	disc: 'Кружечок',
-	georgian: 'Грузинська нумерація (an, ban, gan і т.д.)',
 	lowerAlpha: 'Малі лат. букви (a, b, c, d, e і т.д.)',
-	lowerGreek: 'Малі гр. букви (альфа, бета, гамма і т.д.)',
 	lowerRoman: 'Малі римські (i, ii, iii, iv, v і т.д.)',
 	none: 'Нема',
 	notset: '<не вказано>',

--- a/plugins/liststyle/lang/vi.js
+++ b/plugins/liststyle/lang/vi.js
@@ -3,15 +3,11 @@ Copyright (c) 2003-2018, CKSource - Frederico Knabben. All rights reserved.
 For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-oss-license
 */
 CKEDITOR.plugins.setLang( 'liststyle', 'vi', {
-	armenian: 'Số theo kiểu Armenian',
 	bulletedTitle: 'Thuộc tính danh sách không thứ tự',
 	circle: 'Khuyên tròn',
 	decimal: 'Kiểu số (1, 2, 3 ...)',
-	decimalLeadingZero: 'Kiểu số (01, 02, 03...)',
 	disc: 'Hình đĩa',
-	georgian: 'Số theo kiểu Georgian (an, ban, gan...)',
 	lowerAlpha: 'Kiểu abc thường (a, b, c, d, e...)',
-	lowerGreek: 'Kiểu Hy Lạp (alpha, beta, gamma...)',
 	lowerRoman: 'Số La Mã kiểu thường (i, ii, iii, iv, v...)',
 	none: 'Không gì cả',
 	notset: '<không thiết lập>',

--- a/plugins/liststyle/lang/zh-cn.js
+++ b/plugins/liststyle/lang/zh-cn.js
@@ -3,15 +3,11 @@ Copyright (c) 2003-2018, CKSource - Frederico Knabben. All rights reserved.
 For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-oss-license
 */
 CKEDITOR.plugins.setLang( 'liststyle', 'zh-cn', {
-	armenian: '传统的亚美尼亚编号方式',
 	bulletedTitle: '项目列表属性',
 	circle: '空心圆',
 	decimal: '数字 (1, 2, 3, 等)',
-	decimalLeadingZero: '0开头的数字标记(01, 02, 03, 等)',
 	disc: '实心圆',
-	georgian: '传统的乔治亚编号方式(an, ban, gan, 等)',
 	lowerAlpha: '小写英文字母(a, b, c, d, e, 等)',
-	lowerGreek: '小写希腊字母(alpha, beta, gamma, 等)',
 	lowerRoman: '小写罗马数字(i, ii, iii, iv, v, 等)',
 	none: '无标记',
 	notset: '<没有设置>',

--- a/plugins/liststyle/lang/zh.js
+++ b/plugins/liststyle/lang/zh.js
@@ -3,15 +3,11 @@ Copyright (c) 2003-2018, CKSource - Frederico Knabben. All rights reserved.
 For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-oss-license
 */
 CKEDITOR.plugins.setLang( 'liststyle', 'zh', {
-	armenian: '亞美尼亞數字',
 	bulletedTitle: '項目符號清單屬性',
 	circle: '圓圈',
 	decimal: '小數點 (1, 2, 3, etc.)',
-	decimalLeadingZero: '前綴 0 十位數字 (01, 02, 03, 等)',
 	disc: '圓點',
-	georgian: '喬治王時代數字 (an, ban, gan, 等)',
 	lowerAlpha: '小寫字母 (a, b, c, d, e 等)',
-	lowerGreek: '小寫希臘字母 (alpha, beta, gamma, 等)',
 	lowerRoman: '小寫羅馬數字 (i, ii, iii, iv, v 等)',
 	none: '無',
 	notset: '<未設定>',


### PR DESCRIPTION
## What is the purpose of this pull request?

Task

## What changes did you make?

We had some dead code in our numbered list plugin which I removed. I believe it doesn't require test coverage nor changelog.
I also removed unused language translations for this hidden plugin.

Closes #559
