### PR TITLE
Removed undo plugin causing failing tableselection test

### DIFF
--- a/tests/plugins/tableselection/tableselection.js
+++ b/tests/plugins/tableselection/tableselection.js
@@ -1,5 +1,6 @@
 /* bender-tags: tableselection */
 /* bender-ckeditor-plugins: tableselection */
+/* bender-ckeditor-remove-plugins: undo */
 /* bender-include: _helpers/tableselection.js */
 /* global tableSelectionHelpers, mockMouseSelection */
 


### PR DESCRIPTION
## What is the purpose of this pull request?

Failing test

## Does your PR contain necessary tests?

All patches which change the editor code must include tests. You can always read more
on [PR testing](https://ckeditor.com/docs/ckeditor4/latest/guide/dev_contributing_code.html#tests),
[how to set the testing environment](https://ckeditor.com/docs/ckeditor4/latest/guide/dev_tests.html) and
[how to create tests](https://ckeditor.com/docs/ckeditor4/latest/guide/dev_tests.html#creating-your-own-test)
in the official CKEditor documentation.

### This PR contains

- [ ] Unit tests
- [ ] Manual tests

## What changes did you make?

It looks like the editor is left in an invalid state between tests for `undo` plugin ( tests passes when run separately).

Closes #2522
