### PR TITLE
Fixed: dropdown items are draggable

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -17,6 +17,7 @@ Fixed Issues:
 * [#898](https://github.com/ckeditor/ckeditor-dev/issues/898): Fixed: [Enhanced Image](https://ckeditor.com/cke4/addon/image2) long alt text protrudes into editor when image is selected.
 * [#1113](https://github.com/ckeditor/ckeditor-dev/issues/1113): [Firefox] Fixed: Nested contenteditable elements path not updated on focus with [Div Editing Area](https://ckeditor.com/cke4/addon/divarea) plugin.
 * [#1682](https://github.com/ckeditor/ckeditor-dev/issues/1682) Fixed: Hovering [Balloon Toolbar](https://ckeditor.com/cke4/addon/balloontoolbar) panel changes its size causing flickering.
+* [#2430](https://github.com/ckeditor/ckeditor-dev/issues/2430) Fixed: [Color Button](https://ckeditor.com/cke4/addon/colorbutton) and [List Block](https://ckeditor.com/cke4/addon/listblock) items being draggable.
 
 API Changes:
 

--- a/plugins/colorbutton/plugin.js
+++ b/plugins/colorbutton/plugin.js
@@ -246,6 +246,8 @@ CKEDITOR.plugins.add( 'colorbutton', {
 				// Render the "Automatic" button.
 				output.push( '<a class="cke_colorauto" _cke_focus=1 hidefocus=true' +
 					' title="', lang.auto, '"' +
+					' draggable="false"' +
+					' ondragstart="return false;"' + // Draggable attribute is buggy on Firefox.
 					' onclick="CKEDITOR.tools.callFunction(', clickFn, ',null,\'', type, '\');return false;"' +
 					' href="javascript:void(\'', lang.auto, '\')"' +
 					' role="option" aria-posinset="1" aria-setsize="', total, '">' +
@@ -283,6 +285,8 @@ CKEDITOR.plugins.add( 'colorbutton', {
 				output.push( '<td>' +
 					'<a class="cke_colorbox" _cke_focus=1 hidefocus=true' +
 						' title="', colorLabel, '"' +
+						' draggable="false"' +
+						' ondragstart="return false;"' + // Draggable attribute is buggy on Firefox.
 						' onclick="CKEDITOR.tools.callFunction(', clickFn, ',\'', colorName, '\',\'', type, '\'); return false;"' +
 						' href="javascript:void(\'', colorLabel, '\')"' +
 						' data-value="' + colorCode + '"' +
@@ -299,6 +303,8 @@ CKEDITOR.plugins.add( 'colorbutton', {
 						'<td colspan="' + colorsPerRow + '" align="center">' +
 							'<a class="cke_colormore" _cke_focus=1 hidefocus=true' +
 								' title="', lang.more, '"' +
+								' draggable="false"' +
+								' ondragstart="return false;"' + // Draggable attribute is buggy on Firefox.
 								' onclick="CKEDITOR.tools.callFunction(', clickFn, ',\'?\',\'', type, '\');return false;"' +
 								' href="javascript:void(\'', lang.more, '\')"', ' role="option" aria-posinset="', total, '" aria-setsize="', total, '">', lang.more, '</a>' +
 						'</td>' ); // tr is later in the code.

--- a/plugins/listblock/plugin.js
+++ b/plugins/listblock/plugin.js
@@ -11,6 +11,8 @@ CKEDITOR.plugins.add( 'listblock', {
 			listItem = CKEDITOR.addTemplate( 'panel-list-item', '<li id="{id}" class="cke_panel_listItem" role=presentation>' +
 				'<a id="{id}_option" _cke_focus=1 hidefocus=true' +
 					' title="{title}"' +
+					' draggable="false"' +
+					' ondragstart="return false;"' + // Draggable attribute is buggy on Firefox.
 					' href="javascript:void(\'{val}\')" ' +
 					' {onclick}="CKEDITOR.tools.callFunction({clickFn},\'{val}\'); return false;"' + // https://dev.ckeditor.com/ticket/188
 						' role="option">' +

--- a/tests/plugins/colorbutton/colorbutton.js
+++ b/tests/plugins/colorbutton/colorbutton.js
@@ -184,7 +184,13 @@
 		'test changing text color to automatic': testAutomaticColor(),
 
 		// (#1084)
-		'test changing background color to automatic': testAutomaticColor( true )
+		'test changing background color to automatic': testAutomaticColor( true ),
+
+		// (#2430)
+		'test text color items not draggable': testElementsNotDraggable( 'TextColor' ),
+
+		// (#2430)
+		'test background color items not draggable': testElementsNotDraggable( 'BGColor' )
 	} );
 
 	function testAutomaticColor( isBackgroundColor ) {
@@ -201,6 +207,31 @@
 
 					assert.areEqual( '<p>Foo bar</p>', editor.getData() );
 				} );
+			} );
+
+			colorBtn.click( editor );
+
+			wait();
+		};
+	}
+
+	function testElementsNotDraggable( button ) {
+		return function() {
+			var editor = this.editor,
+				colorBtn = editor.ui.get( button );
+
+			editor.once( 'panelShow', function( evt ) {
+				resume( function() {
+					var block = colorBtn._.panel.getBlock( colorBtn._.id ).element,
+						anchors = block.find( 'a' ).toArray();
+
+					CKEDITOR.tools.array.forEach( anchors, function( element ) {
+						assert.areEqual( 'false', element.getAttribute( 'draggable' ), 'Draggable attribute should be "false".' );
+						assert.areEqual( 'return false;', element.getAttribute( 'ondragstart' ), 'Draggable attribute should be "false".' );
+					} );
+				} );
+
+				evt.data.hide();
 			} );
 
 			colorBtn.click( editor );

--- a/tests/plugins/colorbutton/manual/dragging.html
+++ b/tests/plugins/colorbutton/manual/dragging.html
@@ -1,0 +1,11 @@
+<textarea id="editor">Classic editor.</textarea>
+<div id="inline">Inline editor.</div>
+
+<script>
+	if ( bender.tools.env.mobile ) {
+		bender.ignore();
+	}
+
+	CKEDITOR.replace( 'editor' );
+	CKEDITOR.inline( 'inline' );
+</script>

--- a/tests/plugins/colorbutton/manual/dragging.md
+++ b/tests/plugins/colorbutton/manual/dragging.md
@@ -1,0 +1,14 @@
+@bender-tags: 2340, bug, 4.10.2
+@bender-ui: collapsed
+@bender-ckeditor-plugins: wysiwygarea, toolbar, colorbutton, floatingspace
+
+1. Press color button.
+1. Try to drag various elements from dropdown.
+
+Expected:
+
+Elements can't be dragged.
+
+Unexpected:
+
+Elements are draggable.

--- a/tests/plugins/colorbutton/manual/dragging.md
+++ b/tests/plugins/colorbutton/manual/dragging.md
@@ -1,6 +1,6 @@
 @bender-tags: 2340, bug, 4.10.2
 @bender-ui: collapsed
-@bender-ckeditor-plugins: wysiwygarea, toolbar, colorbutton, floatingspace
+@bender-ckeditor-plugins: wysiwygarea, toolbar, colorbutton, floatingspace, colordialog
 
 1. Press color button.
 1. Try to drag various elements from dropdown.

--- a/tests/plugins/colorbutton/manual/dragging.md
+++ b/tests/plugins/colorbutton/manual/dragging.md
@@ -1,4 +1,4 @@
-@bender-tags: 2340, bug, 4.10.2
+@bender-tags: 2430, bug, 4.10.2
 @bender-ui: collapsed
 @bender-ckeditor-plugins: wysiwygarea, toolbar, colorbutton, floatingspace, colordialog
 

--- a/tests/plugins/colorbutton/manual/dragging.md
+++ b/tests/plugins/colorbutton/manual/dragging.md
@@ -5,10 +5,10 @@
 1. Press color button.
 1. Try to drag various elements from dropdown.
 
-Expected:
+## Expected:
 
 Elements can't be dragged.
 
-Unexpected:
+## Unexpected:
 
 Elements are draggable.

--- a/tests/plugins/listblock/listblock.js
+++ b/tests/plugins/listblock/listblock.js
@@ -44,8 +44,6 @@
 			var editor = this.editor,
 				stylesCombo = editor.ui.get( 'Styles' );
 
-			stylesCombo.createPanel( editor );
-
 			editor.once( 'panelShow', function( evt ) {
 				resume( function() {
 					var block = stylesCombo._.panel.getBlock( stylesCombo.id ).element,
@@ -60,7 +58,7 @@
 				evt.data.hide();
 			} );
 
-			CKEDITOR.document.findOne( '#cke_' + stylesCombo.id ).findOne( 'a' ).$.click();
+			CKEDITOR.document.findOne( '#cke_' + stylesCombo.id ).findOne( 'a' ).$[ CKEDITOR.env.ie ? 'onmouseup' : 'click' ]();
 
 			wait();
 		},

--- a/tests/plugins/listblock/listblock.js
+++ b/tests/plugins/listblock/listblock.js
@@ -1,5 +1,5 @@
 /* bender-tags: editor */
-/* bender-ckeditor-plugins: listblock */
+/* bender-ckeditor-plugins: toolbar, stylescombo */
 
 ( function() {
 	'use strict';
@@ -7,6 +7,8 @@
 	function fixHtml( html ) {
 		return bender.tools.compatHtml( html, 0, 1 );
 	}
+
+	bender.editor = {};
 
 	bender.test( {
 		'test double quote': function() {
@@ -37,6 +39,32 @@
 			);
 		},
 
+		// (#2430)
+		'test list block elements not draggable': function() {
+			var editor = this.editor,
+				stylesCombo = editor.ui.get( 'Styles' );
+
+			stylesCombo.createPanel( editor );
+
+			editor.once( 'panelShow', function( evt ) {
+				resume( function() {
+					var block = stylesCombo._.panel.getBlock( stylesCombo.id ).element,
+						anchors = block.find( 'a' ).toArray();
+
+					CKEDITOR.tools.array.forEach( anchors, function( element ) {
+						assert.areEqual( 'false', element.getAttribute( 'draggable' ), 'Draggable attribute should be "false".' );
+						assert.areEqual( 'return false;', element.getAttribute( 'ondragstart' ), 'Draggable attribute should be "false".' );
+					} );
+				} );
+
+				evt.data.hide();
+			} );
+
+			CKEDITOR.document.findOne( '#cke_' + stylesCombo.id ).findOne( 'a' ).$.click();
+
+			wait();
+		},
+
 		// Expects both object to have following structure:
 		// { value: 'foo', html: 'bar', title: 'baz' }
 		//
@@ -44,7 +72,7 @@
 		// * html is placed as inner html of anchor,
 		// * title is saved to a[title] attribute.
 		assertListBlockAdd: function( expected, input ) {
-				// Mockup of listBlock object required by add() method.
+			// Mockup of listBlock object required by add() method.
 			var mock = {
 					_: {
 						items: {},

--- a/tests/plugins/listblock/manual/dragging.html
+++ b/tests/plugins/listblock/manual/dragging.html
@@ -1,0 +1,11 @@
+<textarea id="editor">Classic editor.</textarea>
+<div id="inline">Inline editor.</div>
+
+<script>
+	if ( bender.tools.env.mobile ) {
+		bender.ignore();
+	}
+
+	CKEDITOR.replace( 'editor' );
+	CKEDITOR.inline( 'inline' );
+</script>

--- a/tests/plugins/listblock/manual/dragging.md
+++ b/tests/plugins/listblock/manual/dragging.md
@@ -5,10 +5,10 @@
 1. Open styles combo.
 1. Try to drag dropdown item.
 
-Expected:
+## Expected:
 
 Element can't be dragged.
 
-Unexpected:
+## Unexpected:
 
 Element is draggable.

--- a/tests/plugins/listblock/manual/dragging.md
+++ b/tests/plugins/listblock/manual/dragging.md
@@ -1,0 +1,14 @@
+@bender-tags: 2340, bug, 4.10.2
+@bender-ui: collapsed
+@bender-ckeditor-plugins: wysiwygarea, toolbar, stylescombo, floatingspace
+
+1. Open styles combo.
+1. Try to drag dropdown item.
+
+Expected:
+
+Element can't be dragged.
+
+Unexpected:
+
+Element is draggable.

--- a/tests/plugins/listblock/manual/dragging.md
+++ b/tests/plugins/listblock/manual/dragging.md
@@ -1,4 +1,4 @@
-@bender-tags: 2340, bug, 4.10.2
+@bender-tags: 2430, bug, 4.10.2
 @bender-ui: collapsed
 @bender-ckeditor-plugins: wysiwygarea, toolbar, stylescombo, floatingspace
 


### PR DESCRIPTION
## What is the purpose of this pull request?

Bug fix

## Does your PR contain necessary tests?

All patches which change the editor code must include tests. You can always read more
on [PR testing](https://ckeditor.com/docs/ckeditor4/latest/guide/dev_contributing_code.html#tests),
[how to set the testing environment](https://ckeditor.com/docs/ckeditor4/latest/guide/dev_tests.html) and
[how to create tests](https://ckeditor.com/docs/ckeditor4/latest/guide/dev_tests.html#creating-your-own-test)
in the official CKEditor documentation.

### This PR contains

- [X] Unit tests
- [X] Manual tests

## What changes did you make?

Added `draggable="false"` and `ondragstart="return false;"` to `listblock` items and to `colorbutton` items.

Closes #2430