### PR TITLE
Fixed issue with incorrectly escaped additional entities

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -35,6 +35,7 @@ Fixed Issues:
 * [#1451](https://github.com/ckeditor/ckeditor-dev/issues/1451): Fixed: Context menu is incorrectly positioned when opened with `Shift-F10`.
 * [#1722](https://github.com/ckeditor/ckeditor-dev/issues/1722): [`CKEDITOR.filter.instances`](https://docs.ckeditor.com/ckeditor4/latest/api/CKEDITOR_filter.html#static-property-instances) is causing memory leaks.
 * [#2491](https://github.com/ckeditor/ckeditor-dev/issues/2491): Fixed: [Mentions](https://ckeditor.com/cke4/addon/mentions) plugin is not matching diacritic characters.
+* [#2448](https://github.com/ckeditor/ckeditor-dev/issues/2448): Fixed: [`Escape HTML Entities`] plugin with custom [additional entities](https://ckeditor.com/docs/ckeditor4/latest/api/CKEDITOR_config.html#cfg-entities_additional) configuration breaks HTML escaping.
 
 API Changes:
 

--- a/plugins/entities/plugin.js
+++ b/plugins/entities/plugin.js
@@ -69,6 +69,9 @@
 			return '';
 		} );
 
+		// Drop trailing comma (#2448).
+		entities = entities.replace( /,$/, '' );
+
 		if ( !reverse && entities ) {
 			// Transforms the entities string into an array.
 			entities = entities.split( ',' );

--- a/tests/plugins/entities/entities.js
+++ b/tests/plugins/entities/entities.js
@@ -8,7 +8,8 @@ bender.editor = {
 		autoParagraph: false,
 		basicEntities: false,
 		entities_processNumerical: true,
-		entities_additional: 'lt,gt,amp,apos,quot',
+		// Add euro symbol to verify if symbols are correctly escaped (#2448).
+		entities_additional: 'euro,lt,gt,amp,apos,quot',
 		entities_latin: false,
 		entities_greek: false
 	}
@@ -33,7 +34,7 @@ bender.test( {
 
 	'test Other Special Characters': function() {
 		var specials = ' ¡¢£¤¥¦§¨©ª«¬®¯°±²³´µ¶·¸¹º»¼½¾¿×÷ƒ•…′″‾⁄℘ℑℜ™ℵ←↑→↓↔↵⇐⇑⇒⇓⇔∀∂∃∅∇∈∉∋∏∑−∗√∝∞∠∧∨' + // jshint ignore:line
-			'∩∪∫∴∼≅≈≠≡≤≥⊂⊃⊄⊆⊇⊕⊗⊥⋅⌈⌉⌊⌋⟨⟩◊♠♣♥♦ˆ˜   ‌‍‎‏–—‘’‚“”„†‡‰‹›€'; // jshint ignore:line
+			'∩∪∫∴∼≅≈≠≡≤≥⊂⊃⊄⊆⊇⊕⊗⊥⋅⌈⌉⌊⌋⟨⟩◊♠♣♥♦ˆ˜   ‌‍‎‏–—‘’‚“”„†‡‰‹›'; // jshint ignore:line
 		// Other characters are encoded as numeric entities.
 		assert.isFalse( /&\w+?;/.test( this.editor.dataProcessor.toDataFormat( specials ) ) );
 	},
@@ -63,6 +64,18 @@ bender.test( {
 	'test HTML encoded in element with contenteditable=true': function() {
 		var inputHtml = '<p contenteditable="true">"\'</p>',
 			expectedHtml = '<p contenteditable="true">&quot;&apos;</p>',
+			editor = this.editor,
+			bot = this.editorBot;
+
+		bot.setData( inputHtml, function() {
+			assert.areEqual( expectedHtml, editor.getData() );
+		} );
+	},
+
+	// (#2448)
+	"test entities_additional doesn't break escaping": function() {
+		var inputHtml = "<p>apos'</p>",
+			expectedHtml = '<p>apos&apos;</p>',
 			editor = this.editor,
 			bot = this.editorBot;
 

--- a/tests/plugins/entities/manual/additional.html
+++ b/tests/plugins/entities/manual/additional.html
@@ -1,0 +1,7 @@
+<div id="editor">apos</div>
+
+<script>
+	CKEDITOR.replace( 'editor', {
+		entities_additional: 'apos'
+	} );
+</script>

--- a/tests/plugins/entities/manual/additional.md
+++ b/tests/plugins/entities/manual/additional.md
@@ -1,0 +1,13 @@
+@bender-tags: bug, 4.11.0, 2448
+@bender-ui: collapsed
+@bender-ckeditor-plugins: wysiwygarea, toolbar, entities, sourcearea
+
+Click `Source` button.
+
+## Expected
+
+Content replace with `<p>apos</p>`.
+
+## Unexpected
+
+Content replace with `<p>&undefined;&undefined;os</p>`.

--- a/tests/plugins/entities/manual/additional.md
+++ b/tests/plugins/entities/manual/additional.md
@@ -6,8 +6,8 @@ Click `Source` button.
 
 ## Expected
 
-Content replace with `<p>apos</p>`.
+Following markup: `<p>apos</p>`.
 
 ## Unexpected
 
-Content replace with `<p>&undefined;&undefined;os</p>`.
+Markup like: `<p>&undefined;&undefined;os</p>`.


### PR DESCRIPTION
## What is the purpose of this pull request?

Bug fix

## Does your PR contain necessary tests?

All patches which change the editor code must include tests. You can always read more
on [PR testing](https://ckeditor.com/docs/ckeditor4/latest/guide/dev_contributing_code.html#tests),
[how to set the testing environment](https://ckeditor.com/docs/ckeditor4/latest/guide/dev_tests.html) and
[how to create tests](https://ckeditor.com/docs/ckeditor4/latest/guide/dev_tests.html#creating-your-own-test)
in the official CKEditor documentation.

### This PR contains

- [x] Unit tests
- [x] Manual tests

## What changes did you make?

Simple comma leftover broke the whole `entities_additional` feature. I could modify regex instead of additional trailing coma removal, although it may look nasty.

Closes #2448
