### PR TITLE
Fix forceSimpleAmpersand config implementation

### DIFF
--- a/plugins/htmlwriter/plugin.js
+++ b/plugins/htmlwriter/plugin.js
@@ -179,9 +179,11 @@ CKEDITOR.htmlWriter = CKEDITOR.tools.createClass( {
 		attribute: function( attName, attValue ) {
 
 			if ( typeof attValue == 'string' ) {
-				this.forceSimpleAmpersand && ( attValue = attValue.replace( /&amp;/g, '&' ) );
 				// Browsers don't always escape special character in attribute values. (http://dev.ckeditor.com/ticket/4683, http://dev.ckeditor.com/ticket/4719).
 				attValue = CKEDITOR.tools.htmlEncodeAttr( attValue );
+				
+				// Run ampersand replacement after the  htmlEncodeAttr, otherwise the results are overwritten (https://github.com/ckeditor/ckeditor-dev/issues/965)
+				this.forceSimpleAmpersand && ( attValue = attValue.replace( /&amp;/g, '&' ) );
 			}
 
 			this._.output.push( ' ', attName, '="', attValue, '"' );

--- a/tests/plugins/htmlwriter/htmlwriter.js
+++ b/tests/plugins/htmlwriter/htmlwriter.js
@@ -39,5 +39,39 @@ bender.test( {
 				assert.areSame( afterFormat, bot.getData( false, false ) );
 			} );
 		} );
+	},
+	'test editor config.forceSimpleAmpersand in html element attributes': function () {
+		var data = '<p><a href="http://www.blah.com?foo=1&bar=2">Test link</a></p>';
+		bender.editorBot.create({
+			name: 'basic_forceSimpleAmpersand',
+			formattedOutput: true,
+
+			config: {
+				allowedContent: true,
+				forceSimpleAmpersand: true,
+
+				on: {
+					instanceReady: function (evt) {
+						var wrtierConfig = {
+							indent: true,
+							breakBeforeOpen: false,
+							breakAfterOpen: false,
+							breakBeforeClose: false,
+							breakAfterClose: false
+						};
+						
+						evt.editor.dataProcessor.writer.setRules('p', wrtierConfig);
+						evt.editor.dataProcessor.writer.setRules('div', wrtierConfig);
+					}
+				}
+			}
+		}, function (bot) {
+			bot.setData( data, function () {
+				var afterFormat = bot.getData( false, false);
+
+				// Trigger getData a second time to reveal bug.
+				assert.areSame( afterFormat, data);
+			});
+		});
 	}
 } );


### PR DESCRIPTION
Run ampersand replacement after the  htmlEncodeAttr, otherwise the results are overwritten (https://github.com/ckeditor/ckeditor-dev/issues/965)

## What is the purpose of this pull request?
Bug fix

<!-- Bug fix / New feature / Typo fix / Other, please explain  -->

## Does your PR contain necessary tests?

All patches which change the editor code must include tests. You can always read more
on [PR testing](https://ckeditor.com/docs/ckeditor4/latest/guide/dev_contributing_code.html#tests),
[how to set the testing environment](https://ckeditor.com/docs/ckeditor4/latest/guide/dev_tests.html) and
[how to create tests](https://ckeditor.com/docs/ckeditor4/latest/guide/dev_tests.html#creating-your-own-test)
in the official CKEditor documentation.

### This PR contains

- [x] Unit tests
- [ ] Manual tests

## What changes did you make?
Run ampersand replacement after CKEDITOR.tools.htmlEncodeAttr() executes against the given attribute 

Closes #965.