### PR TITLE
Fix for:  Custom colors added to `colorButton_colors` in form label/code don't work correctly

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -14,7 +14,7 @@ Fixed Issues:
 
 Fixed Issues:
 
-* [#1478](https://github.com/ckeditor/ckeditor-dev/issues/1478): Fixed: Custom colors added to [Color Button](https://ckeditor.com/cke4/addon/colorbutton) via [`colorButton_colors`](https://ckeditor.com/docs/ckeditor4/latest/api/CKEDITOR_config.html#cfg-colorButton_colors) in form label/code don't work correctly.
+* [#1478](https://github.com/ckeditor/ckeditor-dev/issues/1478): Fixed: Custom colors added to [Color Button](https://ckeditor.com/cke4/addon/colorbutton) via [`config.colorButton_colors`](https://ckeditor.com/docs/ckeditor4/latest/api/CKEDITOR_config.html#cfg-colorButton_colors) in form label/code don't work correctly.
 
 API Changes:
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -11,9 +11,6 @@ New Features:
 Fixed Issues:
 
 * [#2672](https://github.com/ckeditor/ckeditor-dev/issues/2672): Fixed: When resizing [Enhanced Image](https://ckeditor.com/cke4/addon/image2) to minimum size with a resizer the image dialog doesn't show actual values.
-
-Fixed Issues:
-
 * [#1478](https://github.com/ckeditor/ckeditor-dev/issues/1478): Fixed: Custom colors added to [Color Button](https://ckeditor.com/cke4/addon/colorbutton) via [`config.colorButton_colors`](https://ckeditor.com/docs/ckeditor4/latest/api/CKEDITOR_config.html#cfg-colorButton_colors) in form label/code don't work correctly.
 
 API Changes:

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -12,6 +12,10 @@ Fixed Issues:
 
 * [#2672](https://github.com/ckeditor/ckeditor-dev/issues/2672): Fixed: When resizing [Enhanced Image](https://ckeditor.com/cke4/addon/image2) to minimum size with a resizer the image dialog doesn't show actual values.
 
+Fixed Issues:
+
+* [#1478](https://github.com/ckeditor/ckeditor-dev/issues/1478): Fixed: Custom colors added to [Color Button](https://ckeditor.com/cke4/addon/colorbutton) via [`colorButton_colors`](https://ckeditor.com/docs/ckeditor4/latest/api/CKEDITOR_config.html#cfg-colorButton_colors) in form label/code don't work correctly.
+
 API Changes:
 
 * [#1496](https://github.com/ckeditor/ckeditor-dev/issues/1496): [Balloon Toolbar](https://ckeditor.com/cke4/addon/balloontoolbar) exposed methods [`CKEDITOR.ui.balloonToolbar.reposition`](https://ckeditor.com/docs/ckeditor4/latest/api/CKEDITOR_ui_balloonToolbar.html#reposition) and [`CKEDITOR.ui.balloonToolbarView.reposition`](https://ckeditor.com/docs/ckeditor4/latest/api/CKEDITOR_ui_balloonToolbarView.html#reposition).

--- a/plugins/colorbutton/plugin.js
+++ b/plugins/colorbutton/plugin.js
@@ -215,7 +215,7 @@ CKEDITOR.plugins.add( 'colorbutton', {
 						}
 					} );
 				} else {
-					return setColor( color );
+					return setColor( color && '#' + color );
 				}
 
 				function setColor( color ) {
@@ -235,7 +235,7 @@ CKEDITOR.plugins.add( 'colorbutton', {
 
 					editor.focus();
 					if ( color ) {
-						editor.applyStyle( new CKEDITOR.style( colorStyle, { color: '#' + color } ) );
+						editor.applyStyle( new CKEDITOR.style( colorStyle, { color: color } ) );
 					}
 					editor.fire( 'saveSnapshot' );
 				}

--- a/plugins/colorbutton/plugin.js
+++ b/plugins/colorbutton/plugin.js
@@ -379,7 +379,7 @@ CKEDITOR.plugins.add( 'colorbutton', {
  * **Since 4.6.2:** The default color palette has changed. It contains fewer colors in more
  * pastel shades than the previous one.
  *
- * **Since 4.11.2:** Changed how defining colors with names works. Colors names can be defined
+ * **Since 4.12.0:** Changed how defining colors with names works. Colors names can be defined
  * by `colorName/colorCode`. A color name is used only in tooltip. Output will now use a color code.
  * For example, `FontColor/FF9900` will be displayed as a color `#FF9900` in the selector, and will
  * be output as `#FF9900`.

--- a/plugins/colorbutton/plugin.js
+++ b/plugins/colorbutton/plugin.js
@@ -235,7 +235,7 @@ CKEDITOR.plugins.add( 'colorbutton', {
 
 					editor.focus();
 					if ( color ) {
-						editor.applyStyle( new CKEDITOR.style( colorStyle, { color: color } ) );
+						editor.applyStyle( new CKEDITOR.style( colorStyle, { color: '#' + color } ) );
 					}
 					editor.fire( 'saveSnapshot' );
 				}
@@ -286,7 +286,7 @@ CKEDITOR.plugins.add( 'colorbutton', {
 						' title="', colorLabel, '"' +
 						' draggable="false"' +
 						' ondragstart="return false;"' + // Draggable attribute is buggy on Firefox.
-						' onclick="CKEDITOR.tools.callFunction(', clickFn, ',\'#', colorCode, '\',\'', type, '\'); return false;"' +
+						' onclick="CKEDITOR.tools.callFunction(', clickFn, ',\'', colorCode, '\',\'', type, '\'); return false;"' +
 						' href="javascript:void(\'', colorCode, '\')"' +
 						' data-value="' + colorCode + '"' +
 						' role="option" aria-posinset="', ( i + 2 ), '" aria-setsize="', total, '">' +

--- a/plugins/colorbutton/plugin.js
+++ b/plugins/colorbutton/plugin.js
@@ -276,7 +276,6 @@ CKEDITOR.plugins.add( 'colorbutton', {
 				// Additionally, if the data is a single color code then let's try to translate it or fallback on the
 				// color code. If the data is a color name/code, then use directly the color name provided.
 				if ( !parts[ 1 ] ) {
-					colorName = '#' + colorName.replace( /^(.)(.)(.)$/, '$1$1$2$2$3$3' );
 					colorLabel = editor.lang.colorbutton.colors[ colorCode ] || colorCode;
 				} else {
 					colorLabel = colorName;
@@ -287,8 +286,8 @@ CKEDITOR.plugins.add( 'colorbutton', {
 						' title="', colorLabel, '"' +
 						' draggable="false"' +
 						' ondragstart="return false;"' + // Draggable attribute is buggy on Firefox.
-						' onclick="CKEDITOR.tools.callFunction(', clickFn, ',\'', colorName, '\',\'', type, '\'); return false;"' +
-						' href="javascript:void(\'', colorLabel, '\')"' +
+						' onclick="CKEDITOR.tools.callFunction(', clickFn, ',\'#', colorCode, '\',\'', type, '\'); return false;"' +
+						' href="javascript:void(\'', colorCode, '\')"' +
 						' data-value="' + colorCode + '"' +
 						' role="option" aria-posinset="', ( i + 2 ), '" aria-setsize="', total, '">' +
 						'<span class="cke_colorbox" style="background-color:#', colorCode, '"></span>' +

--- a/plugins/colorbutton/plugin.js
+++ b/plugins/colorbutton/plugin.js
@@ -374,9 +374,15 @@ CKEDITOR.plugins.add( 'colorbutton', {
  * **Since 3.3:** A color name may optionally be defined by prefixing the entries with
  * a name and the slash character. For example, `'FontColor1/FF9900'` will be
  * displayed as the color `#FF9900` in the selector, but will be output as `'FontColor1'`.
+ * **This behaviour has been altered in 4.11.2**
  *
  * **Since 4.6.2:** The default color palette has changed. It contains fewer colors in more
  * pastel shades than the previous one.
+ *
+ * **Since 4.11.2:** Changed how defining colors with names works. Colors names can be defined
+ * by `colorName/colorCode`. A color name is used only in tooltip. Output will now use a color code.
+ * For example, `FontColor/FF9900` will be displayed as a color `#FF9900` in the selector, and will
+ * be output as `#FF9900`.
  *
  * Read more in the {@glink guide/dev_colorbutton documentation}
  * and see the {@glink examples/colorbutton example}.

--- a/plugins/colorbutton/plugin.js
+++ b/plugins/colorbutton/plugin.js
@@ -374,7 +374,7 @@ CKEDITOR.plugins.add( 'colorbutton', {
  * **Since 3.3:** A color name may optionally be defined by prefixing the entries with
  * a name and the slash character. For example, `'FontColor1/FF9900'` will be
  * displayed as the color `#FF9900` in the selector, but will be output as `'FontColor1'`.
- * **This behaviour has been altered in 4.11.2**
+ * **This behaviour has been altered in 4.12.0**
  *
  * **Since 4.6.2:** The default color palette has changed. It contains fewer colors in more
  * pastel shades than the previous one.

--- a/tests/plugins/colorbutton/config.js
+++ b/tests/plugins/colorbutton/config.js
@@ -74,7 +74,8 @@
 			colorSquare.$.onclick();
 
 			assert.beautified.html( bender.tools.selection.getWithHtml( editor ), '<p><span style="background-color:#ff9900;">[foo]</span></p>', {
-				customFilters: [ filter ]
+				customFilters: [ filter ],
+				fixStyles: true
 			} );
 		}
 	} );

--- a/tests/plugins/colorbutton/config.js
+++ b/tests/plugins/colorbutton/config.js
@@ -46,6 +46,36 @@
 			CKEDITOR.tools.array.map( colorOptions.toArray(), function( el, index ) {
 				assert.areSame( expectedLabels[ index ], colorOptions.getItem( index ).getAttribute( 'title' ), 'Title for color at index ' + index );
 			} );
+		},
+
+		// #1478
+		'test config.colorButton_colors applies color': function() {
+			var editor = this.editors.colorLabels,
+				bgColorBtn = editor.ui.get( 'BGColor' ),
+				filter = new CKEDITOR.htmlParser.filter( {
+					text: function( value ) {
+						return value.replace( '{', '[' ).replace( '}', ']' );
+					},
+					elements: {
+						br: function() {
+							return false;
+						}
+					}
+				} ),
+				colorSquare;
+
+			bender.tools.selection.setWithHtml( editor, '<p>[foo]</p>' );
+
+			editor.focus();
+			bgColorBtn.click( editor );
+
+			colorSquare = bgColorBtn._.panel.getBlock( bgColorBtn._.id ).element.findOne( 'a.cke_colorbox[data-value=FF9900]' );
+
+			colorSquare.$.onclick();
+
+			assert.beautified.html( bender.tools.selection.getWithHtml( editor ), '<p><span style="background-color:#ff9900;">[foo]</span></p>', {
+				customFilters: [ filter ]
+			} );
 		}
 	} );
 } )();

--- a/tests/plugins/colorbutton/config.js
+++ b/tests/plugins/colorbutton/config.js
@@ -48,7 +48,7 @@
 			} );
 		},
 
-		// #1478
+		// (#1478)
 		'test config.colorButton_colors applies color': function() {
 			var editor = this.editors.colorLabels,
 				bgColorBtn = editor.ui.get( 'BGColor' ),

--- a/tests/plugins/colorbutton/manual/customcolors.html
+++ b/tests/plugins/colorbutton/manual/customcolors.html
@@ -2,6 +2,7 @@
 
 <script>
 	CKEDITOR.replace( 'editor', {
-		colorButton_colors: 'Not blue/F00,00F'
+		colorButton_colors: 'Not blue/F00,00F',
+		removeButtons: 'BGColor'
 	} );
 </script>

--- a/tests/plugins/colorbutton/manual/customcolors.html
+++ b/tests/plugins/colorbutton/manual/customcolors.html
@@ -1,0 +1,7 @@
+<textarea id="editor" name="editor">Test text.</textarea>
+
+<script>
+	CKEDITOR.replace( 'editor', {
+		colorButton_colors: 'Not blue/F00,00F'
+	} );
+</script>

--- a/tests/plugins/colorbutton/manual/customcolors.md
+++ b/tests/plugins/colorbutton/manual/customcolors.md
@@ -1,0 +1,21 @@
+@bender-tags: bug, 1478, 4.11.2
+@bender-ui: collapsed
+@bender-ckeditor-plugins: wysiwygarea, toolbar, colorbutton, colordialog, sourcearea
+
+1. Select first word.
+1. Hover over red square.
+
+	### Expected:
+
+	Tooltip displays: `Not blue`
+
+1. Press red square.
+
+### Expected:
+
+Selected text turns red.
+
+
+### Unexpected:
+
+Selected text doesn't change color.

--- a/tests/plugins/colorbutton/manual/customcolors.md
+++ b/tests/plugins/colorbutton/manual/customcolors.md
@@ -3,6 +3,7 @@
 @bender-ckeditor-plugins: wysiwygarea, toolbar, colorbutton, colordialog, sourcearea
 
 1. Select first word.
+1. Press on text color button.
 1. Hover over red square.
 
 	### Expected:

--- a/tests/plugins/colorbutton/manual/customcolors.md
+++ b/tests/plugins/colorbutton/manual/customcolors.md
@@ -1,4 +1,4 @@
-@bender-tags: bug, 1478, 4.11.2
+@bender-tags: bug, 1478, 4.12.0
 @bender-ui: collapsed
 @bender-ckeditor-plugins: wysiwygarea, toolbar, colorbutton, colordialog, sourcearea
 


### PR DESCRIPTION
## What is the purpose of this pull request?

<!-- Bug fix / New feature / Typo fix / Other, please explain  -->

## Does your PR contain necessary tests?

All patches which change the editor code must include tests. You can always read more
on [PR testing](https://ckeditor.com/docs/ckeditor4/latest/guide/dev_contributing_code.html#tests),
[how to set the testing environment](https://ckeditor.com/docs/ckeditor4/latest/guide/dev_tests.html) and
[how to create tests](https://ckeditor.com/docs/ckeditor4/latest/guide/dev_tests.html#creating-your-own-test)
in the official CKEditor documentation.

### This PR contains

- [x] Unit tests
- [x] Manual tests

## What changes did you make?

Forced plugin to set `colorCode` instead of `colorName` on text.
Reason behind this change can be found here: https://github.com/ckeditor/ckeditor-dev/issues/1478#issuecomment-444112312

Closes #1478