### PR TITLE
Fixed emoji panel jumping when changing categories

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,6 +1,16 @@
 ﻿CKEditor 4 Changelog
 ====================
 
+## CKEditor 4.11.1
+
+Fixed Issues:
+
+* [#2560](https://github.com/ckeditor/ckeditor-dev/issues/2560): [Firefox] Fixed: Visible focus jumping when changing [Emoji](https://ckeditor.com/cke4/addon/emoji) panel categories.
+
+API Changes:
+
+* [#2560](https://github.com/ckeditor/ckeditor-dev/issues/2560): [`panel.block.markItem`](https://ckeditor.com/docs/ckeditor4/latest/api/CKEDITOR_ui_panel_block.html#method-markItem) accepts additional parameter allowing to asynchronously defer function execution.
+
 ## CKEditor 4.11
 
 New Features:

--- a/plugins/emoji/plugin.js
+++ b/plugins/emoji/plugin.js
@@ -464,10 +464,8 @@
 						self.clearSearchInput();
 
 						// Reset focus:
-						CKEDITOR.tools.setTimeout( function() {
-							self.elements.input.focus( true );
-							self.blockObject._.markItem( self.inputIndex );
-						}, 0, self );
+						self.elements.input.focus( true );
+						self.blockObject._.markItem( self.inputIndex, true );
 
 						// Remove statusbar icons:
 						self.clearStatusbar();
@@ -518,16 +516,13 @@
 					this.moveFocus( element.data( 'cke-emoji-group' ) );
 				},
 				moveFocus: function( groupName ) {
-					var firstSectionItem = this.blockElement.findOne( 'a[data-cke-emoji-group="' + htmlEncode( groupName ) + '"]' ),
-						itemIndex;
+					var firstSectionItem = this.blockElement.findOne( 'a[data-cke-emoji-group="' + htmlEncode( groupName ) + '"]' );
 
 					if ( !firstSectionItem ) {
 						return;
 					}
 
-					itemIndex = this.getItemIndex( this.items, firstSectionItem );
-					firstSectionItem.focus( true );
-					this.blockObject._.markItem( itemIndex );
+					this.blockObject._.markItem( this.getItemIndex( this.items, firstSectionItem ), true );
 				},
 				getItemIndex: function( nodeList, item ) {
 					return arrTools.indexOf( nodeList.toArray(), function( element ) {

--- a/plugins/panel/plugin.js
+++ b/plugins/panel/plugin.js
@@ -300,21 +300,39 @@
 
 			/**
 			 * Mark the item specified by the index as current activated.
+			 *
+			 * @param {Number} index
+			 * @param  {Boolean} [defer=false] Whether to asynchronously defer the
+			 * execution by 100 ms. Available since 4.11.0.
 			 */
-			markItem: function( index ) {
-				if ( index == -1 )
-					return;
-				var focusables = this._.getItems();
-				var item = focusables.getItem( this._.focusIndex = index );
+			markItem: ( function() {
+				function exec( index ) {
+					if ( index == -1 ) {
+						return;
+					}
 
-				// Safari need focus on the iframe window first(https://dev.ckeditor.com/ticket/3389), but we need
-				// lock the blur to avoid hiding the panel.
-				if ( CKEDITOR.env.webkit )
-					item.getDocument().getWindow().focus();
-				item.focus();
+					var focusables = this._.getItems();
+					this._.focusIndex = index;
+					var item = focusables.getItem( index );
 
-				this.onMark && this.onMark( item );
-			},
+					// Safari need focus on the iframe window first(https://dev.ckeditor.com/ticket/3389), but we need
+					// lock the blur to avoid hiding the panel.
+					if ( CKEDITOR.env.webkit ) {
+						item.getDocument().getWindow().focus();
+					}
+					item.focus();
+
+					this.onMark && this.onMark( item );
+				}
+
+				return function( index, defer ) {
+					if ( defer ) {
+						CKEDITOR.tools.setTimeout( exec, 100, this, index );
+					} else {
+						exec.call( this, index );
+					}
+				};
+			} )(),
 
 			/**
 			 * Marks the first visible item or the one whose `aria-selected` attribute is set to `true`.

--- a/tests/_benderjs/ckeditor/static/bot.js
+++ b/tests/_benderjs/ckeditor/static/bot.js
@@ -116,9 +116,11 @@
 	 * Open a menu button drop down.
 	 * @param {String} name Name of the panel button.
 	 * @param {Function} callback The function invoked when panel is opened.
+	 * @param {Number} [delay=0] Delays callback execution when panel is opened.
 	 */
 	function menuOrPanel( isPanel ) {
-		return function( name, callback ) {
+		return function( name, callback, delay ) {
+			delay = delay || 0;
 
 			var editor = this.editor,
 				btn = editor.ui.get( name ),
@@ -133,7 +135,7 @@
 							callback.call( tc, isPanel ? btn._.panel : btn._.menu );
 						}
 						);
-				} );
+				}, delay );
 			} );
 
 			btnEl = CKEDITOR.document.getById( btn._.id );
@@ -234,6 +236,7 @@
 		 * Open a menu button drop down.
 		 * @param {String} name Name of the panel button.
 		 * @param {Function} callback The function invoked when panel is opened.
+		 * @param {Number} [delay=0] Delays callback execution when panel is opened.
 		 */
 		menu: menuOrPanel( false ),
 
@@ -241,6 +244,7 @@
 		 * Open a menu button drop down.
 		 * @param {String} name Name of the panel button.
 		 * @param {Function} callback The function invoked when panel is opened.
+		 * @param {Number} [delay=0] Delays callback execution when panel is opened.
 		 */
 		panel: menuOrPanel( true ),
 

--- a/tests/plugins/emoji/dropdown.js
+++ b/tests/plugins/emoji/dropdown.js
@@ -10,6 +10,16 @@
 	bender.editor = true;
 
 	bender.test( {
+
+		_openPanel: function( callback ) {
+			var that = this;
+
+			this.editorBot.panel( 'EmojiPanel', function( panel ) {
+				that._panel = panel;
+				callback( panel );
+			}, 100 );
+		},
+
 		_should: {
 			ignore: {
 				// (#2528).
@@ -26,31 +36,32 @@
 				assert.ignore();
 			}
 		},
-		'test emoji dropdown has proper components': function() {
-			var bot = this.editorBot;
-			bot.panel( 'EmojiPanel', function( panel ) {
-				try {
-					var doc = panel._.iframe.getFrameDocument();
-					assert.areNotSame( 0, doc.find( '.cke_emoji-navigation_item' ).count(), 'There is no navigation in Emoji Panel.' );
-					assert.areSame( 1, doc.find( 'input' ).count(), 'There is no search input in Emoji Panel.' );
-					assert.areSame( 1, doc.find( '.cke_emoji-outer_emoji_block' ).count(), 'There is no emoji block in Emoji Panel.' );
-					assert.areSame( 1, doc.find( '.cke_emoji-status_bar' ).count(), 'There is no emoji status bar in Emoji Panel.' );
 
-					assert.isTrue( doc.findOne( 'input' ).hasListeners( 'input' ), 'Searchbox doesn\'t have listener.' );
-					assert.isTrue( doc.findOne( '.cke_emoji-outer_emoji_block' ).hasListeners( 'mouseover' ), 'Emoji block should have mouseover listener.' );
-					assert.isTrue( doc.findOne( '.cke_emoji-outer_emoji_block' ).hasListeners( 'click' ), 'Emoji block should have click listener.' );
-					assert.isTrue( doc.findOne( '.cke_emoji-outer_emoji_block' ).hasListeners( 'scroll' ), 'Emoji block should have scroll listener.' );
-					assert.isTrue( doc.findOne( 'nav' ).hasListeners( 'click' ), 'Navigation element should have click listener.' );
-				}
-				finally {
-					panel.hide();
-				}
+		tearDown: function() {
+			if ( this._panel ) {
+				this._panel.hide();
+				this._panel = null;
+			}
+		},
+
+		'test emoji dropdown has proper components': function() {
+			this._openPanel( function( panel ) {
+				var doc = panel._.iframe.getFrameDocument();
+				assert.areNotSame( 0, doc.find( '.cke_emoji-navigation_item' ).count(), 'There is no navigation in Emoji Panel.' );
+				assert.areSame( 1, doc.find( 'input' ).count(), 'There is no search input in Emoji Panel.' );
+				assert.areSame( 1, doc.find( '.cke_emoji-outer_emoji_block' ).count(), 'There is no emoji block in Emoji Panel.' );
+				assert.areSame( 1, doc.find( '.cke_emoji-status_bar' ).count(), 'There is no emoji status bar in Emoji Panel.' );
+
+				assert.isTrue( doc.findOne( 'input' ).hasListeners( 'input' ), 'Searchbox doesn\'t have listener.' );
+				assert.isTrue( doc.findOne( '.cke_emoji-outer_emoji_block' ).hasListeners( 'mouseover' ), 'Emoji block should have mouseover listener.' );
+				assert.isTrue( doc.findOne( '.cke_emoji-outer_emoji_block' ).hasListeners( 'click' ), 'Emoji block should have click listener.' );
+				assert.isTrue( doc.findOne( '.cke_emoji-outer_emoji_block' ).hasListeners( 'scroll' ), 'Emoji block should have scroll listener.' );
+				assert.isTrue( doc.findOne( 'nav' ).hasListeners( 'click' ), 'Navigation element should have click listener.' );
 			} );
 		},
 
 		'test emoji dropdown filter search results': function() {
-			var bot = this.editorBot;
-			bot.panel( 'EmojiPanel', function( panel ) {
+			this._openPanel( function( panel ) {
 				var doc = panel._.iframe.getFrameDocument(),
 					input = doc.findOne( 'input' );
 
@@ -59,75 +70,58 @@
 					sender: input
 				} ) );
 				// Timeouts are necessary for IE11, which has problem with refreshing DOM. That's why asserts run asynchronously.
-				CKEDITOR.tools.setTimeout( function() {
-					resume( function() {
-						assert.areSame( 2, doc.find( 'li.cke_emoji-item :not(.hidden)' ).count(), 'There should be returned 2 values for kebab `keyword`' );
-						panel.hide();
-						bot.panel( 'EmojiPanel', function() {
-							CKEDITOR.tools.setTimeout( function() {
-								resume( function() {
-									assert.areSame( '', input.getValue(), 'Search value should be reset after hiding panel.' );
-									assert.areSame( 0, doc.find( 'li.cke_emoji-item.hidden' ).count(), 'All emoji items should be reset to visible state after closing panel.' );
-									panel.hide();
-								} );
-							}, 200 );
-							wait();
-						} );
+				defer( function() {
+					assert.areSame( 2, doc.find( 'li.cke_emoji-item :not(.hidden)' ).count(), 'There should be returned 2 values for kebab `keyword`' );
+					panel.hide();
+
+					this._openPanel( function() {
+						defer( function() {
+							assert.areSame( '', input.getValue(), 'Search value should be reset after hiding panel.' );
+							assert.areSame( 0, doc.find( 'li.cke_emoji-item.hidden' ).count(), 'All emoji items should be reset to visible state after closing panel.' );
+						}, 200 );
 					} );
 				}, 200 );
-				wait();
 			} );
 		},
 
 		'test emoji dropdown update status': function() {
-			var bot = this.editorBot;
-			bot.panel( 'EmojiPanel', function( panel ) {
-				try {
-					var doc = panel._.iframe.getFrameDocument(),
-						statusBarIcon = doc.findOne( '.cke_emoji-status_icon' ),
-						statusBarDescription = doc.findOne( 'p.cke_emoji-status_description' ),
-						testElement;
+			this._openPanel( function( panel ) {
+				var doc = panel._.iframe.getFrameDocument(),
+					statusBarIcon = doc.findOne( '.cke_emoji-status_icon' ),
+					statusBarDescription = doc.findOne( 'p.cke_emoji-status_description' ),
+					testElement;
 
-					assert.areSame( '', statusBarIcon.getText(), 'Status bar icon should be empty when panel is open.' );
-					assert.areSame( '', statusBarDescription.getText(), 'Status bar description should be empty when panel is open.' );
+				assert.areSame( '', statusBarIcon.getText(), 'Status bar icon should be empty when panel is open.' );
+				assert.areSame( '', statusBarDescription.getText(), 'Status bar description should be empty when panel is open.' );
 
-					testElement = doc.findOne( 'a[data-cke-emoji-name="star"]' );
+				testElement = doc.findOne( 'a[data-cke-emoji-name="star"]' );
 
-					doc.findOne( '.cke_emoji-outer_emoji_block' ).fire( 'mouseover', new CKEDITOR.dom.event( {
-						target: testElement.$
-					} ) );
+				doc.findOne( '.cke_emoji-outer_emoji_block' ).fire( 'mouseover', new CKEDITOR.dom.event( {
+					target: testElement.$
+				} ) );
 
-					assert.areSame( '⭐', statusBarIcon.getText(), 'Status bar icon should contain star after mouseover event.' );
-					assert.areSame( 'star', statusBarDescription.getText(), 'Status bar description should contain "star" name after mouseover.' );
-				}
-				finally {
-					panel.hide();
-				}
+				assert.areSame( '⭐', statusBarIcon.getText(), 'Status bar icon should contain star after mouseover event.' );
+				assert.areSame( 'star', statusBarDescription.getText(), 'Status bar description should contain "star" name after mouseover.' );
 			} );
 		},
 
 		'test emoji list scrolls when navigation is clicked': function() {
-			var bot = this.editorBot;
-			bot.panel( 'EmojiPanel', function( panel ) {
-				try {
-					var doc = panel._.iframe.getFrameDocument(),
-						emojiBlock = doc.findOne( '.cke_emoji-outer_emoji_block' );
+			this._openPanel( function( panel ) {
+				var doc = panel._.iframe.getFrameDocument(),
+					emojiBlock = doc.findOne( '.cke_emoji-outer_emoji_block' );
 
-					assert.areSame( 0, emojiBlock.$.scrollTop, 'Emoji elements should be scrolled to the top.' );
+				assert.areSame( 0, emojiBlock.$.scrollTop, 'Emoji elements should be scrolled to the top.' );
 
-					doc.findOne( 'a[href="#flags"]' ).$.click();
+				doc.findOne( 'a[href="#flags"]' ).$.click();
 
+				defer( function() {
 					assert.areNotSame( 0, emojiBlock.$.scrollTop, 'Emoji elements should be scrolled somewhere down.' );
-				}
-				finally {
-					panel.hide();
-				}
+				} );
 			} );
 		},
 
 		'test navigation highlights proper section when scrolls': function() {
-			var bot = this.editorBot;
-			bot.panel( 'EmojiPanel', function( panel ) {
+			this._openPanel( function( panel ) {
 				var doc = panel._.iframe.getFrameDocument(),
 					testElement = doc.findOne( 'a[data-cke-emoji-name="star"]' );
 
@@ -135,19 +129,14 @@
 
 				doc.findOne( '.cke_emoji-outer_emoji_block' ).fire( 'scroll', new CKEDITOR.dom.event() );
 				// Scroll event is throttled that's why we need wait a little bit.
-				CKEDITOR.tools.setTimeout( function() {
-					resume( function() {
-						assert.isTrue( doc.findOne( 'li[data-cke-emoji-group="travel"]' ).hasClass( 'active' ), 'Travel item in navigation should be highlighted' );
-						panel.hide();
-					} );
+				defer( function() {
+					assert.isTrue( doc.findOne( 'li[data-cke-emoji-group="travel"]' ).hasClass( 'active' ), 'Travel item in navigation should be highlighted' );
 				}, 160 );
-				wait();
 			} );
 		},
 
 		'test input is focused element when dropdown opens': function() {
-			var bot = this.editorBot;
-			bot.panel( 'EmojiPanel', function( panel ) {
+			this._openPanel( function( panel ) {
 				var doc = panel._.iframe.getFrameDocument(),
 					inputElement = doc.findOne( 'input' ),
 					panelBlock = emojiTools.getEmojiPanelBlock( panel ),
@@ -157,13 +146,7 @@
 
 				assert.areNotSame( 0, panelBlock._.focusIndex, 'Focus should not be in first element which is navigation.' );
 				assert.areSame( inputIndex, panelBlock._.focusIndex, 'First selected item should be input.' );
-				CKEDITOR.tools.setTimeout( function() {
-					resume( function() {
-						assert.isTrue( inputElement.equals( new CKEDITOR.dom.element( doc.$.activeElement ) ), 'Input should be focused element.' );
-						panel.hide();
-					} );
-				}, 100 );
-				wait();
+				assert.isTrue( inputElement.equals( new CKEDITOR.dom.element( doc.$.activeElement ) ), 'Input should be focused element.' );
 			} );
 		},
 
@@ -171,28 +154,19 @@
 			var bot = this.editorBot,
 				editor = this.editor;
 			bot.setData( '', function() {
-				bot.panel( 'EmojiPanel', function( panel ) {
-					try {
-						var doc = panel._.iframe.getFrameDocument(),
-							testElement = doc.findOne( 'a[data-cke-emoji-name="star"]' );
+				this._openPanel( function( panel ) {
+					var doc = panel._.iframe.getFrameDocument(),
+						testElement = doc.findOne( 'a[data-cke-emoji-name="star"]' );
 
-						doc.findOne( '.cke_emoji-outer_emoji_block' ).fire( 'click', new CKEDITOR.dom.event( {
-							target: testElement.$
-						} ) );
-						assert.areSame( '<p>⭐</p>', bot.getData(), 'Star should be inserted in editor after click.' );
+					doc.findOne( '.cke_emoji-outer_emoji_block' ).fire( 'click', new CKEDITOR.dom.event( {
+						target: testElement.$
+					} ) );
 
-					}
-					finally {
-						panel.hide();
-					}
+					assert.areSame( '<p>⭐</p>', bot.getData(), 'Star should be inserted in editor after click.' );
 
-					CKEDITOR.tools.setTimeout( function() {
-						resume( function() {
-							assert.isTrue( editor.editable().hasFocus, 'Editable should have focus after emoji insertion.' );
-						} );
-					}, 100 );
-
-					wait();
+					defer( function() {
+						assert.isTrue( editor.editable().hasFocus, 'Editable should have focus after emoji insertion.' );
+					} );
 				} );
 			} );
 		},
@@ -201,84 +175,70 @@
 			var bot = this.editorBot,
 				editor = this.editor;
 			bot.setData( '', function() {
-				bot.panel( 'EmojiPanel', function( panel ) {
-					try {
-						var doc = panel._.iframe.getFrameDocument(),
-							testElement = doc.findOne( 'a[data-cke-emoji-name="star"]' ),
-							panelBlock = emojiTools.getEmojiPanelBlock( panel );
+				this._openPanel( function( panel ) {
+					var doc = panel._.iframe.getFrameDocument(),
+						testElement = doc.findOne( 'a[data-cke-emoji-name="star"]' ),
+						panelBlock = emojiTools.getEmojiPanelBlock( panel );
 
-						panelBlock._.focusIndex = CKEDITOR.tools.getIndex( panelBlock._.getItems().toArray(), function( el ) {
-							return el.data( 'cke-emoji-name' ) === 'star';
-						} );
+					panelBlock._.focusIndex = CKEDITOR.tools.getIndex( panelBlock._.getItems().toArray(), function( el ) {
+						return el.data( 'cke-emoji-name' ) === 'star';
+					} );
 
-						doc.fire( 'keydown', new CKEDITOR.dom.event( {
-							target: testElement.$,
-							keyCode: 32
-						} ) );
+					doc.fire( 'keydown', new CKEDITOR.dom.event( {
+						target: testElement.$,
+						keyCode: 32
+					} ) );
 
-						assert.areSame( '<p>⭐</p>', bot.getData(), 'Star should be inserted in editor after pressing space.' );
-					}
-					finally {
-						panel.hide();
-					}
+					assert.areSame( '<p>⭐</p>', bot.getData(), 'Star should be inserted in editor after pressing space.' );
 
-					CKEDITOR.tools.setTimeout( function() {
-						resume( function() {
-							assert.isTrue( editor.editable().hasFocus, 'Editable should have focus after emoji insertion.' );
-						} );
-					}, 100 );
-
-					wait();
+					defer( function() {
+						assert.isTrue( editor.editable().hasFocus, 'Editable should have focus after emoji insertion.' );
+					} );
 				} );
 			} );
 		},
 
 		'test clicking into navigation list item does not throw an error': function() {
-			var bot = this.editorBot;
-			bot.panel( 'EmojiPanel', function( panel ) {
-				try {
-					var doc = panel._.iframe.getFrameDocument(),
-						focusedElement = doc.findOne( 'a[data-cke-emoji-group="flags"' );
+			this._openPanel( function( panel ) {
+				var doc = panel._.iframe.getFrameDocument(),
+					focusedElement = doc.findOne( 'a[data-cke-emoji-group="flags"' );
 
-					doc.findOne( 'a[href="#flags"]' ).getAscendant( 'li' ).$.click();
+				doc.findOne( 'a[href="#flags"]' ).getAscendant( 'li' ).$.click();
+
+				defer( function() {
 					assert.isTrue( focusedElement.equals( new CKEDITOR.dom.element( doc.$.activeElement ) ), 'First flag should be focused.' );
-				}
-				finally {
-					panel.hide();
-				}
+				} );
 			} );
 		},
 
 		'test left and right arrow does not change focus on input element': function() {
-			var bot = this.editorBot;
-			bot.panel( 'EmojiPanel', function( panel ) {
+			this._openPanel( function( panel ) {
 				var doc = panel._.iframe.getFrameDocument(),
 					input = doc.findOne( 'input' );
 
 				// Input is focused asynchronously, that's why we need to run test asynchronously.
-				CKEDITOR.tools.setTimeout( function() {
-					resume( function() {
-						try {
-							doc.fire( 'keydown', new CKEDITOR.dom.event( {
-								target: input.$,
-								keyCode: 37
-							} ) );
-							assert.isTrue( input.equals( new CKEDITOR.dom.element( doc.$.activeElement ), 'Input should be focused after pressing left arrow.' ) );
+				defer( function() {
+					doc.fire( 'keydown', new CKEDITOR.dom.event( {
+						target: input.$,
+						keyCode: 37
+					} ) );
+					assert.isTrue( input.equals( new CKEDITOR.dom.element( doc.$.activeElement ), 'Input should be focused after pressing left arrow.' ) );
 
-							doc.fire( 'keydown', new CKEDITOR.dom.event( {
-								target: input.$,
-								keyCode: 39
-							} ) );
-							assert.isTrue( input.equals( new CKEDITOR.dom.element( doc.$.activeElement ), 'Input should be focused after pressing right arrow.' ) );
-						}
-						finally {
-							panel.hide();
-						}
-					} );
-				}, 100 );
-				wait();
+					doc.fire( 'keydown', new CKEDITOR.dom.event( {
+						target: input.$,
+						keyCode: 39
+					} ) );
+					assert.isTrue( input.equals( new CKEDITOR.dom.element( doc.$.activeElement ), 'Input should be focused after pressing right arrow.' ) );
+				} );
 			} );
 		}
 	} );
+
+	function defer( callback, delay ) {
+		CKEDITOR.tools.setTimeout( function() {
+			resume( callback );
+		}, delay || 100 );
+		wait();
+	}
 
 } )();

--- a/tests/plugins/emoji/manual/dropdown/categories.md
+++ b/tests/plugins/emoji/manual/dropdown/categories.md
@@ -1,0 +1,15 @@
+@bender-tags: 4.11.0, bug, emoji, 2560
+@bender-ckeditor-plugins: wysiwygarea, toolbar, emoji
+@bender-ui: collapsed
+@bender-include: ../../_helpers/tools.js
+
+1. Open emoji dropdown.
+1. Click the last category.
+
+## Expected
+
+Category changes smoothly.
+
+## Unexpected
+
+There is a slight jumping when focusing the last category.


### PR DESCRIPTION
## What is the purpose of this pull request?

Bug fix

## Does your PR contain necessary tests?

All patches which change the editor code must include tests. You can always read more
on [PR testing](https://ckeditor.com/docs/ckeditor4/latest/guide/dev_contributing_code.html#tests),
[how to set the testing environment](https://ckeditor.com/docs/ckeditor4/latest/guide/dev_tests.html) and
[how to create tests](https://ckeditor.com/docs/ckeditor4/latest/guide/dev_tests.html#creating-your-own-test)
in the official CKEditor documentation.

### This PR contains

- [x] Unit tests
- [x] Manual tests

## What changes did you make?

When changing emoji panel categories, the first emoji item has to be focused. In the previous implementation, item focus was doubled, with deferred focus by using `item.focus( true )` and  by `markItem` function. It causes the issue where categories are jumping on FF, also requires some hacky duplicated timeout function for mobiles https://github.com/ckeditor/ckeditor-dev/pull/2461#issuecomment-432142236

I extracted item focusing delay into `markItem` function, so there is only a single delayed focus - delay is needed to wait until dialog opens.

Also, most unit tests were testing panel only partialy, limited to the first synchronous focus. Not sure if there is a reason for dedicated unit test thus most of them where failing and changes are covered by them.

Closes #2560