### PR TITLE
Use permalink for npm readme image

### DIFF
--- a/.npm/README.md
+++ b/.npm/README.md
@@ -13,7 +13,7 @@ Supports a broad range of browsers, including legacy ones.
 
 **Note: This is a developer version.** Use the  [CKEditor 4 optimized package](https://www.npmjs.com/package/ckeditor) for production environment.
 
-![CKEditor 4 screenshot](assets/ckeditor4.png)
+![CKEditor 4 screenshot](https://raw.githubusercontent.com/ckeditor/ckeditor-dev/1c3ad4dcb27ae11b4a84058b79c66a004d8f4f1c/.npm/assets/ckeditor4.png)
 
 ## Getting Started
 


### PR DESCRIPTION
## What is the purpose of this pull request?

Task

## Does your PR contain necessary tests?

All patches which change the editor code must include tests. You can always read more
on [PR testing](https://ckeditor.com/docs/ckeditor4/latest/guide/dev_contributing_code.html#tests),
[how to set the testing environment](https://ckeditor.com/docs/ckeditor4/latest/guide/dev_tests.html) and
[how to create tests](https://ckeditor.com/docs/ckeditor4/latest/guide/dev_tests.html#creating-your-own-test)
in the official CKEditor documentation.

### This PR contains

- [ ] Unit tests
- [ ] Manual tests

No need for tests, markdown only changes.

## What changes did you make?

Fixed the issue of wrong images by replacing it with permalink.

The only problem with this is that readme.md when viewed offline will not show the image, but we're ok with that as we think this is a rare case.

I wanted also remove `assets/ckeditor4.png` (as the image is duplicated now), but we can't do this right now because currently npm links to this image. We'll that in next release.

Closes #2405.