### PR TITLE
Fixed expandable button label when clicked

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -29,6 +29,7 @@ Fixed Issues:
 * [#898](https://github.com/ckeditor/ckeditor-dev/issues/898): Fixed: [Enhanced Image](https://ckeditor.com/cke4/addon/image2) long alt text protrudes into editor when image is selected.
 * [#1113](https://github.com/ckeditor/ckeditor-dev/issues/1113): [Firefox] Fixed: Nested contenteditable elements path not updated on focus with [Div Editing Area](https://ckeditor.com/cke4/addon/divarea) plugin.
 * [#1682](https://github.com/ckeditor/ckeditor-dev/issues/1682) Fixed: Hovering [Balloon Toolbar](https://ckeditor.com/cke4/addon/balloontoolbar) panel changes its size causing flickering.
+* [#421](https://github.com/ckeditor/ckeditor-dev/issues/421) Fixed: Expandable [Button](https://ckeditor.com/cke4/addon/button) puts `(Selected)` text at the end of the label when clicked.
 
 API Changes:
 

--- a/dev/langtool/_common.sh
+++ b/dev/langtool/_common.sh
@@ -46,5 +46,5 @@ fi
 cd ../..
 
 
-plugins=( about autoembed basicstyles bidi blockquote button clipboard codesnippet colorbutton colordialog contextmenu copyformatting devtools div docprops easyimage elementspath embedbase fakeobjects filetools find flash font format forms horizontalrule iframe image image2 imagebase indent language link list liststyle magicline maximize mathjax newpage notification pagebreak pastefromword pastetext placeholder preview print removeformat save selectall showblocks smiley sourcearea sourcedialog specialchar stylescombo table templates toolbar uicolor undo uploadwidget widget )
+plugins=( about autoembed basicstyles bidi blockquote clipboard codesnippet colorbutton colordialog contextmenu copyformatting devtools div docprops easyimage elementspath embedbase fakeobjects filetools find flash font format forms horizontalrule iframe image image2 imagebase indent language link list liststyle magicline maximize mathjax newpage notification pagebreak pastefromword pastetext placeholder preview print removeformat save selectall showblocks smiley sourcearea sourcedialog specialchar stylescombo table templates toolbar uicolor undo uploadwidget widget )
 plugins_dialogs=( a11yhelp specialchar )

--- a/dev/langtool/meta/ckeditor.plugin-button/meta.txt
+++ b/dev/langtool/meta/ckeditor.plugin-button/meta.txt
@@ -1,4 +1,0 @@
-# Copyright (c) 2003-2018, CKSource - Frederico Knabben. All rights reserved.
-# For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-oss-license
-
-selectedLabel = Suffix added to the menu button label for screen readers whenever the button is marked as enabled.

--- a/plugins/button/lang/af.js
+++ b/plugins/button/lang/af.js
@@ -1,8 +1,0 @@
-/**
- * @license Copyright (c) 2003-2018, CKSource - Frederico Knabben. All rights reserved.
- * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-oss-license
- */
-
-CKEDITOR.plugins.setLang( 'button', 'af', {
-	selectedLabel: '%1 uitgekies'
-} );

--- a/plugins/button/lang/ar.js
+++ b/plugins/button/lang/ar.js
@@ -1,8 +1,0 @@
-/**
- * @license Copyright (c) 2003-2018, CKSource - Frederico Knabben. All rights reserved.
- * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-oss-license
- */
-
-CKEDITOR.plugins.setLang( 'button', 'ar', {
-	selectedLabel: '%1 (محدد)'
-} );

--- a/plugins/button/lang/az.js
+++ b/plugins/button/lang/az.js
@@ -1,8 +1,0 @@
-/**
- * @license Copyright (c) 2003-2018, CKSource - Frederico Knabben. All rights reserved.
- * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-oss-license
- */
-
-CKEDITOR.plugins.setLang( 'button', 'az', {
-	selectedLabel: '%1 (seçilib)'
-} );

--- a/plugins/button/lang/bg.js
+++ b/plugins/button/lang/bg.js
@@ -1,8 +1,0 @@
-/**
- * @license Copyright (c) 2003-2018, CKSource - Frederico Knabben. All rights reserved.
- * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-oss-license
- */
-
-CKEDITOR.plugins.setLang( 'button', 'bg', {
-	selectedLabel: '%1 (Избрано)'
-} );

--- a/plugins/button/lang/ca.js
+++ b/plugins/button/lang/ca.js
@@ -1,8 +1,0 @@
-/**
- * @license Copyright (c) 2003-2018, CKSource - Frederico Knabben. All rights reserved.
- * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-oss-license
- */
-
-CKEDITOR.plugins.setLang( 'button', 'ca', {
-	selectedLabel: '%1 (Seleccionat)'
-} );

--- a/plugins/button/lang/cs.js
+++ b/plugins/button/lang/cs.js
@@ -1,8 +1,0 @@
-/**
- * @license Copyright (c) 2003-2018, CKSource - Frederico Knabben. All rights reserved.
- * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-oss-license
- */
-
-CKEDITOR.plugins.setLang( 'button', 'cs', {
-	selectedLabel: '%1 (Vybráno)'
-} );

--- a/plugins/button/lang/da.js
+++ b/plugins/button/lang/da.js
@@ -1,8 +1,0 @@
-/**
- * @license Copyright (c) 2003-2018, CKSource - Frederico Knabben. All rights reserved.
- * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-oss-license
- */
-
-CKEDITOR.plugins.setLang( 'button', 'da', {
-	selectedLabel: '%1 (Valgt)'
-} );

--- a/plugins/button/lang/de-ch.js
+++ b/plugins/button/lang/de-ch.js
@@ -1,8 +1,0 @@
-/**
- * @license Copyright (c) 2003-2018, CKSource - Frederico Knabben. All rights reserved.
- * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-oss-license
- */
-
-CKEDITOR.plugins.setLang( 'button', 'de-ch', {
-	selectedLabel: '%1 (Ausgewählt)'
-} );

--- a/plugins/button/lang/de.js
+++ b/plugins/button/lang/de.js
@@ -1,8 +1,0 @@
-/**
- * @license Copyright (c) 2003-2018, CKSource - Frederico Knabben. All rights reserved.
- * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-oss-license
- */
-
-CKEDITOR.plugins.setLang( 'button', 'de', {
-	selectedLabel: '%1 (Ausgewählt)'
-} );

--- a/plugins/button/lang/el.js
+++ b/plugins/button/lang/el.js
@@ -1,8 +1,0 @@
-/**
- * @license Copyright (c) 2003-2018, CKSource - Frederico Knabben. All rights reserved.
- * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-oss-license
- */
-
-CKEDITOR.plugins.setLang( 'button', 'el', {
-	selectedLabel: '%1 (Επιλεγμένο)'
-} );

--- a/plugins/button/lang/en-au.js
+++ b/plugins/button/lang/en-au.js
@@ -1,8 +1,0 @@
-/**
- * @license Copyright (c) 2003-2018, CKSource - Frederico Knabben. All rights reserved.
- * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-oss-license
- */
-
-CKEDITOR.plugins.setLang( 'button', 'en-au', {
-	selectedLabel: '%1 (Selected)'
-} );

--- a/plugins/button/lang/en-gb.js
+++ b/plugins/button/lang/en-gb.js
@@ -1,8 +1,0 @@
-/**
- * @license Copyright (c) 2003-2018, CKSource - Frederico Knabben. All rights reserved.
- * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-oss-license
- */
-
-CKEDITOR.plugins.setLang( 'button', 'en-gb', {
-	selectedLabel: '%1 (Selected)'
-} );

--- a/plugins/button/lang/en.js
+++ b/plugins/button/lang/en.js
@@ -1,8 +1,0 @@
-/**
- * @license Copyright (c) 2003-2018, CKSource - Frederico Knabben. All rights reserved.
- * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-oss-license
- */
-
-CKEDITOR.plugins.setLang( 'button', 'en', {
-	selectedLabel: '%1 (Selected)'
-} );

--- a/plugins/button/lang/eo.js
+++ b/plugins/button/lang/eo.js
@@ -1,8 +1,0 @@
-/**
- * @license Copyright (c) 2003-2018, CKSource - Frederico Knabben. All rights reserved.
- * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-oss-license
- */
-
-CKEDITOR.plugins.setLang( 'button', 'eo', {
-	selectedLabel: '%1 (Selektita)'
-} );

--- a/plugins/button/lang/es-mx.js
+++ b/plugins/button/lang/es-mx.js
@@ -1,8 +1,0 @@
-/**
- * @license Copyright (c) 2003-2018, CKSource - Frederico Knabben. All rights reserved.
- * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-oss-license
- */
-
-CKEDITOR.plugins.setLang( 'button', 'es-mx', {
-	selectedLabel: '%1 (Seleccionado)'
-} );

--- a/plugins/button/lang/es.js
+++ b/plugins/button/lang/es.js
@@ -1,8 +1,0 @@
-/**
- * @license Copyright (c) 2003-2018, CKSource - Frederico Knabben. All rights reserved.
- * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-oss-license
- */
-
-CKEDITOR.plugins.setLang( 'button', 'es', {
-	selectedLabel: '%1 (Seleccionado)'
-} );

--- a/plugins/button/lang/eu.js
+++ b/plugins/button/lang/eu.js
@@ -1,8 +1,0 @@
-/**
- * @license Copyright (c) 2003-2018, CKSource - Frederico Knabben. All rights reserved.
- * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-oss-license
- */
-
-CKEDITOR.plugins.setLang( 'button', 'eu', {
-	selectedLabel: '%1 (hautatuta)'
-} );

--- a/plugins/button/lang/fa.js
+++ b/plugins/button/lang/fa.js
@@ -1,8 +1,0 @@
-/**
- * @license Copyright (c) 2003-2018, CKSource - Frederico Knabben. All rights reserved.
- * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-oss-license
- */
-
-CKEDITOR.plugins.setLang( 'button', 'fa', {
-	selectedLabel: '%1 (انتخاب شده)'
-} );

--- a/plugins/button/lang/fi.js
+++ b/plugins/button/lang/fi.js
@@ -1,8 +1,0 @@
-/**
- * @license Copyright (c) 2003-2018, CKSource - Frederico Knabben. All rights reserved.
- * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-oss-license
- */
-
-CKEDITOR.plugins.setLang( 'button', 'fi', {
-	selectedLabel: '%1 (Valittu)'
-} );

--- a/plugins/button/lang/fr.js
+++ b/plugins/button/lang/fr.js
@@ -1,8 +1,0 @@
-/**
- * @license Copyright (c) 2003-2018, CKSource - Frederico Knabben. All rights reserved.
- * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-oss-license
- */
-
-CKEDITOR.plugins.setLang( 'button', 'fr', {
-	selectedLabel: '%1 (Sélectionné)'
-} );

--- a/plugins/button/lang/gl.js
+++ b/plugins/button/lang/gl.js
@@ -1,8 +1,0 @@
-/**
- * @license Copyright (c) 2003-2018, CKSource - Frederico Knabben. All rights reserved.
- * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-oss-license
- */
-
-CKEDITOR.plugins.setLang( 'button', 'gl', {
-	selectedLabel: '%1 (seleccionado)'
-} );

--- a/plugins/button/lang/he.js
+++ b/plugins/button/lang/he.js
@@ -1,8 +1,0 @@
-/**
- * @license Copyright (c) 2003-2018, CKSource - Frederico Knabben. All rights reserved.
- * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-oss-license
- */
-
-CKEDITOR.plugins.setLang( 'button', 'he', {
-	selectedLabel: '1% (סומן)'
-} );

--- a/plugins/button/lang/hr.js
+++ b/plugins/button/lang/hr.js
@@ -1,8 +1,0 @@
-/**
- * @license Copyright (c) 2003-2018, CKSource - Frederico Knabben. All rights reserved.
- * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-oss-license
- */
-
-CKEDITOR.plugins.setLang( 'button', 'hr', {
-	selectedLabel: '%1 (Odabrano)'
-} );

--- a/plugins/button/lang/hu.js
+++ b/plugins/button/lang/hu.js
@@ -1,8 +1,0 @@
-/**
- * @license Copyright (c) 2003-2018, CKSource - Frederico Knabben. All rights reserved.
- * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-oss-license
- */
-
-CKEDITOR.plugins.setLang( 'button', 'hu', {
-	selectedLabel: '%1 (Kiválasztva)'
-} );

--- a/plugins/button/lang/id.js
+++ b/plugins/button/lang/id.js
@@ -1,8 +1,0 @@
-/**
- * @license Copyright (c) 2003-2018, CKSource - Frederico Knabben. All rights reserved.
- * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-oss-license
- */
-
-CKEDITOR.plugins.setLang( 'button', 'id', {
-	selectedLabel: '%1(Dipilih)'
-} );

--- a/plugins/button/lang/it.js
+++ b/plugins/button/lang/it.js
@@ -1,8 +1,0 @@
-/**
- * @license Copyright (c) 2003-2018, CKSource - Frederico Knabben. All rights reserved.
- * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-oss-license
- */
-
-CKEDITOR.plugins.setLang( 'button', 'it', {
-	selectedLabel: '%1 (selezionato)'
-} );

--- a/plugins/button/lang/ja.js
+++ b/plugins/button/lang/ja.js
@@ -1,8 +1,0 @@
-/**
- * @license Copyright (c) 2003-2018, CKSource - Frederico Knabben. All rights reserved.
- * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-oss-license
- */
-
-CKEDITOR.plugins.setLang( 'button', 'ja', {
-	selectedLabel: '%1 (選択中)'
-} );

--- a/plugins/button/lang/km.js
+++ b/plugins/button/lang/km.js
@@ -1,8 +1,0 @@
-/**
- * @license Copyright (c) 2003-2018, CKSource - Frederico Knabben. All rights reserved.
- * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-oss-license
- */
-
-CKEDITOR.plugins.setLang( 'button', 'km', {
-	selectedLabel: '%1 (បាន​ជ្រើស​រើស)'
-} );

--- a/plugins/button/lang/ko.js
+++ b/plugins/button/lang/ko.js
@@ -1,8 +1,0 @@
-/**
- * @license Copyright (c) 2003-2018, CKSource - Frederico Knabben. All rights reserved.
- * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-oss-license
- */
-
-CKEDITOR.plugins.setLang( 'button', 'ko', {
-	selectedLabel: '%1 (선택됨)'
-} );

--- a/plugins/button/lang/ku.js
+++ b/plugins/button/lang/ku.js
@@ -1,8 +1,0 @@
-/**
- * @license Copyright (c) 2003-2018, CKSource - Frederico Knabben. All rights reserved.
- * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-oss-license
- */
-
-CKEDITOR.plugins.setLang( 'button', 'ku', {
-	selectedLabel: '%1 (هەڵبژێردراو)'
-} );

--- a/plugins/button/lang/lt.js
+++ b/plugins/button/lang/lt.js
@@ -1,8 +1,0 @@
-/**
- * @license Copyright (c) 2003-2018, CKSource - Frederico Knabben. All rights reserved.
- * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-oss-license
- */
-
-CKEDITOR.plugins.setLang( 'button', 'lt', {
-	selectedLabel: '%1 (Pasirinkta)'
-} );

--- a/plugins/button/lang/lv.js
+++ b/plugins/button/lang/lv.js
@@ -1,8 +1,0 @@
-/**
- * @license Copyright (c) 2003-2018, CKSource - Frederico Knabben. All rights reserved.
- * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-oss-license
- */
-
-CKEDITOR.plugins.setLang( 'button', 'lv', {
-	selectedLabel: '%1 (Atzīmēts)'
-} );

--- a/plugins/button/lang/nb.js
+++ b/plugins/button/lang/nb.js
@@ -1,8 +1,0 @@
-/**
- * @license Copyright (c) 2003-2018, CKSource - Frederico Knabben. All rights reserved.
- * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-oss-license
- */
-
-CKEDITOR.plugins.setLang( 'button', 'nb', {
-	selectedLabel: '%1 (Valgt)'
-} );

--- a/plugins/button/lang/nl.js
+++ b/plugins/button/lang/nl.js
@@ -1,8 +1,0 @@
-/**
- * @license Copyright (c) 2003-2018, CKSource - Frederico Knabben. All rights reserved.
- * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-oss-license
- */
-
-CKEDITOR.plugins.setLang( 'button', 'nl', {
-	selectedLabel: '%1 (Geselecteerd)'
-} );

--- a/plugins/button/lang/no.js
+++ b/plugins/button/lang/no.js
@@ -1,8 +1,0 @@
-/**
- * @license Copyright (c) 2003-2018, CKSource - Frederico Knabben. All rights reserved.
- * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-oss-license
- */
-
-CKEDITOR.plugins.setLang( 'button', 'no', {
-	selectedLabel: '%1 (Valgt)'
-} );

--- a/plugins/button/lang/oc.js
+++ b/plugins/button/lang/oc.js
@@ -1,8 +1,0 @@
-/**
- * @license Copyright (c) 2003-2018, CKSource - Frederico Knabben. All rights reserved.
- * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-oss-license
- */
-
-CKEDITOR.plugins.setLang( 'button', 'oc', {
-	selectedLabel: '%1 (Seleccionat)'
-} );

--- a/plugins/button/lang/pl.js
+++ b/plugins/button/lang/pl.js
@@ -1,8 +1,0 @@
-/**
- * @license Copyright (c) 2003-2018, CKSource - Frederico Knabben. All rights reserved.
- * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-oss-license
- */
-
-CKEDITOR.plugins.setLang( 'button', 'pl', {
-	selectedLabel: '%1 (Wybrany)'
-} );

--- a/plugins/button/lang/pt-br.js
+++ b/plugins/button/lang/pt-br.js
@@ -1,8 +1,0 @@
-/**
- * @license Copyright (c) 2003-2018, CKSource - Frederico Knabben. All rights reserved.
- * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-oss-license
- */
-
-CKEDITOR.plugins.setLang( 'button', 'pt-br', {
-	selectedLabel: '%1 (Selecionado)'
-} );

--- a/plugins/button/lang/pt.js
+++ b/plugins/button/lang/pt.js
@@ -1,8 +1,0 @@
-/**
- * @license Copyright (c) 2003-2018, CKSource - Frederico Knabben. All rights reserved.
- * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-oss-license
- */
-
-CKEDITOR.plugins.setLang( 'button', 'pt', {
-	selectedLabel: '%1 (Selecionado)'
-} );

--- a/plugins/button/lang/ro.js
+++ b/plugins/button/lang/ro.js
@@ -1,8 +1,0 @@
-/**
- * @license Copyright (c) 2003-2018, CKSource - Frederico Knabben. All rights reserved.
- * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-oss-license
- */
-
-CKEDITOR.plugins.setLang( 'button', 'ro', {
-	selectedLabel: '%1 (Selectat)'
-} );

--- a/plugins/button/lang/ru.js
+++ b/plugins/button/lang/ru.js
@@ -1,8 +1,0 @@
-/**
- * @license Copyright (c) 2003-2018, CKSource - Frederico Knabben. All rights reserved.
- * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-oss-license
- */
-
-CKEDITOR.plugins.setLang( 'button', 'ru', {
-	selectedLabel: '%1 (Выбрано)'
-} );

--- a/plugins/button/lang/sk.js
+++ b/plugins/button/lang/sk.js
@@ -1,8 +1,0 @@
-/**
- * @license Copyright (c) 2003-2018, CKSource - Frederico Knabben. All rights reserved.
- * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-oss-license
- */
-
-CKEDITOR.plugins.setLang( 'button', 'sk', {
-	selectedLabel: '%1 (Vybrané)'
-} );

--- a/plugins/button/lang/sl.js
+++ b/plugins/button/lang/sl.js
@@ -1,8 +1,0 @@
-/**
- * @license Copyright (c) 2003-2018, CKSource - Frederico Knabben. All rights reserved.
- * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-oss-license
- */
-
-CKEDITOR.plugins.setLang( 'button', 'sl', {
-	selectedLabel: '%1 (Izbrano)'
-} );

--- a/plugins/button/lang/sq.js
+++ b/plugins/button/lang/sq.js
@@ -1,8 +1,0 @@
-/**
- * @license Copyright (c) 2003-2018, CKSource - Frederico Knabben. All rights reserved.
- * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-oss-license
- */
-
-CKEDITOR.plugins.setLang( 'button', 'sq', {
-	selectedLabel: '%1 (Përzgjedhur)'
-} );

--- a/plugins/button/lang/sv.js
+++ b/plugins/button/lang/sv.js
@@ -1,8 +1,0 @@
-/**
- * @license Copyright (c) 2003-2018, CKSource - Frederico Knabben. All rights reserved.
- * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-oss-license
- */
-
-CKEDITOR.plugins.setLang( 'button', 'sv', {
-	selectedLabel: '%1 (Vald)'
-} );

--- a/plugins/button/lang/tr.js
+++ b/plugins/button/lang/tr.js
@@ -1,8 +1,0 @@
-/**
- * @license Copyright (c) 2003-2018, CKSource - Frederico Knabben. All rights reserved.
- * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-oss-license
- */
-
-CKEDITOR.plugins.setLang( 'button', 'tr', {
-	selectedLabel: '%1 (Seçilmiş)'
-} );

--- a/plugins/button/lang/tt.js
+++ b/plugins/button/lang/tt.js
@@ -1,8 +1,0 @@
-/**
- * @license Copyright (c) 2003-2018, CKSource - Frederico Knabben. All rights reserved.
- * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-oss-license
- */
-
-CKEDITOR.plugins.setLang( 'button', 'tt', {
-	selectedLabel: '%1 (Сайланган)'
-} );

--- a/plugins/button/lang/ug.js
+++ b/plugins/button/lang/ug.js
@@ -1,8 +1,0 @@
-/**
- * @license Copyright (c) 2003-2018, CKSource - Frederico Knabben. All rights reserved.
- * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-oss-license
- */
-
-CKEDITOR.plugins.setLang( 'button', 'ug', {
-	selectedLabel: '%1 (تاللاندى)'
-} );

--- a/plugins/button/lang/uk.js
+++ b/plugins/button/lang/uk.js
@@ -1,8 +1,0 @@
-/**
- * @license Copyright (c) 2003-2018, CKSource - Frederico Knabben. All rights reserved.
- * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-oss-license
- */
-
-CKEDITOR.plugins.setLang( 'button', 'uk', {
-	selectedLabel: '%1 (Вибрано)'
-} );

--- a/plugins/button/lang/vi.js
+++ b/plugins/button/lang/vi.js
@@ -1,8 +1,0 @@
-/**
- * @license Copyright (c) 2003-2018, CKSource - Frederico Knabben. All rights reserved.
- * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-oss-license
- */
-
-CKEDITOR.plugins.setLang( 'button', 'vi', {
-	selectedLabel: '%1 (Đã chọn)'
-} );

--- a/plugins/button/lang/zh-cn.js
+++ b/plugins/button/lang/zh-cn.js
@@ -1,8 +1,0 @@
-/**
- * @license Copyright (c) 2003-2018, CKSource - Frederico Knabben. All rights reserved.
- * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-oss-license
- */
-
-CKEDITOR.plugins.setLang( 'button', 'zh-cn', {
-	selectedLabel: '已选中 %1 项'
-} );

--- a/plugins/button/lang/zh.js
+++ b/plugins/button/lang/zh.js
@@ -1,8 +1,0 @@
-/**
- * @license Copyright (c) 2003-2018, CKSource - Frederico Knabben. All rights reserved.
- * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-oss-license
- */
-
-CKEDITOR.plugins.setLang( 'button', 'zh', {
-	selectedLabel: '%1 (已選取)'
-} );

--- a/plugins/button/plugin.js
+++ b/plugins/button/plugin.js
@@ -331,19 +331,22 @@
 			if ( element ) {
 				element.setState( state, 'cke_button' );
 
-				state == CKEDITOR.TRISTATE_DISABLED ?
-					element.setAttribute( 'aria-disabled', true ) :
+				if ( state == CKEDITOR.TRISTATE_DISABLED ) {
+					element.setAttribute( 'aria-disabled', true );
+				} else {
 					element.removeAttribute( 'aria-disabled' );
+				}
 
 				if ( !this.hasArrow ) {
 					// Note: aria-pressed attribute should not be added to menuButton instances. (https://dev.ckeditor.com/ticket/11331)
-					state == CKEDITOR.TRISTATE_ON ?
-						element.setAttribute( 'aria-pressed', true ) :
+					if ( state == CKEDITOR.TRISTATE_ON ) {
+						element.setAttribute( 'aria-pressed', true );
+					} else {
 						element.removeAttribute( 'aria-pressed' );
+					}
 				} else {
-					var newLabel = state == CKEDITOR.TRISTATE_ON ?
-						this._.editor.lang.button.selectedLabel.replace( /%1/g, this.label ) : this.label;
-					CKEDITOR.document.getById( this._.id + '_label' ).setText( newLabel );
+					element.setAttribute( 'aria-expanded', state == CKEDITOR.TRISTATE_ON );
+					CKEDITOR.document.getById( this._.id + '_label' ).setText( this.label );
 				}
 
 				return true;

--- a/plugins/button/plugin.js
+++ b/plugins/button/plugin.js
@@ -49,9 +49,6 @@
 		btnTpl = CKEDITOR.addTemplate( 'button', template );
 
 	CKEDITOR.plugins.add( 'button', {
-		// jscs:disable maximumLineLength
-		lang: 'af,ar,az,bg,ca,cs,da,de,de-ch,el,en,en-au,en-gb,eo,es,es-mx,eu,fa,fi,fr,gl,he,hr,hu,id,it,ja,km,ko,ku,lt,lv,nb,nl,no,oc,pl,pt,pt-br,ro,ru,sk,sl,sq,sv,tr,tt,ug,uk,vi,zh,zh-cn', // %REMOVE_LINE_CORE%
-		// jscs:enable maximumLineLength
 		beforeInit: function( editor ) {
 			editor.ui.addHandler( CKEDITOR.UI_BUTTON, CKEDITOR.ui.button.handler );
 		}

--- a/plugins/button/plugin.js
+++ b/plugins/button/plugin.js
@@ -327,23 +327,14 @@
 
 			if ( element ) {
 				element.setState( state, 'cke_button' );
-
-				if ( state == CKEDITOR.TRISTATE_DISABLED ) {
-					element.setAttribute( 'aria-disabled', true );
-				} else {
-					element.removeAttribute( 'aria-disabled' );
-				}
+				element.setAttribute( 'aria-disabled', state == CKEDITOR.TRISTATE_DISABLED );
 
 				if ( !this.hasArrow ) {
 					// Note: aria-pressed attribute should not be added to menuButton instances. (https://dev.ckeditor.com/ticket/11331)
-					if ( state == CKEDITOR.TRISTATE_ON ) {
-						element.setAttribute( 'aria-pressed', true );
-					} else {
-						element.removeAttribute( 'aria-pressed' );
-					}
+					element.setAttribute( 'aria-pressed', state == CKEDITOR.TRISTATE_ON );
 				} else {
+					// Indicates that menu button is opened (#421).
 					element.setAttribute( 'aria-expanded', state == CKEDITOR.TRISTATE_ON );
-					CKEDITOR.document.getById( this._.id + '_label' ).setText( this.label );
 				}
 
 				return true;

--- a/plugins/button/plugin.js
+++ b/plugins/button/plugin.js
@@ -331,7 +331,11 @@
 
 				if ( !this.hasArrow ) {
 					// Note: aria-pressed attribute should not be added to menuButton instances. (https://dev.ckeditor.com/ticket/11331)
-					element.setAttribute( 'aria-pressed', state == CKEDITOR.TRISTATE_ON );
+					if ( state === CKEDITOR.TRISTATE_ON ) {
+						element.setAttribute( 'aria-pressed', true );
+					} else {
+						element.removeAttribute( 'aria-pressed' );
+					}
 				} else {
 					// Indicates that menu button is opened (#421).
 					element.setAttribute( 'aria-expanded', state == CKEDITOR.TRISTATE_ON );

--- a/tests/plugins/button/aria.js
+++ b/tests/plugins/button/aria.js
@@ -3,7 +3,7 @@
 
 bender.editor = {
 	config: {
-		toolbar: [ [ 'custom_btn', 'disabled_btn', 'haspopup_btn' ] ],
+		toolbar: [ [ 'custom_btn', 'disabled_btn', 'haspopup_btn', 'arrow_btn' ] ],
 		on: {
 			'pluginsLoaded': function( evt ) {
 				var editor = evt.editor;
@@ -14,8 +14,13 @@ bender.editor = {
 					label: 'disabled button',
 					modes: {} // This button should be disabled because it does not work in any of modes.
 				} );
+
 				editor.ui.addButton( 'haspopup_btn', {
 					hasArrow: 'menu'
+				} );
+
+				editor.ui.addButton( 'arrow_btn', {
+					label: 'arrow button'
 				} );
 			}
 		}
@@ -61,6 +66,23 @@ bender.test( {
 		var btn = this.getUiItem( 'haspopup_btn' ),
 			btnEl = CKEDITOR.document.getById( btn._.id );
 		assert.areEqual( btnEl.getAttribute( 'aria-haspopup' ), 'menu' );
+	},
+
+	// (#421)
+	'test button label with arrow': function() {
+		var button = this.getUiItem( 'arrow_btn' ),
+			expectedAttributes = {
+				'aria-expanded': 'true'
+			};
+
+		button.hasArrow = true;
+		button.setState( CKEDITOR.TRISTATE_ON );
+
+		var buttonEl = this.getButtonDomElement( button ),
+			label = CKEDITOR.document.getById( buttonEl.getAttribute( 'aria-labelledby' ) );
+
+		this.assertAttribtues( expectedAttributes, button );
+		assert.areEqual( 'arrow button', label.getText(), 'innerText of label doesn\'t match' );
 	},
 
 	// Asserts that button has given attributes, with given values.

--- a/tests/plugins/button/manual/label.html
+++ b/tests/plugins/button/manual/label.html
@@ -1,0 +1,27 @@
+<span id="results"></span>
+<div id="editor"></div>
+
+<script>
+	var results = CKEDITOR.document.getById( 'results' ),
+		editor = CKEDITOR.replace( 'editor', {
+			on: {
+				instanceReady: function() {
+					var toolbox = editor.ui.space( 'toolbox' ),
+						langBtn = toolbox.findOne( '.cke_button' );
+
+					updateResults();
+
+					langBtn.on( 'click', updateResults );
+
+					function updateResults() {
+						var ariaExpanded = langBtn.getAttribute( 'aria-expanded' ),
+							label = langBtn.findOne( '.cke_button_label' );
+
+						results.setHtml( '<b>aria-expanded: </b> ' + ariaExpanded +
+							'</br><b>label: </b>' + label.getText()
+						);
+					}
+				}
+			}
+		} );
+</script>

--- a/tests/plugins/button/manual/label.html
+++ b/tests/plugins/button/manual/label.html
@@ -4,6 +4,7 @@
 <script>
 	var results = CKEDITOR.document.getById( 'results' ),
 		editor = CKEDITOR.replace( 'editor', {
+			language: 'en',
 			on: {
 				instanceReady: function() {
 					var toolbox = editor.ui.space( 'toolbox' ),

--- a/tests/plugins/button/manual/label.html
+++ b/tests/plugins/button/manual/label.html
@@ -10,9 +10,9 @@
 					var toolbox = editor.ui.space( 'toolbox' ),
 						langBtn = toolbox.findOne( '.cke_button' );
 
-					updateResults();
+					setInterval( updateResults, 250 );
 
-					langBtn.on( 'click', updateResults );
+					updateResults();
 
 					function updateResults() {
 						var ariaExpanded = langBtn.getAttribute( 'aria-expanded' ),

--- a/tests/plugins/button/manual/label.md
+++ b/tests/plugins/button/manual/label.md
@@ -1,0 +1,15 @@
+@bender-tags: 4.10.2, 421, bug, editor, button
+@bender-ui: collapsed
+@bender-ckeditor-plugins: wysiwygarea, toolbar, language
+
+Click `Language` button.
+
+## Expected
+
+* **aria-expanded:** true
+* **label:** Set language
+
+## Unexpected
+
+* **aria-expanded:** false
+* **label:** Set language ( Selected )

--- a/tests/plugins/button/manual/label.md
+++ b/tests/plugins/button/manual/label.md
@@ -2,14 +2,32 @@
 @bender-ui: collapsed
 @bender-ckeditor-plugins: wysiwygarea, toolbar, language
 
-Click `Language` button.
+## Normal mode
 
-## Expected
+1. Click `Language` button.
+
+### Expected
 
 * **aria-expanded:** true
 * **label:** Set language
 
-## Unexpected
+### Unexpected
 
 * **aria-expanded:** null
 * **label:** Set language (Selected)
+
+## Screen reader
+
+**Note**: you need to enable screen reader for this test.
+
+1. Click `Language` button.
+1. Blur `Language` button by clicking outside of the editor.
+
+### Expected
+
+* When menu is opened, screen reader reads "menu".
+* When menu is closed, screen reader reads "leaving menu".
+
+### Unexpected
+
+Invalid or missing screen reader reads.

--- a/tests/plugins/button/manual/label.md
+++ b/tests/plugins/button/manual/label.md
@@ -11,5 +11,5 @@ Click `Language` button.
 
 ## Unexpected
 
-* **aria-expanded:** false
-* **label:** Set language ( Selected )
+* **aria-expanded:** null
+* **label:** Set language (Selected)

--- a/tests/plugins/button/manual/label.md
+++ b/tests/plugins/button/manual/label.md
@@ -1,33 +1,23 @@
-@bender-tags: 4.10.2, 421, bug, editor, button
+@bender-tags: 4.11.0, 421, bug, editor, button
 @bender-ui: collapsed
 @bender-ckeditor-plugins: wysiwygarea, toolbar, language
 
-## Normal mode
+**Note**: you need to enable screen reader for this test.
 
-1. Click `Language` button.
+1. Focus the editor.
+1. Press `alt+f10` to focus toolbar.
+1. Press `space` to open `Language` menu.
+1. Press `esc` to close `Language` menu.
 
 ### Expected
 
 * **aria-expanded:** true
 * **label:** Set language
-
-### Unexpected
-
-* **aria-expanded:** null
-* **label:** Set language (Selected)
-
-## Screen reader
-
-**Note**: you need to enable screen reader for this test.
-
-1. Navigate to `Language` button.
-1. Blur `Language` button.
-
-### Expected
-
 * When menu is opened, screen reader reads "expanded".
 * When menu is closed, screen reader reads "leaving menu".
 
 ### Unexpected
 
-Invalid or missing screen reader reads.
+* **aria-expanded:** null
+* **label:** Set language (Selected)
+* Invalid or missing screen reader reads.

--- a/tests/plugins/button/manual/label.md
+++ b/tests/plugins/button/manual/label.md
@@ -20,12 +20,12 @@
 
 **Note**: you need to enable screen reader for this test.
 
-1. Click `Language` button.
-1. Blur `Language` button by clicking outside of the editor.
+1. Navigate to `Language` button.
+1. Blur `Language` button.
 
 ### Expected
 
-* When menu is opened, screen reader reads "menu".
+* When menu is opened, screen reader reads "expanded".
 * When menu is closed, screen reader reads "leaving menu".
 
 ### Unexpected


### PR DESCRIPTION
## What is the purpose of this pull request?

Bug fix

## Does your PR contain necessary tests?

All patches which change the editor code must include tests. You can always read more
on [PR testing](https://ckeditor.com/docs/ckeditor4/latest/guide/dev_contributing_code.html#tests),
[how to set the testing environment](https://ckeditor.com/docs/ckeditor4/latest/guide/dev_tests.html) and
[how to create tests](https://ckeditor.com/docs/ckeditor4/latest/guide/dev_tests.html#creating-your-own-test)
in the official CKEditor documentation.

### This PR contains

- [x] Unit tests
- [x] Manual tests

## What changes did you make?

Removed invalid label from an expandable button and added `aria-expanded` attribute for accessibility.
I also removed unused language files and property.

Closes #421