### PR TITLE
Change the applied styles when inserting a figure and selecting "center"

### DIFF
--- a/plugins/image2/plugin.js
+++ b/plugins/image2/plugin.js
@@ -555,7 +555,7 @@
 					// Finally set display for figure.
 					if ( !alignClasses && el.is( 'figure' ) ) {
 						if ( newValue == 'center' )
-							el.setStyle( 'display', 'inline-block' );
+							el.setStyle( 'margin-left:auto;margin-right:auto;' );
 						else
 							el.removeStyle( 'display' );
 					}

--- a/plugins/image2/plugin.js
+++ b/plugins/image2/plugin.js
@@ -554,10 +554,13 @@
 
 					// Finally set display for figure.
 					if ( !alignClasses && el.is( 'figure' ) ) {
-						if ( newValue == 'center' )
-							el.setStyle( 'margin-left:auto;margin-right:auto;' );
-						else
-							el.removeStyle( 'display' );
+						if ( newValue == 'center' ) {
+							el.setStyle('margin-left', 'auto');
+							el.setStyle('margin-right', 'auto');
+						} else {
+							el.removeStyle('margin-left');
+							el.removeStyle('margin-right');
+						}
 					}
 				},
 

--- a/tests/plugins/image2/downcast.html
+++ b/tests/plugins/image2/downcast.html
@@ -21,7 +21,7 @@
 	<div id="w3">
 		<p>x</p>
 		<div style="text-align:center">
-			<figure class="image" style="display:inline-block">
+			<figure class="image" style="margin-left:auto; margin-right:auto">
 				<img alt="foo" src="_assets/foo.png" />
 				<figcaption>Bang</figcaption>
 			</figure>

--- a/tests/plugins/image2/image2.html
+++ b/tests/plugins/image2/image2.html
@@ -38,7 +38,7 @@
 	<textarea id="editor_captionedCentered">
 		<p>x</p>
 		<div style="text-align:center">
-			<figure id="w1" class="image" style="display:inline-block">
+			<figure id="w1" class="image" style="margin-left:auto; margin-right:auto">
 				<img src="_assets/foo.png" alt="foo" />
 				<figcaption>caption1</figcaption>
 			</figure>

--- a/tests/plugins/image2/image2.js
+++ b/tests/plugins/image2/image2.js
@@ -152,7 +152,7 @@
 		} ),
 		newWidgetPattern:
 			'<div style="text-align:center">' +
-				'<figure class="image" style="display:inline-block">' +
+				'<figure class="image" style="margin-left:auto; margin-right:auto">' +
 					'<img alt="bar" height="250" src="_assets/bar.png" width="200" />' +
 					'<figcaption>Caption</figcaption>' +
 				'</figure>' +

--- a/tests/plugins/image2/internal.js
+++ b/tests/plugins/image2/internal.js
@@ -135,7 +135,7 @@
 					'(<br />)?' +
 				'</figure>' ),
 			captionedCentered: new RegExp(
-				'<figure class="image"( data-cke-widget-upcasted="1")?( style="display:inline-block;")?>' +
+				'<figure class="image"( data-cke-widget-upcasted="1")?( style="margin-left:auto;margin-right:auto;")?>' +
 					'<span class="cke_image_resizer_wrapper">' +
 						'<img alt="" data-cke-saved-src="_assets/foo.png"( data-cke-widget-upcasted="1")? id="x" src="_assets/foo.png" />' +
 						'<span class="cke_image_resizer( cke_image_resizer_left)?"></span>' +

--- a/tests/plugins/image2/link.html
+++ b/tests/plugins/image2/link.html
@@ -68,7 +68,7 @@
 <textarea id="captioned-centered">
 	<p>y</p>
 	<div style="text-align:center">
-		<figure class="image" style="display:inline-block">
+		<figure class="image" style="margin-left:auto; margin-right:auto">
 			<img alt="x" id="x" src="_assets/foo.png" />
 			<figcaption>c</figcaption>
 		</figure>
@@ -76,7 +76,7 @@
 	=>
 	<p>y</p>
 	<div style="text-align:center">
-		<figure class="image" style="display:inline-block">
+		<figure class="image" style="margin-left:auto; margin-right:auto">
 			<a href="http://x"><img alt="x" id="x" src="_assets/foo.png" /></a>
 			<figcaption>c</figcaption>
 		</figure>
@@ -141,7 +141,7 @@
 	=>
 	<p>y</p>
 	<div style="text-align:center">
-		<figure class="image" style="display:inline-block;">
+		<figure class="image" style="margin-left:auto; margin-right:auto">
 			<a href="http://x"><img alt="x" id="x" src="_assets/foo.png" /></a>
 			<figcaption>c</figcaption>
 		</figure>
@@ -250,7 +250,7 @@
 	=>
 	<p>y</p>
 	<div style="text-align:center">
-		<figure class="image" style="display:inline-block;">
+		<figure class="image" style="margin-left:auto; margin-right:auto">
 			<img alt="x" id="x" src="_assets/foo.png" />
 			<figcaption>c</figcaption>
 		</figure>

--- a/tests/plugins/image2/states.html
+++ b/tests/plugins/image2/states.html
@@ -11,7 +11,7 @@
 			</figure>
 		</div>
 		<div id="caption:true_align:center_link:no">
-			<figure class="image" id="x" style="display:inline-block;">
+			<figure class="image" id="x" style="margin-left:auto; margin-right:auto">
 				<img alt="foo" src="_assets/foo.png" data-custom="y" lang="es" />
 				<figcaption>Caption</figcaption>
 			</figure>
@@ -31,7 +31,7 @@
 			</figure>
 		</div>
 		<div id="caption:true_align:center_link:yes">
-			<figure class="image" id="x" style="display:inline-block;">
+			<figure class="image" id="x" style="margin-left:auto; margin-right:auto">
 				<a href="http://x"><img alt="foo" src="_assets/foo.png" data-custom="y" lang="es" /></a>
 				<figcaption>Caption</figcaption>
 			</figure>


### PR DESCRIPTION
 ## What is the purpose of this pull request?
Setting `figure {display: inline-block;}` interferes with using `figure {display: table;}` and `figcaption {display: table-caption;}` to ensure the caption wraps to the width of the image.
 
 ## Does your PR contain necessary tests?
 Yes
 
 ## What changes did you make?

### Current behavior:
```
<div style="text-align:center">
    <figure class="image" style="display:inline-block">
    <img alt="" src="your.jpg" width="500" />
        <figcaption>Caption caption caption caption caption</figcaption>
    </figure>
</div>
```

### Desired behavior
```
<figure class="image" style="margin-left: auto; margin-right: auto;">
    <img alt="" src="your.jpg" width="500" />
    <figcaption>Caption caption caption caption caption</figcaption>
</figure>
```

### Notes
* Using `margin-left: auto; margin-right: auto;` avoids overwriting predefined top and bottom margins with `margin: 0 auto;`.
* Figure is a block level element, no need to wrap it in a div.
* These changes do not remove the surrounding div. I'm part of a team that uses this package in our CMS and wanted to assist our developer in remedying this issue I discovered while styling figure. 