### PR TITLE
Fix for: focused input in dialog is scrolled out of viewport when soft keyboard appears

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -29,6 +29,7 @@ Fixed Issues:
 * [#3379](https://github.com/ckeditor/ckeditor-dev/issues/3379): Fixed: Incorrect [`CKEDITOR.editor#getData`](https://ckeditor.com/docs/ckeditor4/latest/api/CKEDITOR_editor.html#method-getData) call when inserting content into the editor.
 * [#3136](https://github.com/ckeditor/ckeditor-dev/issues/3136) [Firefox] Fixed: Clicking on [Balloon Toolbar](https://ckeditor.com/cke4/addon/balloontoolbar) items removes native table selection.
 * [#3381](https://github.com/ckeditor/ckeditor-dev/issues/3381): [IE8] Fixed: [`CKEDITOR.tools.object.keys`](https://ckeditor.com/docs/ckeditor4/latest/api/CKEDITOR_tools_object.html#method-keys) does not accept non-objects.
+* [#2395](https://github.com/ckeditor/ckeditor-dev/issues/2395): Fixed: focused input in [dialog](https://ckeditor.com/cke4/addon/dialog) is scrolled out of viewport when soft keyboard appears.
 
 API Changes:
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -10,6 +10,7 @@ New Features:
     * [#3256](https://github.com/ckeditor/ckeditor-dev/issues/3256): Triple-clicking in last table cell and deleting content no longer pulls content below into table.
     * [#3118](https://github.com/ckeditor/ckeditor-dev/issues/3118): Selecting a paragraph with triple-click and applying heading applies heading only to selected paragraph.
     * [#3161](https://github.com/ckeditor/ckeditor-dev/issues/3161): Double click on a `span` element containing one word only creates correct selection including clicked `span` only.
+* [#3359](https://github.com/ckeditor/ckeditor-dev/issues/3359): Improved [dialog](https://ckeditor.com/cke4/addon/dialog) positioning and behaviour when browser window is resized, dialog resized or moved.
 
 Fixed Issues:
 
@@ -27,9 +28,10 @@ Fixed Issues:
 * [#3101](https://github.com/ckeditor/ckeditor-dev/issues/3101): Fixed: [`CKEDITOR.dom.range#_getTableElement()`](https://ckeditor.com/docs/ckeditor4/latest/api/CKEDITOR_dom_range.html#method-_getTableElement) returns `null` instead of a table element for edge cases.
 * [#3287](https://github.com/ckeditor/ckeditor-dev/issues/3287): Fixed: [`CKEDITOR.tools.promise`](https://ckeditor.com/docs/ckeditor4/latest/api/CKEDITOR_tools_promise.html) incorrectly initialized if an AMD loader is present.
 * [#3379](https://github.com/ckeditor/ckeditor-dev/issues/3379): Fixed: Incorrect [`CKEDITOR.editor#getData`](https://ckeditor.com/docs/ckeditor4/latest/api/CKEDITOR_editor.html#method-getData) call when inserting content into the editor.
-* [#3136](https://github.com/ckeditor/ckeditor-dev/issues/3136) [Firefox] Fixed: Clicking on [Balloon Toolbar](https://ckeditor.com/cke4/addon/balloontoolbar) items removes native table selection.
+* [#3136](https://github.com/ckeditor/ckeditor-dev/issues/3136): [Firefox] Fixed: Clicking on [Balloon Toolbar](https://ckeditor.com/cke4/addon/balloontoolbar) items removes native table selection.
 * [#3381](https://github.com/ckeditor/ckeditor-dev/issues/3381): [IE8] Fixed: [`CKEDITOR.tools.object.keys`](https://ckeditor.com/docs/ckeditor4/latest/api/CKEDITOR_tools_object.html#method-keys) does not accept non-objects.
-* [#2395](https://github.com/ckeditor/ckeditor-dev/issues/2395): Fixed: focused input in [dialog](https://ckeditor.com/cke4/addon/dialog) is scrolled out of viewport when soft keyboard appears.
+* [#2395](https://github.com/ckeditor/ckeditor-dev/issues/2395): [Android] Fixed: Focused input in [dialog](https://ckeditor.com/cke4/addon/dialog) is scrolled out of the viewport when soft keyboard appears.
+* [#453](https://github.com/ckeditor/ckeditor-dev/issues/453): Fixed: [Link](https://ckeditor.com/cke4/addon/link) dialog has invalid width when editor is maximized and browser window resized.
 
 API Changes:
 

--- a/core/dom/element.js
+++ b/core/dom/element.js
@@ -683,6 +683,19 @@ CKEDITOR.dom.element.clearMarkers = function( database, element, removeFromDatab
 		},
 
 		/**
+		 * Gets the elements `clientWidth` and `clientHeight`.
+		 *
+		 * @since 4.13.0
+		 * @returns {Object} An object containing width and height values.
+		 */
+		getClientSize: function() {
+			return {
+				width: this.$.clientWidth,
+				height: this.$.clientHeight
+			};
+		},
+
+		/**
 		 * Gets the current computed value of one of the element CSS style
 		 * properties.
 		 *

--- a/plugins/dialog/plugin.js
+++ b/plugins/dialog/plugin.js
@@ -786,46 +786,54 @@ CKEDITOR.DIALOG_STATE_BUSY = 2;
 		 * @param {Number} y The target y-coordinate.
 		 * @param {Boolean} save Flag indicate whether the dialog position should be remembered on next open up.
 		 */
-		move: function( x, y, save ) {
+		move: ( function() {
+			var fractionOfFreeSpace = {};
 
-			var element = this._.element.getFirst(), rtl = this._.editor.lang.dir == 'rtl';
+			return function( x, y, save ) {
+				var element = this._.element.getFirst(), rtl = this._.editor.lang.dir == 'rtl';
 
-			// (https://dev.ckeditor.com/ticket/8888) In some cases of a very small viewport, dialog is incorrectly
-			// positioned in IE7. It also happens that it remains sticky and user cannot
-			// scroll down/up to reveal dialog's content below/above the viewport; this is
-			// cumbersome.
-			// The only way to fix this is to move mouse out of the browser and
-			// go back to see that dialog position is automagically fixed. No events,
-			// no style change - pure magic. This is a IE7 rendering issue, which can be
-			// fixed with dummy style redraw on each move.
-			if ( CKEDITOR.env.ie )
-				element.setStyle( 'zoom', '100%' );
+				// (https://dev.ckeditor.com/ticket/8888) In some cases of a very small viewport, dialog is incorrectly
+				// positioned in IE7. It also happens that it remains sticky and user cannot
+				// scroll down/up to reveal dialog's content below/above the viewport; this is
+				// cumbersome.
+				// The only way to fix this is to move mouse out of the browser and
+				// go back to see that dialog position is automagically fixed. No events,
+				// no style change - pure magic. This is a IE7 rendering issue, which can be
+				// fixed with dummy style redraw on each move.
+				if ( CKEDITOR.env.ie ) {
+					element.setStyle( 'zoom', '100%' );
+				}
 
-			if ( this._.position && this._.position.x == x && this._.position.y == y )
-				return;
+				var viewPaneSize = CKEDITOR.document.getWindow().getViewPaneSize(),
+					dialogSize = this.getSize(),
+					freeSpace = {
+						width: viewPaneSize.width - dialogSize.width,
+						height: viewPaneSize.height - dialogSize.height
+					};
+				if ( this._.position && this._.position.x == x && this._.position.y == y ) {
+					// If position didn't change window might have been resized.
+					x = freeSpace.width * fractionOfFreeSpace.width;
+					y = freeSpace.height * fractionOfFreeSpace.height;
+				} else {
+					fractionOfFreeSpace.width = x / freeSpace.width;
+					fractionOfFreeSpace.height = y / freeSpace.height;
+				}
+				// Save the current position.
+				this._.position = { x: x, y: y };
 
-			// Save the current position.
-			this._.position = { x: x, y: y };
+				// Translate coordinate for RTL.
+				if ( rtl ) {
+					x = freeSpace.width - x;
+				}
 
-			var viewPaneSize = CKEDITOR.document.getWindow().getViewPaneSize();
+				var styles = { 'top': ( y > 0 ? y : 0 ) + 'px' };
+				styles[ rtl ? 'right' : 'left' ] = ( x > 0 ? x : 0 ) + 'px';
 
-			// Translate coordinate for RTL.
-			if ( rtl ) {
-				var dialogSize = this.getSize();
-				x = viewPaneSize.width - dialogSize.width - x;
-			}
+				element.setStyles( styles );
 
-			// Recalculate pixes into percentages.
-			x = x / viewPaneSize.width * 100;
-			y = y / viewPaneSize.height * 100;
-
-			var styles = { 'top': ( y > 0 ? y : 0 ) + '%' };
-			styles[ rtl ? 'right' : 'left' ] = ( x > 0 ? x : 0 ) + '%';
-
-			element.setStyles( styles );
-
-			save && ( this._.moved = 1 );
-		},
+				save && ( this._.moved = 1 );
+			};
+		} )(),
 
 		/**
 		 * Gets the dialog's position in the window.
@@ -928,9 +936,7 @@ CKEDITOR.DIALOG_STATE_BUSY = 2;
 
 			CKEDITOR.tools.setTimeout( function() {
 				this.layout();
-				if ( CKEDITOR.env.ie && !CKEDITOR.env.edge ) {
-					resizeWithWindow( this );
-				}
+				resizeWithWindow( this );
 
 				this.parts.dialog.setStyle( 'visibility', '' );
 

--- a/plugins/dialog/plugin.js
+++ b/plugins/dialog/plugin.js
@@ -2123,8 +2123,7 @@ CKEDITOR.DIALOG_STATE_BUSY = 2;
 		}
 	}
 
-	// Caching reusable covers and allowing only one cover
-	// on screen.
+	// Caching reusable covers and allowing only one cover on screen.
 	var covers = {},
 		currentCover;
 

--- a/plugins/dialog/plugin.js
+++ b/plugins/dialog/plugin.js
@@ -2119,7 +2119,7 @@ CKEDITOR.DIALOG_STATE_BUSY = 2;
 		}
 	}
 
-	// Caching resuable covers and allowing only one cover
+	// Caching reusable covers and allowing only one cover
 	// on screen.
 	var covers = {},
 		currentCover;

--- a/plugins/dialog/plugin.js
+++ b/plugins/dialog/plugin.js
@@ -137,12 +137,14 @@ CKEDITOR.DIALOG_STATE_BUSY = 2;
 
 	var templateSource = '<div class="cke_reset_all cke_dialog_container {editorId} {editorDialogClass} {hidpi}' +
 		'" dir="{langDir}"' +
+		' style="' + ( !CKEDITOR.env.ie || CKEDITOR.env.edge ? 'display:flex' : '' ) + '"' +
 		' lang="{langCode}"' +
 		' role="dialog"' +
 		' aria-labelledby="cke_dialog_title_{id}"' +
 		'>' +
 		'<table class="cke_dialog ' + CKEDITOR.env.cssClass + ' cke_{langDir}"' +
-			' style="position:absolute" role="presentation">' +
+			' style="' + ( !CKEDITOR.env.ie || CKEDITOR.env.edge ? 'margin:auto' : 'position:absolute' ) + '"' +
+			' role="presentation">' +
 			'<tr><td role="presentation">' +
 			'<div class="cke_dialog_body" role="presentation">' +
 				'<div id="cke_dialog_title_{id}" class="cke_dialog_title" role="presentation"></div>' +
@@ -838,10 +840,13 @@ CKEDITOR.DIALOG_STATE_BUSY = 2;
 			// Insert the dialog's element to the root document.
 			var element = this._.element;
 			var definition = this.definition;
-			if ( !( element.getParent() && element.getParent().equals( CKEDITOR.document.getBody() ) ) )
+
+			if ( !( element.getParent() && element.getParent().equals( CKEDITOR.document.getBody() ) ) ) {
 				element.appendTo( CKEDITOR.document.getBody() );
-			else
-				element.setStyle( 'display', 'block' );
+			} else {
+				var display = ( !CKEDITOR.env.ie && CKEDITOR.env.edge ) ? 'block' : 'flex';
+				element.setStyle( 'display', display );
+			}
 
 			// First, set the dialog to an appropriate size.
 			this.resize(
@@ -948,10 +953,6 @@ CKEDITOR.DIALOG_STATE_BUSY = 2;
 			var el = this.parts.dialog;
 
 			if ( !this._.moved && ( !CKEDITOR.env.ie || CKEDITOR.env.edge ) ) {
-				el.removeStyle( 'position' );
-				el.setStyle( 'margin', 'auto' );
-				el.getParent().setStyle( 'display', 'flex' );
-
 				return;
 			}
 

--- a/plugins/dialog/plugin.js
+++ b/plugins/dialog/plugin.js
@@ -807,14 +807,20 @@ CKEDITOR.DIALOG_STATE_BUSY = 2;
 			// Save the current position.
 			this._.position = { x: x, y: y };
 
+			var viewPaneSize = CKEDITOR.document.getWindow().getViewPaneSize();
+
 			// Translate coordinate for RTL.
 			if ( rtl ) {
-				var dialogSize = this.getSize(), viewPaneSize = CKEDITOR.document.getWindow().getViewPaneSize();
+				var dialogSize = this.getSize();
 				x = viewPaneSize.width - dialogSize.width - x;
 			}
 
-			var styles = { 'top': ( y > 0 ? y : 0 ) + 'px' };
-			styles[ rtl ? 'right' : 'left' ] = ( x > 0 ? x : 0 ) + 'px';
+			// Recalculate pixes into percentages.
+			x = x / viewPaneSize.width * 100;
+			y = y / viewPaneSize.height * 100;
+
+			var styles = { 'top': ( y > 0 ? y : 0 ) + '%' };
+			styles[ rtl ? 'right' : 'left' ] = ( x > 0 ? x : 0 ) + '%';
 
 			element.setStyles( styles );
 

--- a/plugins/dialog/plugin.js
+++ b/plugins/dialog/plugin.js
@@ -258,6 +258,7 @@ CKEDITOR.DIALOG_STATE_BUSY = 2;
 			contents: {},
 			buttons: {},
 			accessKeyMap: {},
+			viewportRatio: {},
 
 			// Initialize the tab and page map.
 			tabs: {},
@@ -717,8 +718,6 @@ CKEDITOR.DIALOG_STATE_BUSY = 2;
 		} );
 	}
 
-	var dialogViewportRatio = {};
-
 	CKEDITOR.dialog.prototype = {
 		destroy: function() {
 			this.hide();
@@ -811,11 +810,11 @@ CKEDITOR.DIALOG_STATE_BUSY = 2;
 				};
 			if ( this._.position && this._.position.x == x && this._.position.y == y ) {
 				// If position didn't change window might have been resized.
-				x = freeSpace.width * dialogViewportRatio.width;
-				y = freeSpace.height * dialogViewportRatio.height;
+				x = freeSpace.width * this._.viewportRatio.width;
+				y = freeSpace.height * this._.viewportRatio.height;
 			} else {
-				dialogViewportRatio.width = x / freeSpace.width;
-				dialogViewportRatio.height = y / freeSpace.height;
+				this._.viewportRatio.width = x / freeSpace.width;
+				this._.viewportRatio.height = y / freeSpace.height;
 			}
 			// Save the current position.
 			this._.position = { x: x, y: y };

--- a/plugins/dialog/plugin.js
+++ b/plugins/dialog/plugin.js
@@ -853,8 +853,7 @@ CKEDITOR.DIALOG_STATE_BUSY = 2;
 			if ( !( element.getParent() && element.getParent().equals( CKEDITOR.document.getBody() ) ) ) {
 				element.appendTo( CKEDITOR.document.getBody() );
 			} else {
-				var display = ( !CKEDITOR.env.ie && CKEDITOR.env.edge ) ? 'block' : 'flex';
-				element.setStyle( 'display', display );
+				element.setStyle( 'display', CKEDITOR.env.ie && !CKEDITOR.env.edge ? 'block' : 'flex' );
 			}
 
 			// First, set the dialog to an appropriate size.

--- a/plugins/dialog/plugin.js
+++ b/plugins/dialog/plugin.js
@@ -283,10 +283,13 @@ CKEDITOR.DIALOG_STATE_BUSY = 2;
 		// Set the startup styles for the dialog, avoiding it enlarging the
 		// page size on the dialog creation.
 		var startStyles = {
-			position: CKEDITOR.env.ie6Compat ? 'absolute' : 'static',
 			top: 0,
 			visibility: 'hidden'
 		};
+
+		if ( CKEDITOR.env.ie6Compat ) {
+			startStyles.position = 'absolute';
+		}
 
 		startStyles[ dir == 'rtl' ? 'right' : 'left' ] = 0;
 		this.parts.dialog.setStyles( startStyles );

--- a/plugins/dialog/plugin.js
+++ b/plugins/dialog/plugin.js
@@ -972,17 +972,9 @@ CKEDITOR.DIALOG_STATE_BUSY = 2;
 				posY = ( viewSize.height - dialogSize.height ) / 2;
 			}
 
-			// Switch to absolute position when viewport is smaller than dialog size.
 			if ( !CKEDITOR.env.ie6Compat ) {
-				if ( dialogSize.height + ( posY > 0 ? posY : 0 ) > viewSize.height || dialogSize.width + ( posX > 0 ? posX : 0 ) > viewSize.width ) {
-					el.setStyles( {
-						position: 'static',
-						margin: 'auto'
-					} );
-				} else {
-					el.setStyle( 'position', 'absolute' );
-					el.removeStyle( 'margin' );
-				}
+				el.setStyle( 'position', 'absolute' );
+				el.removeStyle( 'margin' );
 			}
 
 			this.move( posX, posY );

--- a/plugins/dialog/plugin.js
+++ b/plugins/dialog/plugin.js
@@ -2124,14 +2124,6 @@ CKEDITOR.DIALOG_STATE_BUSY = 2;
 		ev.data.preventDefault( 1 );
 	}
 
-	function hideBodyScrollbars() {
-		CKEDITOR.document.getBody().addClass( 'cke_dialog_open' );
-	}
-
-	function showBodyScrollbars() {
-		CKEDITOR.document.getBody().removeClass( 'cke_dialog_open' );
-	}
-
 	function showCover( editor ) {
 		var win = CKEDITOR.document.getWindow(),
 			config = editor.config,
@@ -2142,7 +2134,7 @@ CKEDITOR.DIALOG_STATE_BUSY = 2;
 			coverKey = CKEDITOR.tools.genKey( backgroundColorStyle, backgroundCoverOpacity, baseFloatZIndex ),
 			coverElement = covers[ coverKey ];
 
-		hideBodyScrollbars();
+		CKEDITOR.document.getBody().addClass( 'cke_dialog_open' );
 
 		if ( !coverElement ) {
 			var html = [
@@ -2240,7 +2232,7 @@ CKEDITOR.DIALOG_STATE_BUSY = 2;
 	}
 
 	function hideCover( editor ) {
-		showBodyScrollbars();
+		CKEDITOR.document.getBody().removeClass( 'cke_dialog_open' );
 		if ( !currentCover )
 			return;
 

--- a/plugins/dialog/plugin.js
+++ b/plugins/dialog/plugin.js
@@ -135,33 +135,34 @@ CKEDITOR.DIALOG_STATE_BUSY = 2;
 		input && input.removeAttribute( 'aria-invalid' );
 	}
 
-	var templateSource = '<div class="cke_reset_all cke_dialog_container {editorId} {editorDialogClass} {hidpi}' +
-		'" dir="{langDir}"' +
-		' style="' + ( !CKEDITOR.env.ie || CKEDITOR.env.edge ? 'display:flex' : '' ) + '"' +
-		' lang="{langCode}"' +
-		' role="dialog"' +
-		' aria-labelledby="cke_dialog_title_{id}"' +
-		'>' +
-		'<table class="cke_dialog ' + CKEDITOR.env.cssClass + ' cke_{langDir}"' +
-			' style="' + ( !CKEDITOR.env.ie || CKEDITOR.env.edge ? 'margin:auto' : 'position:absolute' ) + '"' +
-			' role="presentation">' +
-			'<tr><td role="presentation">' +
-			'<div class="cke_dialog_body" role="presentation">' +
-				'<div id="cke_dialog_title_{id}" class="cke_dialog_title" role="presentation"></div>' +
-				'<a id="cke_dialog_close_button_{id}" class="cke_dialog_close_button" href="javascript:void(0)" title="{closeTitle}" role="button"><span class="cke_label">X</span></a>' +
-				'<div id="cke_dialog_tabs_{id}" class="cke_dialog_tabs" role="tablist"></div>' +
-				'<table class="cke_dialog_contents" role="presentation">' +
-				'<tr>' +
-					'<td id="cke_dialog_contents_{id}" class="cke_dialog_contents_body" role="presentation"></td>' +
-				'</tr>' +
-				'<tr>' +
-					'<td id="cke_dialog_footer_{id}" class="cke_dialog_footer" role="presentation"></td>' +
-				'</tr>' +
-				'</table>' +
-			'</div>' +
-			'</td></tr>' +
-		'</table>' +
-		'</div>';
+	var useFlex = !CKEDITOR.env.ie || CKEDITOR.env.edge,
+		templateSource = '<div class="cke_reset_all cke_dialog_container {editorId} {editorDialogClass} {hidpi}' +
+			'" dir="{langDir}"' +
+			' style="' + ( useFlex ? 'display:flex' : '' ) + '"' +
+			' lang="{langCode}"' +
+			' role="dialog"' +
+			' aria-labelledby="cke_dialog_title_{id}"' +
+			'>' +
+			'<table class="cke_dialog ' + CKEDITOR.env.cssClass + ' cke_{langDir}"' +
+				' style="' + ( useFlex ? 'margin:auto' : 'position:absolute' ) + '"' +
+				' role="presentation">' +
+				'<tr><td role="presentation">' +
+				'<div class="cke_dialog_body" role="presentation">' +
+					'<div id="cke_dialog_title_{id}" class="cke_dialog_title" role="presentation"></div>' +
+					'<a id="cke_dialog_close_button_{id}" class="cke_dialog_close_button" href="javascript:void(0)" title="{closeTitle}" role="button"><span class="cke_label">X</span></a>' +
+					'<div id="cke_dialog_tabs_{id}" class="cke_dialog_tabs" role="tablist"></div>' +
+					'<table class="cke_dialog_contents" role="presentation">' +
+					'<tr>' +
+						'<td id="cke_dialog_contents_{id}" class="cke_dialog_contents_body" role="presentation"></td>' +
+					'</tr>' +
+					'<tr>' +
+						'<td id="cke_dialog_footer_{id}" class="cke_dialog_footer" role="presentation"></td>' +
+					'</tr>' +
+					'</table>' +
+				'</div>' +
+				'</td></tr>' +
+			'</table>' +
+			'</div>';
 
 	function buildDialog( editor ) {
 		var element = CKEDITOR.dom.element.createFromHtml( CKEDITOR.addTemplate( 'dialog', templateSource ).output( {
@@ -963,7 +964,7 @@ CKEDITOR.DIALOG_STATE_BUSY = 2;
 		layout: function() {
 			var el = this.parts.dialog;
 
-			if ( !this._.moved && ( !CKEDITOR.env.ie || CKEDITOR.env.edge ) ) {
+			if ( !this._.moved && ( useFlex ) ) {
 				return;
 			}
 

--- a/plugins/dialog/plugin.js
+++ b/plugins/dialog/plugin.js
@@ -806,8 +806,8 @@ CKEDITOR.DIALOG_STATE_BUSY = 2;
 			var viewPaneSize = CKEDITOR.document.getWindow().getViewPaneSize(),
 				dialogSize = this.getSize(),
 				freeSpace = {
-					width: viewPaneSize.width - dialogSize.width,
-					height: viewPaneSize.height - dialogSize.height
+					width: Math.max( viewPaneSize.width - dialogSize.width, 0 ),
+					height: Math.max( viewPaneSize.height - dialogSize.height, 0 )
 				};
 			if ( this._.position && this._.position.x == x && this._.position.y == y ) {
 				// If position didn't change window might have been resized.

--- a/plugins/dialog/plugin.js
+++ b/plugins/dialog/plugin.js
@@ -2105,7 +2105,7 @@ CKEDITOR.DIALOG_STATE_BUSY = 2;
 				internalWidth = width + dx * ( dialog._.moved ? 1 : 2 ),
 				internalHeight = height + dy * ( dialog._.moved ? 1 : 2 ),
 				element = dialog._.element.getFirst(),
-				right = rtl && CKEDITOR.tools.convertToPx( element.getComputedStyle( 'right' ) ),
+				right = rtl && parseInt( element.getComputedStyle( 'right' ) ),
 				position = dialog.getPosition();
 
 			position.x = position.x || 0;

--- a/plugins/dialog/plugin.js
+++ b/plugins/dialog/plugin.js
@@ -2108,7 +2108,7 @@ CKEDITOR.DIALOG_STATE_BUSY = 2;
 				internalWidth = width + dx * ( dialog._.moved ? 1 : 2 ),
 				internalHeight = height + dy * ( dialog._.moved ? 1 : 2 ),
 				element = dialog._.element.getFirst(),
-				right = rtl && element.getComputedStyle( 'right' ),
+				right = rtl && CKEDITOR.tools.convertToPx( element.getComputedStyle( 'right' ) ),
 				position = dialog.getPosition();
 
 			position.x = position.x || 0;

--- a/plugins/dialog/plugin.js
+++ b/plugins/dialog/plugin.js
@@ -2087,18 +2087,22 @@ CKEDITOR.DIALOG_STATE_BUSY = 2;
 				right = rtl && element.getComputedStyle( 'right' ),
 				position = dialog.getPosition();
 
-			if ( position.y + internalHeight > viewSize.height )
+			if ( position.y + internalHeight > viewSize.height ) {
 				internalHeight = viewSize.height - position.y;
+			}
 
-			if ( ( rtl ? right : position.x ) + internalWidth > viewSize.width )
+			if ( ( rtl ? right : position.x ) + internalWidth > viewSize.width ) {
 				internalWidth = viewSize.width - ( rtl ? right : position.x );
+			}
 
 			// Make sure the dialog will not be resized to the wrong side when it's in the leftmost position for RTL.
-			if ( ( resizable == CKEDITOR.DIALOG_RESIZE_WIDTH || resizable == CKEDITOR.DIALOG_RESIZE_BOTH ) )
+			if ( resizable == CKEDITOR.DIALOG_RESIZE_WIDTH || resizable == CKEDITOR.DIALOG_RESIZE_BOTH ) {
 				width = Math.max( def.minWidth || 0, internalWidth - wrapperWidth );
+			}
 
-			if ( resizable == CKEDITOR.DIALOG_RESIZE_HEIGHT || resizable == CKEDITOR.DIALOG_RESIZE_BOTH )
+			if ( resizable == CKEDITOR.DIALOG_RESIZE_HEIGHT || resizable == CKEDITOR.DIALOG_RESIZE_BOTH ) {
 				height = Math.max( def.minHeight || 0, internalHeight - wrapperHeight );
+			}
 
 			dialog.resize( width, height );
 

--- a/plugins/dialog/plugin.js
+++ b/plugins/dialog/plugin.js
@@ -815,15 +815,17 @@ CKEDITOR.DIALOG_STATE_BUSY = 2;
 					width: Math.max( viewPaneSize.width - dialogSize.width, 0 ),
 					height: Math.max( viewPaneSize.height - dialogSize.height, 0 )
 				};
+
 			if ( this._.position && this._.position.x == x && this._.position.y == y ) {
 				// If position didn't change window might have been resized.
-				x = freeSpace.width * ratios.width;
-				y = freeSpace.height * ratios.height;
+				x = Math.floor( freeSpace.width * ratios.width );
+				y = Math.floor( freeSpace.height * ratios.height );
 			} else {
 				// When no free space don't divide by zero, use previous value.
 				ratios.width = freeSpace.width ? ( x / freeSpace.width ) : ratios.width;
 				ratios.height = freeSpace.height ? ( y / freeSpace.height ) : ratios.height;
 			}
+
 			// Save the current position.
 			this._.position = { x: x, y: y };
 

--- a/plugins/dialog/plugin.js
+++ b/plugins/dialog/plugin.js
@@ -869,7 +869,7 @@ CKEDITOR.DIALOG_STATE_BUSY = 2;
 			if ( !( element.getParent() && element.getParent().equals( CKEDITOR.document.getBody() ) ) ) {
 				element.appendTo( CKEDITOR.document.getBody() );
 			} else {
-				element.setStyle( 'display', useFlex ? 'flex' :'block' );
+				element.setStyle( 'display', useFlex ? 'flex' : 'block' );
 			}
 
 			// First, set the dialog to an appropriate size.

--- a/plugins/dialog/plugin.js
+++ b/plugins/dialog/plugin.js
@@ -987,6 +987,9 @@ CKEDITOR.DIALOG_STATE_BUSY = 2;
 				el.removeStyle( 'margin' );
 			}
 
+			posX = Math.floor( posX );
+			posY = Math.floor( posY );
+
 			this.move( posX, posY );
 		},
 
@@ -1953,19 +1956,24 @@ CKEDITOR.DIALOG_STATE_BUSY = 2;
 			abstractDialogCoords.x += dx;
 			abstractDialogCoords.y += dy;
 
-			if ( abstractDialogCoords.x + margins[ 3 ] < magnetDistance )
+			if ( abstractDialogCoords.x + margins[ 3 ] < magnetDistance ) {
 				realX = -margins[ 3 ];
-			else if ( abstractDialogCoords.x - margins[ 1 ] > viewPaneSize.width - dialogSize.width - magnetDistance )
+			} else if ( abstractDialogCoords.x - margins[ 1 ] > viewPaneSize.width - dialogSize.width - magnetDistance ) {
 				realX = viewPaneSize.width - dialogSize.width + ( editor.lang.dir == 'rtl' ? 0 : margins[ 1 ] );
-			else
+			} else {
 				realX = abstractDialogCoords.x;
+			}
 
-			if ( abstractDialogCoords.y + margins[ 0 ] < magnetDistance )
+			if ( abstractDialogCoords.y + margins[ 0 ] < magnetDistance ) {
 				realY = -margins[ 0 ];
-			else if ( abstractDialogCoords.y - margins[ 2 ] > viewPaneSize.height - dialogSize.height - magnetDistance )
+			} else if ( abstractDialogCoords.y - margins[ 2 ] > viewPaneSize.height - dialogSize.height - magnetDistance ) {
 				realY = viewPaneSize.height - dialogSize.height + margins[ 2 ];
-			else
+			} else {
 				realY = abstractDialogCoords.y;
+			}
+
+			realX = Math.floor( realX );
+			realY = Math.floor( realY );
 
 			dialog.move( realX, realY, 1 );
 
@@ -2033,9 +2041,15 @@ CKEDITOR.DIALOG_STATE_BUSY = 2;
 				content.append( dialogCover );
 			}
 
+			var isBorderBox = !( CKEDITOR.env.gecko || CKEDITOR.env.ie && CKEDITOR.env.quirks ),
+				heightStyle = content.getStyle( 'height' ),
+				widthStyle = content.getStyle( 'width' ),
+				toPx = CKEDITOR.tools.convertToPx;
+
 			// Calculate the offset between content and chrome size.
-			wrapperHeight = startSize.height - dialog.parts.contents.getSize( 'height', !( CKEDITOR.env.gecko || CKEDITOR.env.ie && CKEDITOR.env.quirks ) );
-			wrapperWidth = startSize.width - dialog.parts.contents.getSize( 'width', 1 );
+			// Use inline style, because of (#3144), fallback to `element.getSize`.
+			wrapperHeight = startSize.height - ( heightStyle ? toPx( heightStyle ) : content.getSize( 'height', isBorderBox ) );
+			wrapperWidth = startSize.width - ( widthStyle ? toPx( widthStyle ) : content.getSize( 'width', 1 ) );
 
 			origin = { x: $event.screenX, y: $event.screenY };
 
@@ -2094,6 +2108,9 @@ CKEDITOR.DIALOG_STATE_BUSY = 2;
 			if ( ( rtl ? right : position.x ) + internalWidth > viewSize.width ) {
 				internalWidth = viewSize.width - ( rtl ? right : position.x );
 			}
+
+			internalHeight = Math.floor( internalHeight );
+			internalWidth = Math.floor( internalWidth );
 
 			// Make sure the dialog will not be resized to the wrong side when it's in the leftmost position for RTL.
 			if ( resizable == CKEDITOR.DIALOG_RESIZE_WIDTH || resizable == CKEDITOR.DIALOG_RESIZE_BOTH ) {

--- a/plugins/dialog/plugin.js
+++ b/plugins/dialog/plugin.js
@@ -2234,40 +2234,9 @@ CKEDITOR.DIALOG_STATE_BUSY = 2;
 
 		currentCover = coverElement;
 
-		var scrollFunc = function() {
-				var pos = win.getScrollPosition(),
-					cursor = CKEDITOR.dialog._.currentTop;
-				coverElement.setStyles( {
-					left: pos.x + 'px',
-					top: pos.y + 'px'
-				} );
-
-				if ( cursor ) {
-					do {
-						var dialogPos = cursor.getPosition();
-						cursor.move( dialogPos.x, dialogPos.y );
-					} while ( ( cursor = cursor._.parentDialog ) );
-				}
-			};
-
 		// Using Safari/Mac, focus must be kept where it is (https://dev.ckeditor.com/ticket/7027)
 		if ( !( CKEDITOR.env.mac && CKEDITOR.env.webkit ) )
 			coverElement.focus();
-
-		if ( CKEDITOR.env.ie6Compat ) {
-			// IE BUG: win.$.onscroll assignment doesn't work.. it must be window.onscroll.
-			// So we need to invent a really funny way to make it work.
-			var myScrollHandler = function() {
-					scrollFunc();
-					myScrollHandler.prevScrollHandler.apply( this, arguments );
-				};
-			win.$.setTimeout( function() {
-				myScrollHandler.prevScrollHandler = window.onscroll ||
-				function() {};
-				window.onscroll = myScrollHandler;
-			}, 0 );
-			scrollFunc();
-		}
 	}
 
 	function hideCover( editor ) {
@@ -2278,13 +2247,6 @@ CKEDITOR.DIALOG_STATE_BUSY = 2;
 		editor.focusManager.remove( currentCover );
 		var win = CKEDITOR.document.getWindow();
 		currentCover.hide();
-
-		if ( CKEDITOR.env.ie6Compat ) {
-			win.$.setTimeout( function() {
-				var prevScrollHandler = window.onscroll && window.onscroll.prevScrollHandler;
-				window.onscroll = prevScrollHandler || null;
-			}, 0 );
-		}
 	}
 
 	function removeCovers() {

--- a/plugins/dialog/plugin.js
+++ b/plugins/dialog/plugin.js
@@ -3394,9 +3394,16 @@ CKEDITOR.DIALOG_STATE_BUSY = 2;
 	} );
 } )();
 
+var stylesLoaded = false;
+
 CKEDITOR.plugins.add( 'dialog', {
 	requires: 'dialogui',
 	init: function( editor ) {
+		if ( !stylesLoaded ) {
+			CKEDITOR.document.appendStyleSheet( this.path + 'styles/dialog.css' );
+			stylesLoaded = true;
+		}
+
 		editor.on( 'doubleclick', function( evt ) {
 			if ( evt.data.dialog )
 				editor.openDialog( evt.data.dialog );

--- a/plugins/dialog/plugin.js
+++ b/plugins/dialog/plugin.js
@@ -764,9 +764,9 @@ CKEDITOR.DIALOG_STATE_BUSY = 2;
 
 			// Update dialog position when dimension get changed in RTL.
 			if ( this._.editor.lang.dir == 'rtl' && this._.position ) {
-				var viewPaneWidth = CKEDITOR.document.getWindow().getViewPaneSize().width;
+				var containerWidth = getContainerSize( this ).width;
 
-				this._.position.x = viewPaneWidth - this._.contentSize.width - parseInt( this._.element.getFirst().getStyle( 'right' ), 10 );
+				this._.position.x = containerWidth - this._.contentSize.width - parseInt( this._.element.getFirst().getStyle( 'right' ), 10 );
 			}
 
 			this._.contentSize = { width: width, height: height };
@@ -811,12 +811,12 @@ CKEDITOR.DIALOG_STATE_BUSY = 2;
 				element.setStyle( 'zoom', '100%' );
 			}
 
-			var viewPaneSize = CKEDITOR.document.getWindow().getViewPaneSize(),
+			var containerSize = getContainerSize( this ),
 				dialogSize = this.getSize(),
 				ratios = this._.viewportRatio,
 				freeSpace = {
-					width: Math.max( viewPaneSize.width - dialogSize.width, 0 ),
-					height: Math.max( viewPaneSize.height - dialogSize.height, 0 )
+					width: Math.max( containerSize.width - dialogSize.width, 0 ),
+					height: Math.max( containerSize.height - dialogSize.height, 0 )
 				};
 
 			if ( this._.position && this._.position.x == x && this._.position.y == y ) {
@@ -1955,7 +1955,7 @@ CKEDITOR.DIALOG_STATE_BUSY = 2;
 
 		function mouseMoveHandler( evt ) {
 			var dialogSize = dialog.getSize(),
-				viewPaneSize = CKEDITOR.document.getWindow().getViewPaneSize(),
+				containerSize = getContainerSize( dialog ),
 				x = evt.data.$.screenX,
 				y = evt.data.$.screenY,
 				dx = x - lastCoords.x,
@@ -1968,16 +1968,16 @@ CKEDITOR.DIALOG_STATE_BUSY = 2;
 
 			if ( abstractDialogCoords.x + margins[ 3 ] < magnetDistance ) {
 				realX = -margins[ 3 ];
-			} else if ( abstractDialogCoords.x - margins[ 1 ] > viewPaneSize.width - dialogSize.width - magnetDistance ) {
-				realX = viewPaneSize.width - dialogSize.width + ( editor.lang.dir == 'rtl' ? 0 : margins[ 1 ] );
+			} else if ( abstractDialogCoords.x - margins[ 1 ] > containerSize.width - dialogSize.width - magnetDistance ) {
+				realX = containerSize.width - dialogSize.width + ( editor.lang.dir == 'rtl' ? 0 : margins[ 1 ] );
 			} else {
 				realX = abstractDialogCoords.x;
 			}
 
 			if ( abstractDialogCoords.y + margins[ 0 ] < magnetDistance ) {
 				realY = -margins[ 0 ];
-			} else if ( abstractDialogCoords.y - margins[ 2 ] > viewPaneSize.height - dialogSize.height - magnetDistance ) {
-				realY = viewPaneSize.height - dialogSize.height + margins[ 2 ];
+			} else if ( abstractDialogCoords.y - margins[ 2 ] > containerSize.height - dialogSize.height - magnetDistance ) {
+				realY = containerSize.height - dialogSize.height + margins[ 2 ];
 			} else {
 				realY = abstractDialogCoords.y;
 			}
@@ -2166,13 +2166,22 @@ CKEDITOR.DIALOG_STATE_BUSY = 2;
 		}
 	}
 
+	function getContainerSize( dialog ) {
+		var container = dialog.parts.dialog.getParent();
+
+		return {
+			width: container.$.clientWidth,
+			height: container.$.clientHeight
+		}
+	}
+
 	function updateRatios( dialog, x, y ) {
-		var viewPaneSize = CKEDITOR.document.getWindow().getViewPaneSize(),
+		var containerSize = getContainerSize( dialog ),
 			dialogSize = dialog.getSize(),
 			ratios = dialog._.viewportRatio,
 			freeSpace = {
-				width: Math.max( viewPaneSize.width - dialogSize.width, 0 ),
-				height: Math.max( viewPaneSize.height - dialogSize.height, 0 )
+				width: Math.max( containerSize.width - dialogSize.width, 0 ),
+				height: Math.max( containerSize.height - dialogSize.height, 0 )
 			};
 
 		ratios.width = freeSpace.width ? ( x / freeSpace.width ) : ratios.width;
@@ -2190,8 +2199,7 @@ CKEDITOR.DIALOG_STATE_BUSY = 2;
 	}
 
 	function showCover( editor ) {
-		var win = CKEDITOR.document.getWindow(),
-			config = editor.config,
+		var config = editor.config,
 			skinName = ( CKEDITOR.skinName || editor.config.skin ),
 			backgroundColorStyle = config.dialog_backgroundCoverColor || ( skinName == 'moono-lisa' ? 'black' : 'white' ),
 			backgroundCoverOpacity = config.dialog_backgroundCoverOpacity,
@@ -2271,7 +2279,6 @@ CKEDITOR.DIALOG_STATE_BUSY = 2;
 			return;
 
 		editor.focusManager.remove( currentCover );
-		var win = CKEDITOR.document.getWindow();
 		currentCover.hide();
 	}
 

--- a/plugins/dialog/plugin.js
+++ b/plugins/dialog/plugin.js
@@ -715,9 +715,6 @@ CKEDITOR.DIALOG_STATE_BUSY = 2;
 	function resizeWithWindow( dialog ) {
 		var win = CKEDITOR.document.getWindow();
 		function resizeHandler() {
-			if ( window.prev ) {
-				return;
-			}
 			dialog.layout();
 		}
 		win.on( 'resize', resizeHandler );

--- a/plugins/dialog/plugin.js
+++ b/plugins/dialog/plugin.js
@@ -764,7 +764,7 @@ CKEDITOR.DIALOG_STATE_BUSY = 2;
 
 			// Update dialog position when dimension get changed in RTL.
 			if ( this._.editor.lang.dir == 'rtl' && this._.position ) {
-				var containerWidth = dialog.parts.dialog.getParent().getClientSize().width;
+				var containerWidth = this.parts.dialog.getParent().getClientSize().width;
 
 				this._.position.x = containerWidth - this._.contentSize.width - parseInt( this._.element.getFirst().getStyle( 'right' ), 10 );
 			}

--- a/plugins/dialog/plugin.js
+++ b/plugins/dialog/plugin.js
@@ -824,9 +824,7 @@ CKEDITOR.DIALOG_STATE_BUSY = 2;
 				x = Math.floor( freeSpace.width * ratios.width );
 				y = Math.floor( freeSpace.height * ratios.height );
 			} else {
-				// When no free space don't divide by zero, use previous value.
-				ratios.width = freeSpace.width ? ( x / freeSpace.width ) : ratios.width;
-				ratios.height = freeSpace.height ? ( y / freeSpace.height ) : ratios.height;
+				updateRatios( this, x, y );
 			}
 
 			// Save the current position.
@@ -871,7 +869,7 @@ CKEDITOR.DIALOG_STATE_BUSY = 2;
 			if ( !( element.getParent() && element.getParent().equals( CKEDITOR.document.getBody() ) ) ) {
 				element.appendTo( CKEDITOR.document.getBody() );
 			} else {
-				element.setStyle( 'display', CKEDITOR.env.ie && !CKEDITOR.env.edge ? 'block' : 'flex' );
+				element.setStyle( 'display', useFlex ? 'flex' :'block' );
 			}
 
 			// First, set the dialog to an appropriate size.

--- a/plugins/dialog/plugin.js
+++ b/plugins/dialog/plugin.js
@@ -764,7 +764,7 @@ CKEDITOR.DIALOG_STATE_BUSY = 2;
 
 			// Update dialog position when dimension get changed in RTL.
 			if ( this._.editor.lang.dir == 'rtl' && this._.position ) {
-				var containerWidth = getContainerSize( this ).width;
+				var containerWidth = dialog.parts.dialog.getParent().getClientSize().width;
 
 				this._.position.x = containerWidth - this._.contentSize.width - parseInt( this._.element.getFirst().getStyle( 'right' ), 10 );
 			}
@@ -811,7 +811,7 @@ CKEDITOR.DIALOG_STATE_BUSY = 2;
 				element.setStyle( 'zoom', '100%' );
 			}
 
-			var containerSize = getContainerSize( this ),
+			var containerSize = this.parts.dialog.getParent().getClientSize(),
 				dialogSize = this.getSize(),
 				ratios = this._.viewportRatio,
 				freeSpace = {
@@ -1955,7 +1955,7 @@ CKEDITOR.DIALOG_STATE_BUSY = 2;
 
 		function mouseMoveHandler( evt ) {
 			var dialogSize = dialog.getSize(),
-				containerSize = getContainerSize( dialog ),
+				containerSize = dialog.parts.dialog.getParent().getClientSize(),
 				x = evt.data.$.screenX,
 				y = evt.data.$.screenY,
 				dx = x - lastCoords.x,
@@ -2166,17 +2166,8 @@ CKEDITOR.DIALOG_STATE_BUSY = 2;
 		}
 	}
 
-	function getContainerSize( dialog ) {
-		var container = dialog.parts.dialog.getParent();
-
-		return {
-			width: container.$.clientWidth,
-			height: container.$.clientHeight
-		}
-	}
-
 	function updateRatios( dialog, x, y ) {
-		var containerSize = getContainerSize( dialog ),
+		var containerSize = dialog.parts.dialog.getParent().getClientSize(),
 			dialogSize = dialog.getSize(),
 			ratios = dialog._.viewportRatio,
 			freeSpace = {

--- a/plugins/dialog/plugin.js
+++ b/plugins/dialog/plugin.js
@@ -259,7 +259,11 @@ CKEDITOR.DIALOG_STATE_BUSY = 2;
 			contents: {},
 			buttons: {},
 			accessKeyMap: {},
-			viewportRatio: {},
+			// Default value is 0.5 which means centered dialog.
+			viewportRatio: {
+				width: 0.5,
+				height: 0.5
+			},
 
 			// Initialize the tab and page map.
 			tabs: {},
@@ -806,17 +810,19 @@ CKEDITOR.DIALOG_STATE_BUSY = 2;
 
 			var viewPaneSize = CKEDITOR.document.getWindow().getViewPaneSize(),
 				dialogSize = this.getSize(),
+				ratios = this._.viewportRatio,
 				freeSpace = {
 					width: Math.max( viewPaneSize.width - dialogSize.width, 0 ),
 					height: Math.max( viewPaneSize.height - dialogSize.height, 0 )
 				};
 			if ( this._.position && this._.position.x == x && this._.position.y == y ) {
 				// If position didn't change window might have been resized.
-				x = freeSpace.width * this._.viewportRatio.width;
-				y = freeSpace.height * this._.viewportRatio.height;
+				x = freeSpace.width * ratios.width;
+				y = freeSpace.height * ratios.height;
 			} else {
-				this._.viewportRatio.width = x / freeSpace.width;
-				this._.viewportRatio.height = y / freeSpace.height;
+				// When no free space don't divide by zero, use previous value.
+				ratios.width = freeSpace.width ? ( x / freeSpace.width ) : ratios.width;
+				ratios.height = freeSpace.height ? ( y / freeSpace.height ) : ratios.height;
 			}
 			// Save the current position.
 			this._.position = { x: x, y: y };

--- a/plugins/dialog/plugin.js
+++ b/plugins/dialog/plugin.js
@@ -2119,7 +2119,6 @@ CKEDITOR.DIALOG_STATE_BUSY = 2;
 		}
 	}
 
-	var resizeCover;
 	// Caching resuable covers and allowing only one cover
 	// on screen.
 	var covers = {},
@@ -2154,6 +2153,7 @@ CKEDITOR.DIALOG_STATE_BUSY = 2;
 				'<div tabIndex="-1" style="position: ', ( CKEDITOR.env.ie6Compat ? 'absolute' : 'fixed' ),
 				'; z-index: ', baseFloatZIndex,
 				'; top: 0px; left: 0px; ',
+				'; width: 100%; height: 100%;',
 				( !CKEDITOR.env.ie6Compat ? 'background-color: ' + backgroundColorStyle : '' ),
 				'" class="cke_dialog_background_cover">'
 			];
@@ -2206,13 +2206,6 @@ CKEDITOR.DIALOG_STATE_BUSY = 2;
 		editor.focusManager.add( coverElement );
 
 		currentCover = coverElement;
-		var resizeFunc = function() {
-				var size = win.getViewPaneSize();
-				coverElement.setStyles( {
-					width: size.width + 'px',
-					height: size.height + 'px'
-				} );
-			};
 
 		var scrollFunc = function() {
 				var pos = win.getScrollPosition(),
@@ -2230,9 +2223,6 @@ CKEDITOR.DIALOG_STATE_BUSY = 2;
 				}
 			};
 
-		resizeCover = resizeFunc;
-		win.on( 'resize', resizeFunc );
-		resizeFunc();
 		// Using Safari/Mac, focus must be kept where it is (https://dev.ckeditor.com/ticket/7027)
 		if ( !( CKEDITOR.env.mac && CKEDITOR.env.webkit ) )
 			coverElement.focus();
@@ -2262,17 +2252,12 @@ CKEDITOR.DIALOG_STATE_BUSY = 2;
 		var win = CKEDITOR.document.getWindow();
 		currentCover.hide();
 
-		// Remove the current cover reference once the cover is removed (#589).
-		currentCover = null;
-		win.removeListener( 'resize', resizeCover );
-
 		if ( CKEDITOR.env.ie6Compat ) {
 			win.$.setTimeout( function() {
 				var prevScrollHandler = window.onscroll && window.onscroll.prevScrollHandler;
 				window.onscroll = prevScrollHandler || null;
 			}, 0 );
 		}
-		resizeCover = null;
 	}
 
 	function removeCovers() {

--- a/plugins/dialog/plugin.js
+++ b/plugins/dialog/plugin.js
@@ -734,35 +734,36 @@ CKEDITOR.DIALOG_STATE_BUSY = 2;
 		 * @param {Number} width The width of the dialog in pixels.
 		 * @param {Number} height The height of the dialog in pixels.
 		 */
-		resize: ( function() {
-			return function( width, height ) {
-				if ( this._.contentSize && this._.contentSize.width == width && this._.contentSize.height == height )
-					return;
+		resize: function( width, height ) {
+			if ( this._.contentSize && this._.contentSize.width == width && this._.contentSize.height == height )
+				return;
 
-				CKEDITOR.dialog.fire( 'resize', {
-					dialog: this,
-					width: width,
-					height: height
-				}, this._.editor );
+			CKEDITOR.dialog.fire( 'resize', {
+				dialog: this,
+				width: width,
+				height: height
+			}, this._.editor );
 
-				this.fire( 'resize', {
-					width: width,
-					height: height
-				}, this._.editor );
+			this.fire( 'resize', {
+				width: width,
+				height: height
+			}, this._.editor );
 
-				var contents = this.parts.contents;
-				contents.setStyles( {
-					width: width + 'px',
-					height: height + 'px'
-				} );
+			var contents = this.parts.contents;
+			contents.setStyles( {
+				width: width + 'px',
+				height: height + 'px'
+			} );
 
-				// Update dialog position when dimension get changed in RTL.
-				if ( this._.editor.lang.dir == 'rtl' && this._.position )
-					this._.position.x = CKEDITOR.document.getWindow().getViewPaneSize().width - this._.contentSize.width - parseInt( this._.element.getFirst().getStyle( 'right' ), 10 );
+			// Update dialog position when dimension get changed in RTL.
+			if ( this._.editor.lang.dir == 'rtl' && this._.position ) {
+				var viewPaneWidth = CKEDITOR.document.getWindow().getViewPaneSize().width;
 
-				this._.contentSize = { width: width, height: height };
-			};
-		} )(),
+				this._.position.x = viewPaneWidth - this._.contentSize.width - parseInt( this._.element.getFirst().getStyle( 'right' ), 10 );
+			}
+
+			this._.contentSize = { width: width, height: height };
+		},
 
 		/**
 		 * Gets the current size of the dialog in pixels.

--- a/plugins/dialog/plugin.js
+++ b/plugins/dialog/plugin.js
@@ -971,7 +971,7 @@ CKEDITOR.DIALOG_STATE_BUSY = 2;
 		layout: function() {
 			var el = this.parts.dialog;
 
-			if ( !this._.moved && ( useFlex ) ) {
+			if ( !this._.moved && useFlex ) {
 				return;
 			}
 

--- a/plugins/dialog/plugin.js
+++ b/plugins/dialog/plugin.js
@@ -2101,6 +2101,9 @@ CKEDITOR.DIALOG_STATE_BUSY = 2;
 				right = rtl && element.getComputedStyle( 'right' ),
 				position = dialog.getPosition();
 
+			position.x = position.x || 0;
+			position.y = position.y || 0;
+
 			if ( position.y + internalHeight > viewSize.height ) {
 				internalHeight = viewSize.height - position.y;
 			}

--- a/plugins/dialog/styles/dialog.css
+++ b/plugins/dialog/styles/dialog.css
@@ -1,0 +1,14 @@
+.cke_dialog_open {
+	overflow: hidden;
+}
+
+.cke_dialog_container {
+	position: fixed;
+	overflow-y: auto;
+	overflow-x: auto;
+	width: 100%;
+	height: 100%;
+	top: 0;
+	left: 0;
+	z-index: 10010;
+}

--- a/plugins/dialog/styles/dialog.css
+++ b/plugins/dialog/styles/dialog.css
@@ -12,3 +12,7 @@
 	left: 0;
 	z-index: 10010;
 }
+
+.cke_dialog_body {
+	position: relative;
+}

--- a/plugins/floatpanel/plugin.js
+++ b/plugins/floatpanel/plugin.js
@@ -367,15 +367,15 @@ CKEDITOR.plugins.add( 'floatpanel', {
 						// position and horizontal scrolls. Here we have a
 						// series of hacks to workaround it. (https://dev.ckeditor.com/ticket/6146)
 						if ( CKEDITOR.env.ie && !CKEDITOR.env.edge ) {
-							var offsetParent = new CKEDITOR.dom.element( element.$.offsetParent ),
+							var offsetParent = element.$.offsetParent && new CKEDITOR.dom.element( element.$.offsetParent ),
 								scrollParent = offsetParent;
 
 							// Quirks returns <body>, but standards returns <html>.
-							if ( scrollParent.getName() == 'html' ) {
+							if ( scrollParent && scrollParent.getName() == 'html' ) {
 								scrollParent = scrollParent.getDocument().getBody();
 							}
 
-							if ( scrollParent.getComputedStyle( 'direction' ) == 'rtl' ) {
+							if ( scrollParent && scrollParent.getComputedStyle( 'direction' ) == 'rtl' ) {
 								// For IE8, there is not much logic on this, but it works.
 								if ( CKEDITOR.env.ie8Compat ) {
 									left -= element.getDocument().getDocumentElement().$.scrollLeft * 2;

--- a/skins/kama/dialog.css
+++ b/skins/kama/dialog.css
@@ -897,18 +897,3 @@ a.cke_smile:hover img
 	width:100%;
 	height:100%;
 }
-
-.cke_dialog_open {
-	overflow: hidden;
-}
-
-.cke_dialog_container {
-	position: fixed;
-	overflow-y: auto;
-	overflow-x: auto;
-	width: 100%;
-	height: 100%;
-	top: 0;
-	left: 0;
-	z-index: 10010;
-}

--- a/skins/kama/dialog.css
+++ b/skins/kama/dialog.css
@@ -55,7 +55,6 @@ Comments in this file will give more details about each of the above blocks.
 	padding: 5px;
 	background-color: #fff;
 	border-radius: 5px;
-	position: relative;
 }
 
 /* Due to our reset we have to recover the styles of some elements. */

--- a/skins/moono-lisa/dialog.css
+++ b/skins/moono-lisa/dialog.css
@@ -1157,18 +1157,3 @@ a.cke_dialog_ui_button.cke_dialog_image_browse
 	border: 2px solid #139FF7;
 	padding: 6px;
 }
-
-.cke_dialog_open {
-	overflow: hidden;
-}
-
-.cke_dialog_container {
-	position: fixed;
-	overflow-y: auto;
-	overflow-x: auto;
-	width: 100%;
-	height: 100%;
-	top: 0;
-	left: 0;
-	z-index: 10010;
-}

--- a/skins/moono-lisa/dialog.css
+++ b/skins/moono-lisa/dialog.css
@@ -52,7 +52,6 @@ Comments in this file will give more details about each of the above blocks.
 {
 	z-index: 1;
 	background: #fff;
-	position: relative;
 }
 
 /* Due to our reset we have to recover the styles of some elements. */
@@ -136,7 +135,7 @@ Comments in this file will give more details about each of the above blocks.
 	background-color: #fff;
 	overflow: auto;
 	padding: 15px 10px 5px 10px;
-	margin-top: 1px;
+	margin-top: 43px;
 	border-top: 1px solid #d1d1d1;
 }
 
@@ -210,14 +209,16 @@ The .cke_dialog_tab_selected class is appended to the active tab.
 {
 	height: 33px;
 	display: inline-block;
-	margin: 9px 0 0 11px;
+	margin: 9px 0 0;
+	position: absolute;
 	z-index: 2;
+	left: 11px;
 }
 
 .cke_rtl .cke_dialog_tabs
 {
 	left: auto;
-	margin-right: 11px;
+	right: 11px;
 }
 
 /* A single tab (an <a> element). */

--- a/skins/moono/dialog.css
+++ b/skins/moono/dialog.css
@@ -1064,17 +1064,3 @@ a.cke_specialchar:active
 	height: 100%;
 }
 
-.cke_dialog_open {
-	overflow: hidden;
-}
-
-.cke_dialog_container {
-	position: fixed;
-	overflow-y: auto;
-	overflow-x: auto;
-	width: 100%;
-	height: 100%;
-	top: 0;
-	left: 0;
-	z-index: 10010;
-}

--- a/skins/moono/dialog.css
+++ b/skins/moono/dialog.css
@@ -56,7 +56,6 @@ Comments in this file will give more details about each of the above blocks.
 	border-bottom-color: #999;
 	border-radius: 3px;
 	box-shadow: 0 0 3px rgba(0, 0, 0, .15);
-	position: relative;
 }
 
 /* Due to our reset we have to recover the styles of some elements. */
@@ -1063,4 +1062,3 @@ a.cke_specialchar:active
 	width: 100%;
 	height: 100%;
 }
-

--- a/tests/core/dom/element/element.js
+++ b/tests/core/dom/element/element.js
@@ -1230,6 +1230,20 @@ bender.test( appendDomObjectTests(
 
 			assert.areSame( String( leftMouseButton ), link.getAttribute( 'data-button' ),
 				'Proper event data was passed' );
+		},
+
+		'test getClientSize': function() {
+			var element = new CKEDITOR.dom.element( 'div' );
+
+			element.$ = {
+				clientWidth: 100,
+				clientHeight: 100
+			};
+
+			var size = element.getClientSize();
+
+			assert.areSame( 100, size.width );
+			assert.areSame( 100, size.height );
 		}
 	}
 ) );

--- a/tests/plugins/dialog/manual/inputfocus.html
+++ b/tests/plugins/dialog/manual/inputfocus.html
@@ -4,9 +4,15 @@
 	}
 </style>
 <div class="spacer"></div>
+<h1>Left to right editor:</h1>
 <textarea id="editor"></textarea>
+<h1>Right to left editor:</h1>
+<textarea id="editor_rtl"></textarea>
 <div class="spacer"></div>
 
 <script>
 	CKEDITOR.replace( 'editor' );
+	CKEDITOR.replace( 'editor_rtl', {
+		language: 'he'
+	} );
 </script>

--- a/tests/plugins/dialog/manual/inputfocus.md
+++ b/tests/plugins/dialog/manual/inputfocus.md
@@ -2,19 +2,15 @@
 @bender-ui: collapsed
 @bender-ckeditor-plugins: wysiwygarea, toolbar, link
 
-## Test both editors:
-
+1. Read expected.
 1. Scroll down until editor is visible.
 1. Press link button.
+1. Resize browser window.
+1. Resize dialog window.
+1. Drag dialog window.
+1. Close and reopen dialog.
 
-## Things to check:
-
-- Resize browser window.
-- Resize dialog window.
-- Drag dialog window.
-- Close and reopen dialog.
-
-#### Expected:
+## Expected
 
 - When dialog is shown scrollbars are invisible.
 - When resizing browser window dialog is still horizontally and vertically centered.

--- a/tests/plugins/dialog/manual/inputfocus.md
+++ b/tests/plugins/dialog/manual/inputfocus.md
@@ -1,4 +1,4 @@
-@bender-tags: 2395, bug, 4.11.0
+@bender-tags: 2395, bug, 4.12.0
 @bender-ui: collapsed
 @bender-ckeditor-plugins: wysiwygarea, toolbar, link
 

--- a/tests/plugins/dialog/manual/inputfocus.md
+++ b/tests/plugins/dialog/manual/inputfocus.md
@@ -9,20 +9,6 @@
 
 ## Things to check:
 
-### Touch devices:
-
-- Play around focusing and blurring inputs, zooming and scrolling page.
-
-#### Expected:
-
-- When opening dialog or focusing input caret page should be scrolled in a way caret is visible.
-
-#### Unexpected
-
-- Caret is outside of current viewport.
-
-### Desktop computers:
-
 - Resize browser window.
 - Resize dialog window.
 - Drag dialog window.

--- a/tests/plugins/dialog/manual/inputfocus.md
+++ b/tests/plugins/dialog/manual/inputfocus.md
@@ -1,4 +1,4 @@
-@bender-tags: 2395, bug, 4.10.2
+@bender-tags: 2395, bug, 4.11.0
 @bender-ui: collapsed
 @bender-ckeditor-plugins: wysiwygarea, toolbar, link
 

--- a/tests/plugins/dialog/manual/inputfocus.md
+++ b/tests/plugins/dialog/manual/inputfocus.md
@@ -2,6 +2,8 @@
 @bender-ui: collapsed
 @bender-ckeditor-plugins: wysiwygarea, toolbar, link
 
+## Test both editors:
+
 1. Scroll down until editor is visible.
 1. Press link button.
 
@@ -30,7 +32,7 @@
 
 - When dialog is shown scrollbars are invisible.
 - When resizing browser window dialog is still horizontally and vertically centered.
-- When window too small to fit dialog window scrollbars should appear allowing to scroll dialog.
+- When window is too small to fit dialog window scrollbars should appear allowing to scroll dialog.
 - Dialog window can be resized and dragged around.
 - When closing and reopening dialog it has same size and position as it had before when it was closed.
 

--- a/tests/plugins/dialog/manual/inputfocus.md
+++ b/tests/plugins/dialog/manual/inputfocus.md
@@ -18,4 +18,15 @@
 - Dialog window can be resized and dragged around.
 - When closing and reopening dialog it has same size and position as it had before when it was closed.
 
-Note: When you reposition dialog it won't be centered when resizing browser window.
+### Note
+When you reposition dialog it won't be centered when resizing browser window. Repositioned dialog will move in a way that it will have same percentage of free space on each side. E.g. Consider there is when there is free space around dialog:
+- on the left 10px
+- on the right 90px
+
+Then when window width is increased so that there will be 200px of free space around dialog now there will be:
+- on the left 20px
+- on the right 180px
+
+If instead window width is decreased so there is 50px free space then there will be:
+- on the left 5px
+- on the right 45px

--- a/tests/plugins/dialog/manual/inputfocus.md
+++ b/tests/plugins/dialog/manual/inputfocus.md
@@ -1,4 +1,4 @@
-@bender-tags: 2395, bug, 4.12.0
+@bender-tags: 2395, bug, 4.13.0
 @bender-ui: collapsed
 @bender-ckeditor-plugins: wysiwygarea, toolbar, link
 

--- a/tests/plugins/dialog/manual/inputfocusmobile.html
+++ b/tests/plugins/dialog/manual/inputfocusmobile.html
@@ -11,7 +11,7 @@
 <div class="spacer"></div>
 
 <script>
-	if ( bender.tools.env.mobile ) {
+	if ( !bender.tools.env.mobile ) {
 		bender.ignore();
 	}
 	CKEDITOR.replace( 'editor' );

--- a/tests/plugins/dialog/manual/inputfocusmobile.html
+++ b/tests/plugins/dialog/manual/inputfocusmobile.html
@@ -1,3 +1,7 @@
+<head>
+	<meta name="viewport" content="width=device-width,initial-scale=1">
+</head>
+<body>
 <style>
 	.spacer {
 		height: 2000px;
@@ -19,3 +23,4 @@
 		language: 'he'
 	} );
 </script>
+</body>

--- a/tests/plugins/dialog/manual/inputfocusmobile.md
+++ b/tests/plugins/dialog/manual/inputfocusmobile.md
@@ -2,20 +2,13 @@
 @bender-ui: collapsed
 @bender-ckeditor-plugins: wysiwygarea, toolbar, link
 
-## Test both editors:
+1. Scroll down until editor is visible and press link button.
+1. Focus other input in dialog.
 
-1. Scroll down until editor is visible.
-1. Press link button.
+## Expected:
 
-## Things to check:
+- After each step page should be scrolled in a way caret is visible.
 
-
-- Play around focusing and blurring inputs, zooming and scrolling page.
-
-#### Expected:
-
-- When opening dialog or focusing input caret page should be scrolled in a way caret is visible.
-
-#### Unexpected
+## Unexpected
 
 - Caret is outside of current viewport.

--- a/tests/plugins/dialog/manual/inputfocusmobile.md
+++ b/tests/plugins/dialog/manual/inputfocusmobile.md
@@ -1,4 +1,4 @@
-@bender-tags: 2395, bug, 4.11.0
+@bender-tags: 2395, bug, 4.12.0
 @bender-ui: collapsed
 @bender-ckeditor-plugins: wysiwygarea, toolbar, link
 

--- a/tests/plugins/dialog/manual/inputfocusmobile.md
+++ b/tests/plugins/dialog/manual/inputfocusmobile.md
@@ -1,0 +1,21 @@
+@bender-tags: 2395, bug, 4.11.0
+@bender-ui: collapsed
+@bender-ckeditor-plugins: wysiwygarea, toolbar, link
+
+## Test both editors:
+
+1. Scroll down until editor is visible.
+1. Press link button.
+
+## Things to check:
+
+
+- Play around focusing and blurring inputs, zooming and scrolling page.
+
+#### Expected:
+
+- When opening dialog or focusing input caret page should be scrolled in a way caret is visible.
+
+#### Unexpected
+
+- Caret is outside of current viewport.

--- a/tests/plugins/dialog/manual/inputfocusmobile.md
+++ b/tests/plugins/dialog/manual/inputfocusmobile.md
@@ -1,4 +1,4 @@
-@bender-tags: 2395, bug, 4.12.0
+@bender-tags: 2395, bug, 4.13.0
 @bender-ui: collapsed
 @bender-ckeditor-plugins: wysiwygarea, toolbar, link
 

--- a/tests/plugins/dialog/manual/inputfocusmobile.md
+++ b/tests/plugins/dialog/manual/inputfocusmobile.md
@@ -12,3 +12,6 @@
 ## Unexpected
 
 - Caret is outside of current viewport.
+
+## Note
+When testing with device which has small screen you should hide test steps with `X` button, so editor has enough space.

--- a/tests/plugins/dialog/manual/skins/kama.md
+++ b/tests/plugins/dialog/manual/skins/kama.md
@@ -1,4 +1,4 @@
-@bender-tags: 2395, bug, 4.10.2
+@bender-tags: 2395, bug, 4.11.2
 @bender-ui: collapsed
 @bender-ckeditor-plugins: wysiwygarea, toolbar, link
 

--- a/tests/plugins/dialog/manual/skins/kama.md
+++ b/tests/plugins/dialog/manual/skins/kama.md
@@ -2,4 +2,4 @@
 @bender-ui: collapsed
 @bender-ckeditor-plugins: wysiwygarea, toolbar, link
 
-Play around with dialog window to see if it's styling looks correct with no visible glitches.
+Press link button and play around with dialog window to see if it's styling looks correct with no visible glitches.

--- a/tests/plugins/dialog/manual/skins/kama.md
+++ b/tests/plugins/dialog/manual/skins/kama.md
@@ -1,4 +1,4 @@
-@bender-tags: 2395, bug, 4.11.2
+@bender-tags: 2395, bug, 4.12.0
 @bender-ui: collapsed
 @bender-ckeditor-plugins: wysiwygarea, toolbar, link
 

--- a/tests/plugins/dialog/manual/skins/kama.md
+++ b/tests/plugins/dialog/manual/skins/kama.md
@@ -1,4 +1,4 @@
-@bender-tags: 2395, bug, 4.12.0
+@bender-tags: 2395, bug, 4.13.0
 @bender-ui: collapsed
 @bender-ckeditor-plugins: wysiwygarea, toolbar, link
 

--- a/tests/plugins/dialog/manual/skins/moono.md
+++ b/tests/plugins/dialog/manual/skins/moono.md
@@ -1,4 +1,4 @@
-@bender-tags: 2395, bug, 4.10.2
+@bender-tags: 2395, bug, 4.11.2
 @bender-ui: collapsed
 @bender-ckeditor-plugins: wysiwygarea, toolbar, link
 

--- a/tests/plugins/dialog/manual/skins/moono.md
+++ b/tests/plugins/dialog/manual/skins/moono.md
@@ -1,4 +1,4 @@
-@bender-tags: 2395, bug, 4.11.2
+@bender-tags: 2395, bug, 4.12.0
 @bender-ui: collapsed
 @bender-ckeditor-plugins: wysiwygarea, toolbar, link
 

--- a/tests/plugins/dialog/manual/skins/moono.md
+++ b/tests/plugins/dialog/manual/skins/moono.md
@@ -1,4 +1,4 @@
-@bender-tags: 2395, bug, 4.12.0
+@bender-tags: 2395, bug, 4.13.0
 @bender-ui: collapsed
 @bender-ckeditor-plugins: wysiwygarea, toolbar, link
 

--- a/tests/plugins/dialog/manual/skins/moonolisa.md
+++ b/tests/plugins/dialog/manual/skins/moonolisa.md
@@ -1,4 +1,4 @@
-@bender-tags: 2395, bug, 4.10.2
+@bender-tags: 2395, bug, 4.11.2
 @bender-ui: collapsed
 @bender-ckeditor-plugins: wysiwygarea, toolbar, link
 

--- a/tests/plugins/dialog/manual/skins/moonolisa.md
+++ b/tests/plugins/dialog/manual/skins/moonolisa.md
@@ -1,4 +1,4 @@
-@bender-tags: 2395, bug, 4.11.2
+@bender-tags: 2395, bug, 4.12.0
 @bender-ui: collapsed
 @bender-ckeditor-plugins: wysiwygarea, toolbar, link
 

--- a/tests/plugins/dialog/manual/skins/moonolisa.md
+++ b/tests/plugins/dialog/manual/skins/moonolisa.md
@@ -1,4 +1,4 @@
-@bender-tags: 2395, bug, 4.12.0
+@bender-tags: 2395, bug, 4.13.0
 @bender-ui: collapsed
 @bender-ckeditor-plugins: wysiwygarea, toolbar, link
 

--- a/tests/plugins/dialog/positioning.js
+++ b/tests/plugins/dialog/positioning.js
@@ -58,20 +58,24 @@
 		},
 		// When drag starts, dialog becomes centered with `position:absolute`, then it moves together with mouse (#2395).
 		'test dialog move': function() {
+			var window = CKEDITOR.document.getWindow(),
+				viewPaneSize = {
+					width: 1000,
+					height: 1000
+				},
+				stubs = {
+					getWindow: sinon.stub( CKEDITOR.document, 'getWindow' ),
+					getViewPane: sinon.stub( window, 'getViewPaneSize' )
+				};
+
+			stubs.getWindow.returns( window );
+			stubs.getViewPane.returns( viewPaneSize );
+
 			this.editorBot.dialog( 'link', function( dialog ) {
-				var window = CKEDITOR.document.getWindow(),
-					viewPaneSize = {
-						width: 1000,
-						height: 1000
-					},
-					element = dialog._.element.getFirst(),
+				var element = dialog._.element.getFirst(),
 					dialogSize = dialog.getSize(),
 					expectedX = Math.floor( ( viewPaneSize.width - dialogSize.width ) / 2 ),
-					expectedY = Math.floor( ( viewPaneSize.height - dialogSize.height ) / 2 ),
-					stubs = {
-						getWindow: sinon.stub( CKEDITOR.document, 'getWindow' ),
-						getViewPane: sinon.stub( window, 'getViewPaneSize' )
-					};
+					expectedY = Math.floor( ( viewPaneSize.height - dialogSize.height ) / 2 );
 
 				stubs.getWindow.returns( window );
 				stubs.getViewPane.returns( viewPaneSize );

--- a/tests/plugins/dialog/positioning.js
+++ b/tests/plugins/dialog/positioning.js
@@ -8,6 +8,7 @@
 
 	bender.test( {
 		setUp: function() {
+			// Make sure page is scrollable on vertical screens.
 			CKEDITOR.document.document.getBody().appendHtml( '<div style="height:4000px"></div>' );
 		},
 		tearDown: function() {
@@ -60,6 +61,33 @@
 			} );
 		},
 		// When drag starts, dialog becomes centered with `position:absolute`, then it moves together with mouse (#2395).
+		//
+		// A - mouse cursor
+		//
+		// Drag start:
+		// +----------------------------------+
+		// |      Editor viewport             |
+		// |                                  |
+		// |        +-------------A--+        |
+		// |        |                |        |
+		// |        |   Dialog       |        |
+		// |        |                |        |
+		// |        +----------------+        |
+		// |                                  |
+		// +----------------------------------+
+		//
+		// Drag end:
+		// +----------------------------------+
+		// |      Editor viewport             |
+		// |                                  |
+		// |                                  |
+		// |                +-------------A--+|
+		// |                |                ||
+		// |                |   Dialog       ||
+		// |                |                ||
+		// |                +----------------+|
+		// +----------------------------------+
+		//
 		'test dialog move': function() {
 			var window = CKEDITOR.document.getWindow(),
 				viewPaneSize = {

--- a/tests/plugins/dialog/positioning.js
+++ b/tests/plugins/dialog/positioning.js
@@ -16,31 +16,16 @@
 			}
 			var bot = this.editorBot,
 				document = CKEDITOR.document,
-				body = document.getBody(),
-				scrollBarWidth;
+				body = document.getBody();
 
 			body.appendHtml( '<div style="height:4000px"></div>' );
-			scrollBarWidth = document.getWindow().$.innerWidth - document.$.documentElement.clientWidth;
 
 			bot.dialog( 'link', function( dialog ) {
 				assert.isTrue( body.hasClass( 'cke_dialog_open' ), 'Body should have proper class.' );
-				assert.isTrue( body.hasClass( 'cke_body_extra_padding' ), 'Body should have proper class.' );
-				assert.areSame( scrollBarWidth + 'px', body.getStyle( 'padding-right' ), 'Body should have right padding.' );
 
 				dialog.hide();
 
 				assert.isFalse( body.hasClass( 'cke_dialog_open' ), 'Body shouldn\'t have class.' );
-				assert.areSame( '', body.getStyle( 'padding-right' ), 'Body shouldn\'t have right padding.' );
-
-				body.setStyle( 'padding-right', '1em' );
-
-				bot.dialog( 'link', function( dialog ) {
-					assert.areSame( '1em', body.getStyle( 'padding-right' ), 'Right padding should be preserved on body.' );
-					assert.isFalse( body.hasClass( 'cke_body_extra_padding' ), 'Body shouldn\'t have class.' );
-					dialog.hide();
-
-					assert.areSame( '1em', body.getStyle( 'padding-right' ), 'Right padding should be preserved on body.' );
-				} );
 			} );
 		},
 		// Dialog is initially centered by CSS styles:
@@ -57,6 +42,16 @@
 				assert.areEqual( container.getStyle( 'display' ), 'flex', 'Dialog container should have `display:flex`.' );
 				assert.areEqual( element.getStyle( 'position' ), '', 'Dialog element should\'t have position style.' );
 				assert.areEqual( element.getStyle( 'margin' ), 'auto', 'Dialog element should have `margin:auto`.' );
+
+				dialog.hide();
+			} );
+		},
+		'test dialog cover styles': function() {
+			this.editorBot.dialog( 'link', function( dialog ) {
+				var cover = CKEDITOR.document.findOne( '.cke_dialog_background_cover' );
+
+				assert.areEqual( cover.getStyle( 'width' ), '100%', 'Dialog element should have `width:100%`.' );
+				assert.areEqual( cover.getStyle( 'height' ), '100%', 'Dialog element should have `height:100%`.' );
 
 				dialog.hide();
 			} );

--- a/tests/plugins/dialog/positioning.js
+++ b/tests/plugins/dialog/positioning.js
@@ -17,6 +17,7 @@
 				dialog.hide();
 			}
 		},
+
 		// (#2395).
 		'test body has hidden scrollbars when dialog is opened': function() {
 			if ( CKEDITOR.env.ie && !CKEDITOR.env.edge ) {
@@ -33,6 +34,7 @@
 				assert.isFalse( body.hasClass( 'cke_dialog_open' ), 'Body shouldn\'t have class.' );
 			} );
 		},
+
 		// (#2395).
 		'test dialog is initially centered': function() {
 			if ( CKEDITOR.env.ie && !CKEDITOR.env.edge ) {
@@ -47,6 +49,7 @@
 				assert.areEqual( element.getStyle( 'margin' ), 'auto', 'Dialog element should have `margin:auto`.' );
 			} );
 		},
+
 		// (#2395).
 		'test dialog cover styles': function() {
 			this.editorBot.dialog( 'link', function() {
@@ -56,6 +59,7 @@
 				assert.areEqual( cover.getStyle( 'height' ), '100%', 'Dialog element should have `height:100%`.' );
 			} );
 		},
+
 		// When drag starts, dialog becomes centered with `position:absolute`, then it moves together with mouse (#2395).
 		//
 		// A - mouse cursor

--- a/tests/plugins/dialog/positioning.js
+++ b/tests/plugins/dialog/positioning.js
@@ -59,6 +59,23 @@
 		// When drag starts, dialog becomes centered with `position:absolute`, then it moves together with mouse (#2395).
 		'test dialog move': function() {
 			this.editorBot.dialog( 'link', function( dialog ) {
+				var window = CKEDITOR.document.getWindow(),
+					viewPaneSize = {
+						width: 1000,
+						height: 1000
+					},
+					element = dialog._.element.getFirst(),
+					dialogSize = dialog.getSize(),
+					expectedX = Math.floor( ( viewPaneSize.width - dialogSize.width ) / 2 ),
+					expectedY = Math.floor( ( viewPaneSize.height - dialogSize.height ) / 2 ),
+					stubs = {
+						getWindow: sinon.stub( CKEDITOR.document, 'getWindow' ),
+						getViewPane: sinon.stub( window, 'getViewPaneSize' )
+					};
+
+				stubs.getWindow.returns( window );
+				stubs.getViewPane.returns( viewPaneSize );
+
 				dialog.parts.title.fire( 'mousedown', {
 					$: {
 						screenX: 0,
@@ -67,12 +84,7 @@
 					preventDefault: function() {}
 				} );
 
-				var element = dialog._.element.getFirst(),
-					dialogSize = dialog.getSize(),
-					viewPaneSize = CKEDITOR.document.getWindow().getViewPaneSize(),
-					expectedX = Math.floor( ( viewPaneSize.width - dialogSize.width ) / 2 ),
-					expectedY = Math.floor( ( viewPaneSize.height - dialogSize.height ) / 2 ),
-					actualX = parseInt( element.getStyle( 'left' ), 10 ),
+				var actualX = parseInt( element.getStyle( 'left' ), 10 ),
 					actualY = parseInt( element.getStyle( 'top' ), 10 );
 
 				assert.areEqual( 'absolute', element.getStyle( 'position' ), 'Dialog element should have `position:absolute`.' );
@@ -95,6 +107,10 @@
 
 				CKEDITOR.document.fire( 'mouseup' );
 				dialog.hide();
+
+				for ( var key in stubs ) {
+					stubs[ key ].restore();
+				}
 			} );
 		}
 	} );

--- a/tests/plugins/dialog/positioning.js
+++ b/tests/plugins/dialog/positioning.js
@@ -7,18 +7,22 @@
 	bender.editor = {};
 
 	bender.test( {
-		// When dialog is shown body has overflow hidden from class 'cke_dialog_open'
-		// and right padding equal to the scrollbars width. When there is predefined right padding
-		// it should be preserved. All extra styling is removed on dialog hide (#2395).
+		setUp: function() {
+			CKEDITOR.document.document.getBody().appendHtml( '<div style="height:4000px"></div>' );
+		},
+		tearDown: function() {
+			var dialog = CKEDITOR.dialog.getCurrent();
+			if ( dialog ) {
+				dialog.hide();
+			}
+		},
+		// (#2395).
 		'test body has hidden scrollbars when dialog is opened': function() {
 			if ( CKEDITOR.env.ie && !CKEDITOR.env.edge ) {
 				assert.ignore();
 			}
 			var bot = this.editorBot,
-				document = CKEDITOR.document,
-				body = document.getBody();
-
-			body.appendHtml( '<div style="height:4000px"></div>' );
+				body = CKEDITOR.document.getBody();
 
 			bot.dialog( 'link', function( dialog ) {
 				assert.isTrue( body.hasClass( 'cke_dialog_open' ), 'Body should have proper class.' );
@@ -28,9 +32,7 @@
 				assert.isFalse( body.hasClass( 'cke_dialog_open' ), 'Body shouldn\'t have class.' );
 			} );
 		},
-		// Dialog is initially centered by CSS styles:
-		// When dialog is shown page is covered by fixed dialog container with `display: flex`.
-		// Dialog element doesn't have `position` style, and has `margin: auto` (#2395).
+		// (#2395).
 		'test dialog is initially centered': function() {
 			if ( CKEDITOR.env.ie && !CKEDITOR.env.edge ) {
 				assert.ignore();
@@ -46,6 +48,7 @@
 				dialog.hide();
 			} );
 		},
+		// (#2395).
 		'test dialog cover styles': function() {
 			this.editorBot.dialog( 'link', function( dialog ) {
 				var cover = CKEDITOR.document.findOne( '.cke_dialog_background_cover' );
@@ -89,11 +92,8 @@
 				} );
 
 				var actualX = parseInt( element.getStyle( 'left' ), 10 ),
-					actualY = parseInt( element.getStyle( 'top' ), 10 );
-
-				assert.areEqual( 'absolute', element.getStyle( 'position' ), 'Dialog element should have `position:absolute`.' );
-				assert.areEqual( expectedX, actualX, 'Dialog should be horizontally centered.' );
-				assert.areEqual( expectedY, actualY, 'Dialog should be vertically centered.' );
+					actualY = parseInt( element.getStyle( 'top' ), 10 ),
+					elementStyle = element.getStyle( 'position' );
 
 				CKEDITOR.document.fire( 'mousemove', {
 					$: {
@@ -103,6 +103,14 @@
 					preventDefault: function() {}
 				} );
 
+				for ( var key in stubs ) {
+					stubs[ key ].restore();
+				}
+
+				assert.areEqual( 'absolute', elementStyle, 'Dialog element should have `position:absolute`.' );
+				assert.areEqual( expectedX, actualX, 'Dialog should be horizontally centered.' );
+				assert.areEqual( expectedY, actualY, 'Dialog should be vertically centered.' );
+
 				actualX = parseInt( element.getStyle( 'left' ), 10 );
 				actualY = parseInt( element.getStyle( 'top' ), 10 );
 
@@ -111,10 +119,6 @@
 
 				CKEDITOR.document.fire( 'mouseup' );
 				dialog.hide();
-
-				for ( var key in stubs ) {
-					stubs[ key ].restore();
-				}
 			} );
 		}
 	} );

--- a/tests/plugins/dialog/positioning.js
+++ b/tests/plugins/dialog/positioning.js
@@ -150,12 +150,21 @@
 			this.editorBot.dialog( 'link', function( dialog ) {
 				var dialogSize = dialog.getSize(),
 					resizer = dialog._.element.findOne( '.cke_resizer' ),
+					evt = {
+						screenX: 0,
+						screenY: 0
+					},
 					sizeChange;
 
-				resizer.$.onmousedown( {
-					screenX: 0,
-					screenY: 0
-				} );
+				// IE8 doesn't pass fake evt when manually calling resizer.$.onmousedown.
+				if ( CKEDITOR.env.ie && CKEDITOR.env.version < 9 ) {
+					var str = resizer.$.onmousedown.toString();
+					str = str.match( /[(](.*?),/ )[ 1 ];
+
+					CKEDITOR.tools.callFunction( Number( str ), evt );
+				} else {
+					resizer.$.onmousedown( evt );
+				}
 
 				CKEDITOR.document.fire( 'mousemove', {
 					$: {

--- a/tests/plugins/dialog/positioning.js
+++ b/tests/plugins/dialog/positioning.js
@@ -85,18 +85,11 @@
 		// +----------------------------------+
 		//
 		'test dialog move': function() {
-			var window = CKEDITOR.document.getWindow(),
-				viewPaneSize = {
+			var viewPaneSize = {
 					width: 1000,
 					height: 1000
 				},
-				stubs = {
-					getWindow: sinon.stub( CKEDITOR.document, 'getWindow' ),
-					getViewPane: sinon.stub( window, 'getViewPaneSize' )
-				};
-
-			stubs.getWindow.returns( window );
-			stubs.getViewPane.returns( viewPaneSize );
+				stubs = mockWindowGetViewPaneSize( viewPaneSize );
 
 			this.editorBot.dialog( 'link', function( dialog ) {
 				var element = dialog._.element.getFirst(),
@@ -144,6 +137,12 @@
 
 		// (#2395)
 		'test dialog resize': function() {
+			var viewPaneSize = {
+					width: 1000,
+					height: 1000
+				},
+				stubs = mockWindowGetViewPaneSize( viewPaneSize );
+
 			this.editorBot.dialog( 'link', function( dialog ) {
 				var dialogSize = dialog.getSize(),
 					resizer = dialog._.element.findOne( '.cke_resizer' ),
@@ -169,10 +168,27 @@
 					height: dialog.getSize().height - dialogSize.height
 				};
 
+				for ( var key in stubs ) {
+					stubs[ key ].restore();
+				}
+
 				// When resizing some floats might be rounded.
 				assert.isNumberInRange( 10, sizeChange.width - 1, sizeChange.width );
 				assert.isNumberInRange( 10, sizeChange.height - 1, sizeChange.height );
 			} );
 		}
 	} );
+
+	function mockWindowGetViewPaneSize( viewPaneSize ) {
+		var window = CKEDITOR.document.getWindow(),
+			stubs = {
+				getWindow: sinon.stub( CKEDITOR.document, 'getWindow' ),
+				getViewPane: sinon.stub( window, 'getViewPaneSize' )
+			};
+
+		stubs.getWindow.returns( window );
+		stubs.getViewPane.returns( viewPaneSize );
+
+		return stubs;
+	}
 } )();

--- a/tests/plugins/dialog/positioning.js
+++ b/tests/plugins/dialog/positioning.js
@@ -142,6 +142,7 @@
 			} );
 		},
 
+		// (#2395)
 		'test dialog resize': function() {
 			this.editorBot.dialog( 'link', function( dialog ) {
 				var dialogSize = dialog.getSize(),

--- a/tests/plugins/dialog/positioning.js
+++ b/tests/plugins/dialog/positioning.js
@@ -9,7 +9,7 @@
 	bender.test( {
 		setUp: function() {
 			// Make sure page is scrollable on vertical screens.
-			CKEDITOR.document.document.getBody().appendHtml( '<div style="height:4000px"></div>' );
+			CKEDITOR.document.getBody().appendHtml( '<div style="height:4000px"></div>' );
 		},
 		tearDown: function() {
 			var dialog = CKEDITOR.dialog.getCurrent();

--- a/tests/plugins/dialog/positioning.js
+++ b/tests/plugins/dialog/positioning.js
@@ -108,9 +108,6 @@
 					expectedX = Math.floor( ( viewPaneSize.width - dialogSize.width ) / 2 ),
 					expectedY = Math.floor( ( viewPaneSize.height - dialogSize.height ) / 2 );
 
-				stubs.getWindow.returns( window );
-				stubs.getViewPane.returns( viewPaneSize );
-
 				dialog.parts.title.fire( 'mousedown', {
 					$: {
 						screenX: 0,
@@ -147,6 +144,38 @@
 
 				CKEDITOR.document.fire( 'mouseup' );
 				dialog.hide();
+			} );
+		},
+
+		'test dialog resize': function() {
+			this.editorBot.dialog( 'link', function( dialog ) {
+				var dialogSize = dialog.getSize(),
+					resizer = dialog._.element.findOne( '.cke_resizer' ),
+					sizeChange;
+
+				resizer.$.onmousedown( {
+					screenX: 0,
+					screenY: 0
+				} );
+
+				CKEDITOR.document.fire( 'mousemove', {
+					$: {
+						screenX: 10,
+						screenY: 10
+					},
+					preventDefault: function() {}
+				} );
+
+				CKEDITOR.document.fire( 'mouseup' );
+
+				sizeChange = {
+					width: dialog.getSize().width - dialogSize.width,
+					height: dialog.getSize().height - dialogSize.height
+				};
+
+				// When resizing some floats might be rounded.
+				assert.isNumberInRange( 10, sizeChange.width - 1, sizeChange.width );
+				assert.isNumberInRange( 10, sizeChange.height - 1, sizeChange.height );
 			} );
 		}
 	} );

--- a/tests/plugins/dialog/positioning.js
+++ b/tests/plugins/dialog/positioning.js
@@ -137,6 +137,10 @@
 
 		// (#2395)
 		'test dialog resize': function() {
+			// Mobile browsers doesn't support dialog resize.
+			if ( bender.tools.env.mobile ) {
+				assert.ignore();
+			}
 			var viewPaneSize = {
 					width: 1000,
 					height: 1000

--- a/tests/plugins/dialog/positioning.js
+++ b/tests/plugins/dialog/positioning.js
@@ -45,19 +45,15 @@
 				assert.areEqual( container.getStyle( 'display' ), 'flex', 'Dialog container should have `display:flex`.' );
 				assert.areEqual( element.getStyle( 'position' ), '', 'Dialog element should\'t have position style.' );
 				assert.areEqual( element.getStyle( 'margin' ), 'auto', 'Dialog element should have `margin:auto`.' );
-
-				dialog.hide();
 			} );
 		},
 		// (#2395).
 		'test dialog cover styles': function() {
-			this.editorBot.dialog( 'link', function( dialog ) {
+			this.editorBot.dialog( 'link', function() {
 				var cover = CKEDITOR.document.findOne( '.cke_dialog_background_cover' );
 
 				assert.areEqual( cover.getStyle( 'width' ), '100%', 'Dialog element should have `width:100%`.' );
 				assert.areEqual( cover.getStyle( 'height' ), '100%', 'Dialog element should have `height:100%`.' );
-
-				dialog.hide();
 			} );
 		},
 		// When drag starts, dialog becomes centered with `position:absolute`, then it moves together with mouse (#2395).
@@ -143,7 +139,6 @@
 				assert.areEqual( 100, actualY - expectedY, 'Dialog should be moved by 100px down.' );
 
 				CKEDITOR.document.fire( 'mouseup' );
-				dialog.hide();
 			} );
 		},
 

--- a/tests/plugins/dialog/positioning.js
+++ b/tests/plugins/dialog/positioning.js
@@ -200,12 +200,27 @@
 		var window = CKEDITOR.document.getWindow(),
 			stubs = {
 				getWindow: sinon.stub( CKEDITOR.document, 'getWindow' ),
-				getViewPane: sinon.stub( window, 'getViewPaneSize' )
+				getViewPane: sinon.stub( window, 'getViewPaneSize' ),
+				getContainerSize: mockDialogContainerSize( viewPaneSize )
 			};
 
 		stubs.getWindow.returns( window );
 		stubs.getViewPane.returns( viewPaneSize );
 
 		return stubs;
+	}
+
+	function mockDialogContainerSize( sizes ) {
+		var originalMethod = CKEDITOR.dom.element.prototype.getClientSize;
+
+		CKEDITOR.dom.element.prototype.getClientSize = function() {
+			return this.hasClass( 'cke_dialog_container' ) ? sizes :  originalMethod.call( this );
+		};
+
+		return {
+			restore: function() {
+				CKEDITOR.dom.element.prototype.getClientSize = originalMethod;
+			}
+		};
 	}
 } )();


### PR DESCRIPTION
## What is the purpose of this pull request?

Bug fix

## Does your PR contain necessary tests?

All patches which change the editor code must include tests. You can always read more
on [PR testing](https://ckeditor.com/docs/ckeditor4/latest/guide/dev_contributing_code.html#tests),
[how to set the testing environment](https://ckeditor.com/docs/ckeditor4/latest/guide/dev_tests.html) and
[how to create tests](https://ckeditor.com/docs/ckeditor4/latest/guide/dev_tests.html#creating-your-own-test)
in the official CKEditor documentation.

### This PR contains

- [X] Unit tests
- [X] Manual tests

## What changes did you make?

This is early PR with proposal of solution.

### Current solution

When soft keyboard appears on touch devices it causes 'resize' event on which we were recalculating center position of fixed dialog. After that browser tried to scroll into view of input but it took wrong position, probably before moving it.
Such complex way of centering dialog is unnecessary, as dialog can't be dragged without mouse.

I have reworked how a dialog is styled:
- Dialogs wrapper now has `position: fixed` with `width` and `height` set to 100%.
- When the dialog is shown `document.body` gets a class with 'overflow:hidden', and style `padding-right` calculated from width of scrollbar.
- In IE the dialog is centered via `absolute` position calculated by script.
- In any other browser the dialog is centered by only CSS.
- When the dialog is is dragged it becomes `absolute` positioned.

After changes we won't adjust dialogs position once opened on the mobile devices, it will be positioned only by CSS and the way it's scrolled into view of focused inputs is only relying on browser implementation.

Unfortunately browsers implementation isn't perfect and sometimes it still scrolls it in wrong way, but that's rare. And it should be mentioned that this can happen even with fully static pages, with no js, and everything relative positioned.

### Other solution

Adding `once( 'scroll' ...` inside `focus` listener and calling `scrollIntoView` on currently focused input. This is much simpler, but creates visible flickering, so I dropped this idea for now.

### Todo

- Adding styles to other skins, and testing them.
- Improving way how missing scrollbars are covered with padding, or dropping idea to let page expand.
- Unit tests.
- Cleaning code.

Closes #2395. Closes #3359. Closes #453.