### PR TITLE
Fixed issue with tableselection styles leaking

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -6,7 +6,8 @@
 Fixed Issues:
 
 * [#1986](https://github.com/ckeditor/ckeditor-dev/issues/1986): Fixed: Cell Properties dialog from [Table Tools](https://ckeditor.com/cke4/addon/tabletools) plugin shows styles that are not allowed through [`config.allowedContent`](https://ckeditor.com/docs/ckeditor4/latest/api/CKEDITOR_config.html#cfg-allowedContent).
-* [#2403](https://github.com/ckeditor/ckeditor-dev/issues/2403): Fixed: Styling inline editor initialized inside a table is causing style leaks.
+* [#2403](https://github.com/ckeditor/ckeditor-dev/issues/2403): Fixed: Styling inline editor initialized inside a table with [Table Selection](https://ckeditor.com/cke4/addon/tabletools) plugin is causing style leaks.
+* [#2514](https://github.com/ckeditor/ckeditor-dev/issues/2403): Fixed: Pasting table data into inline editor initialized inside a table with [Table Selection](https://ckeditor.com/cke4/addon/tabletools) plugin inserts pasted content into a wrapping table.
 
 Other Changes:
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -6,6 +6,7 @@
 Fixed Issues:
 
 * [#1986](https://github.com/ckeditor/ckeditor-dev/issues/1986): Fixed: Cell Properties dialog from [Table Tools](https://ckeditor.com/cke4/addon/tabletools) plugin shows styles that are not allowed through [`config.allowedContent`](https://ckeditor.com/docs/ckeditor4/latest/api/CKEDITOR_config.html#cfg-allowedContent).
+* [#2403](https://github.com/ckeditor/ckeditor-dev/issues/2403): Fixed: Styling inline editor initialized inside a table is causing style leaks.
 
 Other Changes:
 

--- a/core/dom/range.js
+++ b/core/dom/range.js
@@ -2749,6 +2749,11 @@ CKEDITOR.dom.range = function( root ) {
 				startTable = start.getAscendant( 'table', true ),
 				endTable = end.getAscendant( 'table', true );
 
+			// Inline editor may be initialized inside a table (#2403).
+			if ( startTable && !this.root.contains( startTable ) ) {
+				return null;
+			}
+
 			// Super weird edge case in Safari: if there is a table with only one cell inside and that cell
 			// is selected, then the end boundary of the table is moved into editor's editable.
 			// That case is also present when selecting the last cell inside nested table.

--- a/tests/core/dom/range/gettableelement.html
+++ b/tests/core/dom/range/gettableelement.html
@@ -51,3 +51,11 @@
 </table>
 
 <p id="table-paragraph">Simple text</p>
+
+<table>
+	<tr>
+		<td>
+			<div id="inner" >text</div>
+		</td>
+	</tr>
+</table>

--- a/tests/core/dom/range/gettableelement.js
+++ b/tests/core/dom/range/gettableelement.js
@@ -21,8 +21,8 @@
 		playground.setHtml( html.join( '\n' ) );
 	}
 
-	function createRange( options ) {
-		var range = new CKEDITOR.dom.range( doc );
+	function createRange( options, root ) {
+		var range = new CKEDITOR.dom.range( root || doc );
 
 		if ( options.element ) {
 			range.setStartBefore( options.element );
@@ -241,6 +241,14 @@
 			range = createRange( { element: table } );
 
 			assertElements( cell, range, 'td' );
+		},
+
+		// (#2403)
+		'get cell from outer scope': function() {
+			var root = doc.getById( 'inner' ),
+				range = createRange( { element: root.getChild( 0 ) }, root );
+
+			assertElements( null, range );
 		},
 
 		'multi-table range': function() {

--- a/tests/core/dom/range/gettableelement.js
+++ b/tests/core/dom/range/gettableelement.js
@@ -21,8 +21,8 @@
 		playground.setHtml( html.join( '\n' ) );
 	}
 
-	function createRange( options, root ) {
-		var range = new CKEDITOR.dom.range( root || doc );
+	function createRange( options ) {
+		var range = new CKEDITOR.dom.range( options.root || doc );
 
 		if ( options.element ) {
 			range.setStartBefore( options.element );
@@ -246,7 +246,10 @@
 		// (#2403)
 		'get cell from outer scope': function() {
 			var root = doc.getById( 'inner' ),
-				range = createRange( { element: root.getChild( 0 ) }, root );
+				range = createRange( {
+					element: root.getChild( 0 ),
+					root: root
+				} );
 
 			assertElements( null, range );
 		},

--- a/tests/plugins/tableselection/integrations/clipboard/pastewrapped.html
+++ b/tests/plugins/tableselection/integrations/clipboard/pastewrapped.html
@@ -1,0 +1,18 @@
+<table>
+	<tr>
+		<td>
+			<div contenteditable=true id="wrapped"></div>
+		</td>
+	</tr>
+</table>
+
+<table id="2x2-table">
+	<tr>
+		<td>1.1</td>
+		<td>1.2</td>
+	</tr>
+	<tr>
+		<td>2.1</td>
+		<td>2.2</td>
+	</tr>
+</table>

--- a/tests/plugins/tableselection/integrations/clipboard/pastewrapped.js
+++ b/tests/plugins/tableselection/integrations/clipboard/pastewrapped.js
@@ -1,0 +1,37 @@
+/* bender-tags: tableselection, clipboard */
+/* bender-ckeditor-plugins: tableselection */
+/* bender-ckeditor-remove-plugins: dialogadvtab */
+/* bender-include: ../../_helpers/tableselection.js */
+/* global tableSelectionHelpers */
+
+( function() {
+
+	'use strict';
+
+	var tests = {
+		'test pasting table': function() {
+			var editor = CKEDITOR.inline( CKEDITOR.document.getById( 'wrapped' ), {
+					allowedContent: true
+				} ),
+				tableHtml = CKEDITOR.document.getById( '2x2-table' ).getOuterHtml();
+
+			editor.once( 'instanceReady', function() {
+				bender.tools.setHtmlWithSelection( editor, '^' );
+				bender.tools.emulatePaste( editor, tableHtml );
+
+				editor.once( 'afterPaste', function() {
+					resume( function() {
+						assert.beautified.html( tableHtml, editor.getData() );
+					} );
+				} );
+			} );
+
+			wait();
+		}
+	};
+
+	tableSelectionHelpers.ignoreUnsupportedEnvironment( tests );
+
+	bender.test( tests );
+
+} )();

--- a/tests/plugins/tableselection/integrations/clipboard/pastewrapped.js
+++ b/tests/plugins/tableselection/integrations/clipboard/pastewrapped.js
@@ -9,6 +9,7 @@
 	'use strict';
 
 	var tests = {
+		// (#2403)
 		'test pasting table': function() {
 			var editor = CKEDITOR.inline( CKEDITOR.document.getById( 'wrapped' ), {
 					allowedContent: true

--- a/tests/plugins/tableselection/manual/pastenestedtable.html
+++ b/tests/plugins/tableselection/manual/pastenestedtable.html
@@ -1,0 +1,33 @@
+<h2>Table</h2>
+<table width="600"  border="1" cellpadding="0" cellspacing="0">
+	<tbody>
+		<tr>
+			<td>1.1</td>
+			<td>1.2</td>
+		</tr>
+		<tr>
+			<td>2.1</td>
+			<td>2.2</td>
+		</tr>
+	</tbody>
+</table>
+
+<h2>Editor</h2>
+
+<table width="600"  border="1" cellpadding="0" cellspacing="0">
+	<tbody>
+		<tr>
+			<td>
+				<div id="editor"  contenteditable="true">paste here</div>
+			</td>
+		</tr>
+	</tbody>
+</table>
+
+<script>
+	if ( ( CKEDITOR.env.ie && CKEDITOR.env.version < 11 ) || bender.tools.env.mobile ) {
+		bender.ignore();
+	}
+
+	CKEDITOR.inline( 'editor' );
+</script>

--- a/tests/plugins/tableselection/manual/pastenestedtable.html
+++ b/tests/plugins/tableselection/manual/pastenestedtable.html
@@ -18,7 +18,7 @@
 	<tbody>
 		<tr>
 			<td>
-				<div id="editor"  contenteditable="true">paste here</div>
+				<div style="border: 3px solid red;" id="editor"  contenteditable="true">paste here</div>
 			</td>
 		</tr>
 	</tbody>

--- a/tests/plugins/tableselection/manual/pastenestedtable.md
+++ b/tests/plugins/tableselection/manual/pastenestedtable.md
@@ -12,3 +12,5 @@ Table cells has been inserted into editor.
 ## Unexpected
 
 Table cells has been inserted outside of the editor.
+
+**Note**: You can recognize boundaries of the editor by red border.

--- a/tests/plugins/tableselection/manual/pastenestedtable.md
+++ b/tests/plugins/tableselection/manual/pastenestedtable.md
@@ -1,0 +1,14 @@
+@bender-ui: collapsed
+@bender-tags: bug, 4.11.0, 2514
+@bender-ckeditor-plugins: wysiwygarea, tableselection, basicstyles, floatingspace
+
+1. Copy table cells using table above the editor.
+1. Paste clipboard output into the editor.
+
+## Expected
+
+Table cells has been inserted into editor.
+
+## Unexpected
+
+Table cells has been inserted outside of the editor.

--- a/tests/plugins/tableselection/manual/pastenestedtable.md
+++ b/tests/plugins/tableselection/manual/pastenestedtable.md
@@ -1,5 +1,5 @@
 @bender-ui: collapsed
-@bender-tags: bug, 4.11.0, 2514
+@bender-tags: bug, 4.11.2, 2514
 @bender-ckeditor-plugins: wysiwygarea, tableselection, basicstyles, floatingspace
 
 1. Copy table cells using table above the editor.

--- a/tests/plugins/tableselection/manual/styleleak.html
+++ b/tests/plugins/tableselection/manual/styleleak.html
@@ -1,0 +1,19 @@
+<table width="600"  border="1" cellpadding="0" cellspacing="0">
+	<tbody>
+		<tr>
+			<td>
+				<div>
+					<div id="editor"  contenteditable="true">select me</div>
+				</div>
+			</td>
+		</tr>
+	</tbody>
+</table>
+
+<script>
+	if ( ( CKEDITOR.env.ie && CKEDITOR.env.version < 11 ) || bender.tools.env.mobile ) {
+		bender.ignore();
+	}
+
+	CKEDITOR.inline( 'editor' );
+</script>

--- a/tests/plugins/tableselection/manual/styleleak.html
+++ b/tests/plugins/tableselection/manual/styleleak.html
@@ -2,9 +2,7 @@
 	<tbody>
 		<tr>
 			<td>
-				<div>
-					<div id="editor"  contenteditable="true">select me</div>
-				</div>
+				<div id="editor"  contenteditable="true">select me</div>
 			</td>
 		</tr>
 	</tbody>

--- a/tests/plugins/tableselection/manual/styleleak.md
+++ b/tests/plugins/tableselection/manual/styleleak.md
@@ -1,0 +1,14 @@
+@bender-ui: collapsed
+@bender-tags: bug, 4.11.0, 2403
+@bender-ckeditor-plugins: wysiwygarea, tableselection, basicstyles, floatingspace
+
+1. Select text inside the editor.
+1. Press `Bold` style button
+
+## Expected
+
+Table cell doesn't change.
+
+## Unexpected
+
+Table cell is greyed out.

--- a/tests/plugins/tableselection/manual/styleleak.md
+++ b/tests/plugins/tableselection/manual/styleleak.md
@@ -1,5 +1,5 @@
 @bender-ui: collapsed
-@bender-tags: bug, 4.11.0, 2403
+@bender-tags: bug, 4.11.2, 2403
 @bender-ckeditor-plugins: wysiwygarea, tableselection, basicstyles, floatingspace
 
 1. Select text inside the editor.


### PR DESCRIPTION
## What is the purpose of this pull request?

Bug fix

## Does your PR contain necessary tests?

All patches which change the editor code must include tests. You can always read more
on [PR testing](https://ckeditor.com/docs/ckeditor4/latest/guide/dev_contributing_code.html#tests),
[how to set the testing environment](https://ckeditor.com/docs/ckeditor4/latest/guide/dev_tests.html) and
[how to create tests](https://ckeditor.com/docs/ckeditor4/latest/guide/dev_tests.html#creating-your-own-test)
in the official CKEditor documentation.

### This PR contains

- [x] Unit tests
- [x] Manual tests

## What changes did you make?

Getting table cells by range didn't work correctly when used with the inline editor - I added a condition that getting table cells should be limited to the range root element.

Closes #2403, closes #2514