### PR TITLE
Add Ctrl+K keystroke for link command

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -12,6 +12,7 @@ New Features:
 * [#706](https://github.com/ckeditor/ckeditor-dev/issues/706): Added different cursor style when selecting cells for [Table Selection](https://ckeditor.com/cke4/addon/tableselection) plugin.
 * [#651](https://github.com/ckeditor/ckeditor-dev/issues/651): Text pasted using [Paste from Word](https://ckeditor.com/cke4/addon/pastefromword) preservers indentation in paragraphs.
 * [#1176](https://github.com/ckeditor/ckeditor-dev/pull/1176): The [Balloon Panel](https://ckeditor.com/cke4/addon/balloonpanel) can be attached to selection instead of element.
+* [#2478](https://github.com/ckeditor/ckeditor-dev/issues/2478): Link could be inserted using <kbd>Ctrl</kbd>/<kbd>Cmd</kbd> + <kbd>K</kbd> keystroke.
 
 Fixed Issues:
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -12,7 +12,7 @@ New Features:
 * [#706](https://github.com/ckeditor/ckeditor-dev/issues/706): Added different cursor style when selecting cells for [Table Selection](https://ckeditor.com/cke4/addon/tableselection) plugin.
 * [#651](https://github.com/ckeditor/ckeditor-dev/issues/651): Text pasted using [Paste from Word](https://ckeditor.com/cke4/addon/pastefromword) preservers indentation in paragraphs.
 * [#1176](https://github.com/ckeditor/ckeditor-dev/pull/1176): The [Balloon Panel](https://ckeditor.com/cke4/addon/balloonpanel) can be attached to selection instead of element.
-* [#2478](https://github.com/ckeditor/ckeditor-dev/issues/2478): Link could be inserted using <kbd>Ctrl</kbd>/<kbd>Cmd</kbd> + <kbd>K</kbd> keystroke.
+* [#2478](https://github.com/ckeditor/ckeditor-dev/issues/2478): [Link](https://ckeditor.com/cke4/addon/link) can be inserted using <kbd>Ctrl</kbd>/<kbd>Cmd</kbd> + <kbd>K</kbd> keystroke.
 
 Fixed Issues:
 

--- a/plugins/link/plugin.js
+++ b/plugins/link/plugin.js
@@ -70,6 +70,9 @@
 
 			editor.setKeystroke( CKEDITOR.CTRL + 76 /*L*/, 'link' );
 
+			// (#2478)
+			editor.setKeystroke( CKEDITOR.CTRL + 75 /*K*/, 'link' );
+
 			if ( editor.ui.addButton ) {
 				editor.ui.addButton( 'Link', {
 					label: editor.lang.link.toolbar,

--- a/tests/plugins/link/link.js
+++ b/tests/plugins/link/link.js
@@ -617,7 +617,6 @@
 			} );
 		},
 
-		// (#2478)
 		'test Ctrl+L keystroke': function() {
 			var bot = this.editorBots.noValidation,
 				editor = bot.editor;

--- a/tests/plugins/link/link.js
+++ b/tests/plugins/link/link.js
@@ -595,50 +595,34 @@
 		} ),
 
 		// (#2478)
-		'test Ctrl+K keystroke': function() {
-			var bot = this.editorBots.noValidation,
-				editor = bot.editor;
+		'test Ctrl+K keystroke': assertKeystroke( 75 ),
 
-			bot.setData( '', function() {
-				editor.once( 'dialogShow', function( evt ) {
-					resume( function() {
-						var dialog = evt.data;
-
-						dialog.hide();
-						assert.areSame( 'link', dialog._.name );
-					} );
-				} );
-
-				editor.editable().fire( 'keydown', new CKEDITOR.dom.event( {
-					keyCode: 75,
-					ctrlKey: true
-				} ) );
-				wait();
-			} );
-		},
-
-		'test Ctrl+L keystroke': function() {
-			var bot = this.editorBots.noValidation,
-				editor = bot.editor;
-
-			bot.setData( '', function() {
-				editor.once( 'dialogShow', function( evt ) {
-					resume( function() {
-						var dialog = evt.data;
-
-						dialog.hide();
-						assert.areSame( 'link', dialog._.name );
-					} );
-				} );
-
-				editor.editable().fire( 'keydown', new CKEDITOR.dom.event( {
-					keyCode: 76,
-					ctrlKey: true
-				} ) );
-				wait();
-			} );
-		}
+		'test Ctrl+L keystroke': assertKeystroke( 76 )
 	} );
+
+	function assertKeystroke( key ) {
+		return function() {
+			var bot = this.editorBots.noValidation,
+				editor = bot.editor;
+
+			bot.setData( '', function() {
+				editor.once( 'dialogShow', function( evt ) {
+					resume( function() {
+						var dialog = evt.data;
+
+						dialog.hide();
+						assert.areSame( 'link', dialog._.name );
+					} );
+				} );
+
+				editor.editable().fire( 'keydown', new CKEDITOR.dom.event( {
+					keyCode: key,
+					ctrlKey: true
+				} ) );
+				wait();
+			} );
+		};
+	}
 
 	function assertPhoneLinks( config ) {
 		return function() {

--- a/tests/plugins/link/link.js
+++ b/tests/plugins/link/link.js
@@ -592,7 +592,53 @@
 			correctInput: '123456789',
 			incorrectLinkAssertionCallback: assertIncorrectLinks,
 			correctLinkAssertionCallback: assertCorrectLinks
-		} )
+		} ),
+
+		// (#2478)
+		'test Ctrl+K keystroke': function() {
+			var bot = this.editorBots.noValidation,
+				editor = bot.editor;
+
+			bot.setData( '', function() {
+				editor.once( 'dialogShow', function( evt ) {
+					resume( function() {
+						var dialog = evt.data;
+
+						dialog.hide();
+						assert.areSame( 'link', dialog._.name );
+					} );
+				} );
+
+				editor.editable().fire( 'keydown', new CKEDITOR.dom.event( {
+					keyCode: 75,
+					ctrlKey: true
+				} ) );
+				wait();
+			} );
+		},
+
+		// (#2478)
+		'test Ctrl+L keystroke': function() {
+			var bot = this.editorBots.noValidation,
+				editor = bot.editor;
+
+			bot.setData( '', function() {
+				editor.once( 'dialogShow', function( evt ) {
+					resume( function() {
+						var dialog = evt.data;
+
+						dialog.hide();
+						assert.areSame( 'link', dialog._.name );
+					} );
+				} );
+
+				editor.editable().fire( 'keydown', new CKEDITOR.dom.event( {
+					keyCode: 76,
+					ctrlKey: true
+				} ) );
+				wait();
+			} );
+		}
 	} );
 
 	function assertPhoneLinks( config ) {

--- a/tests/plugins/link/manual/keystroke.html
+++ b/tests/plugins/link/manual/keystroke.html
@@ -1,0 +1,6 @@
+<div id="editor">
+	<p>Hi, I'm CKEditor 4!</p>
+</div>
+<script>
+	CKEDITOR.replace( 'editor' );
+</script>

--- a/tests/plugins/link/manual/keystroke.md
+++ b/tests/plugins/link/manual/keystroke.md
@@ -6,8 +6,13 @@
 1. Focus the editor.
 2. Press <kbd>Ctrl</kbd>/<kbd>Cmd</kbd> + <kbd>K</kbd>.
 
-## Expected
+	## Expected
 
-Link dialog is open.
+	Link dialog is open.
 
-Repeat the procedure for <kbd>Ctrl</kbd>/<kbd>Cmd</kbd> + <kbd>L</kbd> keystroke.
+	## Unexpected
+
+	Nothing happens.
+
+3. Close the dialog.
+4. Repeat the procedure for <kbd>Ctrl</kbd>/<kbd>Cmd</kbd> + <kbd>L</kbd> keystroke.

--- a/tests/plugins/link/manual/keystroke.md
+++ b/tests/plugins/link/manual/keystroke.md
@@ -1,0 +1,13 @@
+@bender-tags: feature, link, 2478, 4.11.0
+@bender-ckeditor-plugins: link, toolbar, wysiwygarea
+@bender-ui: collapsed
+----
+
+1. Focus the editor.
+2. Press <kbd>Ctrl</kbd>/<kbd>Cmd</kbd> + <kbd>K</kbd>.
+
+## Expected
+
+Link dialog is open.
+
+Repeat the procedure for <kbd>Ctrl</kbd>/<kbd>Cmd</kbd> + <kbd>L</kbd> keystroke.


### PR DESCRIPTION
## What is the purpose of this pull request?

New feature

## Does your PR contain necessary tests?

All patches which change the editor code must include tests. You can always read more
on [PR testing](https://ckeditor.com/docs/ckeditor4/latest/guide/dev_contributing_code.html#tests),
[how to set the testing environment](https://ckeditor.com/docs/ckeditor4/latest/guide/dev_tests.html) and
[how to create tests](https://ckeditor.com/docs/ckeditor4/latest/guide/dev_tests.html#creating-your-own-test)
in the official CKEditor documentation.

### This PR contains

- [x] Unit tests
- [x] Manual tests

## What changes did you make?

I've added new keystroke for link command. Additionally I added tests to check if it's working alongside the old <kbd>Ctrl</kbd> + <kbd>L</kbd> one.

Closes #2478.
