### PR TITLE
Fix for: image2 throws an exception when empty figure with class 'image' is upcasted

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -10,6 +10,7 @@ Fixed Issues:
 * [#2514](https://github.com/ckeditor/ckeditor-dev/issues/2403): Fixed: Pasting table data into inline editor initialized inside a table with [Table Selection](https://ckeditor.com/cke4/addon/tabletools) plugin inserts pasted content into a wrapping table.
 * [#2451](https://github.com/ckeditor/ckeditor-dev/issues/2451): Fixed: The [Remove Format](https://ckeditor.com/cke4/addon/removeformat) changes selection.
 * [#2546](https://github.com/ckeditor/ckeditor-dev/issues/2546): Fixed: Separator in toolbar moves when buttons are focused.
+* [#2506](https://github.com/ckeditor/ckeditor-dev/issues/2506): Fixed: [Enhanced Image](https://ckeditor.com/cke4/addon/image2) throws type error when empty figure tag with 'image' class is upcasted.
 
 Other Changes:
 

--- a/plugins/image2/plugin.js
+++ b/plugins/image2/plugin.js
@@ -942,7 +942,8 @@
 
 			// No center wrapper has been found.
 			else if ( name == 'figure' && el.hasClass( captionedClass ) ) {
-				image = el.getFirst( 'img' ) || el.getFirst( 'a' ).getFirst( 'img' );
+				var anchor = el.getFirst( 'a' );
+				image = el.getFirst( 'img' ) || ( anchor && anchor.getFirst( 'img' ) );
 
 				// Upcast linked image like <a><img/></a>.
 			} else if ( isLinkedOrStandaloneImage( el ) ) {

--- a/plugins/image2/plugin.js
+++ b/plugins/image2/plugin.js
@@ -942,8 +942,10 @@
 
 			// No center wrapper has been found.
 			else if ( name == 'figure' && el.hasClass( captionedClass ) ) {
-				var anchor = el.getFirst( 'a' );
-				image = el.getFirst( 'img' ) || ( anchor && anchor.getFirst( 'img' ) );
+				image = el.find( function( child ) {
+					return child.name === 'img' &&
+						CKEDITOR.tools.array.indexOf( [ 'figure', 'a' ], child.parent.name ) !== -1;
+				}, true )[ 0 ];
 
 				// Upcast linked image like <a><img/></a>.
 			} else if ( isLinkedOrStandaloneImage( el ) ) {

--- a/tests/plugins/image2/manual/upcast.html
+++ b/tests/plugins/image2/manual/upcast.html
@@ -1,0 +1,8 @@
+<textarea id="editor"></textarea>
+
+<script>
+	if ( bender.tools.env.mobile ) {
+		bender.ignore();
+	}
+	CKEDITOR.replace( 'editor' );
+</script>

--- a/tests/plugins/image2/manual/upcast.html
+++ b/tests/plugins/image2/manual/upcast.html
@@ -1,8 +1,27 @@
 <textarea id="editor"></textarea>
-
+<div class="buttons">
+	<button data-empty-figure="true">
+		Insert empty figure element.
+	</button>
+	<button data-empty-figure="false">
+		Insert figure element containing anchor element.
+	</button>
+</div>
 <script>
 	if ( bender.tools.env.mobile ) {
 		bender.ignore();
 	}
-	CKEDITOR.replace( 'editor' );
+	var editor = CKEDITOR.replace( 'editor', { allowedContent: true } ),
+		emptyFigure = '<figure class="image"></figure>',
+		figureWithAnchor = '<figure class="image"><a href="#">Foo</a></figure>';
+
+	CKEDITOR.document.findOne( '.buttons' ).on( 'click', function( evt ) {
+		var target = evt.data.getTarget();
+
+		if ( !target.hasAttribute( 'data-empty-figure' ) ) {
+			return;
+		}
+
+		editor.setData( target.getAttribute( 'data-empty-figure' ) === 'true' ? emptyFigure : figureWithAnchor );
+	} );
 </script>

--- a/tests/plugins/image2/manual/upcast.md
+++ b/tests/plugins/image2/manual/upcast.md
@@ -1,12 +1,9 @@
 @bender-tags: 4.11.2, bug, 2506
 @bender-ui: collapsed
-@bender-ckeditor-plugins: wysiwygarea, toolbar, image2, sourcearea
+@bender-ckeditor-plugins: wysiwygarea, toolbar, image2
 
 1. Open developer console.
-1. Press `source` button.
-1. Paste following into editor:
-<textarea><figure class="image"></figure></textarea>
-1. Press `source` again.
+1. Press both buttons below editor.
 
 ## Expected:
 

--- a/tests/plugins/image2/manual/upcast.md
+++ b/tests/plugins/image2/manual/upcast.md
@@ -1,0 +1,17 @@
+@bender-tags: 4.11.2, bug, 2506
+@bender-ui: collapsed
+@bender-ckeditor-plugins: wysiwygarea, toolbar, image2, sourcearea
+
+1. Open developer console.
+1. Press `source` button.
+1. Paste following into editor:
+<textarea><figure class="image"></figure></textarea>
+1. Press `source` again.
+
+## Expected:
+
+- There are no errors logged to console.
+
+## Unexpected:
+
+- `TypeError` is thrown.

--- a/tests/plugins/image2/upcast.js
+++ b/tests/plugins/image2/upcast.js
@@ -37,7 +37,7 @@
 				name: 'enterP',
 				data: '<p style="text-align:center">' +
 					'<img id="w1" src="_assets/foo.png" alt="foo" />' +
-				'</p>'
+					'</p>'
 			}, function( editor ) {
 				var instances = objToArray( editor.widgets.instances ),
 					widget = instances[ 0 ];
@@ -53,7 +53,7 @@
 				data: '<p style="text-align:center">' +
 					'<span>sibling</span>' +
 					'<img id="w1" src="_assets/foo.png" alt="foo" />' +
-				'</p>'
+					'</p>'
 			}, function( editor ) {
 				var instances = objToArray( editor.widgets.instances ),
 					widget = instances[ 0 ];
@@ -69,7 +69,7 @@
 				name: 'enterP',
 				data: '<div style="text-align:center">' +
 					'<img id="w1" src="_assets/foo.png" alt="foo" />' +
-				'</div>'
+					'</div>'
 			}, function( editor ) {
 				var instances = objToArray( editor.widgets.instances ),
 					widget = instances[ 0 ];
@@ -85,7 +85,7 @@
 				name: 'enterBR',
 				data: '<div style="text-align:center">' +
 					'<img id="w1" src="_assets/foo.png" alt="foo" />' +
-				'</div>'
+					'</div>'
 			}, function( editor ) {
 				var instances = objToArray( editor.widgets.instances ),
 					widget = instances[ 0 ];
@@ -102,7 +102,7 @@
 				data: '<div style="text-align:center">' +
 					'sibling' +
 					'<img id="w1" src="_assets/foo.png" alt="foo" />' +
-				'</div>'
+					'</div>'
 			}, function( editor ) {
 				var instances = objToArray( editor.widgets.instances ),
 					widget = instances[ 0 ];
@@ -119,7 +119,7 @@
 				data: '<div style="text-align:center">' +
 					'sibling' +
 					'<img id="w1" src="_assets/foo.png" alt="foo" />' +
-				'</div>'
+					'</div>'
 			}, function( editor ) {
 				var instances = objToArray( editor.widgets.instances ),
 					widget = instances[ 0 ],
@@ -128,6 +128,17 @@
 
 				assert.areSame( expectedLabel, widget.getLabel(), 'getLabel() return value' );
 				assert.areSame( expectedLabel, widget.wrapper.getAttribute( 'aria-label' ), 'widget aria-label value' );
+			} );
+		},
+
+		// #2506
+		'test upcast: empty figure with class="image"': function() {
+			assertUpcast( {
+				name: 'enterP',
+				data: '<figure class="image"></figure>'
+			}, function( editor ) {
+				var instances = objToArray( editor.widgets.instances );
+				assert.areEqual( instances.length, 0, 'Element shouldn\'t be upcasted as widget.' );
 			} );
 		}
 	} );

--- a/tests/plugins/image2/upcast.js
+++ b/tests/plugins/image2/upcast.js
@@ -36,7 +36,7 @@
 			assertUpcast( {
 				name: 'enterP',
 				data: '<p style="text-align:center">' +
-					'<img id="w1" src="_assets/foo.png" alt="foo" />' +
+						'<img id="w1" src="_assets/foo.png" alt="foo" />' +
 					'</p>'
 			}, function( editor ) {
 				var instances = objToArray( editor.widgets.instances ),
@@ -51,8 +51,8 @@
 			assertUpcast( {
 				name: 'enterP',
 				data: '<p style="text-align:center">' +
-					'<span>sibling</span>' +
-					'<img id="w1" src="_assets/foo.png" alt="foo" />' +
+						'<span>sibling</span>' +
+						'<img id="w1" src="_assets/foo.png" alt="foo" />' +
 					'</p>'
 			}, function( editor ) {
 				var instances = objToArray( editor.widgets.instances ),
@@ -68,7 +68,7 @@
 			assertUpcast( {
 				name: 'enterP',
 				data: '<div style="text-align:center">' +
-					'<img id="w1" src="_assets/foo.png" alt="foo" />' +
+						'<img id="w1" src="_assets/foo.png" alt="foo" />' +
 					'</div>'
 			}, function( editor ) {
 				var instances = objToArray( editor.widgets.instances ),
@@ -84,7 +84,7 @@
 			assertUpcast( {
 				name: 'enterBR',
 				data: '<div style="text-align:center">' +
-					'<img id="w1" src="_assets/foo.png" alt="foo" />' +
+						'<img id="w1" src="_assets/foo.png" alt="foo" />' +
 					'</div>'
 			}, function( editor ) {
 				var instances = objToArray( editor.widgets.instances ),
@@ -100,8 +100,8 @@
 			assertUpcast( {
 				name: 'enterBR',
 				data: '<div style="text-align:center">' +
-					'sibling' +
-					'<img id="w1" src="_assets/foo.png" alt="foo" />' +
+						'sibling' +
+						'<img id="w1" src="_assets/foo.png" alt="foo" />' +
 					'</div>'
 			}, function( editor ) {
 				var instances = objToArray( editor.widgets.instances ),
@@ -117,8 +117,8 @@
 			assertUpcast( {
 				name: 'enterP',
 				data: '<div style="text-align:center">' +
-					'sibling' +
-					'<img id="w1" src="_assets/foo.png" alt="foo" />' +
+						'sibling' +
+						'<img id="w1" src="_assets/foo.png" alt="foo" />' +
 					'</div>'
 			}, function( editor ) {
 				var instances = objToArray( editor.widgets.instances ),


### PR DESCRIPTION
## What is the purpose of this pull request?

Bug Fix

## Does your PR contain necessary tests?

All patches which change the editor code must include tests. You can always read more
on [PR testing](https://ckeditor.com/docs/ckeditor4/latest/guide/dev_contributing_code.html#tests),
[how to set the testing environment](https://ckeditor.com/docs/ckeditor4/latest/guide/dev_tests.html) and
[how to create tests](https://ckeditor.com/docs/ckeditor4/latest/guide/dev_tests.html#creating-your-own-test)
in the official CKEditor documentation.

### This PR contains

- [x] Unit tests
- [x] Manual tests

## What changes did you make?

Added an extra check in upcasting method, so it won't throw type error.

Closes #2506