### PR TITLE
Fixed: #2595 Internal Drag and Drop of any Inline Wrapped Content Causes Content to Disappear in CKEDITOR4

### DIFF
--- a/plugins/clipboard/plugin.js
+++ b/plugins/clipboard/plugin.js
@@ -1547,6 +1547,9 @@
 					dragRange = data.dragRange,
 					dataTransfer = data.dataTransfer;
 
+				// Include inline element if possible.
+				dragRange.enlarge( CKEDITOR.ENLARGE_INLINE, 1 );
+
 				if ( dataTransfer.getTransferType( editor ) == CKEDITOR.DATA_TRANSFER_INTERNAL ) {
 					// Execute drop with a timeout because otherwise selection, after drop,
 					// on IE is in the drag position, instead of drop position.

--- a/tests/plugins/clipboard/drop.md
+++ b/tests/plugins/clipboard/drop.md
@@ -1,0 +1,29 @@
+@bender-tags: 4.6.2, 4.7.3, 4.8.0, 4.9.2, 4.10.1, 4.11.1, bug, clipboard, 2595
+@bender-ckeditor-plugins: clipboard
+
+1. Fully select any inline (`<a>`, `<strong>`, etc.) wrapped content, eg. `aaa <strong>[bbb]</strong> ccc`.
+2. Drag selection to the boundaries of the editor; somewhere that's invalid, but within the editor. Works best using the nearest border.
+3. Release mouse.
+
+## Expected
+
+Content in dragged selection should remain in DOM, eg. `aaa <strong>[bbb]</strong> ccc`.
+
+## Unexpected
+
+Content in dragged selection is removed from DOM, eg. `aaa ccc`.
+
+Error is thrown in console:
+```
+Uncaught TypeError: Cannot read property 'type' of null
+at window.CKEDITOR.window.CKEDITOR.dom.CKEDITOR.dom.range.setStart (ckeditor.js:165)
+at window.CKEDITOR.window.CKEDITOR.dom.CKEDITOR.dom.range.setStartAfter (ckeditor.js:166)
+at window.CKEDITOR.window.CKEDITOR.dom.CKEDITOR.dom.range.setStartAt (ckeditor.js:167)
+at window.CKEDITOR.window.CKEDITOR.dom.CKEDITOR.dom.range.moveToPosition (ckeditor.js:164)
+at window.CKEDITOR.window.CKEDITOR.dom.CKEDITOR.dom.range.splitElement (ckeditor.js:170)
+at ckeditor.js:386
+at $.insertHtml (ckeditor.js:354)
+at $. (ckeditor.js:364)
+at a.d (ckeditor.js:10)
+at a. (ckeditor.js:11)
+```


### PR DESCRIPTION
## What is the purpose of this pull request?
Bug fix

## Does your PR contain necessary tests?
All patches which change the editor code must include tests. You can always read more
on [PR testing](https://ckeditor.com/docs/ckeditor4/latest/guide/dev_contributing_code.html#tests),
[how to set the testing environment](https://ckeditor.com/docs/ckeditor4/latest/guide/dev_tests.html) and
[how to create tests](https://ckeditor.com/docs/ckeditor4/latest/guide/dev_tests.html#creating-your-own-test)
in the official CKEditor documentation.

### This PR contains
* [ ]  Unit tests
* [x]  Manual tests

## What changes did you make?
Fixed issue where drop range bookmark was inside drag range bookmarks.
```html
<p>
	I'm an instance of 
	<span data-cke-bookmark="1" DEBUG_startNode DEBUG_range_bookmark" style="display: none;">&nbsp;</span>
	<a data-cke-saved-href="https://ckeditor.com" href="https://ckeditor.com">
		<span data-cke-bookmark="1" DEBUG_startNode DEBUG_drop_target_bookmark style="display: none;">&nbsp;</span>
		CKEditor
	</a>
	<span data-cke-bookmark="1" DEBUG_endNode" DEBUG_range_bookmark" style="display: none;">&nbsp;</span>
	.
</p>
```

Solution was to enlarge drag range to include fully selected inline elements selections.

Closes #2595