### PR TITLE
Mentions plugin now matches diacritic characters

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -34,6 +34,7 @@ Fixed Issues:
 * [#1454](https://github.com/ckeditor/ckeditor-dev/issues/1454): Fixed: [Upload Widget](https://ckeditor.com/cke4/addon/uploadwidget) [`onAbort`](https://docs.ckeditor.com/ckeditor4/docs/#!/api/CKEDITOR.fileTools.uploadWidgetDefinition-property-onAbort) method is not called when loader is aborted.
 * [#1451](https://github.com/ckeditor/ckeditor-dev/issues/1451): Fixed: Context menu is incorrectly positioned when opened with `Shift-F10`.
 * [#1722](https://github.com/ckeditor/ckeditor-dev/issues/1722): [`CKEDITOR.filter.instances`](https://docs.ckeditor.com/ckeditor4/latest/api/CKEDITOR_filter.html#static-property-instances) is causing memory leaks.
+* [#2491](https://github.com/ckeditor/ckeditor-dev/issues/2491): Fixed: [Mentions](https://ckeditor.com/cke4/addon/mentions) plugin is not matching diacritic characters.
 
 API Changes:
 

--- a/plugins/mentions/plugin.js
+++ b/plugins/mentions/plugin.js
@@ -142,7 +142,8 @@
 	};
 
 	function createPattern( marker, minChars ) {
-		var pattern = '\\' + marker + '\\w';
+		// Match also diacritic characters (#2491).
+		var pattern = '\\' + marker + '[_A-z0-9À-ž]';
 
 		if ( minChars ) {
 			pattern += '{' + minChars + ',}';

--- a/plugins/mentions/plugin.js
+++ b/plugins/mentions/plugin.js
@@ -143,7 +143,7 @@
 
 	function createPattern( marker, minChars ) {
 		// Match also diacritic characters (#2491).
-		var pattern = '\\' + marker + '[_A-z0-9À-ž]';
+		var pattern = '\\' + marker + '[_a-zA-Z0-9À-ž]';
 
 		if ( minChars ) {
 			pattern += '{' + minChars + ',}';
@@ -166,6 +166,7 @@
 		};
 
 		function matchCallback( text, offset ) {
+			console.log( text )
 			var match = text.slice( 0, offset )
 				.match( pattern );
 

--- a/plugins/mentions/plugin.js
+++ b/plugins/mentions/plugin.js
@@ -166,7 +166,6 @@
 		};
 
 		function matchCallback( text, offset ) {
-			console.log( text )
 			var match = text.slice( 0, offset )
 				.match( pattern );
 

--- a/tests/plugins/mentions/manual/diacritic.html
+++ b/tests/plugins/mentions/manual/diacritic.html
@@ -1,0 +1,15 @@
+<textarea id="editor"></textarea>
+
+<script>
+
+	if ( CKEDITOR.env.ie && CKEDITOR.env.version < 9 ) {
+		bender.ignore();
+	}
+
+	CKEDITOR.replace( 'editor', {
+		mentions: [ {
+			feed: [ 'bączek', 'ćwikła', 'trąba_bomba' ],
+			minChars: 0
+		} ]
+	} );
+</script>

--- a/tests/plugins/mentions/manual/diacritic.md
+++ b/tests/plugins/mentions/manual/diacritic.md
@@ -1,0 +1,16 @@
+@bender-tags: 4.11.0, 2491, bug, mentions
+@bender-ui: collapsed
+@bender-ckeditor-plugins: wysiwygarea, toolbar, basicstyles, mentions
+
+1. Focus the editor.
+2. Type `@trąba_`.
+
+## Expected
+
+Dropdown with `@trąba_bomba` entry shows up.
+
+## Unexpected
+
+Nothing happens.
+
+3. Play with the rest of the names available after typing `@` to check if diacritic characters matching.

--- a/tests/plugins/mentions/manual/diacritic.md
+++ b/tests/plugins/mentions/manual/diacritic.md
@@ -2,8 +2,9 @@
 @bender-ui: collapsed
 @bender-ckeditor-plugins: wysiwygarea, toolbar, basicstyles, mentions
 
-1. Focus the editor.
-2. Type `@trąba_`.
+1. Set Polish keyboard on your OS.
+2. Focus the editor.
+3. Type `@trąba_`.
 
 ## Expected
 
@@ -13,4 +14,4 @@ Dropdown with `@trąba_bomba` entry shows up.
 
 Nothing happens.
 
-3. Play with the rest of the names available after typing `@` to check if diacritic characters matching.
+4. Play with the rest of the names available after typing `@` to check if diacritic characters matching.

--- a/tests/plugins/mentions/mentions.js
+++ b/tests/plugins/mentions/mentions.js
@@ -59,6 +59,8 @@
 				var expected = specialCharacters[ i ],
 					viewElement = mentions._autocomplete.view.element;
 
+				// Some characters e.g. `[` are used as selection markers,
+				// they need to be inserted directly to the editor.
 				this.editorBot.setHtmlWithSelection( '<p>^</p>' );
 				editor.insertText( '@' + expected );
 

--- a/tests/plugins/mentions/mentions.js
+++ b/tests/plugins/mentions/mentions.js
@@ -29,6 +29,22 @@
 			}
 		},
 
+		// (#2491)
+		'test matching diacritic characters': function() {
+			var diacritics = 'áàâäãéèëêíìïîóòöôõúùüûñçăşţ';
+
+			this.editorBot.setHtmlWithSelection( '<p>@' + diacritics + '^</p>' );
+			testView( this.createMentionsInstance( { feed: [ diacritics ] } ), [ diacritics ] );
+		},
+
+		// (#2491)
+		'test matching underscore character': function() {
+			var expected = 'john_doe';
+
+			this.editorBot.setHtmlWithSelection( '<p>@' + expected + '^</p>' );
+			testView( this.createMentionsInstance( { feed: [ expected ] } ), [ expected ] );
+		},
+
 		'test array feed with match': function() {
 			this.editorBot.setHtmlWithSelection( '<p>@An^</p>' );
 			testView( this.createMentionsInstance( { feed: feedData } ), expectedFeedData );

--- a/tests/plugins/mentions/mentions.js
+++ b/tests/plugins/mentions/mentions.js
@@ -45,6 +45,31 @@
 			testView( this.createMentionsInstance( { feed: [ expected ] } ), [ expected ] );
 		},
 
+		// (#2491)
+		'test not matching special characters': function() {
+			var editor = this.editor,
+				specialCharacters = '~!@#$%^&*()-+=`/.,\'"<>?|\\/[]{}'.split( '' ),
+				mentions = this.createMentionsInstance( {
+					feed: specialCharacters,
+					throttle: 0,
+					minChars: 0
+				} );
+
+			for ( var i = 0; i < specialCharacters.length; i++ ) {
+				var expected = specialCharacters[ i ],
+					viewElement = mentions._autocomplete.view.element;
+
+				this.editorBot.setHtmlWithSelection( '<p>^</p>' );
+				editor.insertText( '@' + expected );
+
+				editor.editable().fire( 'keyup', new CKEDITOR.dom.event( {} ) );
+
+				assert.isFalse( viewElement.hasClass( 'cke_autocomplete_opened' ),
+					'View should be closed for "' + expected + '" character' );
+
+			}
+		},
+
 		'test array feed with match': function() {
 			this.editorBot.setHtmlWithSelection( '<p>@An^</p>' );
 			testView( this.createMentionsInstance( { feed: feedData } ), expectedFeedData );
@@ -453,15 +478,15 @@
 			itemsArray = items.toArray();
 
 		if ( matches.length ) {
-			assert.isTrue( isOpened, 'View should be opened' );
+			assert.isTrue( isOpened, 'View should be opened.' );
 		} else {
-			assert.isFalse( isOpened, 'View should be closed' );
+			assert.isFalse( isOpened, 'View should be closed.' );
 		}
 
-		assert.areEqual( matches.length, items.count(), 'Invalid items count' );
+		assert.areEqual( matches.length, items.count(), 'Invalid items count.' );
 
 		for ( var i = items.count() - 1; i >= 0; i-- ) {
-			assert.areEqual( mentions.marker + matches[ i ], itemsArray[ i ].getHtml(), 'Match and item html are not equal' );
+			assert.areEqual( mentions.marker + matches[ i ], itemsArray[ i ].getHtml(), 'Match and item html are not equal.' );
 		}
 	}
 


### PR DESCRIPTION
## What is the purpose of this pull request?

Bug

## Does your PR contain necessary tests?

All patches which change the editor code must include tests. You can always read more
on [PR testing](https://ckeditor.com/docs/ckeditor4/latest/guide/dev_contributing_code.html#tests),
[how to set the testing environment](https://ckeditor.com/docs/ckeditor4/latest/guide/dev_tests.html) and
[how to create tests](https://ckeditor.com/docs/ckeditor4/latest/guide/dev_tests.html#creating-your-own-test)
in the official CKEditor documentation.

### This PR contains

- [x] Unit tests
- [x] Manual tests

## What changes did you make?

Fixed mentions regex to match diacritic characters.

Closes #2491
