### PR TITLE
Ignored tests/plugins/contextmenu/keystroke test on ie8

### DIFF
--- a/tests/plugins/contextmenu/keystroke.js
+++ b/tests/plugins/contextmenu/keystroke.js
@@ -16,6 +16,11 @@
 
 	var tests = {
 		'test opening context menu with keystroke': function( editor ) {
+			// Test with inline editor fails because of the #549 issue.
+			if ( CKEDITOR.env.ie && CKEDITOR.env.version < 9 && editor.editable().isInline() ) {
+				assert.ignore();
+			}
+
 			var range = new CKEDITOR.dom.range( editor.document ),
 				selectionRect,
 				frame = CKEDITOR.document.getWindow().getFrame();


### PR DESCRIPTION
## What is the purpose of this pull request?

Failing test

## Does your PR contain necessary tests?

All patches which change the editor code must include tests. You can always read more
on [PR testing](https://ckeditor.com/docs/ckeditor4/latest/guide/dev_contributing_code.html#tests),
[how to set the testing environment](https://ckeditor.com/docs/ckeditor4/latest/guide/dev_tests.html) and
[how to create tests](https://ckeditor.com/docs/ckeditor4/latest/guide/dev_tests.html#creating-your-own-test)
in the official CKEditor documentation.

### This PR contains

- [ ] Unit tests
- [ ] Manual tests

## What changes did you make?

Ignored test for an inline editor on IE8 due to #549 issue.

Closes #2530
