### PR TITLE
Determine merging direction of blocks by content

### DIFF
--- a/core/editable.js
+++ b/core/editable.js
@@ -2548,15 +2548,22 @@
 
 		// If something has left of the block to be merged, clean it up.
 		// It may happen when merging with list items.
-		if ( endBlock.getParent() ) {
-			// Move children to the first block.
-			endBlock.moveChildren( startBlock, false );
+		if ( startBlock.getParent() && endBlock.getParent() ) {
+			// Merge to the second block when the first block is empty.
+			var mergeForward = !startBlock.getText();
+
+			// Move children to the target block.
+			if ( mergeForward ) {
+				startBlock.moveChildren( endBlock, true );
+			} else {
+				endBlock.moveChildren( startBlock, false );
+			}
 
 			// ...and merge them if that's possible.
 			startPath.lastElement.mergeSiblings();
 
 			// If expanded selection, things are always merged like with BACKSPACE.
-			pruneEmptyDisjointAncestors( startBlock, endBlock, true );
+			pruneEmptyDisjointAncestors( startBlock, endBlock, !mergeForward );
 		}
 
 		// Make sure the result selection is collapsed.


### PR DESCRIPTION
## What is the purpose of this pull request?

Before the change, CKEditor always merged the secod block into the first one, preserving a style applied to the latter when the user merge two adjacent blocks by deleting content in the middle of them.

However, this behavior is not always desired when you select the entire first block and a part of the second one and delete the content. In that case, the user would expect the formatting of the remaining block (the second one) to be preserved which is not the case with the existing implementation.

This PR intends to solve this problem to make it feel more intuitive to users.

## Does your PR contain necessary tests?

No. But I'm not entirely sure if the proposed change is a reasonable one as I know very little about internals of CKEditor.

If my PR proves to be a sound one, I'll try to write a unit test to it if it's a requirement before it could get merged.

### This PR contains

- [ ] Unit tests
- [ ] Manual tests

## What changes did you make?

The change checks if the first block in the above described operation has any content left, and reverse the merge direction if necessary.