### PR TITLE
Fixed /tests/plugins/contextmenu/manual/contentscss test

### DIFF
--- a/tests/plugins/contextmenu/manual/contentscss.html
+++ b/tests/plugins/contextmenu/manual/contentscss.html
@@ -3,6 +3,9 @@
 </div>
 
 <script>
+	// Avoiding error on built version (#2533).
+	CKEDITOR.skinName = 'moono-lisa';
+
 	CKEDITOR.replace( 'editor', {
 		contextmenu_contentsCss: [
 			CKEDITOR.skin.getPath( 'editor' ),


### PR DESCRIPTION
## What is the purpose of this pull request?

Failing test

## Does your PR contain necessary tests?

All patches which change the editor code must include tests. You can always read more
on [PR testing](https://ckeditor.com/docs/ckeditor4/latest/guide/dev_contributing_code.html#tests),
[how to set the testing environment](https://ckeditor.com/docs/ckeditor4/latest/guide/dev_tests.html) and
[how to create tests](https://ckeditor.com/docs/ckeditor4/latest/guide/dev_tests.html#creating-your-own-test)
in the official CKEditor documentation.

### This PR contains

- [ ] Unit tests
- [ ] Manual tests

## What changes did you make?

It looks like `CKEDITOR.skinName` is missing in built version. Not sure if it's a bug (if so, I prefer extracting it to the separate issue thus it would require some additional testing), however setting this configuration explicit fixes the issue with a manual test.

Closes #2533