### PR TITLE
fixed tableselection if ckeditor is inside table

### DIFF
--- a/plugins/tableselection/plugin.js
+++ b/plugins/tableselection/plugin.js
@@ -254,6 +254,9 @@
 		editor.fire( 'lockSnapshot' );
 
 		for ( i = 0; i < cells.length; i++ ) {
+                        if ( !cells[ i ].parent().hasClass("cke_editable") ) {
+                            continue;
+                        }
 			cells[ i ].addClass( fakeSelectedClass );
 		}
 


### PR DESCRIPTION
## What is the purpose of this pull request?

Bug fix for #2403 

## Does your PR contain necessary tests?
No tests included.

### This PR contains

- [ ] Unit tests
- [ ] Manual tests

## What changes did you make?

Added check to only add fake-selection class to ckeditor-related table elements.
