### PR TITLE
Moved loupe icon into emoji search field, increased height of field to 25px

### DIFF
--- a/plugins/emoji/skins/default.css
+++ b/plugins/emoji/skins/default.css
@@ -84,7 +84,7 @@
 /* SEARCHBOX */
 .cke_emoji-search {
 	position: relative;
-	height: 21px;
+	height: 25px;
 	display: block;
 	border: 1px solid #d1d1d1;
 	margin-left: 10px;
@@ -92,8 +92,8 @@
 }
 
 .cke_emoji-search .cke_emoji-search_loupe {
-	position: relative;
-	top: 3px;
+	position: absolute;
+	top: 5px;
 	left: 5px;
 	display: inline-block;
 	width: 15px;
@@ -113,23 +113,17 @@
 }
 
 .cke_emoji-search input {
-	margin-left: 10px;
-	margin-right: 0px;
-	border: 0;
-	width: 263px;
+	-webkit-appearance: none;
+	border: none;
+	width: 100%;
 	height: 100%;
-	padding-left: 3px;
+	padding-left: 30px;
 	padding-right: 3px;
 }
 
 .cke_rtl .cke_emoji-search input {
 	margin-left: 0px;
 	margin-right: 10px;
-}
-
-.cke_browser_ie .cke_emoji-search input {
-	width: 255px;
-	height: auto;
 }
 
 /* EMOJI */

--- a/plugins/emoji/skins/default.css
+++ b/plugins/emoji/skins/default.css
@@ -117,14 +117,14 @@
 	border: none;
 	width: 100%;
 	height: 100%;
-	padding-left: 30px;
+	padding-left: 25px;
 	padding-right: 10px;
 	margin-left: 0
 }
 
 .cke_rtl .cke_emoji-search input {
 	padding-left: 10px;
-	padding-right: 30px;
+	padding-right: 25px;
 	margin-right: 0;
 }
 

--- a/plugins/emoji/skins/default.css
+++ b/plugins/emoji/skins/default.css
@@ -93,17 +93,17 @@
 
 .cke_emoji-search .cke_emoji-search_loupe {
 	position: absolute;
-	top: 5px;
-	left: 5px;
+	top: 6px;
+	left: 6px;
 	display: inline-block;
-	width: 15px;
-	height: 15px;
+	width: 14px;
+	height: 14px;
 	opacity: 0.4;
 }
 
 .cke_rtl .cke_emoji-search .cke_emoji-search_loupe {
 	left: auto;
-	right: 5px;
+	right: 6px;
 }
 
 .cke_emoji-search span {
@@ -118,12 +118,14 @@
 	width: 100%;
 	height: 100%;
 	padding-left: 30px;
-	padding-right: 3px;
+	padding-right: 10px;
+	margin-left: 0
 }
 
 .cke_rtl .cke_emoji-search input {
-	padding-left: 3px;
+	padding-left: 10px;
 	padding-right: 30px;
+	margin-right: 0;
 }
 
 /* EMOJI */
@@ -141,7 +143,7 @@
 .cke_emoji-outer_emoji_block h2 {
 	font-size: 1.3em;
 	font-weight: 600;
-	margin: 5px 0 3px 8px;
+	margin: 5px 0 3px 0;
 }
 
 .cke_emoji-outer_emoji_block ul {

--- a/plugins/emoji/skins/default.css
+++ b/plugins/emoji/skins/default.css
@@ -122,8 +122,8 @@
 }
 
 .cke_rtl .cke_emoji-search input {
-	margin-left: 0px;
-	margin-right: 10px;
+	padding-left: 3px;
+	padding-right: 30px;
 }
 
 /* EMOJI */

--- a/tests/plugins/emoji/manual/dropdown/dropdowninputoutline.html
+++ b/tests/plugins/emoji/manual/dropdown/dropdowninputoutline.html
@@ -1,0 +1,22 @@
+<h1>Left to right editor:</h1>
+
+<textarea id="editor_ltr" cols="10" rows="10">
+	<p>Test</p>
+</textarea>
+
+<h1>Right to left editor:</h1>
+
+<textarea id="editor_rtl" cols="10" rows="10">
+	<p>Test</p>
+</textarea>
+
+<script>
+	if ( emojiTools.notSupportedEnvironment) {
+		bender.ignore();
+	}
+
+	CKEDITOR.replace( 'editor_ltr' );
+	CKEDITOR.replace( 'editor_rtl', {
+		language: 'ar'
+	} );
+</script>

--- a/tests/plugins/emoji/manual/dropdown/dropdowninputoutline.md
+++ b/tests/plugins/emoji/manual/dropdown/dropdowninputoutline.md
@@ -1,0 +1,15 @@
+@bender-tags: 4.11.0, feature, emoji, 2547
+@bender-ckeditor-plugins: wysiwygarea, toolbar, emoji
+@bender-ui: collapsed
+@bender-include: ../../_helpers/tools.js
+
+1. Open emoji dropdown.
+2. Inspect emoji search field.
+
+## Expected
+
+- Blue outline is around whole search field with loupe icon inside.
+
+## Unexpected
+
+- Loupe icon is outside of outline.

--- a/tests/plugins/emoji/manual/dropdown/dropdowninputoutline.md
+++ b/tests/plugins/emoji/manual/dropdown/dropdowninputoutline.md
@@ -3,6 +3,8 @@
 @bender-ui: collapsed
 @bender-include: ../../_helpers/tools.js
 
+For both editors:
+
 1. Open emoji dropdown.
 2. Inspect emoji search field.
 


### PR DESCRIPTION
## What is the purpose of this pull request?

Bug fix/ styling improvement

## Does your PR contain necessary tests?

All patches which change the editor code must include tests. You can always read more
on [PR testing](https://ckeditor.com/docs/ckeditor4/latest/guide/dev_contributing_code.html#tests),
[how to set the testing environment](https://ckeditor.com/docs/ckeditor4/latest/guide/dev_tests.html) and
[how to create tests](https://ckeditor.com/docs/ckeditor4/latest/guide/dev_tests.html#creating-your-own-test)
in the official CKEditor documentation.

### This PR contains

- [ ] Unit tests
- [X] Manual tests

## What changes did you make?

Changed styling of emoji button input field, so loupe icon is contained within it, and increased it's height to 25px.

Closes #2547 