### PR TITLE
Add option to allow non-merging deletion across blocks

### DIFF
--- a/config.js
+++ b/config.js
@@ -11,7 +11,8 @@ CKEDITOR.editorConfig = function( config ) {
 	config.plugins =
 		'about,' +
 		'a11yhelp,' +
-		'basicstyles,' +
+		//'basicstyles,' +
+		'computedstyles,' +
 		'bidi,' +
 		'blockquote,' +
 		'clipboard,' +
@@ -28,7 +29,8 @@ CKEDITOR.editorConfig = function( config ) {
 		'find,' +
 		'flash,' +
 		'floatingspace,' +
-		'font,' +
+		//'font,' +
+		'computedfont,' +
 		'format,' +
 		'forms,' +
 		'horizontalrule,' +
@@ -54,6 +56,7 @@ CKEDITOR.editorConfig = function( config ) {
 		'resize,' +
 		'save,' +
 		'selectall,' +
+		'spacingsliders,' +
 		'showblocks,' +
 		'showborders,' +
 		'smiley,' +

--- a/core/editable.js
+++ b/core/editable.js
@@ -1197,13 +1197,14 @@
 							range = sel.getRanges()[ 0 ],
 							startPath = range.startPath();
 
-						if ( range.collapsed ) {
-							if ( !mergeBlocksCollapsedSelection( editor, range, backspace, startPath ) )
-								return;
-						} else {
-							if ( !mergeBlocksNonCollapsedSelection( editor, range, startPath ) )
-								return;
-						}
+		    			if ( range.collapsed ) {
+	    					if ( CKEDITOR.tools.trim( editor.element.getText() ).length > 0 && 
+								!mergeBlocksCollapsedSelection( editor, range, backspace, startPath ) )
+    							return;
+   						} else {
+						    if ( !mergeBlocksNonCollapsedSelection( editor, range, startPath ) )
+					    		return;
+				    	}
 
 						// Scroll to the new position of the caret (https://dev.ckeditor.com/ticket/11960).
 						editor.getSelection().scrollIntoView();

--- a/core/editable.js
+++ b/core/editable.js
@@ -2546,17 +2546,19 @@
 		// Delete range contents. Do NOT merge. Merging is weird.
 		range.deleteContents();
 
-		// If something has left of the block to be merged, clean it up.
-		// It may happen when merging with list items.
-		if ( endBlock.getParent() ) {
-			// Move children to the first block.
-			endBlock.moveChildren( startBlock, false );
+		if ( editor.config.forceMergeBlocks !== false ) {
+			// If something has left of the block to be merged, clean it up.
+			// It may happen when merging with list items.
+			if ( endBlock.getParent() ) {
+				// Move children to the first block.
+				endBlock.moveChildren( startBlock, false );
 
-			// ...and merge them if that's possible.
-			startPath.lastElement.mergeSiblings();
+				// ...and merge them if that's possible.
+				startPath.lastElement.mergeSiblings();
 
-			// If expanded selection, things are always merged like with BACKSPACE.
-			pruneEmptyDisjointAncestors( startBlock, endBlock, true );
+				// If expanded selection, things are always merged like with BACKSPACE.
+				pruneEmptyDisjointAncestors( startBlock, endBlock, true );
+			}
 		}
 
 		// Make sure the result selection is collapsed.
@@ -3303,4 +3305,14 @@
  * @param {String} data.dialog The dialog window to be opened. If set by the listener,
  * the specified dialog window will be opened.
  * @member CKEDITOR.editor
+ */
+
+/**
+ * Whether the editor must merge the blocks when a selection spans across them is deleted.
+ *
+ * When set to false, only the content contained in the selection gets deleted while the 
+ * blocks remain intact.
+ *
+ * @cfg {Boolean} [forceMergeBlocks=true]
+ * @member CKEDITOR.config
  */

--- a/dev/builder/build-config.js
+++ b/dev/builder/build-config.js
@@ -3,10 +3,30 @@
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-oss-license
  */
 
-/* exported CKBUILDER_CONFIG */
+/**
+ * This file was added automatically by CKEditor builder.
+ * You may re-use it at any time to build CKEditor again.
+ *
+ * If you would like to build CKEditor online again
+ * (for example to upgrade), visit one the following links:
+ *
+ * (1) http://ckeditor.com/builder
+ *     Visit online builder to build CKEditor from scratch.
+ *
+ * (2) http://ckeditor.com/builder/0eca852e9dabede1d704b1bd0d4aeb22
+ *     Visit online builder to build CKEditor, starting with the same setup as before.
+ *
+ * (3) http://ckeditor.com/builder/download/0eca852e9dabede1d704b1bd0d4aeb22
+ *     Straight download link to the latest version of CKEditor (Optimized) with the same setup as before.
+ *
+ * NOTE:
+ *    This file is not used by CKEditor, you may remove it.
+ *    Changing this file will not change your CKEditor configuration.
+ */
 
 var CKBUILDER_CONFIG = {
 	skin: 'moono-lisa',
+	preset: 'basic',
 	ignore: [
 		'bender.js',
 		'bender.ci.js',
@@ -32,66 +52,30 @@ var CKBUILDER_CONFIG = {
 		'README.md',
 		'tests'
 	],
-	plugins: {
-		a11yhelp: 1,
-		about: 1,
-		basicstyles: 1,
-		bidi: 1,
-		blockquote: 1,
-		clipboard: 1,
-		colorbutton: 1,
-		colordialog: 1,
-		copyformatting: 1,
-		contextmenu: 1,
-		dialogadvtab: 1,
-		div: 1,
-		elementspath: 1,
-		enterkey: 1,
-		entities: 1,
-		filebrowser: 1,
-		find: 1,
-		flash: 1,
-		floatingspace: 1,
-		font: 1,
-		format: 1,
-		forms: 1,
-		horizontalrule: 1,
-		htmlwriter: 1,
-		iframe: 1,
-		image: 1,
-		indentlist: 1,
-		indentblock: 1,
-		justify: 1,
-		language: 1,
-		link: 1,
-		list: 1,
-		liststyle: 1,
-		magicline: 1,
-		maximize: 1,
-		newpage: 1,
-		pagebreak: 1,
-		pastefromword: 1,
-		pastetext: 1,
-		preview: 1,
-		print: 1,
-		removeformat: 1,
-		resize: 1,
-		save: 1,
-		selectall: 1,
-		showblocks: 1,
-		showborders: 1,
-		smiley: 1,
-		sourcearea: 1,
-		specialchar: 1,
-		stylescombo: 1,
-		tab: 1,
-		table: 1,
-		tableselection: 1,
-		tabletools: 1,
-		templates: 1,
-		toolbar: 1,
-		undo: 1,
-		uploadimage: 1,
-		wysiwygarea: 1
+	plugins : {
+		'autogrow' : 1,
+		'clipboard' : 1,
+		'colorbutton' : 1,
+		'colordialog' : 1,
+		'computedfont' : 1,
+		'computedstyles' : 1,
+		'spacingsliders' : 1,
+		'enterkey' : 1,
+		'entities' : 1,
+		'floatingspace' : 1,
+		'indentlist' : 1,
+		'justify' : 1,
+		'pastetext' : 1,
+		'removeformat' : 1,
+		'selectall' : 1,
+		'sharedspace' : 1,
+		'stylescombo' : 1,
+		'toolbar' : 1,
+		'undo' : 1,
+		'wysiwygarea' : 1
+	},
+	languages : {
+		'en' : 1,
+		'ko' : 1
 	}
 };

--- a/skins/moono-lisa/editor.css
+++ b/skins/moono-lisa/editor.css
@@ -67,3 +67,5 @@ legend.cke_voice_label
 {
 	display: none;
 }
+
+@import url("grapplet.css");

--- a/skins/moono-lisa/grapplet.css
+++ b/skins/moono-lisa/grapplet.css
@@ -1,0 +1,128 @@
+.cke_reset_all, .cke_reset_all *,
+.cke_reset_all a, .cke_reset_all textarea, .cke_colorblock {
+    font-family: "Roboto", "Raleway", "Noto Sans KR", -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol";
+    font-size: 14px;
+    color: #828891;
+}
+
+.cke_dialog {
+    border: 1px solid rgba(0, 0, 0, 0.2);
+}
+
+.cke_dialog .cke_dialog_title, .cke_dialog .cke_dialog_footer {
+    background-color: transparent;
+    padding: 20px;
+}
+
+.cke_dialog .cke_dialog_title {
+    font-family: "Montserrat", "Noto Sans KR", -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol";
+    font-size: 18px;
+    font-weight: 500;
+    color: #1a77ff !important;
+    border-bottom-color: #dbe2e7;
+}
+
+.cke_dialog .cke_dialog_footer {
+    border: none;
+}
+
+.cke_dialog .cke_dialog_contents_body {
+    padding: 20px 20px 0 20px;
+}
+
+.cke_dialog_background_cover {
+    opacity: 0.4;
+}
+
+.cke_dialog_ui_button, .cke_colormore {
+    font-weight: 500;
+    border: none !important;
+    border-radius: 0 !important;
+}
+
+.cke_dialog_footer a.cke_dialog_ui_button {
+    font-size: 13px !important;
+    padding: 13px 22px !important;
+}
+
+.cke_dialog_footer a.cke_dialog_ui_button, .cke_colormore {
+    color: white !important;
+    background-color: #828891;
+}
+
+.cke_dialog_footer a.cke_dialog_ui_button:hover, .cke_colormore:hover {
+    background-color: #9da1a6 !important;
+}
+
+.cke_dialog_footer a.cke_dialog_ui_button:active, .cke_colormore:active {
+    background-color: #474e56 !important;
+}
+
+.cke_dialog_footer a.cke_dialog_ui_button.cke_dialog_ui_button_ok {
+    background-color: #1a77ff !important;
+}
+
+.cke_dialog_footer a.cke_dialog_ui_button.cke_dialog_ui_button_ok:hover {
+    background-color: #3889ff !important;
+}
+
+.cke_dialog_footer a.cke_dialog_ui_button.cke_dialog_ui_button_ok:active {
+    background-color: #005ee6 !important;
+}
+
+span.cke_dialog_ui_button {
+    background-color: transparent !important;
+}
+
+.cke_colormore {
+    font-weight: 500 !important;
+    color: white !important;
+}
+
+.cke_dialog_close_button {
+    top: 24px !important;
+    right: 30px !important;
+    font-family: "GrappletIcons" !important;
+    font-size: 2.25rem !important;
+    line-height: 1.3125rem !important;
+    color: #1a77ff !important;
+    background: none !important;
+}
+
+.cke_dialog_close_button:before {
+    content: "\e9ed";
+}
+
+.cke_dialog_close_button span {
+    display: none;
+}
+
+.cke_colorauto {
+    border: none !important;
+}
+
+.cke_colorauto:hover {
+    color: #474e56 !important;
+}
+
+input, button, select:focus {
+    outline: none !important;
+    box-shadow: none !important;
+}
+
+input {
+    border-top: none !important;
+    border-right: none !important;
+    border-left: none !important;
+    border-bottom: 1px solid #828891 !important;
+    background-color: white;
+}
+
+.cke_colorblock, .cke_colorblock a {
+    color: #828891;
+}
+
+.cke_resizer {
+    display: none;
+}
+

--- a/tests/core/editable/keystrokes/delbackspacequirks/collapsed.js
+++ b/tests/core/editable/keystrokes/delbackspacequirks/collapsed.js
@@ -75,6 +75,18 @@
 			}
 		},
 
+		'test backspace on two paragraphs with forceMergeBlocks=false': function() {
+			CKEDITOR.config.forceMergeBlocks = false;
+
+			try {
+				b( '<p>Te</p><p>{}st</p>', '<p>Te^st</p>' ).call( this );
+			} catch ( e ) {
+				throw e;
+			} finally {
+				delete CKEDITOR.config.forceMergeBlocks;
+			}
+		},
+
 		'test CTRL+backspace works as backspace when merging blocks':		assertKeystroke( BACKSPACE, CKEDITOR.CTRL, 0,	'<p>x</p><p>{}y</p>',	'<p>x^y</p>' ),
 		'test SHIFT+backspace works as backspace when merging blocks':		assertKeystroke( BACKSPACE, CKEDITOR.SHIFT, 0,	'<p>x</p><p>{}y</p>',	'<p>x^y</p>' ),
 		'test CTRL+delete works as delete when merging blocks':				assertKeystroke( DEL, CKEDITOR.CTRL, 0,			'<p>x{}</p><p>y</p>',	'<p>x^y</p>' ),

--- a/tests/core/editable/keystrokes/delbackspacequirks/expanded.js
+++ b/tests/core/editable/keystrokes/delbackspacequirks/expanded.js
@@ -63,6 +63,18 @@
 			}
 		},
 
+		'test backspace and delete on two paragraphs with forceMergeBlocks=false': function() {
+			CKEDITOR.config.forceMergeBlocks = false;
+
+			try {
+				bd( '<p>Te[st</p><p>Te]st</p>', '<p>Te^</p><p>st</p>' ).call( this );
+			} catch ( e ) {
+				throw e;
+			} finally {
+				delete CKEDITOR.config.forceMergeBlocks;
+			}
+		},
+
 		'test backspace and delete #1':					bd( '<p>xx[x</p><p>y]yy</p>',															'<p>xx^yy</p>' ),
 		'test backspace and delete #2':					bd( '<div>xx[x</div><div>y]yy</div>',													'<div>xx^yy</div>' ),
 		'test backspace and delete #3':					bd( '<p>x<strong>x[x</strong></p><p>y]yy</p>',											'<p>x<strong>x^</strong>yy</p>' ),


### PR DESCRIPTION
## What is the purpose of this pull request?

This PR adds an option `forceMergeBlocks` to allow deleting of content without merging blocks when the selection spans across two or more blocks when it's set to `false` (default to `true` which is the current behavior).

Popular word processors like Microsoft Word, for example, lets users to select texts across two adjacent blocks and delete the content without merging them, thus preserving their respective styles.

In comparison, CKEditor always merge the blocks if an expanded selection spans across them. It may not be a desired behavior, especially when the blocks have different styles (i.e. line-height) from each other.

## Does your PR contain necessary tests?

### This PR contains

- [x] Unit tests
- [ ] Manual tests

## What changes did you make?

Adds `config.forceMergeBlocks` options which determines how the above mentioned behavior works. The default value leaves the current behavior as it is, as it's shown in one of the unit tests.
