### PR TITLE
Fix incorrect positioning of context menu in Firefox

### DIFF
--- a/plugins/contextmenu/plugin.js
+++ b/plugins/contextmenu/plugin.js
@@ -65,7 +65,7 @@ CKEDITOR.plugins.add( 'contextmenu', {
 						// Cancel the browser context menu.
 						domEvent.preventDefault();
 
-						// Do not react to this event (#2548).
+						// Do not react to this event, as it might open context menu in wrong position (#2548).
 						if ( keystrokeActive ) {
 							return;
 						}

--- a/plugins/contextmenu/plugin.js
+++ b/plugins/contextmenu/plugin.js
@@ -49,7 +49,8 @@ CKEDITOR.plugins.add( 'contextmenu', {
 				 * <kbd>Ctrl</kbd> key is held on opening the context menu. See {@link CKEDITOR.config#browserContextMenuOnCtrl}.
 				 */
 				addTarget: function( element, nativeContextMenuOnCtrl ) {
-					var keystrokeActive;
+					var holdCtrlKey,
+						keystrokeActive;
 
 					element.on( 'contextmenu', function( event ) {
 						var domEvent = event.data,
@@ -97,8 +98,7 @@ CKEDITOR.plugins.add( 'contextmenu', {
 					}, this );
 
 					if ( CKEDITOR.env.webkit ) {
-						var holdCtrlKey,
-							onKeyDown = function( event ) {
+						var onKeyDown = function( event ) {
 								holdCtrlKey = CKEDITOR.env.mac ? event.data.$.metaKey : event.data.$.ctrlKey;
 							},
 							resetOnKeyUp = function() {

--- a/tests/plugins/contextmenu/manual/keystroke.html
+++ b/tests/plugins/contextmenu/manual/keystroke.html
@@ -1,4 +1,4 @@
-<br><br><br><br><br><br><br><br><br><br><br><br><br><br><br><br><br><br><br><br><br><br><br><br><br><br><br><br>
+<div style="height: 1000px"></div>
 <H1> Left to right editors:</H1>
 <textarea id="classic-ltr">
 	<p>Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore mag</p>
@@ -119,7 +119,7 @@
 		</table>
 	</div>
 </div>
-<br><br><br><br><br><br><br><br><br><br><br><br><br><br><br><br><br><br><br><br><br><br><br><br><br><br><br><br>
+<div style="height: 1000px"></div>
 <script>
 	CKEDITOR.replace( 'classic-ltr', {
 	} );

--- a/tests/plugins/contextmenu/manual/keystroke.md
+++ b/tests/plugins/contextmenu/manual/keystroke.md
@@ -3,8 +3,9 @@
 @bender-ckeditor-plugins: wysiwygarea,toolbar,contextmenu,clipboard,table,tableselection,floatingspace
 
 ## For each editor:
+
 1. Scroll page so editor as at the top.
-1. Select some editor context with mouse or keyboard.
+1. Select some editor content with mouse or keyboard.
 1. Press <kbd>Shift</kbd> + <kbd>F10</kbd> to open context menu from keyboard.
 
 ### Expected

--- a/tests/plugins/contextmenu/manual/keystroke.md
+++ b/tests/plugins/contextmenu/manual/keystroke.md
@@ -5,7 +5,7 @@
 ## For each editor:
 1. Scroll page so editor as at the top.
 1. Select some editor context with mouse or keyboard.
-1. Press `Shift + F10` to open context menu from keyboard.
+1. Press <kbd>Shift</kbd> + <kbd>F10</kbd> to open context menu from keyboard.
 
 ### Expected
 
@@ -15,6 +15,10 @@
 #### Right to left editors:
 - The panel shows itself on the left side of selection.
 
+## Additional checks for Firefox
+
+* Check if menu can be opened using mouse after opening it using keyboard.
+* Check if subsequent pressing <kbd>Shift</kbd> + <kbd>F10</kbd> also opens menu.
 
 ### Note:
 


### PR DESCRIPTION
## What is the purpose of this pull request?

Bug fix

## Does your PR contain necessary tests?

All patches which change the editor code must include tests. You can always read more
on [PR testing](https://ckeditor.com/docs/ckeditor4/latest/guide/dev_contributing_code.html#tests),
[how to set the testing environment](https://ckeditor.com/docs/ckeditor4/latest/guide/dev_tests.html) and
[how to create tests](https://ckeditor.com/docs/ckeditor4/latest/guide/dev_tests.html#creating-your-own-test)
in the official CKEditor documentation.

### This PR contains

- [ ] Unit tests
- [x] Manual tests

## What changes did you make?

I've forced preventing opening our menu for native `contextmenu` event fired by <kbd>Shift</kbd> + <kbd>F10</kbd> keystroke.

Closes #2548.