### PR TITLE
Fix for: table dialog validator fails when function getValue is defined in global scope

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -11,6 +11,7 @@ Fixed Issues:
 * [#2451](https://github.com/ckeditor/ckeditor-dev/issues/2451): Fixed: The [Remove Format](https://ckeditor.com/cke4/addon/removeformat) changes selection.
 * [#2546](https://github.com/ckeditor/ckeditor-dev/issues/2546): Fixed: Separator in toolbar moves when buttons are focused.
 * [#2506](https://github.com/ckeditor/ckeditor-dev/issues/2506): Fixed: [Enhanced Image](https://ckeditor.com/cke4/addon/image2) throws type error when empty figure tag with 'image' class is upcasted.
+* [#2650](https://github.com/ckeditor/ckeditor-dev/issues/2650): Fixed: [Table](https://ckeditor.com/cke4/addon/table) dialog validator fails when function `getValue` is defined in global scope.
 
 Other Changes:
 

--- a/plugins/table/dialogs/table.js
+++ b/plugins/table/dialogs/table.js
@@ -34,7 +34,7 @@
 	function validatorNum( msg ) {
 		return function() {
 			var value = this.getValue(),
-				pass = !!( CKEDITOR.dialog.validate.integer()( value ) && value > 0 );
+				pass = !!( CKEDITOR.dialog.validate.integer().call( this, value ) && value > 0 );
 
 			if ( !pass ) {
 				alert( msg ); // jshint ignore:line

--- a/tests/plugins/table/manual/dialogvalidate.html
+++ b/tests/plugins/table/manual/dialogvalidate.html
@@ -1,0 +1,6 @@
+<textarea id="editor"></textarea>
+
+<script>
+	CKEDITOR.replace( 'editor' );
+	window.getValue = function() {return false;}
+</script>

--- a/tests/plugins/table/manual/dialogvalidate.md
+++ b/tests/plugins/table/manual/dialogvalidate.md
@@ -1,0 +1,15 @@
+@bender-tags: 4.11.2, bug, 2650
+@bender-ui: collapsed
+@bender-ckeditor-plugins: wysiwygarea,toolbar,table,sourcearea,dialogadvtab
+
+1. Open table dialog.
+2. Press `ok`.
+
+## Expected
+
+Table is inserted into editor.
+
+## Unexpected
+
+Alert popups with information:
+`Number of rows must be a number greater than 0.`

--- a/tests/plugins/table/validate.js
+++ b/tests/plugins/table/validate.js
@@ -1,0 +1,20 @@
+/* bender-tags: editor */
+/* bender-ckeditor-plugins: dialogadvtab,table,toolbar,wysiwygarea */
+
+( function() {
+	'use strict';
+
+	bender.editor = {};
+
+	bender.test( {
+		// #2650
+		'test validator when global scope is polluted': function() {
+			this.editorBot.dialog( 'table', function( dialog ) {
+				var spy = window.getValue = sinon.spy();
+
+				dialog.getButton( 'ok' ).click();
+				assert.isFalse( spy.called );
+			} );
+		}
+	} );
+} )();


### PR DESCRIPTION
## What is the purpose of this pull request?

Bug fix

## Does your PR contain necessary tests?

All patches which change the editor code must include tests. You can always read more
on [PR testing](https://ckeditor.com/docs/ckeditor4/latest/guide/dev_contributing_code.html#tests),
[how to set the testing environment](https://ckeditor.com/docs/ckeditor4/latest/guide/dev_tests.html) and
[how to create tests](https://ckeditor.com/docs/ckeditor4/latest/guide/dev_tests.html#creating-your-own-test)
in the official CKEditor documentation.

### This PR contains

- [X] Unit tests
- [X] Manual tests

## What changes did you make?

As `dialog.validate` methods are defined to be used with proper context I've updated `validatorNum ` helper in table dialog.

Closes #2650 