### PR TITLE
Fix for: Failing tests /tests/core/tools/absoluterectposition

### DIFF
--- a/tests/core/tools/absoluterectposition.js
+++ b/tests/core/tools/absoluterectposition.js
@@ -3,12 +3,23 @@
 ( function() {
 	'use strict';
 
-	var tests = {
+	var scrollPositionMock,
+		windowMock,
+		tests = {
 		setUp: function() {
+			var window = CKEDITOR.document.getWindow();
+
+			windowMock = sinon.stub( CKEDITOR.document, 'getWindow' );
+			windowMock.returns( window );
+
 			CKEDITOR.document.getBody().setStyle( 'height', '5000px' );
+
+			scrollPositionMock = sinon.stub( window, 'getScrollPosition' );
+			scrollPositionMock.returns( { x: 0, y: 0 } );
 		},
 		tearDown: function() {
-			window.scrollBy( 0, -CKEDITOR.document.getWindow().getScrollPosition().y );
+			scrollPositionMock.restore();
+			windowMock.restore();
 		},
 		'test absolute rect inline': function() {
 			var rect = {
@@ -32,7 +43,7 @@
 
 			assertRect( absoluteRect, expected );
 
-			window.scrollBy( 0, 100 );
+			scrollPositionMock.returns( { x: 0, y: 100 } );
 			// We are adjusting the rect, as an element would move when scrolling.
 			updateVerticalRectParts( rect, -100 );
 			absoluteRect = CKEDITOR.tools.getAbsoluteRectPosition( mockedWindow, rect );
@@ -89,7 +100,7 @@
 
 			assertRect( absoluteRect, expected );
 
-			window.scrollBy( 0, 100 );
+			scrollPositionMock.returns( { x: 0, y: 100 } );
 			// We need to change frameRect as it would be scrolled.
 			updateVerticalRectParts( frameRect, -100 );
 			absoluteRect = CKEDITOR.tools.getAbsoluteRectPosition( mockedWindow, rect );

--- a/tests/core/tools/absoluterectposition.js
+++ b/tests/core/tools/absoluterectposition.js
@@ -7,14 +7,16 @@
 		tests = {
 		setUp: function() {
 			CKEDITOR.document.getBody().setStyle( 'height', '5000px' );
-
-			scrollPositionMock = sinon.stub( CKEDITOR.dom.window.prototype, 'getScrollPosition' );
-			scrollPositionMock.returns( { x: 0, y: 0 } );
 		},
 		tearDown: function() {
-			scrollPositionMock.restore();
+			if ( scrollPositionMock ) {
+				scrollPositionMock.restore();
+				scrollPositionMock = null;
+			}
 		},
 		'test absolute rect inline': function() {
+			scrollPositionMock = sinon.stub( CKEDITOR.dom.window.prototype, 'getScrollPosition' ).returns( { x: 0, y: 0 } );
+
 			var rect = {
 					bottom: 10,
 					height: 10,
@@ -44,6 +46,8 @@
 			assertRect( absoluteRect, expected );
 		},
 		'test absolute rect classic': function() {
+			scrollPositionMock = sinon.stub( CKEDITOR.dom.window.prototype, 'getScrollPosition' ).returns( { x: 0, y: 0 } );
+
 			var rect = {
 					bottom: 10,
 					height: 10,

--- a/tests/core/tools/absoluterectposition.js
+++ b/tests/core/tools/absoluterectposition.js
@@ -4,22 +4,15 @@
 	'use strict';
 
 	var scrollPositionMock,
-		windowMock,
 		tests = {
 		setUp: function() {
-			var window = CKEDITOR.document.getWindow();
-
-			windowMock = sinon.stub( CKEDITOR.document, 'getWindow' );
-			windowMock.returns( window );
-
 			CKEDITOR.document.getBody().setStyle( 'height', '5000px' );
 
-			scrollPositionMock = sinon.stub( window, 'getScrollPosition' );
+			scrollPositionMock = sinon.stub( CKEDITOR.dom.window.prototype, 'getScrollPosition' );
 			scrollPositionMock.returns( { x: 0, y: 0 } );
 		},
 		tearDown: function() {
 			scrollPositionMock.restore();
-			windowMock.restore();
 		},
 		'test absolute rect inline': function() {
 			var rect = {

--- a/tests/core/tools/absoluterectposition.js
+++ b/tests/core/tools/absoluterectposition.js
@@ -5,106 +5,106 @@
 
 	var scrollPositionMock,
 		tests = {
-		setUp: function() {
-			CKEDITOR.document.getBody().setStyle( 'height', '5000px' );
-		},
-		tearDown: function() {
-			if ( scrollPositionMock ) {
-				scrollPositionMock.restore();
-				scrollPositionMock = null;
+			setUp: function() {
+				CKEDITOR.document.getBody().setStyle( 'height', '5000px' );
+			},
+			tearDown: function() {
+				if ( scrollPositionMock ) {
+					scrollPositionMock.restore();
+					scrollPositionMock = null;
+				}
+			},
+			'test absolute rect inline': function() {
+				scrollPositionMock = sinon.stub( CKEDITOR.dom.window.prototype, 'getScrollPosition' ).returns( { x: 0, y: 0 } );
+
+				var rect = {
+						bottom: 10,
+						height: 10,
+						left: 0,
+						right: 10,
+						top: 0,
+						width: 10,
+						x: 0,
+						y: 0
+					},
+					expected = CKEDITOR.tools.copy( rect ),
+					// Mimic inline editor, as it is outside of an iframe.
+					mockedWindow = {
+						getFrame: function() {
+							return null;
+						}
+					},
+					absoluteRect = CKEDITOR.tools.getAbsoluteRectPosition( mockedWindow, rect );
+
+				assertRect( absoluteRect, expected );
+
+				scrollPositionMock.returns( { x: 0, y: 100 } );
+				// We are adjusting the rect, as an element would move when scrolling.
+				updateVerticalRectParts( rect, -100 );
+				absoluteRect = CKEDITOR.tools.getAbsoluteRectPosition( mockedWindow, rect );
+
+				assertRect( absoluteRect, expected );
+			},
+			'test absolute rect classic': function() {
+				scrollPositionMock = sinon.stub( CKEDITOR.dom.window.prototype, 'getScrollPosition' ).returns( { x: 0, y: 0 } );
+
+				var rect = {
+						bottom: 10,
+						height: 10,
+						left: 0,
+						right: 10,
+						top: 0,
+						width: 10,
+						x: 0,
+						y: 0
+					},
+					expected = {
+						bottom: 119,
+						height: 10,
+						left: 100,
+						right: 110,
+						top: 109,
+						width: 10,
+						x: 100,
+						y: 109
+					},
+					frameRect = {
+						bottom: 309,
+						height: 200,
+						left: 100,
+						right: 400,
+						top: 109,
+						width: 300,
+						x: 100,
+						y: 109
+					},
+					// Mimic classic editor, as it would be inside an iframe.
+					mockedWindow = {
+						getFrame: function() {
+							return {
+								getClientRect: function() {
+									return frameRect;
+								},
+								getWindow: function() {
+									return {
+										getFrame: function() {}
+									};
+								}
+							};
+						}
+					},
+					absoluteRect = CKEDITOR.tools.getAbsoluteRectPosition( mockedWindow, rect );
+
+				assertRect( absoluteRect, expected );
+
+				scrollPositionMock.returns( { x: 0, y: 100 } );
+				// We need to change frameRect as it would be scrolled.
+				updateVerticalRectParts( frameRect, -100 );
+				absoluteRect = CKEDITOR.tools.getAbsoluteRectPosition( mockedWindow, rect );
+
+				assertRect( absoluteRect, expected );
 			}
-		},
-		'test absolute rect inline': function() {
-			scrollPositionMock = sinon.stub( CKEDITOR.dom.window.prototype, 'getScrollPosition' ).returns( { x: 0, y: 0 } );
-
-			var rect = {
-					bottom: 10,
-					height: 10,
-					left: 0,
-					right: 10,
-					top: 0,
-					width: 10,
-					x: 0,
-					y: 0
-				},
-				expected = CKEDITOR.tools.copy( rect ),
-				// Mimic inline editor, as it is outside of an iframe.
-				mockedWindow = {
-					getFrame: function() {
-						return null;
-					}
-				},
-				absoluteRect = CKEDITOR.tools.getAbsoluteRectPosition( mockedWindow, rect );
-
-			assertRect( absoluteRect, expected );
-
-			scrollPositionMock.returns( { x: 0, y: 100 } );
-			// We are adjusting the rect, as an element would move when scrolling.
-			updateVerticalRectParts( rect, -100 );
-			absoluteRect = CKEDITOR.tools.getAbsoluteRectPosition( mockedWindow, rect );
-
-			assertRect( absoluteRect, expected );
-		},
-		'test absolute rect classic': function() {
-			scrollPositionMock = sinon.stub( CKEDITOR.dom.window.prototype, 'getScrollPosition' ).returns( { x: 0, y: 0 } );
-
-			var rect = {
-					bottom: 10,
-					height: 10,
-					left: 0,
-					right: 10,
-					top: 0,
-					width: 10,
-					x: 0,
-					y: 0
-				},
-				expected = {
-					bottom: 119,
-					height: 10,
-					left: 100,
-					right: 110,
-					top: 109,
-					width: 10,
-					x: 100,
-					y: 109
-				},
-				frameRect = {
-					bottom: 309,
-					height: 200,
-					left: 100,
-					right: 400,
-					top: 109,
-					width: 300,
-					x: 100,
-					y: 109
-				},
-				// Mimic classic editor, as it would be inside an iframe.
-				mockedWindow = {
-					getFrame: function() {
-						return {
-							getClientRect: function() {
-								return frameRect;
-							},
-							getWindow: function() {
-								return {
-									getFrame: function() {}
-								};
-							}
-						};
-					}
-				},
-				absoluteRect = CKEDITOR.tools.getAbsoluteRectPosition( mockedWindow, rect );
-
-			assertRect( absoluteRect, expected );
-
-			scrollPositionMock.returns( { x: 0, y: 100 } );
-			// We need to change frameRect as it would be scrolled.
-			updateVerticalRectParts( frameRect, -100 );
-			absoluteRect = CKEDITOR.tools.getAbsoluteRectPosition( mockedWindow, rect );
-
-			assertRect( absoluteRect, expected );
-		}
-	};
+		};
 
 	bender.test( tests );
 


### PR DESCRIPTION
## What is the purpose of this pull request?

Fix for failing tests

## Does your PR contain necessary tests?

All patches which change the editor code must include tests. You can always read more
on [PR testing](https://ckeditor.com/docs/ckeditor4/latest/guide/dev_contributing_code.html#tests),
[how to set the testing environment](https://ckeditor.com/docs/ckeditor4/latest/guide/dev_tests.html) and
[how to create tests](https://ckeditor.com/docs/ckeditor4/latest/guide/dev_tests.html#creating-your-own-test)
in the official CKEditor documentation.

### This PR contains

- [ ] Unit tests
- [ ] Manual tests

## What changes did you make?

Mocked `window.getScrollPosition` so test gives consistent results.

Closes #2566 
