### PR TITLE
Fix incorrect styles for combo buttons in balloontoolbar

### DIFF
--- a/plugins/balloontoolbar/skins/moono-lisa/balloontoolbar.css
+++ b/plugins/balloontoolbar/skins/moono-lisa/balloontoolbar.css
@@ -16,12 +16,16 @@ For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-oss-license
 	margin-right: 2px;
 }
 
+.cke_balloon.cke_balloontoolbar .cke_combo:first-child a.cke_combo_button{
+	margin-left: 0;
+}
+
 .cke_balloon.cke_balloontoolbar .cke_combo:last-child{
 	margin-right: 0;
 }
 
 .cke_balloon.cke_balloontoolbar .cke_combo a.cke_combo_button{
-	margin-right: 1px;
+	margin: 0 1px 0 -2px;
 }
 
 /* Combo states (#1682). */
@@ -32,6 +36,6 @@ For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-oss-license
 {
 	border: none;
 	padding: 1px;
-	margin: 0 1px 0 0;
+	// margin: 0 1px 0 0;
 	outline: 1px solid #bcbcbc;
 }

--- a/plugins/balloontoolbar/skins/moono-lisa/balloontoolbar.css
+++ b/plugins/balloontoolbar/skins/moono-lisa/balloontoolbar.css
@@ -16,15 +16,19 @@ For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-oss-license
 	margin-right: 2px;
 }
 
-.cke_balloon.cke_balloontoolbar .cke_combo:first-child a.cke_combo_button{
+.cke_balloon.cke_balloontoolbar .cke_combo:first-child a.cke_combo_button
+{
 	margin-left: 0;
 }
 
-.cke_balloon.cke_balloontoolbar .cke_combo:last-child{
+.cke_balloon.cke_balloontoolbar .cke_combo:last-child
+{
 	margin-right: 0;
 }
 
-.cke_balloon.cke_balloontoolbar .cke_combo a.cke_combo_button{
+/* Negative value for left margin is needed to overlap separator (#2535). */
+.cke_balloon.cke_balloontoolbar .cke_combo a.cke_combo_button
+{
 	margin: 0 1px 0 -2px;
 }
 
@@ -36,6 +40,5 @@ For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-oss-license
 {
 	border: none;
 	padding: 1px;
-	// margin: 0 1px 0 0;
 	outline: 1px solid #bcbcbc;
 }

--- a/tests/plugins/balloontoolbar/manual/moonolisaflickering.html
+++ b/tests/plugins/balloontoolbar/manual/moonolisaflickering.html
@@ -15,7 +15,8 @@
 		image.on( 'click', function() {
 			panel.addItems( {
 				Styles: evt.editor.ui.create( 'Styles' ),
-				Styles2: evt.editor.ui.create( 'Styles' )
+				Styles2: evt.editor.ui.create( 'Styles' ),
+				Styles3: evt.editor.ui.create( 'Styles' )
 			} );
 			panel.attach( this );
 		} );

--- a/tests/plugins/balloontoolbar/manual/moonolisaflickering.md
+++ b/tests/plugins/balloontoolbar/manual/moonolisaflickering.md
@@ -3,7 +3,7 @@
 @bender-ckeditor-plugins: wysiwygarea,toolbar,balloontoolbar,image,stylescombo
 
 1. Focus the image.
-1. Hover over balloon both options.
+1. Hover over balloon options.
 
 ## Expected
 

--- a/tests/plugins/balloontoolbar/manual/moonolisaflickering.md
+++ b/tests/plugins/balloontoolbar/manual/moonolisaflickering.md
@@ -9,9 +9,10 @@
 
 * Balloon option hovers smoothly.
 * Hovered option has equal left and right margin.
+* Options separator is hidden under hover style.
 
 ## Unexpected
 
 * Visible flickering occurs on the right edge of the balloon panel.
 * Hovered option has bigger right margin compared to left margin.
-* Options separator is hidden under hover style.
+* Options separator is visible under hover style.


### PR DESCRIPTION
## What is the purpose of this pull request?

Bug fix

## Does your PR contain necessary tests?

All patches which change the editor code must include tests. You can always read more
on [PR testing](https://ckeditor.com/docs/ckeditor4/latest/guide/dev_contributing_code.html#tests),
[how to set the testing environment](https://ckeditor.com/docs/ckeditor4/latest/guide/dev_tests.html) and
[how to create tests](https://ckeditor.com/docs/ckeditor4/latest/guide/dev_tests.html#creating-your-own-test)
in the official CKEditor documentation.

### This PR contains

- [ ] Unit tests
- [ ] Manual tests

## What changes did you make?

I've changed styles for combo buttons inside balloontoolbar to overlap separators on hover.

Closes #2535.