### PR TITLE
Correct manual test to work on IE8

### DIFF
--- a/tests/core/editor/manual/filterdestroy.html
+++ b/tests/core/editor/manual/filterdestroy.html
@@ -1,10 +1,9 @@
-<button id="rebuild">Rebuild editor</button>
+<button id="rebuild" onclick="rebuildEditor()">Rebuild editor</button>
 <span id="counter"></span>
 <textarea id="editor">
 </textarea>
 <script>
 	var counter = document.getElementById( 'counter' );
-	document.getElementById( 'rebuild' ).addEventListener( 'click', rebuildEditor );
 
 	// Global filter.
 	new CKEDITOR.filter( 'br' );


### PR DESCRIPTION
## What is the purpose of this pull request?

Test fix

### This PR contains

- [ ] Unit tests
- [ ] Manual tests

## What changes did you make?

- remove not supported `addEventListener` on IE8 from manual test.

Close #2549 