### PR TITLE
Replace SDK entries with Example

### DIFF
--- a/.github/SUPPORT.md
+++ b/.github/SUPPORT.md
@@ -18,5 +18,5 @@ For more advanced needs (e.g. CKEditor integration in your products, or developm
 For more reading visit our supporting resources:
 
 * An extensive [CKEditor 4 documentation](https://ckeditor.com/docs/ckeditor4) with information about CKEditor features and configuration settings.
-* [CKEditor 4 samples](https://sdk.ckeditor.com/) that you can try out and even download to copy and implement in your own environment.
+* [CKEditor 4 samples](https://ckeditor.com/docs/ckeditor4/latest/examples/index.html) that you can try out and even download to copy and implement in your own environment.
 * A knowledge base with [Frequently Asked Questions](https://support.ckeditor.com/hc/en-us/sections/115000842245-CKEditor-4-FAQ).

--- a/.github/SUPPORT.md
+++ b/.github/SUPPORT.md
@@ -18,5 +18,5 @@ For more advanced needs (e.g. CKEditor integration in your products, or developm
 For more reading visit our supporting resources:
 
 * An extensive [CKEditor 4 documentation](https://ckeditor.com/docs/ckeditor4) with information about CKEditor features and configuration settings.
-* [CKEditor 4 samples](https://ckeditor.com/docs/ckeditor4/latest/examples/index.html) that you can try out and even download to copy and implement in your own environment.
+* [CKEditor 4 examples](https://ckeditor.com/docs/ckeditor4/latest/examples/index.html) that you can try out and even download to copy and implement in your own environment.
 * A knowledge base with [Frequently Asked Questions](https://support.ckeditor.com/hc/en-us/sections/115000842245-CKEditor-4-FAQ).

--- a/.npm/README.md
+++ b/.npm/README.md
@@ -50,7 +50,7 @@ You can also load CKEditor 4 using [CDN](https://cdn.ckeditor.com/#ckeditor4).
 
 ## Presets
 
-The CKEditor 4 dev npm package comes in the `full-all` preset, so it includes all official CKEditor plugins, with those from the [full package](https://sdk.ckeditor.com/samples/fullpreset.html) active by default.
+The CKEditor 4 dev npm package comes in the `full-all` preset, so it includes all official CKEditor plugins, with those from the [full package](https://ckeditor.com/docs/ckeditor4/latest/examples/fullpreset.html) active by default.
 
 ## Further Resources
 
@@ -58,7 +58,7 @@ The CKEditor 4 dev npm package comes in the `full-all` preset, so it includes al
 * [Documentation](https://ckeditor.com/docs/ckeditor4/latest/)
 * [API documentation](https://ckeditor.com/docs/ckeditor4/latest/api/index.html)
 * [Configuration reference](https://ckeditor.com/docs/ckeditor4/latest/api/CKEDITOR_config.html)
-* [CKEditor SDK with more samples](https://sdk.ckeditor.com/)
+* [CKEditor Examples with more samples](https://ckeditor.com/docs/ckeditor4/latest/examples/index.html)
 
 If you are looking for CKEditor 5, here's a link to the relevant npm package: <https://www.npmjs.com/package/ckeditor5>
 

--- a/.npm/README.md
+++ b/.npm/README.md
@@ -58,7 +58,7 @@ The CKEditor 4 dev npm package comes in the `full-all` preset, so it includes al
 * [Documentation](https://ckeditor.com/docs/ckeditor4/latest/)
 * [API documentation](https://ckeditor.com/docs/ckeditor4/latest/api/index.html)
 * [Configuration reference](https://ckeditor.com/docs/ckeditor4/latest/api/CKEDITOR_config.html)
-* [CKEditor Examples with more samples](https://ckeditor.com/docs/ckeditor4/latest/examples/index.html)
+* [CKEditor Examples](https://ckeditor.com/docs/ckeditor4/latest/examples/index.html)
 
 If you are looking for CKEditor 5, here's a link to the relevant npm package: <https://www.npmjs.com/package/ckeditor5>
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -860,7 +860,7 @@ New Features:
     * Direct access to clipboard could only be implemented in Chrome, Safari on Mac OS, Opera and Firefox. In other browsers the pastebin must still be used.
 
 * [#12875](https://dev.ckeditor.com/ticket/12875): Samples and toolbar configuration tools.
-  * The old set of samples shipped with every CKEditor package was replaced with a shiny new single-page sample. This change concluded a long term plan which started from introducing the [CKEditor SDK](https://ckeditor.com/docs/ckeditor4/latest/examples/index.html) and [CKEditor Functionality Overview](https://ckeditor.com/docs/ckeditor4/latest/guide/dev_features.html) section in the documentation which essentially redefined the old samples.
+  * The old set of samples shipped with every CKEditor package was replaced with a shiny new single-page sample. This change concluded a long term plan which started from introducing the [CKEditor Examples](https://ckeditor.com/docs/ckeditor4/latest/examples/index.html) and [CKEditor Functionality Overview](https://ckeditor.com/docs/ckeditor4/latest/guide/dev_features.html) section in the documentation which essentially redefined the old samples.
   * Toolbar configurators with live previews were introduced. They will be shipped with every CKEditor package and are meant to help in configuring toolbar layouts.
 
 * [#10925](https://dev.ckeditor.com/ticket/10925): The [Media Embed](https://ckeditor.com/cke4/addon/embed) and [Semantic Media Embed](https://ckeditor.com/cke4/addon/embedsemantic) plugins were introduced. Read more about the new features in the [Embedding Content](https://ckeditor.com/docs/ckeditor4/latest/guide/dev_media_embed.html) article.

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -641,7 +641,7 @@ Other Changes:
 	- New features:
 		- CKEditor [Language](https://ckeditor.com/cke4/addon/language) plugin support.
 		- CKEditor [Placeholder](https://ckeditor.com/cke4/addon/placeholder) plugin support.
-		- [Drag&Drop](https://sdk.ckeditor.com/samples/fileupload.html) support.
+		- [Drag&Drop](https://ckeditor.com/docs/ckeditor4/latest/examples/fileupload.html) support.
 		- **Experimental** [GRAYT](https://ckeditor.com/docs/ckeditor4/latest/api/CKEDITOR_config.html#cfg-grayt_autoStartup) (Grammar As You Type) functionality.
 	- Fixed issues:
 		* [#98](https://github.com/WebSpellChecker/ckeditor-plugin-scayt/issues/98): SCAYT affects dialog double-click. Fixed in SCAYT core.
@@ -860,7 +860,7 @@ New Features:
     * Direct access to clipboard could only be implemented in Chrome, Safari on Mac OS, Opera and Firefox. In other browsers the pastebin must still be used.
 
 * [#12875](https://dev.ckeditor.com/ticket/12875): Samples and toolbar configuration tools.
-  * The old set of samples shipped with every CKEditor package was replaced with a shiny new single-page sample. This change concluded a long term plan which started from introducing the [CKEditor SDK](https://sdk.ckeditor.com/) and [CKEditor Functionality Overview](https://ckeditor.com/docs/ckeditor4/latest/guide/dev_features.html) section in the documentation which essentially redefined the old samples.
+  * The old set of samples shipped with every CKEditor package was replaced with a shiny new single-page sample. This change concluded a long term plan which started from introducing the [CKEditor SDK](https://ckeditor.com/docs/ckeditor4/latest/examples/index.html) and [CKEditor Functionality Overview](https://ckeditor.com/docs/ckeditor4/latest/guide/dev_features.html) section in the documentation which essentially redefined the old samples.
   * Toolbar configurators with live previews were introduced. They will be shipped with every CKEditor package and are meant to help in configuring toolbar layouts.
 
 * [#10925](https://dev.ckeditor.com/ticket/10925): The [Media Embed](https://ckeditor.com/cke4/addon/embed) and [Semantic Media Embed](https://ckeditor.com/cke4/addon/embedsemantic) plugins were introduced. Read more about the new features in the [Embedding Content](https://ckeditor.com/docs/ckeditor4/latest/guide/dev_media_embed.html) article.

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -860,7 +860,7 @@ New Features:
     * Direct access to clipboard could only be implemented in Chrome, Safari on Mac OS, Opera and Firefox. In other browsers the pastebin must still be used.
 
 * [#12875](https://dev.ckeditor.com/ticket/12875): Samples and toolbar configuration tools.
-  * The old set of samples shipped with every CKEditor package was replaced with a shiny new single-page sample. This change concluded a long term plan which started from introducing the [CKEditor Examples](https://ckeditor.com/docs/ckeditor4/latest/examples/index.html) and [CKEditor Functionality Overview](https://ckeditor.com/docs/ckeditor4/latest/guide/dev_features.html) section in the documentation which essentially redefined the old samples.
+  * The old set of samples shipped with every CKEditor package was replaced with a shiny new single-page sample. This change concluded a long term plan which started from introducing the [CKEditor SDK](https://ckeditor.com/docs/ckeditor4/latest/examples/index.html) and [CKEditor Functionality Overview](https://ckeditor.com/docs/ckeditor4/latest/guide/dev_features.html) section in the documentation which essentially redefined the old samples.
   * Toolbar configurators with live previews were introduced. They will be shipped with every CKEditor package and are meant to help in configuring toolbar layouts.
 
 * [#10925](https://dev.ckeditor.com/ticket/10925): The [Media Embed](https://ckeditor.com/cke4/addon/embed) and [Semantic Media Embed](https://ckeditor.com/cke4/addon/embedsemantic) plugins were introduced. Read more about the new features in the [Embedding Content](https://ckeditor.com/docs/ckeditor4/latest/guide/dev_media_embed.html) article.

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ Additionally, all releases have their respective tags in the following form: 4.4
 ## Samples
 
 The `samples/` folder contains some examples that can be used to test your
-installation. Visit [CKEditor 4 SDK](https://sdk.ckeditor.com/) for plenty of samples
+installation. Visit [CKEditor 4 Examples](https://ckeditor.com/docs/ckeditor4/latest/examples/index.html) for plenty of samples
 showcasing numerous editor features, with source code readily available to view, copy
 and use in your own solution.
 

--- a/core/config.js
+++ b/core/config.js
@@ -15,7 +15,7 @@
  * using the <kbd>Enter</kbd> key.
  *
  * Read more in the {@glink guide/dev_enterkey documentation} and see the
- * [SDK sample](https://sdk.ckeditor.com/samples/enterkey.html).
+ * {@glink examples/enterkey example}.
  *
  * @readonly
  * @property {Number} [=1]
@@ -30,7 +30,7 @@ CKEDITOR.ENTER_P = 1;
  * using the <kbd>Enter</kbd> key.
  *
  * Read more in the {@glink guide/dev_enterkey documentation} and see the
- * [SDK sample](https://sdk.ckeditor.com/samples/enterkey.html).
+ * {@glink examples/enterkey example}.
  *
  * @readonly
  * @property {Number} [=2]
@@ -45,7 +45,7 @@ CKEDITOR.ENTER_BR = 2;
  * using the <kbd>Enter</kbd> key.
  *
  * Read more in the {@glink guide/dev_enterkey documentation} and see the
- * [SDK sample](https://sdk.ckeditor.com/samples/enterkey.html).
+ * {@glink examples/enterkey example}.
  *
  * @readonly
  * @property {Number} [=3]
@@ -101,7 +101,7 @@ CKEDITOR.config = {
 	 * configuration setting is used.
 	 *
 	 * Read more in the {@glink guide/dev_uilanguage documentation} and see the
-	 * [SDK sample](https://sdk.ckeditor.com/samples/uilanguages.html).
+	 * {@glink examples/uilanguages example}.
 	 *
 	 *		// Load the German interface.
 	 *		config.language = 'de';
@@ -115,7 +115,7 @@ CKEDITOR.config = {
 	 * setting is left empty and it is not possible to localize the editor to the user language.
 	 *
 	 * Read more in the {@glink guide/dev_uilanguage documentation} and see the
-	 * [SDK sample](https://sdk.ckeditor.com/samples/uilanguages.html).
+	 * {@glink examples/uilanguages example}.
 	 *
 	 *		config.defaultLanguage = 'it';
 	 *
@@ -134,7 +134,7 @@ CKEDITOR.config = {
 	 * * `'ltr'` &ndash; Indicates a Left-To-Right text direction (like in English).
 	 * * `'rtl'` &ndash; Indicates a Right-To-Left text direction (like in Arabic).
 	 *
-	 * See the [SDK sample](https://sdk.ckeditor.com/samples/language.html).
+	 * See the {@glink examples/language example}.
 	 *
 	 * Example:
 	 *
@@ -158,7 +158,7 @@ CKEDITOR.config = {
 	 * its semantic value and correctness. The editor is optimized for this setting.
 	 *
 	 * Read more in the {@glink guide/dev_enterkey documentation} and see the
-	 * [SDK sample](https://sdk.ckeditor.com/samples/enterkey.html).
+	 * {@glink examples/enterkey example}.
 	 *
 	 *		// Not recommended.
 	 *		config.enterMode = CKEDITOR.ENTER_BR;
@@ -175,7 +175,7 @@ CKEDITOR.config = {
 	 * instead of a `<div>`.
 	 *
 	 * Read more in the {@glink guide/dev_enterkey documentation} and see the
-	 * [SDK sample](https://sdk.ckeditor.com/samples/enterkey.html).
+	 * {@glink examples/enterkey example}.
 	 *
 	 *		// Not recommended.
 	 *		config.forceEnterMode = true;
@@ -196,7 +196,7 @@ CKEDITOR.config = {
 	 * * {@link CKEDITOR#ENTER_DIV} (3) &ndash; New `<div>` blocks are created.
 	 *
 	 * Read more in the {@glink guide/dev_enterkey documentation} and see the
-	 * [SDK sample](https://sdk.ckeditor.com/samples/enterkey.html).
+	 * {@glink examples/enterkey example}.
 	 *
 	 * Example:
 	 *
@@ -257,7 +257,7 @@ CKEDITOR.config = {
 	 * `<body>` content only if this setting is disabled.
 	 *
 	 * Read more in the {@glink guide/dev_fullpage documentation} and see the
-	 * [SDK sample](https://sdk.ckeditor.com/samples/fullpage.html).
+	 * {@glink examples/fullpage example}.
 	 *
 	 *		config.fullPage = true;
 	 *
@@ -274,7 +274,7 @@ CKEDITOR.config = {
 	 * **Note:** This configuration option is ignored by {@glink guide/dev_inline inline editor}.
 	 *
 	 * Read more in the {@glink guide/dev_size documentation} and see the
-	 * [SDK sample](https://sdk.ckeditor.com/samples/size.html).
+	 * {@glink examples/size example}.
 	 *
 	 *		config.height = 500;		// 500 pixels.
 	 *		config.height = '25em';		// CSS length.
@@ -295,7 +295,7 @@ CKEDITOR.config = {
 	 * which the developer has full control over the page HTML code.
 	 *
 	 * Read more in the {@glink guide/dev_styles documentation} and see the
-	 * [SDK sample](https://sdk.ckeditor.com/samples/styles.html).
+	 * {@glink examples/styles example}.
 	 *
 	 *		config.contentsCss = '/css/mysitestyles.css';
 	 *		config.contentsCss = [ '/css/mysitestyles.css', '/css/anotherfile.css' ];
@@ -360,7 +360,7 @@ CKEDITOR.config = {
 	 * The editor `tabindex` value.
 	 *
 	 * Read more in the {@glink guide/dev_tabindex documentation} and see the
-	 * [SDK sample](https://sdk.ckeditor.com/samples/tabindex.html).
+	 * {@glink examples/tabindex example}.
 	 *
 	 *		config.tabIndex = 1;
 	 *
@@ -379,7 +379,7 @@ CKEDITOR.config = {
 	 * **Note:** This configuration option is ignored by {@glink guide/dev_inline inline editor}.
 	 *
 	 * Read more in the {@glink guide/dev_size documentation} and see the
-	 * [SDK sample](https://sdk.ckeditor.com/samples/size.html).
+	 * {@glink examples/size example}.
 	 *
 	 *		config.width = 850;		// 850 pixels wide.
 	 *		config.width = '75%';	// CSS unit.
@@ -437,7 +437,7 @@ CKEDITOR.config = {
  * {@glink guide/skin_sdk_chameleon compatible with this setting}.
  *
  * Read more in the {@glink guide/dev_uicolor documentation} and see the
- * [SDK sample](https://sdk.ckeditor.com/samples/uicolor.html).
+ * {@glink examples/uicolor example}.
  *
  *		// Using a color code.
  *		config.uiColor = '#AADC6E';

--- a/core/editor.js
+++ b/core/editor.js
@@ -1631,7 +1631,7 @@ CKEDITOR.ELEMENT_MODE_INLINE = 3;
  * if the linked `<textarea>` element has the `disabled` attribute.
  *
  * Read more in the {@glink guide/dev_readonly documentation}
- * and see the [SDK sample](https://sdk.ckeditor.com/samples/readonly.html).
+ * and see the {@glink examples/readonly example}.
  *
  *		config.readOnly = true;
  *

--- a/core/filter.js
+++ b/core/filter.js
@@ -2363,7 +2363,7 @@
  * editor features. To do that, use the {@link #disallowedContent} option.
  *
  * Read more in the {@glink guide/dev_acf documentation}
- * and see the [SDK sample](https://sdk.ckeditor.com/samples/acf.html).
+ * and see the {@glink examples/acf example}.
  *
  * @since 4.1
  * @cfg {CKEDITOR.filter.allowedContentRules/Boolean} [allowedContent=null]
@@ -2394,7 +2394,7 @@
  *		} );
  *
  * Read more in the [documentation](#!/guide/dev_acf-section-automatic-mode-and-allow-additional-tagsproperties)
- * and see the [SDK sample](https://sdk.ckeditor.com/samples/acf.html).
+ * and see the {@glink examples/acf example}.
  * See also {@link CKEDITOR.config#allowedContent} for more details.
  *
  * @since 4.1
@@ -2407,7 +2407,7 @@
  * Read more in the {@glink guide/dev_disallowed_content Disallowed Content guide}.
  *
  * Read more in the [documentation](#!/guide/dev_acf-section-automatic-mode-but-disallow-certain-tagsproperties)
- * and see the [SDK sample](https://sdk.ckeditor.com/samples/acf.html).
+ * and see the {@glink examples/acf example}.
  * See also {@link CKEDITOR.config#allowedContent} and {@link CKEDITOR.config#extraAllowedContent}.
  *
  * @since 4.4

--- a/core/plugindefinition.js
+++ b/core/plugindefinition.js
@@ -17,9 +17,9 @@
  *
  * See also:
  *
- * * {@glink guide/plugin_sdk_intro The Plugin SDK}
+ * * {@glink guide/plugin_sdk_intro The Plugin Examples}
  * * {@glink guide/plugin_sdk_sample Creating a CKEditor plugin in 20 Lines of Code}
- * * [Creating a Simple Plugin Tutorial](#!/guide/plugin_sdk_sample_1)
+ * * {@glink guide/plugin_sdk_sample_1 Creating a Simple Plugin Tutorial}
  *
  * @class CKEDITOR.pluginDefinition
  * @abstract

--- a/core/plugindefinition.js
+++ b/core/plugindefinition.js
@@ -17,7 +17,7 @@
  *
  * See also:
  *
- * * {@glink guide/plugin_sdk_intro The Plugin Examples}
+ * * {@glink guide/plugin_sdk_intro The Plugin SDK}
  * * {@glink guide/plugin_sdk_sample Creating a CKEditor plugin in 20 Lines of Code}
  * * {@glink guide/plugin_sdk_sample_1 Creating a Simple Plugin Tutorial}
  *

--- a/core/style.js
+++ b/core/style.js
@@ -2092,7 +2092,7 @@ CKEDITOR.tools.extend( CKEDITOR.editor.prototype, {
  * to prevent loading any styles set.
  *
  * Read more in the {@glink guide/dev_styles documentation}
- * and see the [SDK sample](https://sdk.ckeditor.com/samples/styles.html).
+ * and see the {@glink examples/styles example}.
  *
  *		// Do not load any file. The styles set is empty.
  *		config.stylesSet = false;

--- a/plugins/autoembed/plugin.js
+++ b/plugins/autoembed/plugin.js
@@ -209,7 +209,7 @@
 	 * For example, there is the `embedsemantic` plugin and the `embedSemantic` widget.
 	 *
 	 * Read more in the [documentation](#!/guide/dev_media_embed-section-automatic-embedding-on-paste)
-	 * and see the [SDK sample](https://sdk.ckeditor.com/samples/mediaembed.html).
+	 * and see the {@glink examples/mediaembed example}.
 	 *
 	 * @since 4.5
 	 * @cfg {String/Function} [autoEmbed_widget='embed,embedSemantic']

--- a/plugins/autogrow/plugin.js
+++ b/plugins/autogrow/plugin.js
@@ -166,7 +166,7 @@
  * feature. This option accepts a value in pixels, without the unit (for example: `300`).
  *
  * Read more in the {@glink guide/dev_autogrow documentation}
- * and see the [SDK sample](https://sdk.ckeditor.com/samples/autogrow.html).
+ * and see the {@glink examples/autogrow example}.
  *
  *		config.autoGrow_minHeight = 300;
  *
@@ -181,7 +181,7 @@
  * Zero (`0`) means that the maximum height is not limited and the editor will expand infinitely.
  *
  * Read more in the {@glink guide/dev_autogrow documentation}
- * and see the [SDK sample](https://sdk.ckeditor.com/samples/autogrow.html).
+ * and see the {@glink examples/autogrow example}.
  *
  *		config.autoGrow_maxHeight = 400;
  *
@@ -195,7 +195,7 @@
  * editor creation.
  *
  * Read more in the {@glink guide/dev_autogrow documentation}
- * and see the [SDK sample](https://sdk.ckeditor.com/samples/autogrow.html).
+ * and see the {@glink examples/autogrow example}.
  *
  *		config.autoGrow_onStartup = true;
  *
@@ -210,7 +210,7 @@
  * without the unit (for example: `50`).
  *
  * Read more in the {@glink guide/dev_autogrow documentation}
- * and see the [SDK sample](https://sdk.ckeditor.com/samples/autogrow.html).
+ * and see the {@glink examples/autogrow example}.
  *
  *		config.autoGrow_bottomSpace = 50;
  *

--- a/plugins/autogrow/samples/autogrow.html
+++ b/plugins/autogrow/samples/autogrow.html
@@ -18,7 +18,7 @@ For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-oss-license
 		<a href="../../../samples/old/index.html">CKEditor Samples</a> &raquo; Using AutoGrow Plugin
 	</h1>
 	<div class="warning deprecated">
-		This sample is not maintained anymore. Check out its <a href="https://ckeditor.com/docs/ckeditor4/latest/examples/autogrow.html">brand new version in CKEditor SDK</a>.
+		This sample is not maintained anymore. Check out its <a href="https://ckeditor.com/docs/ckeditor4/latest/examples/autogrow.html">brand new version in CKEditor Examples</a>.
 	</div>
 	<div class="description">
 		<p>

--- a/plugins/autogrow/samples/autogrow.html
+++ b/plugins/autogrow/samples/autogrow.html
@@ -18,7 +18,7 @@ For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-oss-license
 		<a href="../../../samples/old/index.html">CKEditor Samples</a> &raquo; Using AutoGrow Plugin
 	</h1>
 	<div class="warning deprecated">
-		This sample is not maintained anymore. Check out its <a href="https://sdk.ckeditor.com/samples/autogrow.html">brand new version in CKEditor SDK</a>.
+		This sample is not maintained anymore. Check out its <a href="https://ckeditor.com/docs/ckeditor4/latest/examples/autogrow.html">brand new version in CKEditor SDK</a>.
 	</div>
 	<div class="description">
 		<p>

--- a/plugins/basicstyles/plugin.js
+++ b/plugins/basicstyles/plugin.js
@@ -109,7 +109,7 @@ CKEDITOR.plugins.add( 'basicstyles', {
  * The style definition that applies the **bold** style to the text.
  *
  * Read more in the {@glink guide/dev_basicstyles documentation}
- * and see the [SDK sample](https://sdk.ckeditor.com/samples/basicstyles.html).
+ * and see the {@glink examples/basicstyles example}.
  *
  *		config.coreStyles_bold = { element: 'b', overrides: 'strong' };
  *
@@ -127,7 +127,7 @@ CKEDITOR.config.coreStyles_bold = { element: 'strong', overrides: 'b' };
  * The style definition that applies the *italics* style to the text.
  *
  * Read more in the {@glink guide/dev_basicstyles documentation}
- * and see the [SDK sample](https://sdk.ckeditor.com/samples/basicstyles.html).
+ * and see the {@glink examples/basicstyles example}.
  *
  *		config.coreStyles_italic = { element: 'i', overrides: 'em' };
  *
@@ -145,7 +145,7 @@ CKEDITOR.config.coreStyles_italic = { element: 'em', overrides: 'i' };
  * The style definition that applies the <u>underline</u> style to the text.
  *
  * Read more in the {@glink guide/dev_basicstyles documentation}
- * and see the [SDK sample](https://sdk.ckeditor.com/samples/basicstyles.html).
+ * and see the {@glink examples/basicstyles example}.
  *
  *		CKEDITOR.config.coreStyles_underline = {
  *			element: 'span',
@@ -161,7 +161,7 @@ CKEDITOR.config.coreStyles_underline = { element: 'u' };
  * The style definition that applies the <strike>strikethrough</strike> style to the text.
  *
  * Read more in the {@glink guide/dev_basicstyles documentation}
- * and see the [SDK sample](https://sdk.ckeditor.com/samples/basicstyles.html).
+ * and see the {@glink examples/basicstyles example}.
  *
  *		CKEDITOR.config.coreStyles_strike = {
  *			element: 'span',
@@ -178,7 +178,7 @@ CKEDITOR.config.coreStyles_strike = { element: 's', overrides: 'strike' };
  * The style definition that applies the subscript style to the text.
  *
  * Read more in the {@glink guide/dev_basicstyles documentation}
- * and see the [SDK sample](https://sdk.ckeditor.com/samples/basicstyles.html).
+ * and see the {@glink examples/basicstyles example}.
  *
  *		CKEDITOR.config.coreStyles_subscript = {
  *			element: 'span',
@@ -195,7 +195,7 @@ CKEDITOR.config.coreStyles_subscript = { element: 'sub' };
  * The style definition that applies the superscript style to the text.
  *
  * Read more in the {@glink guide/dev_basicstyles documentation}
- * and see the [SDK sample](https://sdk.ckeditor.com/samples/basicstyles.html).
+ * and see the {@glink examples/basicstyles example}.
  *
  *		CKEDITOR.config.coreStyles_superscript = {
  *			element: 'span',

--- a/plugins/bbcode/samples/bbcode.html
+++ b/plugins/bbcode/samples/bbcode.html
@@ -20,7 +20,7 @@ For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-oss-license
 		<a href="../../../samples/old/index.html">CKEditor Samples</a> &raquo; BBCode Plugin
 	</h1>
 	<div class="warning deprecated">
-		This sample is not maintained anymore. Check out its <a href="https://sdk.ckeditor.com/samples/bbcode.html">brand new version in CKEditor SDK</a>.
+		This sample is not maintained anymore. Check out its <a href="https://ckeditor.com/docs/ckeditor4/latest/examples/bbcode.html">brand new version in CKEditor SDK</a>.
 	</div>
 	<div class="description">
 		<p>

--- a/plugins/bbcode/samples/bbcode.html
+++ b/plugins/bbcode/samples/bbcode.html
@@ -20,7 +20,7 @@ For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-oss-license
 		<a href="../../../samples/old/index.html">CKEditor Samples</a> &raquo; BBCode Plugin
 	</h1>
 	<div class="warning deprecated">
-		This sample is not maintained anymore. Check out its <a href="https://ckeditor.com/docs/ckeditor4/latest/examples/bbcode.html">brand new version in CKEditor SDK</a>.
+		This sample is not maintained anymore. Check out its <a href="https://ckeditor.com/docs/ckeditor4/latest/examples/bbcode.html">brand new version in CKEditor Examples</a>.
 	</div>
 	<div class="description">
 		<p>

--- a/plugins/codesnippet/plugin.js
+++ b/plugins/codesnippet/plugin.js
@@ -431,7 +431,7 @@
  * See {@link CKEDITOR.plugins.codesnippet.highlighter} to read more.
  *
  * Read more in the {@glink guide/dev_codesnippet documentation}
- * and see the [SDK sample](https://sdk.ckeditor.com/samples/codesnippet.html).
+ * and see the {@glink examples/codesnippet example}.
  *
  * @since 4.4
  * @cfg {String} [codeSnippet_codeClass='hljs']
@@ -447,7 +447,7 @@ CKEDITOR.config.codeSnippet_codeClass = 'hljs';
  * you may need to refer to external documentation to set `config.codeSnippet_languages` properly.
  *
  * Read more in the [documentation](#!/guide/dev_codesnippet-section-changing-supported-languages)
- * and see the [SDK sample](https://sdk.ckeditor.com/samples/codesnippet.html).
+ * and see the {@glink examples/codesnippet example}.
  *
  *		// Restricts languages to JavaScript and PHP.
  *		config.codeSnippet_languages = {
@@ -467,7 +467,7 @@ CKEDITOR.config.codeSnippet_codeClass = 'hljs';
  * ([highlight.js](http://highlightjs.org/static/test.html)).
  *
  * Read more in the [documentation](#!/guide/dev_codesnippet-section-changing-highlighter-theme)
- * and see the [SDK sample](https://sdk.ckeditor.com/samples/codesnippet.html).
+ * and see the {@glink examples/codesnippet example}.
  *
  *		// Changes the theme to "pojoaque".
  *		config.codeSnippet_theme = 'pojoaque';

--- a/plugins/codesnippet/samples/codesnippet.html
+++ b/plugins/codesnippet/samples/codesnippet.html
@@ -31,7 +31,7 @@ For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-oss-license
 		<a href="../../../samples/old/index.html">CKEditor Samples</a> &raquo; Code Snippet Plugin
 	</h1>
 	<div class="warning deprecated">
-		This sample is not maintained anymore. Check out its <a href="https://ckeditor.com/docs/ckeditor4/latest/examples/codesnippet.html">brand new version in CKEditor SDK</a>.
+		This sample is not maintained anymore. Check out its <a href="https://ckeditor.com/docs/ckeditor4/latest/examples/codesnippet.html">brand new version in CKEditor Examples</a>.
 	</div>
 
 	<div class="description">

--- a/plugins/codesnippet/samples/codesnippet.html
+++ b/plugins/codesnippet/samples/codesnippet.html
@@ -31,7 +31,7 @@ For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-oss-license
 		<a href="../../../samples/old/index.html">CKEditor Samples</a> &raquo; Code Snippet Plugin
 	</h1>
 	<div class="warning deprecated">
-		This sample is not maintained anymore. Check out its <a href="https://sdk.ckeditor.com/samples/codesnippet.html">brand new version in CKEditor SDK</a>.
+		This sample is not maintained anymore. Check out its <a href="https://ckeditor.com/docs/ckeditor4/latest/examples/codesnippet.html">brand new version in CKEditor SDK</a>.
 	</div>
 
 	<div class="description">

--- a/plugins/colorbutton/plugin.js
+++ b/plugins/colorbutton/plugin.js
@@ -360,7 +360,7 @@ CKEDITOR.plugins.add( 'colorbutton', {
  * Whether to enable the **More Colors** button in the color selectors.
  *
  * Read more in the {@glink guide/dev_colorbutton documentation}
- * and see the [SDK sample](https://sdk.ckeditor.com/samples/colorbutton.html).
+ * and see the {@glink examples/colorbutton example}.
  *
  *		config.colorButton_enableMore = false;
  *
@@ -380,7 +380,7 @@ CKEDITOR.plugins.add( 'colorbutton', {
  * pastel shades than the previous one.
  *
  * Read more in the {@glink guide/dev_colorbutton documentation}
- * and see the [SDK sample](https://sdk.ckeditor.com/samples/colorbutton.html).
+ * and see the {@glink examples/colorbutton example}.
  *
  *		// Brazil colors only.
  *		config.colorButton_colors = '00923E,F8C100,28166F';
@@ -407,7 +407,7 @@ CKEDITOR.config.colorButton_colors = '1ABC9C,2ECC71,3498DB,9B59B6,4E5F70,F1C40F,
  * Stores the style definition that applies the text foreground color.
  *
  * Read more in the {@glink guide/dev_colorbutton documentation}
- * and see the [SDK sample](https://sdk.ckeditor.com/samples/colorbutton.html).
+ * and see the {@glink examples/colorbutton example}.
  *
  *		// This is actually the default value.
  *		config.colorButton_foreStyle = {
@@ -430,7 +430,7 @@ CKEDITOR.config.colorButton_foreStyle = {
  * Stores the style definition that applies the text background color.
  *
  * Read more in the {@glink guide/dev_colorbutton documentation}
- * and see the [SDK sample](https://sdk.ckeditor.com/samples/colorbutton.html).
+ * and see the {@glink examples/colorbutton example}.
  *
  *		// This is actually the default value.
  *		config.colorButton_backStyle = {
@@ -450,7 +450,7 @@ CKEDITOR.config.colorButton_backStyle = {
  * Whether to enable the **Automatic** button in the color selectors.
  *
  * Read more in the {@glink guide/dev_colorbutton documentation}
- * and see the [SDK sample](https://sdk.ckeditor.com/samples/colorbutton.html).
+ * and see the {@glink examples/colorbutton example}.
  *
  *		config.colorButton_enableAutomatic = false;
  *
@@ -462,7 +462,7 @@ CKEDITOR.config.colorButton_backStyle = {
  * Defines how many colors will be shown per row in the color selectors.
  *
  * Read more in the {@glink guide/dev_colorbutton documentation}
- * and see the [SDK sample](https://sdk.ckeditor.com/samples/colorbutton.html).
+ * and see the {@glink examples/colorbutton example}.
  *
  *		config.colorButton_colorsPerRow = 8;
  *

--- a/plugins/copyformatting/plugin.js
+++ b/plugins/copyformatting/plugin.js
@@ -1110,7 +1110,7 @@
 	 *		config.copyFormatting_outerCursor = false;
 	 *
 	 * Read more in the {@glink guide/dev_copyformatting documentation}
-	 * and see the [SDK sample](https://sdk.ckeditor.com/samples/copyformatting.html).
+	 * and see the {@glink examples/copyformatting example}.
 	 *
 	 * @since 4.6.0
 	 * @cfg [copyFormatting_outerCursor=true]
@@ -1130,7 +1130,7 @@
 	 *
 	 *
 	 * Read more in the {@glink guide/dev_copyformatting documentation}
-	 * and see the [SDK sample](https://sdk.ckeditor.com/samples/copyformatting.html).
+	 * and see the {@glink examples/copyformatting example}.
 	 *
 	 * @since 4.6.0
 	 * @cfg [copyFormatting_allowRules='b; s; u; strong; span; p; div; table; thead; tbody; ' +
@@ -1149,7 +1149,7 @@
 	 *
 	 *
 	 * Read more in the {@glink guide/dev_copyformatting documentation}
-	 * and see the [SDK sample](https://sdk.ckeditor.com/samples/copyformatting.html).
+	 * and see the {@glink examples/copyformatting example}.
 	 *
 	 * @since 4.6.0
 	 * @cfg [copyFormatting_disallowRules='*[data-cke-widget*,data-widget*,data-cke-realelement](cke_widget*)']
@@ -1173,7 +1173,7 @@
 	 *		config.copyFormatting_allowedContexts = true;
 	 *
 	 * Read more in the {@glink guide/dev_copyformatting documentation}
-	 * and see the [SDK sample](https://sdk.ckeditor.com/samples/copyformatting.html).
+	 * and see the {@glink examples/copyformatting example}.
 	 *
 	 * @since 4.6.0
 	 * @cfg {Boolean/String[]} [copyFormatting_allowedContexts=true]
@@ -1191,7 +1191,7 @@
 	 *		config.copyFormatting_keystrokeCopy = false;
 	 *
 	 * Read more in the {@glink guide/dev_copyformatting documentation}
-	 * and see the [SDK sample](https://sdk.ckeditor.com/samples/copyformatting.html).
+	 * and see the {@glink examples/copyformatting example}.
 	 *
 	 * @since 4.6.0
 	 * @cfg {Number} [copyFormatting_keystrokeCopy=CKEDITOR.CTRL + CKEDITOR.SHIFT + 67]
@@ -1209,7 +1209,7 @@
 	 *		config.copyFormatting_keystrokePaste = false;
 	 *
 	 * Read more in the {@glink guide/dev_copyformatting documentation}
-	 * and see the [SDK sample](https://sdk.ckeditor.com/samples/copyformatting.html).
+	 * and see the {@glink examples/copyformatting example}.
 	 *
 	 * @since 4.6.0
 	 * @cfg {Number} [copyFormatting_keystrokePaste=CKEDITOR.CTRL + CKEDITOR.SHIFT + 86]

--- a/plugins/devtools/plugin.js
+++ b/plugins/devtools/plugin.js
@@ -115,7 +115,7 @@ CKEDITOR.plugins.add( 'devtools', {
  * tooltip when hovering over a dialog UI element.
  *
  * Read more in the {@glink guide/dev_devtools documentation}
- * and see the [SDK sample](https://sdk.ckeditor.com/samples/devtools.html).
+ * and see the {@glink examples/devtools example}.
  *
  *		// This is actually the default value.
  *		// Show dialog window name, tab ID, and element ID.
@@ -151,7 +151,7 @@ CKEDITOR.plugins.add( 'devtools', {
  * A setting that stores CSS rules to be injected into the page with styles to be applied to the tooltip element.
  *
  * Read more in the {@glink guide/dev_devtools documentation}
- * and see the [SDK sample](https://sdk.ckeditor.com/samples/devtools.html).
+ * and see the {@glink examples/devtools example}.
  *
  *		// This is actually the default value.
  *		CKEDITOR.config.devtools_styles =

--- a/plugins/devtools/samples/devtools.html
+++ b/plugins/devtools/samples/devtools.html
@@ -18,7 +18,7 @@ For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-oss-license
 		<a href="../../../samples/old/index.html">CKEditor Samples</a> &raquo; Using the Developer Tools Plugin
 	</h1>
 	<div class="warning deprecated">
-		This sample is not maintained anymore. Check out its <a href="https://ckeditor.com/docs/ckeditor4/latest/examples/devtools.html">brand new version in CKEditor SDK</a>.
+		This sample is not maintained anymore. Check out its <a href="https://ckeditor.com/docs/ckeditor4/latest/examples/devtools.html">brand new version in CKEditor Examples</a>.
 	</div>
 	<div class="description">
 		<p>

--- a/plugins/devtools/samples/devtools.html
+++ b/plugins/devtools/samples/devtools.html
@@ -18,7 +18,7 @@ For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-oss-license
 		<a href="../../../samples/old/index.html">CKEditor Samples</a> &raquo; Using the Developer Tools Plugin
 	</h1>
 	<div class="warning deprecated">
-		This sample is not maintained anymore. Check out its <a href="https://sdk.ckeditor.com/samples/devtools.html">brand new version in CKEditor SDK</a>.
+		This sample is not maintained anymore. Check out its <a href="https://ckeditor.com/docs/ckeditor4/latest/examples/devtools.html">brand new version in CKEditor SDK</a>.
 	</div>
 	<div class="description">
 		<p>

--- a/plugins/dialog/samples/dialog.html
+++ b/plugins/dialog/samples/dialog.html
@@ -137,7 +137,7 @@ For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-oss-license
 		<a href="../../../samples/old/index.html">CKEditor Samples</a> &raquo; Using CKEditor Dialog API
 	</h1>
 	<div class="warning deprecated">
-		This sample is not maintained anymore. Check out the <a href="https://sdk.ckeditor.com/">brand new samples in CKEditor SDK</a>.
+		This sample is not maintained anymore. Check out the <a href="https://ckeditor.com/docs/ckeditor4/latest/examples/index.html">brand new samples in CKEditor SDK</a>.
 	</div>
 	<div class="description">
 		<p>

--- a/plugins/dialog/samples/dialog.html
+++ b/plugins/dialog/samples/dialog.html
@@ -137,7 +137,7 @@ For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-oss-license
 		<a href="../../../samples/old/index.html">CKEditor Samples</a> &raquo; Using CKEditor Dialog API
 	</h1>
 	<div class="warning deprecated">
-		This sample is not maintained anymore. Check out the <a href="https://ckeditor.com/docs/ckeditor4/latest/examples/index.html">brand new samples in CKEditor SDK</a>.
+		This sample is not maintained anymore. Check out the <a href="https://ckeditor.com/docs/ckeditor4/latest/examples/index.html">brand new samples in CKEditor Examples</a>.
 	</div>
 	<div class="description">
 		<p>

--- a/plugins/divarea/samples/divarea.html
+++ b/plugins/divarea/samples/divarea.html
@@ -18,7 +18,7 @@ For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-oss-license
 		<a href="../../../samples/old/index.html">CKEditor Samples</a> &raquo; Replace Textarea with a "DIV-based" editor
 	</h1>
 	<div class="warning deprecated">
-		This sample is not maintained anymore. Check out the <a href="https://ckeditor.com/docs/ckeditor4/latest/examples/index.html">brand new samples in CKEditor SDK</a>.
+		This sample is not maintained anymore. Check out the <a href="https://ckeditor.com/docs/ckeditor4/latest/examples/index.html">brand new samples in CKEditor Examples</a>.
 	</div>
 	<form action="../../../samples/sample_posteddata.php" method="post">
 		<div class="description">

--- a/plugins/divarea/samples/divarea.html
+++ b/plugins/divarea/samples/divarea.html
@@ -18,7 +18,7 @@ For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-oss-license
 		<a href="../../../samples/old/index.html">CKEditor Samples</a> &raquo; Replace Textarea with a "DIV-based" editor
 	</h1>
 	<div class="warning deprecated">
-		This sample is not maintained anymore. Check out the <a href="https://sdk.ckeditor.com/">brand new samples in CKEditor SDK</a>.
+		This sample is not maintained anymore. Check out the <a href="https://ckeditor.com/docs/ckeditor4/latest/examples/index.html">brand new samples in CKEditor SDK</a>.
 	</div>
 	<form action="../../../samples/sample_posteddata.php" method="post">
 		<div class="description">

--- a/plugins/docprops/samples/docprops.html
+++ b/plugins/docprops/samples/docprops.html
@@ -18,7 +18,7 @@ For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-oss-license
 		<a href="../../../samples/old/index.html">CKEditor Samples</a> &raquo; Document Properties Plugin
 	</h1>
 	<div class="warning deprecated">
-		This sample is not maintained anymore. Check out its <a href="https://ckeditor.com/docs/ckeditor4/latest/examples/fullpage.html">brand new version in CKEditor SDK</a>.
+		This sample is not maintained anymore. Check out its <a href="https://ckeditor.com/docs/ckeditor4/latest/examples/fullpage.html">brand new version in CKEditor Examples</a>.
 	</div>
 	<div class="description">
 		<p>

--- a/plugins/docprops/samples/docprops.html
+++ b/plugins/docprops/samples/docprops.html
@@ -18,7 +18,7 @@ For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-oss-license
 		<a href="../../../samples/old/index.html">CKEditor Samples</a> &raquo; Document Properties Plugin
 	</h1>
 	<div class="warning deprecated">
-		This sample is not maintained anymore. Check out its <a href="https://sdk.ckeditor.com/samples/fullpage.html">brand new version in CKEditor SDK</a>.
+		This sample is not maintained anymore. Check out its <a href="https://ckeditor.com/docs/ckeditor4/latest/examples/fullpage.html">brand new version in CKEditor SDK</a>.
 	</div>
 	<div class="description">
 		<p>

--- a/plugins/embed/plugin.js
+++ b/plugins/embed/plugin.js
@@ -92,7 +92,7 @@
  * better control over embedded content.
  *
  * Read more in the {@glink guide/dev_media_embed documentation}
- * and see the [SDK sample](https://sdk.ckeditor.com/samples/mediaembed.html).
+ * and see the {@glink examples/mediaembed example}.
  *
  * Refer to {@link CKEDITOR.plugins.embedBase.baseDefinition#providerUrl} for more information about content providers.
  *

--- a/plugins/enterkey/samples/enterkey.html
+++ b/plugins/enterkey/samples/enterkey.html
@@ -38,7 +38,7 @@ For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-oss-license
 		<a href="../../../samples/old/index.html">CKEditor Samples</a> &raquo; ENTER Key Configuration
 	</h1>
 	<div class="warning deprecated">
-		This sample is not maintained anymore. Check out its <a href="https://ckeditor.com/docs/ckeditor4/latest/examples/enterkey.html">brand new version in CKEditor SDK</a>.
+		This sample is not maintained anymore. Check out its <a href="https://ckeditor.com/docs/ckeditor4/latest/examples/enterkey.html">brand new version in CKEditor Examples</a>.
 	</div>
 	<div class="description">
 		<p>

--- a/plugins/enterkey/samples/enterkey.html
+++ b/plugins/enterkey/samples/enterkey.html
@@ -38,7 +38,7 @@ For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-oss-license
 		<a href="../../../samples/old/index.html">CKEditor Samples</a> &raquo; ENTER Key Configuration
 	</h1>
 	<div class="warning deprecated">
-		This sample is not maintained anymore. Check out its <a href="https://sdk.ckeditor.com/samples/enterkey.html">brand new version in CKEditor SDK</a>.
+		This sample is not maintained anymore. Check out its <a href="https://ckeditor.com/docs/ckeditor4/latest/examples/enterkey.html">brand new version in CKEditor SDK</a>.
 	</div>
 	<div class="description">
 		<p>

--- a/plugins/filebrowser/plugin.js
+++ b/plugins/filebrowser/plugin.js
@@ -468,7 +468,7 @@
  * **Link**, **Image**, and **Flash** dialog windows.
  *
  * Read more in the {@glink guide/dev_file_browse_upload documentation}
- * and see the [SDK sample](https://sdk.ckeditor.com/samples/fileupload.html).
+ * and see the {@glink examples/fileupload example}.
  *
  *		config.filebrowserBrowseUrl = '/browser/browse.php';
  *
@@ -483,7 +483,7 @@
  * and **Flash** dialog windows.
  *
  * Read more in the {@glink guide/dev_file_browse_upload documentation}
- * and see the [SDK sample](https://sdk.ckeditor.com/samples/fileupload.html).
+ * and see the {@glink examples/fileupload example}.
  *
  *		config.filebrowserUploadUrl = '/uploader/upload.php';
  *
@@ -503,7 +503,7 @@
  * If not set, CKEditor will use {@link CKEDITOR.config#filebrowserBrowseUrl}.
  *
  * Read more in the [documentation](#!/guide/dev_file_manager_configuration-section-adding-file-manager-scripts-for-selected-dialog-windows)
- * and see the [SDK sample](https://sdk.ckeditor.com/samples/fileupload.html).
+ * and see the {@glink examples/fileupload example}.
  *
  *		config.filebrowserImageBrowseUrl = '/browser/browse.php?type=Images';
  *
@@ -519,7 +519,7 @@
  * If not set, CKEditor will use {@link CKEDITOR.config#filebrowserBrowseUrl}.
  *
  * Read more in the [documentation](#!/guide/dev_file_manager_configuration-section-adding-file-manager-scripts-for-selected-dialog-windows)
- * and see the [SDK sample](https://sdk.ckeditor.com/samples/fileupload.html).
+ * and see the {@glink examples/fileupload example}.
  *
  *		config.filebrowserFlashBrowseUrl = '/browser/browse.php?type=Flash';
  *
@@ -534,7 +534,7 @@
  * If not set, CKEditor will use {@link CKEDITOR.config#filebrowserUploadUrl}.
  *
  * Read more in the [documentation](#!/guide/dev_file_manager_configuration-section-adding-file-manager-scripts-for-selected-dialog-windows)
- * and see the [SDK sample](https://sdk.ckeditor.com/samples/fileupload.html).
+ * and see the {@glink examples/fileupload example}.
  *
  *		config.filebrowserImageUploadUrl = '/uploader/upload.php?type=Images';
  *
@@ -553,7 +553,7 @@
  * If not set, CKEditor will use {@link CKEDITOR.config#filebrowserUploadUrl}.
  *
  * Read more in the [documentation](#!/guide/dev_file_manager_configuration-section-adding-file-manager-scripts-for-selected-dialog-windows)
- * and see the [SDK sample](https://sdk.ckeditor.com/samples/fileupload.html).
+ * and see the {@glink examples/fileupload example}.
  *
  *		config.filebrowserFlashUploadUrl = '/uploader/upload.php?type=Flash';
  *
@@ -569,7 +569,7 @@
  * If not set, CKEditor will use {@link CKEDITOR.config#filebrowserBrowseUrl}.
  *
  * Read more in the [documentation](#!/guide/dev_file_manager_configuration-section-adding-file-manager-scripts-for-selected-dialog-windows)
- * and see the [SDK sample](https://sdk.ckeditor.com/samples/fileupload.html).
+ * and see the {@glink examples/fileupload example}.
  *
  *		config.filebrowserImageBrowseLinkUrl = '/browser/browse.php';
  *
@@ -593,7 +593,7 @@
  * pixels or a percent string.
  *
  * Read more in the [documentation](#!/guide/dev_file_manager_configuration-section-file-manager-window-size)
- * and see the [SDK sample](https://sdk.ckeditor.com/samples/fileupload.html).
+ * and see the {@glink examples/fileupload example}.
  *
  *		config.filebrowserWindowWidth = 750;
  *
@@ -608,7 +608,7 @@
  * pixels or a percent string.
  *
  * Read more in the [documentation](#!/guide/dev_file_manager_configuration-section-file-manager-window-size)
- * and see the [SDK sample](https://sdk.ckeditor.com/samples/fileupload.html).
+ * and see the {@glink examples/fileupload example}.
  *
  *		config.filebrowserWindowHeight = 580;
  *

--- a/plugins/format/plugin.js
+++ b/plugins/format/plugin.js
@@ -142,7 +142,7 @@ CKEDITOR.plugins.add( 'format', {
  * definition taken from [config.format_p](#!/api/CKEDITOR.config-cfg-format_p).
  *
  * Read more in the {@glink guide/dev_format documentation}
- * and see the [SDK sample](https://sdk.ckeditor.com/samples/format.html).
+ * and see the {@glink examples/format example}.
  *
  *		config.format_tags = 'p;h2;h3;pre';
  *
@@ -155,7 +155,7 @@ CKEDITOR.config.format_tags = 'p;h1;h2;h3;h4;h5;h6;pre;address;div';
  * The style definition to be used to apply the `Normal` format.
  *
  * Read more in the {@glink guide/dev_format documentation}
- * and see the [SDK sample](https://sdk.ckeditor.com/samples/format.html).
+ * and see the {@glink examples/format example}.
  *
  *		config.format_p = { element: 'p', attributes: { 'class': 'normalPara' } };
  *
@@ -168,7 +168,7 @@ CKEDITOR.config.format_p = { element: 'p' };
  * The style definition to be used to apply the `Normal (DIV)` format.
  *
  * Read more in the {@glink guide/dev_format documentation}
- * and see the [SDK sample](https://sdk.ckeditor.com/samples/format.html).
+ * and see the {@glink examples/format example}.
  *
  *		config.format_div = { element: 'div', attributes: { 'class': 'normalDiv' } };
  *
@@ -181,7 +181,7 @@ CKEDITOR.config.format_div = { element: 'div' };
  * The style definition to be used to apply the `Formatted` format.
  *
  * Read more in the {@glink guide/dev_format documentation}
- * and see the [SDK sample](https://sdk.ckeditor.com/samples/format.html).
+ * and see the {@glink examples/format example}.
  *
  *		config.format_pre = { element: 'pre', attributes: { 'class': 'code' } };
  *
@@ -194,7 +194,7 @@ CKEDITOR.config.format_pre = { element: 'pre' };
  * The style definition to be used to apply the `Address` format.
  *
  * Read more in the {@glink guide/dev_format documentation}
- * and see the [SDK sample](https://sdk.ckeditor.com/samples/format.html).
+ * and see the {@glink examples/format example}.
  *
  *		config.format_address = { element: 'address', attributes: { 'class': 'styledAddress' } };
  *
@@ -207,7 +207,7 @@ CKEDITOR.config.format_address = { element: 'address' };
  * The style definition to be used to apply the `Heading 1` format.
  *
  * Read more in the {@glink guide/dev_format documentation}
- * and see the [SDK sample](https://sdk.ckeditor.com/samples/format.html).
+ * and see the {@glink examples/format example}.
  *
  *		config.format_h1 = { element: 'h1', attributes: { 'class': 'contentTitle1' } };
  *
@@ -220,7 +220,7 @@ CKEDITOR.config.format_h1 = { element: 'h1' };
  * The style definition to be used to apply the `Heading 2` format.
  *
  * Read more in the {@glink guide/dev_format documentation}
- * and see the [SDK sample](https://sdk.ckeditor.com/samples/format.html).
+ * and see the {@glink examples/format example}.
  *
  *		config.format_h2 = { element: 'h2', attributes: { 'class': 'contentTitle2' } };
  *
@@ -233,7 +233,7 @@ CKEDITOR.config.format_h2 = { element: 'h2' };
  * The style definition to be used to apply the `Heading 3` format.
  *
  * Read more in the {@glink guide/dev_format documentation}
- * and see the [SDK sample](https://sdk.ckeditor.com/samples/format.html).
+ * and see the {@glink examples/format example}.
  *
  *		config.format_h3 = { element: 'h3', attributes: { 'class': 'contentTitle3' } };
  *
@@ -246,7 +246,7 @@ CKEDITOR.config.format_h3 = { element: 'h3' };
  * The style definition to be used to apply the `Heading 4` format.
  *
  * Read more in the {@glink guide/dev_format documentation}
- * and see the [SDK sample](https://sdk.ckeditor.com/samples/format.html).
+ * and see the {@glink examples/format example}.
  *
  *		config.format_h4 = { element: 'h4', attributes: { 'class': 'contentTitle4' } };
  *
@@ -259,7 +259,7 @@ CKEDITOR.config.format_h4 = { element: 'h4' };
  * The style definition to be used to apply the `Heading 5` format.
  *
  * Read more in the {@glink guide/dev_format documentation}
- * and see the [SDK sample](https://sdk.ckeditor.com/samples/format.html).
+ * and see the {@glink examples/format example}.
  *
  *		config.format_h5 = { element: 'h5', attributes: { 'class': 'contentTitle5' } };
  *
@@ -272,7 +272,7 @@ CKEDITOR.config.format_h5 = { element: 'h5' };
  * The style definition to be used to apply the `Heading 6` format.
  *
  * Read more in the {@glink guide/dev_format documentation}
- * and see the [SDK sample](https://sdk.ckeditor.com/samples/format.html).
+ * and see the {@glink examples/format example}.
  *
  *		config.format_h6 = { element: 'h6', attributes: { 'class': 'contentTitle6' } };
  *

--- a/plugins/htmlwriter/samples/outputforflash.html
+++ b/plugins/htmlwriter/samples/outputforflash.html
@@ -33,7 +33,7 @@ For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-oss-license
 		<a href="../../../samples/old/index.html">CKEditor Samples</a> &raquo; Producing Flash Compliant HTML Output
 	</h1>
 	<div class="warning deprecated">
-		This sample is not maintained anymore. Check out the <a href="https://sdk.ckeditor.com/">brand new samples in CKEditor SDK</a>.
+		This sample is not maintained anymore. Check out the <a href="https://ckeditor.com/docs/ckeditor4/latest/examples/index.html">brand new samples in CKEditor SDK</a>.
 	</div>
 	<div class="description">
 		<p>

--- a/plugins/htmlwriter/samples/outputforflash.html
+++ b/plugins/htmlwriter/samples/outputforflash.html
@@ -33,7 +33,7 @@ For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-oss-license
 		<a href="../../../samples/old/index.html">CKEditor Samples</a> &raquo; Producing Flash Compliant HTML Output
 	</h1>
 	<div class="warning deprecated">
-		This sample is not maintained anymore. Check out the <a href="https://ckeditor.com/docs/ckeditor4/latest/examples/index.html">brand new samples in CKEditor SDK</a>.
+		This sample is not maintained anymore. Check out the <a href="https://ckeditor.com/docs/ckeditor4/latest/examples/index.html">brand new samples in CKEditor Examples</a>.
 	</div>
 	<div class="description">
 		<p>

--- a/plugins/htmlwriter/samples/outputhtml.html
+++ b/plugins/htmlwriter/samples/outputhtml.html
@@ -20,7 +20,7 @@ For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-oss-license
 		<a href="../../../samples/old/index.html">CKEditor Samples</a> &raquo; Producing HTML Compliant Output
 	</h1>
 	<div class="warning deprecated">
-		This sample is not maintained anymore. Check out the <a href="https://sdk.ckeditor.com/">brand new samples in CKEditor SDK</a>.
+		This sample is not maintained anymore. Check out the <a href="https://ckeditor.com/docs/ckeditor4/latest/examples/index.html">brand new samples in CKEditor SDK</a>.
 	</div>
 	<div class="description">
 		<p>

--- a/plugins/htmlwriter/samples/outputhtml.html
+++ b/plugins/htmlwriter/samples/outputhtml.html
@@ -20,7 +20,7 @@ For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-oss-license
 		<a href="../../../samples/old/index.html">CKEditor Samples</a> &raquo; Producing HTML Compliant Output
 	</h1>
 	<div class="warning deprecated">
-		This sample is not maintained anymore. Check out the <a href="https://ckeditor.com/docs/ckeditor4/latest/examples/index.html">brand new samples in CKEditor SDK</a>.
+		This sample is not maintained anymore. Check out the <a href="https://ckeditor.com/docs/ckeditor4/latest/examples/index.html">brand new samples in CKEditor Examples</a>.
 	</div>
 	<div class="description">
 		<p>

--- a/plugins/image2/plugin.js
+++ b/plugins/image2/plugin.js
@@ -1614,7 +1614,7 @@
  * A CSS class applied to the `<figure>` element of a captioned image.
  *
  * Read more in the [documentation](#!/guide/dev_image2) and see the
- * [SDK sample](https://sdk.ckeditor.com/samples/image2.html).
+ * {@glink examples/image2 example}.
  *
  *		// Changes the class to "captionedImage".
  *		config.image2_captionedClass = 'captionedImage';
@@ -1629,7 +1629,7 @@ CKEDITOR.config.image2_captionedClass = 'image';
  * plugin dialog window.
  *
  * Read more in the [documentation](#!/guide/dev_image2) and see the
- * [SDK sample](https://sdk.ckeditor.com/samples/image2.html).
+ * {@glink examples/image2 example}.
  *
  *		config.image2_prefillDimensions = false;
  *
@@ -1642,7 +1642,7 @@ CKEDITOR.config.image2_captionedClass = 'image';
  * Disables the image resizer. By default the resizer is enabled.
  *
  * Read more in the [documentation](#!/guide/dev_image2) and see the
- * [SDK sample](https://sdk.ckeditor.com/samples/image2.html).
+ * {@glink examples/image2 example}.
  *
  *		config.image2_disableResizer = true;
  *
@@ -1702,7 +1702,7 @@ CKEDITOR.config.image2_captionedClass = 'image';
  *		}
  *
  * Read more in the [documentation](#!/guide/dev_image2) and see the
- * [SDK sample](https://sdk.ckeditor.com/samples/image2.html).
+ * {@glink examples/image2 example}.
  *
  * @since 4.4
  * @cfg {String[]} [image2_alignClasses=null]
@@ -1715,7 +1715,7 @@ CKEDITOR.config.image2_captionedClass = 'image';
  *		config.image2_altRequired = true;
  *
  * Read more in the [documentation](#!/guide/dev_image2) and see the
- * [SDK sample](https://sdk.ckeditor.com/samples/image2.html).
+ * {@glink examples/image2 example}.
  *
  * @since 4.6.0
  * @cfg {Boolean} [image2_altRequired=false]

--- a/plugins/image2/samples/image2.html
+++ b/plugins/image2/samples/image2.html
@@ -23,7 +23,7 @@ For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-oss-license
 		<a href="../../../samples/old/index.html">CKEditor Samples</a> &raquo; New Image plugin
 	</h1>
 	<div class="warning deprecated">
-		This sample is not maintained anymore. Check out its <a href="https://sdk.ckeditor.com/samples/image2.html">brand new version in CKEditor SDK</a>.
+		This sample is not maintained anymore. Check out its <a href="https://ckeditor.com/docs/ckeditor4/latest/examples/image2.html">brand new version in CKEditor SDK</a>.
 	</div>
 
 	<div class="description">

--- a/plugins/image2/samples/image2.html
+++ b/plugins/image2/samples/image2.html
@@ -23,7 +23,7 @@ For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-oss-license
 		<a href="../../../samples/old/index.html">CKEditor Samples</a> &raquo; New Image plugin
 	</h1>
 	<div class="warning deprecated">
-		This sample is not maintained anymore. Check out its <a href="https://ckeditor.com/docs/ckeditor4/latest/examples/image2.html">brand new version in CKEditor SDK</a>.
+		This sample is not maintained anymore. Check out its <a href="https://ckeditor.com/docs/ckeditor4/latest/examples/image2.html">brand new version in CKEditor Examples</a>.
 	</div>
 
 	<div class="description">

--- a/plugins/language/plugin.js
+++ b/plugins/language/plugin.js
@@ -166,7 +166,7 @@
  * * _textDirection_: (optional) One of the following values: `rtl` or `ltr`,
  * 	indicating the reading direction of the language. Defaults to `ltr`.
  *
- * See the [SDK sample](https://sdk.ckeditor.com/samples/language.html).
+ * See the {@glink examples/language example}.
  *
  *		config.language_list = [ 'he:Hebrew:rtl', 'pt:Portuguese', 'de:German' ];
  *

--- a/plugins/magicline/plugin.js
+++ b/plugins/magicline/plugin.js
@@ -1776,7 +1776,7 @@
  * `15` for 15 pixels).
  *
  * Read more in the {@glink guide/dev_magicline documentation}
- * and see the [SDK sample](https://sdk.ckeditor.com/samples/magicline.html).
+ * and see the {@glink examples/magicline example}.
  *
  *		// Changes the offset to 15px.
  *		CKEDITOR.config.magicline_triggerOffset = 15;
@@ -1792,7 +1792,7 @@
  * This value is relative to {@link #magicline_triggerOffset}.
  *
  * Read more in the {@glink guide/dev_magicline documentation}
- * and see the [SDK sample](https://sdk.ckeditor.com/samples/magicline.html).
+ * and see the {@glink examples/magicline example}.
  *
  *		// Increases the distance to 80% of CKEDITOR.config.magicline_triggerOffset.
  *		CKEDITOR.config.magicline_holdDistance = .8;
@@ -1807,7 +1807,7 @@
  * the caret (start of the selection). If there is no focus space available, the selection remains unchanged.
  *
  * Read more in the {@glink guide/dev_magicline documentation}
- * and see the [SDK sample](https://sdk.ckeditor.com/samples/magicline.html).
+ * and see the {@glink examples/magicline example}.
  *
  *		// Changes the default keystroke to "Ctrl + ,".
  *		CKEDITOR.config.magicline_keystrokePrevious = CKEDITOR.CTRL + 188;
@@ -1822,7 +1822,7 @@ CKEDITOR.config.magicline_keystrokePrevious = CKEDITOR.CTRL + CKEDITOR.SHIFT + 5
  * the caret (start of the selection). If there is no focus space available, the selection remains unchanged.
  *
  * Read more in the {@glink guide/dev_magicline documentation}
- * and see the [SDK sample](https://sdk.ckeditor.com/samples/magicline.html).
+ * and see the {@glink examples/magicline example}.
  *
  *		// Changes keystroke to "Ctrl + .".
  *		CKEDITOR.config.magicline_keystrokeNext = CKEDITOR.CTRL + 190;
@@ -1837,7 +1837,7 @@ CKEDITOR.config.magicline_keystrokeNext = CKEDITOR.CTRL + CKEDITOR.SHIFT + 52; /
  * used within these elements.
  *
  * Read more in the {@glink guide/dev_magicline documentation}
- * and see the [SDK sample](https://sdk.ckeditor.com/samples/magicline.html).
+ * and see the {@glink examples/magicline example}.
  *
  *		// Adds the "data-tabu" attribute to the magic line tabu list.
  *		CKEDITOR.config.magicline_tabuList = [ 'data-tabu' ];
@@ -1850,7 +1850,7 @@ CKEDITOR.config.magicline_keystrokeNext = CKEDITOR.CTRL + CKEDITOR.SHIFT + 52; /
  * Defines the color of the magic line. The color may be adjusted to enhance readability.
  *
  * Read more in the {@glink guide/dev_magicline documentation}
- * and see the [SDK sample](https://sdk.ckeditor.com/samples/magicline.html).
+ * and see the {@glink examples/magicline example}.
  *
  *		// Changes magic line color to blue.
  *		CKEDITOR.config.magicline_color = '#0000FF';
@@ -1864,7 +1864,7 @@ CKEDITOR.config.magicline_keystrokeNext = CKEDITOR.CTRL + CKEDITOR.SHIFT + 52; /
  * {@link CKEDITOR.dtd#$block} elements as accessible by the magic line.
  *
  * Read more in the {@glink guide/dev_magicline documentation}
- * and see the [SDK sample](https://sdk.ckeditor.com/samples/magicline.html).
+ * and see the {@glink examples/magicline example}.
  *
  *		// Enables the greedy "put everywhere" mode.
  *		CKEDITOR.config.magicline_everywhere = true;

--- a/plugins/magicline/samples/magicline.html
+++ b/plugins/magicline/samples/magicline.html
@@ -18,7 +18,7 @@ For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-oss-license
 		<a href="../../../samples/old/index.html">CKEditor Samples</a> &raquo; Using Magicline plugin
 	</h1>
 	<div class="warning deprecated">
-		This sample is not maintained anymore. Check out its <a href="https://sdk.ckeditor.com/samples/magicline.html">brand new version in CKEditor SDK</a>.
+		This sample is not maintained anymore. Check out its <a href="https://ckeditor.com/docs/ckeditor4/latest/examples/magicline.html">brand new version in CKEditor SDK</a>.
 	</div>
 	<div class="description">
 		<p>

--- a/plugins/magicline/samples/magicline.html
+++ b/plugins/magicline/samples/magicline.html
@@ -18,7 +18,7 @@ For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-oss-license
 		<a href="../../../samples/old/index.html">CKEditor Samples</a> &raquo; Using Magicline plugin
 	</h1>
 	<div class="warning deprecated">
-		This sample is not maintained anymore. Check out its <a href="https://ckeditor.com/docs/ckeditor4/latest/examples/magicline.html">brand new version in CKEditor SDK</a>.
+		This sample is not maintained anymore. Check out its <a href="https://ckeditor.com/docs/ckeditor4/latest/examples/magicline.html">brand new version in CKEditor Examples</a>.
 	</div>
 	<div class="description">
 		<p>

--- a/plugins/mathjax/plugin.js
+++ b/plugins/mathjax/plugin.js
@@ -441,7 +441,7 @@
  * Please note that this must be a full or absolute path.
  *
  * Read more in the {@glink guide/dev_mathjax documentation}
- * and see the [SDK sample](https://sdk.ckeditor.com/samples/mathjax.html).
+ * and see the {@glink examples/mathjax example}.
  *
  *		config.mathJaxLib = '//cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.4/MathJax.js?config=TeX-AMS_HTML';
  *
@@ -467,7 +467,7 @@
  *		<span class="my-math">\( \sqrt{4} = 2 \)</span>
  *
  * Read more in the {@glink guide/dev_mathjax documentation}
- * and see the [SDK sample](https://sdk.ckeditor.com/samples/mathjax.html).
+ * and see the {@glink examples/mathjax example}.
  *
  * @cfg {String} [mathJaxClass='math-tex']
  * @member CKEDITOR.config

--- a/plugins/mathjax/samples/mathjax.html
+++ b/plugins/mathjax/samples/mathjax.html
@@ -22,7 +22,7 @@ For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-oss-license
 		<a href="../../../samples/old/index.html">CKEditor Samples</a> &raquo; Mathematical Formulas
 	</h1>
 	<div class="warning deprecated">
-		This sample is not maintained anymore. Check out its <a href="https://ckeditor.com/docs/ckeditor4/latest/examples/mathjax.html">brand new version in CKEditor SDK</a>.
+		This sample is not maintained anymore. Check out its <a href="https://ckeditor.com/docs/ckeditor4/latest/examples/mathjax.html">brand new version in CKEditor Examples</a>.
 	</div>
 	<div id="footer">
 		<hr>

--- a/plugins/mathjax/samples/mathjax.html
+++ b/plugins/mathjax/samples/mathjax.html
@@ -22,7 +22,7 @@ For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-oss-license
 		<a href="../../../samples/old/index.html">CKEditor Samples</a> &raquo; Mathematical Formulas
 	</h1>
 	<div class="warning deprecated">
-		This sample is not maintained anymore. Check out its <a href="https://sdk.ckeditor.com/samples/mathjax.html">brand new version in CKEditor SDK</a>.
+		This sample is not maintained anymore. Check out its <a href="https://ckeditor.com/docs/ckeditor4/latest/examples/mathjax.html">brand new version in CKEditor SDK</a>.
 	</div>
 	<div id="footer">
 		<hr>

--- a/plugins/placeholder/samples/placeholder.html
+++ b/plugins/placeholder/samples/placeholder.html
@@ -19,7 +19,7 @@ For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-oss-license
 		<a href="../../../samples/old/index.html">CKEditor Samples</a> &raquo; Using the Placeholder Plugin
 	</h1>
 	<div class="warning deprecated">
-		This sample is not maintained anymore. Check out its <a href="https://sdk.ckeditor.com/samples/placeholder.html">brand new version in CKEditor SDK</a>.
+		This sample is not maintained anymore. Check out its <a href="https://ckeditor.com/docs/ckeditor4/latest/examples/placeholder.html">brand new version in CKEditor SDK</a>.
 	</div>
 	<div class="description">
 		<p>

--- a/plugins/placeholder/samples/placeholder.html
+++ b/plugins/placeholder/samples/placeholder.html
@@ -19,7 +19,7 @@ For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-oss-license
 		<a href="../../../samples/old/index.html">CKEditor Samples</a> &raquo; Using the Placeholder Plugin
 	</h1>
 	<div class="warning deprecated">
-		This sample is not maintained anymore. Check out its <a href="https://ckeditor.com/docs/ckeditor4/latest/examples/placeholder.html">brand new version in CKEditor SDK</a>.
+		This sample is not maintained anymore. Check out its <a href="https://ckeditor.com/docs/ckeditor4/latest/examples/placeholder.html">brand new version in CKEditor Examples</a>.
 	</div>
 	<div class="description">
 		<p>

--- a/plugins/resize/plugin.js
+++ b/plugins/resize/plugin.js
@@ -115,7 +115,7 @@ CKEDITOR.plugins.add( 'resize', {
  * Note: It falls back to editor's actual width if it is smaller than the default value.
  *
  * Read more in the {@glink guide/dev_resize documentation}
- * and see the [SDK sample](https://sdk.ckeditor.com/samples/resize.html).
+ * and see the {@glink examples/resize example}.
  *
  *		config.resize_minWidth = 500;
  *
@@ -128,7 +128,7 @@ CKEDITOR.plugins.add( 'resize', {
  * Note: It falls back to editor's actual height if it is smaller than the default value.
  *
  * Read more in the {@glink guide/dev_resize documentation}
- * and see the [SDK sample](https://sdk.ckeditor.com/samples/resize.html).
+ * and see the {@glink examples/resize example}.
  *
  *		config.resize_minHeight = 600;
  *
@@ -140,7 +140,7 @@ CKEDITOR.plugins.add( 'resize', {
  * The maximum editor width, in pixels, when resizing the editor interface by using the resize handle.
  *
  * Read more in the {@glink guide/dev_resize documentation}
- * and see the [SDK sample](https://sdk.ckeditor.com/samples/resize.html).
+ * and see the {@glink examples/resize example}.
  *
  *		config.resize_maxWidth = 750;
  *
@@ -152,7 +152,7 @@ CKEDITOR.plugins.add( 'resize', {
  * The maximum editor height, in pixels, when resizing the editor interface by using the resize handle.
  *
  * Read more in the {@glink guide/dev_resize documentation}
- * and see the [SDK sample](https://sdk.ckeditor.com/samples/resize.html).
+ * and see the {@glink examples/resize example}.
  *
  *		config.resize_maxHeight = 600;
  *
@@ -164,7 +164,7 @@ CKEDITOR.plugins.add( 'resize', {
  * Whether to enable the resizing feature. If this feature is disabled, the resize handle will not be visible.
  *
  * Read more in the {@glink guide/dev_resize documentation}
- * and see the [SDK sample](https://sdk.ckeditor.com/samples/resize.html).
+ * and see the {@glink examples/resize example}.
  *
  *		config.resize_enabled = false;
  *
@@ -177,7 +177,7 @@ CKEDITOR.plugins.add( 'resize', {
  * are `both`, `vertical`, and `horizontal`.
  *
  * Read more in the {@glink guide/dev_resize documentation}
- * and see the [SDK sample](https://sdk.ckeditor.com/samples/resize.html).
+ * and see the {@glink examples/resize example}.
  *
  *		config.resize_dir = 'both';
  *

--- a/plugins/sharedspace/plugin.js
+++ b/plugins/sharedspace/plugin.js
@@ -115,7 +115,7 @@
  * will be displayed.
  *
  * Read more in the {@glink guide/dev_sharedspace documentation}
- * and see the [SDK sample](https://sdk.ckeditor.com/samples/sharedspace.html).
+ * and see the {@glink examples/sharedspace example}.
  *
  *		// Place the toolbar inside the element with an ID of "someElementId" and the
  *		// elements path into the element with an  ID of "anotherId".

--- a/plugins/sharedspace/samples/sharedspace.html
+++ b/plugins/sharedspace/samples/sharedspace.html
@@ -18,7 +18,7 @@ For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-oss-license
 		<a href="../../../samples/old/index.html">CKEditor Samples</a> &raquo; Sharing Toolbar and Bottom-bar Spaces
 	</h1>
 	<div class="warning deprecated">
-		This sample is not maintained anymore. Check out its <a href="https://ckeditor.com/docs/ckeditor4/latest/examples/sharedspace.html">brand new version in CKEditor SDK</a>.
+		This sample is not maintained anymore. Check out its <a href="https://ckeditor.com/docs/ckeditor4/latest/examples/sharedspace.html">brand new version in CKEditor Examples</a>.
 	</div>
 	<div class="description">
 		<p>

--- a/plugins/sharedspace/samples/sharedspace.html
+++ b/plugins/sharedspace/samples/sharedspace.html
@@ -18,7 +18,7 @@ For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-oss-license
 		<a href="../../../samples/old/index.html">CKEditor Samples</a> &raquo; Sharing Toolbar and Bottom-bar Spaces
 	</h1>
 	<div class="warning deprecated">
-		This sample is not maintained anymore. Check out its <a href="https://sdk.ckeditor.com/samples/sharedspace.html">brand new version in CKEditor SDK</a>.
+		This sample is not maintained anymore. Check out its <a href="https://ckeditor.com/docs/ckeditor4/latest/examples/sharedspace.html">brand new version in CKEditor SDK</a>.
 	</div>
 	<div class="description">
 		<p>

--- a/plugins/sourcedialog/samples/sourcedialog.html
+++ b/plugins/sourcedialog/samples/sourcedialog.html
@@ -28,7 +28,7 @@ For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-oss-license
 		<a href="../../../samples/old/index.html">CKEditor Samples</a> &raquo; Editing source code in a dialog
 	</h1>
 	<div class="warning deprecated">
-		This sample is not maintained anymore. Check out its <a href="https://sdk.ckeditor.com/samples/sourcearea.html">brand new version in CKEditor SDK</a>.
+		This sample is not maintained anymore. Check out its <a href="https://ckeditor.com/docs/ckeditor4/latest/examples/sourcearea.html">brand new version in CKEditor SDK</a>.
 	</div>
 	<div class="description">
 		<p>

--- a/plugins/sourcedialog/samples/sourcedialog.html
+++ b/plugins/sourcedialog/samples/sourcedialog.html
@@ -28,7 +28,7 @@ For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-oss-license
 		<a href="../../../samples/old/index.html">CKEditor Samples</a> &raquo; Editing source code in a dialog
 	</h1>
 	<div class="warning deprecated">
-		This sample is not maintained anymore. Check out its <a href="https://ckeditor.com/docs/ckeditor4/latest/examples/sourcearea.html">brand new version in CKEditor SDK</a>.
+		This sample is not maintained anymore. Check out its <a href="https://ckeditor.com/docs/ckeditor4/latest/examples/sourcearea.html">brand new version in CKEditor Examples</a>.
 	</div>
 	<div class="description">
 		<p>

--- a/plugins/stylesheetparser/plugin.js
+++ b/plugins/stylesheetparser/plugin.js
@@ -129,7 +129,7 @@
  * in the Styles drop-down list.
  *
  * Read more in the [documentation](#!/guide/dev_styles-section-the-stylesheet-parser-plugin)
- * and see the [SDK sample](https://sdk.ckeditor.com/samples/styles.html).
+ * and see the {@glink examples/styles example}.
  *
  *		// Ignore rules for body and caption elements, classes starting with "high", and any class defined for no specific element.
  *		config.stylesheetParser_skipSelectors = /(^body\.|^caption\.|\.high|^\.)/i;
@@ -146,7 +146,7 @@
  * expression will be available in the Styles drop-down list.
  *
  * Read more in the [documentation](#!/guide/dev_styles-section-the-stylesheet-parser-plugin)
- * and see the [SDK sample](https://sdk.ckeditor.com/samples/styles.html).
+ * and see the {@glink examples/styles example}.
  *
  *		// Only add rules for p and span elements.
  *		config.stylesheetParser_validSelectors = /\^(p|span)\.\w+/;

--- a/plugins/stylesheetparser/samples/stylesheetparser.html
+++ b/plugins/stylesheetparser/samples/stylesheetparser.html
@@ -20,7 +20,7 @@ For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-oss-license
 		<a href="../../../samples/old/index.html">CKEditor Samples</a> &raquo; Using the Stylesheet Parser Plugin
 	</h1>
 	<div class="warning deprecated">
-		This sample is not maintained anymore. Check out its <a href="https://sdk.ckeditor.com/samples/styles.html">brand new version in CKEditor SDK</a>.
+		This sample is not maintained anymore. Check out its <a href="https://ckeditor.com/docs/ckeditor4/latest/examples/styles.html">brand new version in CKEditor SDK</a>.
 	</div>
 	<div class="description">
 		<p>

--- a/plugins/stylesheetparser/samples/stylesheetparser.html
+++ b/plugins/stylesheetparser/samples/stylesheetparser.html
@@ -20,7 +20,7 @@ For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-oss-license
 		<a href="../../../samples/old/index.html">CKEditor Samples</a> &raquo; Using the Stylesheet Parser Plugin
 	</h1>
 	<div class="warning deprecated">
-		This sample is not maintained anymore. Check out its <a href="https://ckeditor.com/docs/ckeditor4/latest/examples/styles.html">brand new version in CKEditor SDK</a>.
+		This sample is not maintained anymore. Check out its <a href="https://ckeditor.com/docs/ckeditor4/latest/examples/styles.html">brand new version in CKEditor Examples</a>.
 	</div>
 	<div class="description">
 		<p>

--- a/plugins/tableresize/samples/tableresize.html
+++ b/plugins/tableresize/samples/tableresize.html
@@ -18,7 +18,7 @@ For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-oss-license
 		<a href="../../../samples/old/index.html">CKEditor Samples</a> &raquo; Using the TableResize Plugin
 	</h1>
 	<div class="warning deprecated">
-		This sample is not maintained anymore. Check out its <a href="https://sdk.ckeditor.com/samples/table.html">brand new version in CKEditor SDK</a>.
+		This sample is not maintained anymore. Check out its <a href="https://ckeditor.com/docs/ckeditor4/latest/examples/table.html">brand new version in CKEditor SDK</a>.
 	</div>
 	<div class="description">
 		<p>

--- a/plugins/tableresize/samples/tableresize.html
+++ b/plugins/tableresize/samples/tableresize.html
@@ -18,7 +18,7 @@ For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-oss-license
 		<a href="../../../samples/old/index.html">CKEditor Samples</a> &raquo; Using the TableResize Plugin
 	</h1>
 	<div class="warning deprecated">
-		This sample is not maintained anymore. Check out its <a href="https://ckeditor.com/docs/ckeditor4/latest/examples/table.html">brand new version in CKEditor SDK</a>.
+		This sample is not maintained anymore. Check out its <a href="https://ckeditor.com/docs/ckeditor4/latest/examples/table.html">brand new version in CKEditor Examples</a>.
 	</div>
 	<div class="description">
 		<p>

--- a/plugins/toolbar/plugin.js
+++ b/plugins/toolbar/plugin.js
@@ -666,7 +666,7 @@ CKEDITOR.UI_SEPARATOR = 'separator';
  * position is set dynamically depending on the position of the editable element on the screen.
  *
  * Read more in the {@glink guide/dev_toolbarlocation documentation}
- * and see the [SDK sample](https://sdk.ckeditor.com/samples/toolbarlocation.html).
+ * and see the {@glink examples/toolbarlocation example}.
  *
  *		config.toolbarLocation = 'bottom';
  *

--- a/plugins/uicolor/samples/uicolor.html
+++ b/plugins/uicolor/samples/uicolor.html
@@ -18,7 +18,7 @@ For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-oss-license
 		<a href="../../../samples/old/index.html">CKEditor Samples</a> &raquo; UI Color Plugin
 	</h1>
 	<div class="warning deprecated">
-		This sample is not maintained anymore. Check out its <a href="https://sdk.ckeditor.com/samples/uicolorpicker.html">brand new version in CKEditor SDK</a>.
+		This sample is not maintained anymore. Check out its <a href="https://ckeditor.com/docs/ckeditor4/latest/examples/uicolorpicker.html">brand new version in CKEditor SDK</a>.
 	</div>
 	<div class="description">
 		<p>

--- a/plugins/uicolor/samples/uicolor.html
+++ b/plugins/uicolor/samples/uicolor.html
@@ -18,7 +18,7 @@ For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-oss-license
 		<a href="../../../samples/old/index.html">CKEditor Samples</a> &raquo; UI Color Plugin
 	</h1>
 	<div class="warning deprecated">
-		This sample is not maintained anymore. Check out its <a href="https://ckeditor.com/docs/ckeditor4/latest/examples/uicolorpicker.html">brand new version in CKEditor SDK</a>.
+		This sample is not maintained anymore. Check out its <a href="https://ckeditor.com/docs/ckeditor4/latest/examples/uicolorpicker.html">brand new version in CKEditor Examples</a>.
 	</div>
 	<div class="description">
 		<p>

--- a/plugins/wysiwygarea/samples/fullpage.html
+++ b/plugins/wysiwygarea/samples/fullpage.html
@@ -20,7 +20,7 @@ For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-oss-license
 		<a href="../../../samples/old/index.html">CKEditor Samples</a> &raquo; Full Page Editing
 	</h1>
 	<div class="warning deprecated">
-		This sample is not maintained anymore. Check out its <a href="https://sdk.ckeditor.com/samples/fullpage.html">brand new version in CKEditor SDK</a>.
+		This sample is not maintained anymore. Check out its <a href="https://ckeditor.com/docs/ckeditor4/latest/examples/fullpage.html">brand new version in CKEditor SDK</a>.
 	</div>
 	<div class="description">
 		<p>

--- a/plugins/wysiwygarea/samples/fullpage.html
+++ b/plugins/wysiwygarea/samples/fullpage.html
@@ -20,7 +20,7 @@ For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-oss-license
 		<a href="../../../samples/old/index.html">CKEditor Samples</a> &raquo; Full Page Editing
 	</h1>
 	<div class="warning deprecated">
-		This sample is not maintained anymore. Check out its <a href="https://ckeditor.com/docs/ckeditor4/latest/examples/fullpage.html">brand new version in CKEditor SDK</a>.
+		This sample is not maintained anymore. Check out its <a href="https://ckeditor.com/docs/ckeditor4/latest/examples/fullpage.html">brand new version in CKEditor Examples</a>.
 	</div>
 	<div class="description">
 		<p>

--- a/samples/index.html
+++ b/samples/index.html
@@ -85,7 +85,7 @@ For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-oss-license
 
 			<section>
 				<h2>More Samples!</h2>
-				<p>Visit the <a href="https://sdk.ckeditor.com">CKEditor SDK</a> for a huge collection of samples showcasing editor features, with source code readily available to copy and use in your own implementation.</p>
+				<p>Visit the <a href="https://ckeditor.com/docs/ckeditor4/latest/examples/index.html">CKEditor SDK</a> for a huge collection of samples showcasing editor features, with source code readily available to copy and use in your own implementation.</p>
 			</section>
 
 			<section>

--- a/samples/index.html
+++ b/samples/index.html
@@ -98,7 +98,7 @@ For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-oss-license
 					<p>When you have the basics sorted out, feel free to browse some more advanced sections like:</p>
 				<ul>
 					<li><a href="https://ckeditor.com/docs/ckeditor4/latest/guide/dev_features.html">Functionality Overview</a> &ndash; Descriptions and samples of various editor features.</li>
-					<li><a href="https://ckeditor.com/docs/ckeditor4/latest/guide/plugin_sdk_intro.html">Plugin SDK</a>, <a href="https://ckeditor.com/docs/ckeditor4/latest/guide/widget_sdk_intro.html">Widget SDK</a>, and <a href="https://ckeditor.com/docs/ckeditor4/latest/guide/skin_sdk_intro.html">Skin SDK</a> &ndash; Useful when you want to create your own editor components.</li>
+					<li><a href="https://ckeditor.com/docs/ckeditor4/latest/guide/plugin_sdk_intro.html">Plugin Examples</a>, <a href="https://ckeditor.com/docs/ckeditor4/latest/guide/widget_sdk_intro.html">Widget Examples</a>, and <a href="https://ckeditor.com/docs/ckeditor4/latest/guide/skin_sdk_intro.html">Skin Examples</a> &ndash; Useful when you want to create your own editor components.</li>
 				</ul>
 			</section>
 

--- a/samples/index.html
+++ b/samples/index.html
@@ -85,7 +85,7 @@ For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-oss-license
 
 			<section>
 				<h2>More Samples!</h2>
-				<p>Visit the <a href="https://ckeditor.com/docs/ckeditor4/latest/examples/index.html">CKEditor SDK</a> for a huge collection of samples showcasing editor features, with source code readily available to copy and use in your own implementation.</p>
+				<p>Visit the <a href="https://ckeditor.com/docs/ckeditor4/latest/examples/index.html">CKEditor Examples</a> for a huge collection of samples showcasing editor features, with source code readily available to copy and use in your own implementation.</p>
 			</section>
 
 			<section>

--- a/samples/index.html
+++ b/samples/index.html
@@ -98,7 +98,7 @@ For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-oss-license
 					<p>When you have the basics sorted out, feel free to browse some more advanced sections like:</p>
 				<ul>
 					<li><a href="https://ckeditor.com/docs/ckeditor4/latest/guide/dev_features.html">Functionality Overview</a> &ndash; Descriptions and samples of various editor features.</li>
-					<li><a href="https://ckeditor.com/docs/ckeditor4/latest/guide/plugin_sdk_intro.html">Plugin Examples</a>, <a href="https://ckeditor.com/docs/ckeditor4/latest/guide/widget_sdk_intro.html">Widget Examples</a>, and <a href="https://ckeditor.com/docs/ckeditor4/latest/guide/skin_sdk_intro.html">Skin Examples</a> &ndash; Useful when you want to create your own editor components.</li>
+					<li><a href="https://ckeditor.com/docs/ckeditor4/latest/guide/plugin_sdk_intro.html">Plugin SDK</a>, <a href="https://ckeditor.com/docs/ckeditor4/latest/guide/widget_sdk_intro.html">Widget SDK</a>, and <a href="https://ckeditor.com/docs/ckeditor4/latest/guide/skin_sdk_intro.html">Skin SDK</a> &ndash; Useful when you want to create your own editor components.</li>
 				</ul>
 			</section>
 

--- a/samples/old/ajax.html
+++ b/samples/old/ajax.html
@@ -43,7 +43,7 @@ For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-oss-license
 		<a href="index.html">CKEditor Samples</a> &raquo; Create and Destroy Editor Instances for Ajax Applications
 	</h1>
 	<div class="warning deprecated">
-		This sample is not maintained anymore. Check out its <a href="https://sdk.ckeditor.com/samples/saveajax.html">brand new version in CKEditor SDK</a>.
+		This sample is not maintained anymore. Check out its <a href="https://ckeditor.com/docs/ckeditor4/latest/examples/saveajax.html">brand new version in CKEditor SDK</a>.
 	</div>
 	<div class="description">
 		<p>

--- a/samples/old/ajax.html
+++ b/samples/old/ajax.html
@@ -43,7 +43,7 @@ For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-oss-license
 		<a href="index.html">CKEditor Samples</a> &raquo; Create and Destroy Editor Instances for Ajax Applications
 	</h1>
 	<div class="warning deprecated">
-		This sample is not maintained anymore. Check out its <a href="https://ckeditor.com/docs/ckeditor4/latest/examples/saveajax.html">brand new version in CKEditor SDK</a>.
+		This sample is not maintained anymore. Check out its <a href="https://ckeditor.com/docs/ckeditor4/latest/examples/saveajax.html">brand new version in CKEditor Examples</a>.
 	</div>
 	<div class="description">
 		<p>

--- a/samples/old/api.html
+++ b/samples/old/api.html
@@ -125,7 +125,7 @@ function onBlur() {
 		<a href="index.html">CKEditor Samples</a> &raquo; Using CKEditor JavaScript API
 	</h1>
 	<div class="warning deprecated">
-		This sample is not maintained anymore. Check out its <a href="https://sdk.ckeditor.com/samples/api.html">brand new version in CKEditor SDK</a>.
+		This sample is not maintained anymore. Check out its <a href="https://ckeditor.com/docs/ckeditor4/latest/examples/api.html">brand new version in CKEditor SDK</a>.
 	</div>
 	<div class="description">
 	<p>

--- a/samples/old/api.html
+++ b/samples/old/api.html
@@ -125,7 +125,7 @@ function onBlur() {
 		<a href="index.html">CKEditor Samples</a> &raquo; Using CKEditor JavaScript API
 	</h1>
 	<div class="warning deprecated">
-		This sample is not maintained anymore. Check out its <a href="https://ckeditor.com/docs/ckeditor4/latest/examples/api.html">brand new version in CKEditor SDK</a>.
+		This sample is not maintained anymore. Check out its <a href="https://ckeditor.com/docs/ckeditor4/latest/examples/api.html">brand new version in CKEditor Examples</a>.
 	</div>
 	<div class="description">
 	<p>

--- a/samples/old/appendto.html
+++ b/samples/old/appendto.html
@@ -15,7 +15,7 @@ For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-oss-license
 		<a href="index.html">CKEditor Samples</a> &raquo; Append To Page Element Using JavaScript Code
 	</h1>
 	<div class="warning deprecated">
-		This sample is not maintained anymore. Check out the <a href="https://sdk.ckeditor.com/">brand new samples in CKEditor SDK</a>.
+		This sample is not maintained anymore. Check out the <a href="https://ckeditor.com/docs/ckeditor4/latest/examples/index.html">brand new samples in CKEditor SDK</a>.
 	</div>
 	<div id="section1">
 		<div class="description">

--- a/samples/old/appendto.html
+++ b/samples/old/appendto.html
@@ -15,7 +15,7 @@ For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-oss-license
 		<a href="index.html">CKEditor Samples</a> &raquo; Append To Page Element Using JavaScript Code
 	</h1>
 	<div class="warning deprecated">
-		This sample is not maintained anymore. Check out the <a href="https://ckeditor.com/docs/ckeditor4/latest/examples/index.html">brand new samples in CKEditor SDK</a>.
+		This sample is not maintained anymore. Check out the <a href="https://ckeditor.com/docs/ckeditor4/latest/examples/index.html">brand new samples in CKEditor Examples</a>.
 	</div>
 	<div id="section1">
 		<div class="description">

--- a/samples/old/datafiltering.html
+++ b/samples/old/datafiltering.html
@@ -19,7 +19,7 @@ For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-oss-license
 		<a href="index.html">CKEditor Samples</a> &raquo; Data Filtering and Features Activation
 	</h1>
 	<div class="warning deprecated">
-		This sample is not maintained anymore. Check out its <a href="https://sdk.ckeditor.com/samples/acf.html">brand new version in CKEditor SDK</a>.
+		This sample is not maintained anymore. Check out its <a href="https://ckeditor.com/docs/ckeditor4/latest/examples/acf.html">brand new version in CKEditor SDK</a>.
 	</div>
 	<div class="description">
 		<p>

--- a/samples/old/datafiltering.html
+++ b/samples/old/datafiltering.html
@@ -19,7 +19,7 @@ For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-oss-license
 		<a href="index.html">CKEditor Samples</a> &raquo; Data Filtering and Features Activation
 	</h1>
 	<div class="warning deprecated">
-		This sample is not maintained anymore. Check out its <a href="https://ckeditor.com/docs/ckeditor4/latest/examples/acf.html">brand new version in CKEditor SDK</a>.
+		This sample is not maintained anymore. Check out its <a href="https://ckeditor.com/docs/ckeditor4/latest/examples/acf.html">brand new version in CKEditor Examples</a>.
 	</div>
 	<div class="description">
 		<p>

--- a/samples/old/divreplace.html
+++ b/samples/old/divreplace.html
@@ -72,7 +72,7 @@ For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-oss-license
 		<a href="index.html">CKEditor Samples</a> &raquo; Replace DIV with CKEditor on the Fly
 	</h1>
 	<div class="warning deprecated">
-		This sample is not maintained anymore. Check out the <a href="https://sdk.ckeditor.com/">brand new samples in CKEditor SDK</a>.
+		This sample is not maintained anymore. Check out the <a href="https://ckeditor.com/docs/ckeditor4/latest/examples/index.html">brand new samples in CKEditor SDK</a>.
 	</div>
 	<div class="description">
 		<p>

--- a/samples/old/divreplace.html
+++ b/samples/old/divreplace.html
@@ -72,7 +72,7 @@ For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-oss-license
 		<a href="index.html">CKEditor Samples</a> &raquo; Replace DIV with CKEditor on the Fly
 	</h1>
 	<div class="warning deprecated">
-		This sample is not maintained anymore. Check out the <a href="https://ckeditor.com/docs/ckeditor4/latest/examples/index.html">brand new samples in CKEditor SDK</a>.
+		This sample is not maintained anymore. Check out the <a href="https://ckeditor.com/docs/ckeditor4/latest/examples/index.html">brand new samples in CKEditor Examples</a>.
 	</div>
 	<div class="description">
 		<p>

--- a/samples/old/index.html
+++ b/samples/old/index.html
@@ -14,7 +14,7 @@ For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-oss-license
 		CKEditor Samples
 	</h1>
 	<div class="warning deprecated">
-		These samples are not maintained anymore. Check out the <a href="https://sdk.ckeditor.com/">brand new samples in CKEditor SDK</a>.
+		These samples are not maintained anymore. Check out the <a href="https://ckeditor.com/docs/ckeditor4/latest/examples/index.html">brand new samples in CKEditor SDK</a>.
 	</div>
 	<div class="twoColumns">
 		<div class="twoColumnsLeft">

--- a/samples/old/index.html
+++ b/samples/old/index.html
@@ -14,7 +14,7 @@ For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-oss-license
 		CKEditor Samples
 	</h1>
 	<div class="warning deprecated">
-		These samples are not maintained anymore. Check out the <a href="https://ckeditor.com/docs/ckeditor4/latest/examples/index.html">brand new samples in CKEditor SDK</a>.
+		These samples are not maintained anymore. Check out the <a href="https://ckeditor.com/docs/ckeditor4/latest/examples/index.html">brand new samples in CKEditor Examples</a>.
 	</div>
 	<div class="twoColumns">
 		<div class="twoColumnsLeft">

--- a/samples/old/inlineall.html
+++ b/samples/old/inlineall.html
@@ -194,7 +194,7 @@ For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-oss-license
 <div>
 	<h1 class="samples"><a href="index.html">CKEditor Samples</a> &raquo; Massive inline editing</h1>
 	<div class="warning deprecated">
-		This sample is not maintained anymore. Check out its <a href="https://sdk.ckeditor.com/samples/inline.html">brand new version in CKEditor SDK</a>.
+		This sample is not maintained anymore. Check out its <a href="https://ckeditor.com/docs/ckeditor4/latest/examples/inline.html">brand new version in CKEditor SDK</a>.
 	</div>
 	<div class="description">
 		<p>This sample page demonstrates the inline editing feature - CKEditor instances will be created automatically from page elements with <strong>contentEditable</strong> attribute set to value <strong>true</strong>:</p>

--- a/samples/old/inlineall.html
+++ b/samples/old/inlineall.html
@@ -194,7 +194,7 @@ For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-oss-license
 <div>
 	<h1 class="samples"><a href="index.html">CKEditor Samples</a> &raquo; Massive inline editing</h1>
 	<div class="warning deprecated">
-		This sample is not maintained anymore. Check out its <a href="https://ckeditor.com/docs/ckeditor4/latest/examples/inline.html">brand new version in CKEditor SDK</a>.
+		This sample is not maintained anymore. Check out its <a href="https://ckeditor.com/docs/ckeditor4/latest/examples/inline.html">brand new version in CKEditor Examples</a>.
 	</div>
 	<div class="description">
 		<p>This sample page demonstrates the inline editing feature - CKEditor instances will be created automatically from page elements with <strong>contentEditable</strong> attribute set to value <strong>true</strong>:</p>

--- a/samples/old/inlinebycode.html
+++ b/samples/old/inlinebycode.html
@@ -24,7 +24,7 @@ For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-oss-license
 		<a href="index.html">CKEditor Samples</a> &raquo; Inline Editing by Code
 	</h1>
 	<div class="warning deprecated">
-		This sample is not maintained anymore. Check out its <a href="https://ckeditor.com/docs/ckeditor4/latest/examples/inline.html">brand new version in CKEditor SDK</a>.
+		This sample is not maintained anymore. Check out its <a href="https://ckeditor.com/docs/ckeditor4/latest/examples/inline.html">brand new version in CKEditor Examples</a>.
 	</div>
 	<div class="description">
 		<p>

--- a/samples/old/inlinebycode.html
+++ b/samples/old/inlinebycode.html
@@ -24,7 +24,7 @@ For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-oss-license
 		<a href="index.html">CKEditor Samples</a> &raquo; Inline Editing by Code
 	</h1>
 	<div class="warning deprecated">
-		This sample is not maintained anymore. Check out its <a href="https://sdk.ckeditor.com/samples/inline.html">brand new version in CKEditor SDK</a>.
+		This sample is not maintained anymore. Check out its <a href="https://ckeditor.com/docs/ckeditor4/latest/examples/inline.html">brand new version in CKEditor SDK</a>.
 	</div>
 	<div class="description">
 		<p>

--- a/samples/old/inlinetextarea.html
+++ b/samples/old/inlinetextarea.html
@@ -29,7 +29,7 @@ For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-oss-license
 		<a href="index.html">CKEditor Samples</a> &raquo; Replace Textarea with Inline Editor
 	</h1>
 	<div class="warning deprecated">
-		This sample is not maintained anymore. Check out its <a href="https://sdk.ckeditor.com/samples/inline.html">brand new version in CKEditor SDK</a>.
+		This sample is not maintained anymore. Check out its <a href="https://ckeditor.com/docs/ckeditor4/latest/examples/inline.html">brand new version in CKEditor SDK</a>.
 	</div>
 	<div class="description">
 		<p>

--- a/samples/old/inlinetextarea.html
+++ b/samples/old/inlinetextarea.html
@@ -29,7 +29,7 @@ For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-oss-license
 		<a href="index.html">CKEditor Samples</a> &raquo; Replace Textarea with Inline Editor
 	</h1>
 	<div class="warning deprecated">
-		This sample is not maintained anymore. Check out its <a href="https://ckeditor.com/docs/ckeditor4/latest/examples/inline.html">brand new version in CKEditor SDK</a>.
+		This sample is not maintained anymore. Check out its <a href="https://ckeditor.com/docs/ckeditor4/latest/examples/inline.html">brand new version in CKEditor Examples</a>.
 	</div>
 	<div class="description">
 		<p>

--- a/samples/old/jquery.html
+++ b/samples/old/jquery.html
@@ -40,7 +40,7 @@ For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-oss-license
 		<a href="index.html" id="a-test">CKEditor Samples</a> &raquo; Create Editors with jQuery
 	</h1>
 	<div class="warning deprecated">
-		This sample is not maintained anymore. Check out the <a href="https://sdk.ckeditor.com/">brand new samples in CKEditor SDK</a>.
+		This sample is not maintained anymore. Check out the <a href="https://ckeditor.com/docs/ckeditor4/latest/examples/index.html">brand new samples in CKEditor SDK</a>.
 	</div>
 	<form action="sample_posteddata.php" method="post">
 		<div class="description">

--- a/samples/old/jquery.html
+++ b/samples/old/jquery.html
@@ -40,7 +40,7 @@ For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-oss-license
 		<a href="index.html" id="a-test">CKEditor Samples</a> &raquo; Create Editors with jQuery
 	</h1>
 	<div class="warning deprecated">
-		This sample is not maintained anymore. Check out the <a href="https://ckeditor.com/docs/ckeditor4/latest/examples/index.html">brand new samples in CKEditor SDK</a>.
+		This sample is not maintained anymore. Check out the <a href="https://ckeditor.com/docs/ckeditor4/latest/examples/index.html">brand new samples in CKEditor Examples</a>.
 	</div>
 	<form action="sample_posteddata.php" method="post">
 		<div class="description">

--- a/samples/old/readonly.html
+++ b/samples/old/readonly.html
@@ -41,7 +41,7 @@ For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-oss-license
 		<a href="index.html">CKEditor Samples</a> &raquo; Using the CKEditor Read-Only API
 	</h1>
 	<div class="warning deprecated">
-		This sample is not maintained anymore. Check out its <a href="https://ckeditor.com/docs/ckeditor4/latest/examples/readonly.html">brand new version in CKEditor SDK</a>.
+		This sample is not maintained anymore. Check out its <a href="https://ckeditor.com/docs/ckeditor4/latest/examples/readonly.html">brand new version in CKEditor Examples</a>.
 	</div>
 	<div class="description">
 		<p>

--- a/samples/old/readonly.html
+++ b/samples/old/readonly.html
@@ -41,7 +41,7 @@ For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-oss-license
 		<a href="index.html">CKEditor Samples</a> &raquo; Using the CKEditor Read-Only API
 	</h1>
 	<div class="warning deprecated">
-		This sample is not maintained anymore. Check out its <a href="https://sdk.ckeditor.com/samples/readonly.html">brand new version in CKEditor SDK</a>.
+		This sample is not maintained anymore. Check out its <a href="https://ckeditor.com/docs/ckeditor4/latest/examples/readonly.html">brand new version in CKEditor SDK</a>.
 	</div>
 	<div class="description">
 		<p>

--- a/samples/old/replacebyclass.html
+++ b/samples/old/replacebyclass.html
@@ -15,7 +15,7 @@ For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-oss-license
 		<a href="index.html">CKEditor Samples</a> &raquo; Replace Textarea Elements by Class Name
 	</h1>
 	<div class="warning deprecated">
-		This sample is not maintained anymore. Check out the <a href="https://sdk.ckeditor.com/">brand new samples in CKEditor SDK</a>.
+		This sample is not maintained anymore. Check out the <a href="https://ckeditor.com/docs/ckeditor4/latest/examples/index.html">brand new samples in CKEditor SDK</a>.
 	</div>
 	<div class="description">
 		<p>

--- a/samples/old/replacebyclass.html
+++ b/samples/old/replacebyclass.html
@@ -15,7 +15,7 @@ For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-oss-license
 		<a href="index.html">CKEditor Samples</a> &raquo; Replace Textarea Elements by Class Name
 	</h1>
 	<div class="warning deprecated">
-		This sample is not maintained anymore. Check out the <a href="https://ckeditor.com/docs/ckeditor4/latest/examples/index.html">brand new samples in CKEditor SDK</a>.
+		This sample is not maintained anymore. Check out the <a href="https://ckeditor.com/docs/ckeditor4/latest/examples/index.html">brand new samples in CKEditor Examples</a>.
 	</div>
 	<div class="description">
 		<p>

--- a/samples/old/replacebycode.html
+++ b/samples/old/replacebycode.html
@@ -15,7 +15,7 @@ For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-oss-license
 		<a href="index.html">CKEditor Samples</a> &raquo; Replace Textarea Elements Using JavaScript Code
 	</h1>
 	<div class="warning deprecated">
-		This sample is not maintained anymore. Check out its <a href="https://ckeditor.com/docs/ckeditor4/latest/examples/classic.html">brand new version in CKEditor SDK</a>.
+		This sample is not maintained anymore. Check out its <a href="https://ckeditor.com/docs/ckeditor4/latest/examples/classic.html">brand new version in CKEditor Examples</a>.
 	</div>
 	<form action="sample_posteddata.php" method="post">
 		<div class="description">

--- a/samples/old/replacebycode.html
+++ b/samples/old/replacebycode.html
@@ -15,7 +15,7 @@ For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-oss-license
 		<a href="index.html">CKEditor Samples</a> &raquo; Replace Textarea Elements Using JavaScript Code
 	</h1>
 	<div class="warning deprecated">
-		This sample is not maintained anymore. Check out its <a href="https://sdk.ckeditor.com/samples/classic.html">brand new version in CKEditor SDK</a>.
+		This sample is not maintained anymore. Check out its <a href="https://ckeditor.com/docs/ckeditor4/latest/examples/classic.html">brand new version in CKEditor SDK</a>.
 	</div>
 	<form action="sample_posteddata.php" method="post">
 		<div class="description">

--- a/samples/old/tabindex.html
+++ b/samples/old/tabindex.html
@@ -45,7 +45,7 @@ For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-oss-license
 		<a href="index.html">CKEditor Samples</a> &raquo; TAB Key-Based Navigation
 	</h1>
 	<div class="warning deprecated">
-		This sample is not maintained anymore. Check out its <a href="https://ckeditor.com/docs/ckeditor4/latest/examples/tabindex.html">brand new version in CKEditor SDK</a>.
+		This sample is not maintained anymore. Check out its <a href="https://ckeditor.com/docs/ckeditor4/latest/examples/tabindex.html">brand new version in CKEditor Examples</a>.
 	</div>
 	<div class="description">
 		<p>

--- a/samples/old/tabindex.html
+++ b/samples/old/tabindex.html
@@ -45,7 +45,7 @@ For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-oss-license
 		<a href="index.html">CKEditor Samples</a> &raquo; TAB Key-Based Navigation
 	</h1>
 	<div class="warning deprecated">
-		This sample is not maintained anymore. Check out its <a href="https://sdk.ckeditor.com/samples/tabindex.html">brand new version in CKEditor SDK</a>.
+		This sample is not maintained anymore. Check out its <a href="https://ckeditor.com/docs/ckeditor4/latest/examples/tabindex.html">brand new version in CKEditor SDK</a>.
 	</div>
 	<div class="description">
 		<p>

--- a/samples/old/uicolor.html
+++ b/samples/old/uicolor.html
@@ -15,7 +15,7 @@ For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-oss-license
 		<a href="index.html">CKEditor Samples</a> &raquo; UI Color
 	</h1>
 	<div class="warning deprecated">
-		This sample is not maintained anymore. Check out its <a href="https://sdk.ckeditor.com/samples/uicolor.html">brand new version in CKEditor SDK</a>.
+		This sample is not maintained anymore. Check out its <a href="https://ckeditor.com/docs/ckeditor4/latest/examples/uicolor.html">brand new version in CKEditor SDK</a>.
 	</div>
 	<div class="description">
 		<p>

--- a/samples/old/uicolor.html
+++ b/samples/old/uicolor.html
@@ -15,7 +15,7 @@ For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-oss-license
 		<a href="index.html">CKEditor Samples</a> &raquo; UI Color
 	</h1>
 	<div class="warning deprecated">
-		This sample is not maintained anymore. Check out its <a href="https://ckeditor.com/docs/ckeditor4/latest/examples/uicolor.html">brand new version in CKEditor SDK</a>.
+		This sample is not maintained anymore. Check out its <a href="https://ckeditor.com/docs/ckeditor4/latest/examples/uicolor.html">brand new version in CKEditor Examples</a>.
 	</div>
 	<div class="description">
 		<p>

--- a/samples/old/uilanguages.html
+++ b/samples/old/uilanguages.html
@@ -16,7 +16,7 @@ For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-oss-license
 		<a href="index.html">CKEditor Samples</a> &raquo; User Interface Languages
 	</h1>
 	<div class="warning deprecated">
-		This sample is not maintained anymore. Check out its <a href="https://sdk.ckeditor.com/samples/uilanguages.html">brand new version in CKEditor SDK</a>.
+		This sample is not maintained anymore. Check out its <a href="https://ckeditor.com/docs/ckeditor4/latest/examples/uilanguages.html">brand new version in CKEditor SDK</a>.
 	</div>
 	<div class="description">
 		<p>

--- a/samples/old/uilanguages.html
+++ b/samples/old/uilanguages.html
@@ -16,7 +16,7 @@ For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-oss-license
 		<a href="index.html">CKEditor Samples</a> &raquo; User Interface Languages
 	</h1>
 	<div class="warning deprecated">
-		This sample is not maintained anymore. Check out its <a href="https://ckeditor.com/docs/ckeditor4/latest/examples/uilanguages.html">brand new version in CKEditor SDK</a>.
+		This sample is not maintained anymore. Check out its <a href="https://ckeditor.com/docs/ckeditor4/latest/examples/uilanguages.html">brand new version in CKEditor Examples</a>.
 	</div>
 	<div class="description">
 		<p>

--- a/samples/old/xhtmlstyle.html
+++ b/samples/old/xhtmlstyle.html
@@ -17,7 +17,7 @@ For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-oss-license
 		<a href="index.html">CKEditor Samples</a> &raquo; Producing XHTML Compliant Output
 	</h1>
 	<div class="warning deprecated">
-		This sample is not maintained anymore. Check out its <a href="https://ckeditor.com/docs/ckeditor4/latest/examples/basicstyles.html">brand new version in CKEditor SDK</a>.
+		This sample is not maintained anymore. Check out its <a href="https://ckeditor.com/docs/ckeditor4/latest/examples/basicstyles.html">brand new version in CKEditor Examples</a>.
 	</div>
 	<div class="description">
 		<p>

--- a/samples/old/xhtmlstyle.html
+++ b/samples/old/xhtmlstyle.html
@@ -17,7 +17,7 @@ For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-oss-license
 		<a href="index.html">CKEditor Samples</a> &raquo; Producing XHTML Compliant Output
 	</h1>
 	<div class="warning deprecated">
-		This sample is not maintained anymore. Check out its <a href="https://sdk.ckeditor.com/samples/basicstyles.html">brand new version in CKEditor SDK</a>.
+		This sample is not maintained anymore. Check out its <a href="https://ckeditor.com/docs/ckeditor4/latest/examples/basicstyles.html">brand new version in CKEditor SDK</a>.
 	</div>
 	<div class="description">
 		<p>

--- a/skins/kama/readme.md
+++ b/skins/kama/readme.md
@@ -4,7 +4,7 @@
 "Kama" is the default skin of CKEditor 3.x.
 It's been ported to CKEditor 4 and fully featured.
 
-For more information about skins, please check the [CKEditor Skin SDK](https://ckeditor.com/docs/ckeditor4/latest/guide/skin_sdk_intro.html)
+For more information about skins, please check the [CKEditor Skin Example(https://ckeditor.com/docs/ckeditor4/latest/guide/skin_sdk_intro.html)
 documentation.
 
 Directory Structure

--- a/skins/kama/readme.md
+++ b/skins/kama/readme.md
@@ -4,7 +4,7 @@
 "Kama" is the default skin of CKEditor 3.x.
 It's been ported to CKEditor 4 and fully featured.
 
-For more information about skins, please check the [CKEditor Skin Example(https://ckeditor.com/docs/ckeditor4/latest/guide/skin_sdk_intro.html)
+For more information about skins, please check the [CKEditor Skin SDK](https://ckeditor.com/docs/ckeditor4/latest/guide/skin_sdk_intro.html)
 documentation.
 
 Directory Structure

--- a/skins/kama/reset.css
+++ b/skins/kama/reset.css
@@ -19,7 +19,7 @@ editors:
 	* .cke_reset_all: Intended to reset not only the element holding it, but
 	   also its child elements.
 
-To understand why "reset" is needed, check the CKEditor Skin SDK:
+To understand why "reset" is needed, check the CKEditor Skin Example:
 https://ckeditor.com/docs/ckeditor4/latest/guide/skin_sdk_reset.html
 */
 

--- a/skins/kama/reset.css
+++ b/skins/kama/reset.css
@@ -19,7 +19,7 @@ editors:
 	* .cke_reset_all: Intended to reset not only the element holding it, but
 	   also its child elements.
 
-To understand why "reset" is needed, check the CKEditor Skin Example:
+To understand why "reset" is needed, check the CKEditor Skin SDK:
 https://ckeditor.com/docs/ckeditor4/latest/guide/skin_sdk_reset.html
 */
 

--- a/skins/moono-lisa/readme.md
+++ b/skins/moono-lisa/readme.md
@@ -3,7 +3,7 @@
 
 This skin has been made a **default skin** starting from CKEditor 4.6.0 and is maintained by the core developers.
 
-For more information about skins, please check the [CKEditor Skin SDK](https://ckeditor.com/docs/ckeditor4/latest/guide/skin_sdk_intro.html)
+For more information about skins, please check the [CKEditor Skin Example](https://ckeditor.com/docs/ckeditor4/latest/guide/skin_sdk_intro.html)
 documentation.
 
 Features

--- a/skins/moono-lisa/readme.md
+++ b/skins/moono-lisa/readme.md
@@ -3,7 +3,7 @@
 
 This skin has been made a **default skin** starting from CKEditor 4.6.0 and is maintained by the core developers.
 
-For more information about skins, please check the [CKEditor Skin Example](https://ckeditor.com/docs/ckeditor4/latest/guide/skin_sdk_intro.html)
+For more information about skins, please check the [CKEditor Skin SDK](https://ckeditor.com/docs/ckeditor4/latest/guide/skin_sdk_intro.html)
 documentation.
 
 Features

--- a/skins/moono-lisa/reset.css
+++ b/skins/moono-lisa/reset.css
@@ -19,7 +19,7 @@ editors:
 	* .cke_reset_all: Intended to reset not only the element holding it, but
 	   also its child elements.
 
-To understand why "reset" is needed, check the CKEditor Skin SDK:
+To understand why "reset" is needed, check the CKEditor Skin Example:
 https://ckeditor.com/docs/ckeditor4/latest/guide/skin_sdk_reset.html
 */
 

--- a/skins/moono-lisa/reset.css
+++ b/skins/moono-lisa/reset.css
@@ -19,7 +19,7 @@ editors:
 	* .cke_reset_all: Intended to reset not only the element holding it, but
 	   also its child elements.
 
-To understand why "reset" is needed, check the CKEditor Skin Example:
+To understand why "reset" is needed, check the CKEditor Skin SDK:
 https://ckeditor.com/docs/ckeditor4/latest/guide/skin_sdk_reset.html
 */
 

--- a/skins/moono/readme.md
+++ b/skins/moono/readme.md
@@ -5,7 +5,7 @@ This skin has been chosen for the **default skin** of CKEditor 4.x (replaced by 
 elected from the CKEditor [skin contest](https://ckeditor.com/blog/CKEditor-4-Skin-Contest-Winner/) and further shaped by
 the CKEditor team. "Moono" is maintained by the core developers.
 
-For more information about skins, please check the [CKEditor Skin SDK](https://ckeditor.com/docs/ckeditor4/latest/guide/skin_sdk_intro.html)
+For more information about skins, please check the [CKEditor Skin Example](https://ckeditor.com/docs/ckeditor4/latest/guide/skin_sdk_intro.html)
 documentation.
 
 Features

--- a/skins/moono/readme.md
+++ b/skins/moono/readme.md
@@ -5,7 +5,7 @@ This skin has been chosen for the **default skin** of CKEditor 4.x (replaced by 
 elected from the CKEditor [skin contest](https://ckeditor.com/blog/CKEditor-4-Skin-Contest-Winner/) and further shaped by
 the CKEditor team. "Moono" is maintained by the core developers.
 
-For more information about skins, please check the [CKEditor Skin Example](https://ckeditor.com/docs/ckeditor4/latest/guide/skin_sdk_intro.html)
+For more information about skins, please check the [CKEditor Skin SDK](https://ckeditor.com/docs/ckeditor4/latest/guide/skin_sdk_intro.html)
 documentation.
 
 Features

--- a/skins/moono/reset.css
+++ b/skins/moono/reset.css
@@ -19,7 +19,7 @@ editors:
 	* .cke_reset_all: Intended to reset not only the element holding it, but
 	   also its child elements.
 
-To understand why "reset" is needed, check the CKEditor Skin SDK:
+To understand why "reset" is needed, check the CKEditor Skin Example:
 https://ckeditor.com/docs/ckeditor4/latest/guide/skin_sdk_reset.html
 */
 

--- a/skins/moono/reset.css
+++ b/skins/moono/reset.css
@@ -19,7 +19,7 @@ editors:
 	* .cke_reset_all: Intended to reset not only the element holding it, but
 	   also its child elements.
 
-To understand why "reset" is needed, check the CKEditor Skin Example:
+To understand why "reset" is needed, check the CKEditor Skin SDK:
 https://ckeditor.com/docs/ckeditor4/latest/guide/skin_sdk_reset.html
 */
 

--- a/tests/plugins/clipboard/manual/draganddropdata.html
+++ b/tests/plugins/clipboard/manual/draganddropdata.html
@@ -23,7 +23,7 @@
 
 <script>
 	/**
-	 * Test inspired by the SDK "Drag & Drop" sample.
+	 * Test inspired by the Example "Drag & Drop" sample.
 	 * */
 
 	if ( !CKEDITOR.env.edge ) {

--- a/tests/plugins/clipboard/manual/draganddropdata.html
+++ b/tests/plugins/clipboard/manual/draganddropdata.html
@@ -23,7 +23,7 @@
 
 <script>
 	/**
-	 * Test inspired by the Example "Drag & Drop" sample.
+	 * Test inspired by the "Drag & Drop" example.
 	 * */
 
 	if ( !CKEDITOR.env.edge ) {


### PR DESCRIPTION
## What is the purpose of this pull request?

Docs and links improvements

Task to merge after: https://github.com/ckeditor/ckeditor-docs/pull/184

### This PR contains

- [ ] Unit tests
- [ ] Manual tests

## What changes did you make?

* Replace SDK shortcut from repository and replace it with new name "Examples" to unify its occurrence.

Close #2640 