### PR TITLE
Fix for: Remove Format changes selection

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -6,6 +6,7 @@
 Fixed Issues:
 
 * [#1986](https://github.com/ckeditor/ckeditor-dev/issues/1986): Fixed: Cell Properties dialog from [Table Tools](https://ckeditor.com/cke4/addon/tabletools) plugin shows styles that are not allowed through [`config.allowedContent`](https://ckeditor.com/docs/ckeditor4/latest/api/CKEDITOR_config.html#cfg-allowedContent).
+* [#2451](https://github.com/ckeditor/ckeditor-dev/issues/2451): Fixed: The [Remove Format](https://ckeditor.com/cke4/addon/removeformat) changes selection.
 
 Other Changes:
 

--- a/plugins/removeformat/plugin.js
+++ b/plugins/removeformat/plugin.js
@@ -32,9 +32,18 @@ CKEDITOR.plugins.removeformat = {
 					isElement = function( element ) {
 						return element.type == CKEDITOR.NODE_ELEMENT;
 					},
+					newRanges = [],
 					range;
 
 				while ( ( range = iterator.getNextRange() ) ) {
+					// if ( !range.collapsed )
+					// 	range.enlarge( CKEDITOR.ENLARGE_INLINE );
+
+					var bookmarkForRangeRecreation = range.createBookmark();
+					range = editor.createRange();
+					range.setStartBefore( bookmarkForRangeRecreation.startNode );
+					bookmarkForRangeRecreation.endNode && range.setEndAfter( bookmarkForRangeRecreation.endNode );
+
 					if ( !range.collapsed )
 						range.enlarge( CKEDITOR.ENLARGE_ELEMENT );
 
@@ -99,7 +108,7 @@ CKEDITOR.plugins.removeformat = {
 							// Cache the next node to be processed. Do it now, because
 							// currentNode may be removed.
 							var nextNode = currentNode.getNextSourceNode( false, CKEDITOR.NODE_ELEMENT ),
-								isFakeElement = currentNode.getName() == 'img' && currentNode.data( 'cke-realelement' );
+								isFakeElement = ( currentNode.getName() == 'img' && currentNode.data( 'cke-realelement' ) ) || currentNode.hasAttribute( 'data-cke-bookmark' );
 
 							// This node must not be a fake element, and must not be read-only.
 							if ( !isFakeElement && filter( editor, currentNode ) ) {
@@ -116,13 +125,16 @@ CKEDITOR.plugins.removeformat = {
 						}
 					}
 
-					range.moveToBookmark( bookmark );
+					bookmark.startNode.remove();
+					bookmark.endNode && bookmark.endNode.remove();
+					range.moveToBookmark( bookmarkForRangeRecreation );
+					newRanges.push( range );
 				}
 
 				// The selection path may not changed, but we should force a selection
 				// change event to refresh command states, due to the above attribution change. (https://dev.ckeditor.com/ticket/9238)
 				editor.forceNextSelectionCheck();
-				editor.getSelection().selectRanges( ranges );
+				editor.getSelection().selectRanges( newRanges );
 			}
 		}
 	},

--- a/tests/plugins/removeformat/manual/selection.html
+++ b/tests/plugins/removeformat/manual/selection.html
@@ -1,0 +1,7 @@
+<textarea id="editor">
+	<h1>Test</h1>
+</textarea>
+
+<script>
+	CKEDITOR.replace( 'editor' );
+</script>

--- a/tests/plugins/removeformat/manual/selection.md
+++ b/tests/plugins/removeformat/manual/selection.md
@@ -2,8 +2,8 @@
 @bender-ui: collapsed
 @bender-ckeditor-plugins: wysiwygarea, toolbar, elementspath, format, list, removeformat
 
-1. Select whole editor content.
 1. Press `numbered list` button.
+1. Select `h1` with elements path.
 1. Press `remove format` button.
 
 ## Expected

--- a/tests/plugins/removeformat/manual/selection.md
+++ b/tests/plugins/removeformat/manual/selection.md
@@ -1,0 +1,19 @@
+@bender-tags: 4.11.2, bug, 2451
+@bender-ui: collapsed
+@bender-ckeditor-plugins: wysiwygarea, toolbar, elementspath, format, list, removeformat
+
+1. Select whole editor content.
+1. Press `numbered list` button.
+1. Press `remove format` button.
+
+## Expected
+
+Elements path shows:
+
+`body ol li h1`
+
+## Unexpected
+
+Elements path shows:
+
+`body ol`

--- a/tests/plugins/removeformat/plugin.js
+++ b/tests/plugins/removeformat/plugin.js
@@ -157,12 +157,21 @@ bender.test(
 	// #2451
 	'test remove format keeps selection': function() {
 		var editor = this.editor,
-			html = '<ol><li><h1>[Test]</h1></li></ol>';
+			html = '<ol><li><h1>[Test]</h1></li></ol>',
+			filter = new CKEDITOR.htmlParser.filter( {
+				text: function( value ) {
+					return value.replace( '{', '[' ).replace( '}', ']' );
+				},
+				elements: {
+					br: function() {
+						return false;
+					}
+				}
+			} );
 
 		bender.tools.selection.setWithHtml( editor, html );
 		editor.execCommand( 'removeFormat' );
 
-		assert.beautified.html( html, bender.tools.selection.getWithHtml( editor ) );
+		assert.beautified.html( html, bender.tools.selection.getWithHtml( editor ), { customFilters: [ filter ] } );
 	}
-
 } );

--- a/tests/plugins/removeformat/plugin.js
+++ b/tests/plugins/removeformat/plugin.js
@@ -152,6 +152,17 @@ bender.test(
 			bot.editor.execCommand( 'removeFormat' );
 			assert.areEqual( '<p>foo <b>bar</b></p>', bot.getData() );
 		} );
+	},
+
+	// #2451
+	'test remove format keeps selection': function() {
+		var editor = this.editor,
+			html = '<ol><li><h1>[Test]</h1></li></ol>';
+
+		bender.tools.selection.setWithHtml( editor, html );
+		editor.execCommand( 'removeFormat' );
+
+		assert.beautified.html( html, bender.tools.selection.getWithHtml( editor ) );
 	}
 
 } );


### PR DESCRIPTION
## What is the purpose of this pull request?

Bug Fix

## Does your PR contain necessary tests?

All patches which change the editor code must include tests. You can always read more
on [PR testing](https://ckeditor.com/docs/ckeditor4/latest/guide/dev_contributing_code.html#tests),
[how to set the testing environment](https://ckeditor.com/docs/ckeditor4/latest/guide/dev_tests.html) and
[how to create tests](https://ckeditor.com/docs/ckeditor4/latest/guide/dev_tests.html#creating-your-own-test)
in the official CKEditor documentation.

### This PR contains

- [X] Unit tests
- [X] Manual tests

## What changes did you make?

The `Remove Format` plugin changhes the ranges with [`CKEDITOR.dom.range.enlarge`](https://ckeditor.com/docs/ckeditor4/latest/api/CKEDITOR_dom_range.html#method-enlarge) with [CKEDITOR.ENLARGE_ELEMENT](https://ckeditor.com/docs/ckeditor4/latest/api/CKEDITOR.html#property-ENLARGE_ELEMENT) given as attribute. I've tried other ways to enlarge range, but that broke removeFormat.

So instead I've stored original range as additional bookmark and restored it after format removing is done.

This solution is unlikely to break how the plugin works, as it only improves recreation of selection.