### PR TITLE
Fixed failing tests on mobile devices

### DIFF
--- a/tests/plugins/table/table.js
+++ b/tests/plugins/table/table.js
@@ -16,9 +16,16 @@
 
 	bender.test( {
 		'test create table': function() {
-			var bot = this.editorBots.editor;
+			var bot = this.editorBots.editor,
+				editable = bot.editor.editable(),
+				spy = sinon.stub( editable, 'getSize' );
+
+			// Dialog width is set to 100% whenever editable width is lower than 500px.
+			// This happens on mobile devices when run from dashboard.
+			spy.withArgs( 'width' ).returns( 500 );
 
 			bot.dialog( 'tableProperties', function( dialog ) {
+				spy.restore();
 				// Check defaults.
 				assert.areSame( '500px', dialog.getValueOf( 'info', 'txtWidth' ) );
 				assert.areSame( '3', dialog.getValueOf( 'info', 'txtRows' ) );

--- a/tests/plugins/table/table.js
+++ b/tests/plugins/table/table.js
@@ -17,19 +17,15 @@
 	bender.test( {
 		'test create table': function() {
 			var bot = this.editorBots.editor,
-				editable = bot.editor.editable(),
-				spy = sinon.stub( editable, 'getSize' );
-
-			// Dialog width is set to 100% whenever editable width is lower than 500px.
-			// This happens on mobile devices when run from dashboard.
-			spy.withArgs( 'width' ).returns( 500 );
+				editable = bot.editor.editable();
 
 			bot.dialog( 'tableProperties', function( dialog ) {
-				spy.restore();
+				var isSmallViewport = editable.getSize( 'width' ) < 500;
 				// Check defaults.
-				assert.areSame( '500px', dialog.getValueOf( 'info', 'txtWidth' ) );
 				assert.areSame( '3', dialog.getValueOf( 'info', 'txtRows' ) );
 				assert.areSame( '2', dialog.getValueOf( 'info', 'txtCols' ) );
+				// Table width is set either to 100% or 500px depending on the editable size.
+				assert.areSame( isSmallViewport ? '100%' : '500px', dialog.getValueOf( 'info', 'txtWidth' ) );
 
 				dialog.fire( 'ok' );
 				dialog.hide();
@@ -39,6 +35,11 @@
 					var output = bender.tools.getHtmlWithSelection( bot.editor );
 					output = bender.tools.fixHtml( bender.tools.compatHtml( output ) );
 					var expected = bender.tools.compatHtml( bender.tools.getValueAsHtml( 'create-table' ) );
+
+					if ( isSmallViewport ) {
+						expected = expected.replace( /500\s*px/, '100%' );
+					}
+
 					assert.areSame( expected, output );
 				}, 0 );
 			} );

--- a/tests/tickets/14755/1.js
+++ b/tests/tickets/14755/1.js
@@ -18,13 +18,18 @@
 
 	bender.test( {
 		'test regular case': function() {
-			var editor = this.editor;
+			var editor = this.editor,
+				editable = editor.editable(),
+				// Dialog width is set to 100% whenever editable width is lower than 500px.
+				// This happens on mobile devices when run from dashboard.
+				spy = sinon.stub( editable, 'getSize' );
 
 			this.editorBot.setHtmlWithSelection( '<ol><li>[aaaaaaaaaaaaaaaa</li><li>&nbsp;]</li></ol>' );
 
 			this.editorBot.dialog( 'table', function( dialog ) {
 				assert.isTrue( true );
 				dialog.getButton( 'ok' ).click();
+				spy.restore();
 
 				assert.isInnerHtmlMatching(
 					// jscs:disable maximumLineLength

--- a/tests/tickets/14755/1.js
+++ b/tests/tickets/14755/1.js
@@ -20,16 +20,15 @@
 		'test regular case': function() {
 			var editor = this.editor,
 				editable = editor.editable(),
-				// Dialog width is set to 100% whenever editable width is lower than 500px.
-				// This happens on mobile devices when run from dashboard.
-				spy = sinon.stub( editable, 'getSize' );
+				// The default width of inserted table is dependent on editable viewport, mock it to
+				// keep consistent results.
+				stub = sinon.stub( editable, 'getSize' ).returns( 1080 );
 
 			this.editorBot.setHtmlWithSelection( '<ol><li>[aaaaaaaaaaaaaaaa</li><li>&nbsp;]</li></ol>' );
 
 			this.editorBot.dialog( 'table', function( dialog ) {
-				assert.isTrue( true );
 				dialog.getButton( 'ok' ).click();
-				spy.restore();
+				stub.restore();
 
 				assert.isInnerHtmlMatching(
 					// jscs:disable maximumLineLength


### PR DESCRIPTION
## What is the purpose of this pull request?

Failing test fix

## Does your PR contain necessary tests?

All patches which change the editor code must include tests. You can always read more
on [PR testing](https://ckeditor.com/docs/ckeditor4/latest/guide/dev_contributing_code.html#tests),
[how to set the testing environment](https://ckeditor.com/docs/ckeditor4/latest/guide/dev_tests.html) and
[how to create tests](https://ckeditor.com/docs/ckeditor4/latest/guide/dev_tests.html#creating-your-own-test)
in the official CKEditor documentation.

### This PR contains

- [ ] Unit tests
- [ ] Manual tests

## What changes did you make?

When test is run from dashbord on mobiles editable might have width < 500px, which results in different default table styling.

https://github.com/ckeditor/ckeditor-dev/blob/8b8d7fd0832330232af8dfce34e6a0484a728062/plugins/table/dialogs/table.js#L382

I fixed it by forcing editable to return 500px width.

Closes #2529 