### PR TITLE
Fix for failing test tests/plugins/balloontoolbar/positioning

### DIFF
--- a/tests/plugins/balloontoolbar/positioning.js
+++ b/tests/plugins/balloontoolbar/positioning.js
@@ -52,7 +52,7 @@
 			}
 		},
 
-		'test divaera - out of view - bottom center': function( editor ) {
+		'test panel - out of view - bottom center': function( editor ) {
 			if ( editor.name == 'divarea' ) {
 				// divarea tests are failing, it's an upstream issue from balloonpanel (#1064).
 				assert.ignore();
@@ -91,7 +91,7 @@
 			balloonToolbar = null;
 		},
 
-		'test divaera - out of view - hcenter top': function( editor ) {
+		'test panel - out of view - hcenter top': function( editor ) {
 			if ( editor.name == 'divarea' ) {
 				// divarea tests are failing, it's an upstream issue from balloonpanel (#1064).
 				assert.ignore();

--- a/tests/plugins/balloontoolbar/positioning.js
+++ b/tests/plugins/balloontoolbar/positioning.js
@@ -34,7 +34,16 @@
 				parentFrame.style.height = '900px';
 			}
 
-			CKEDITOR.document.$.documentElement.scrollTop = 0;
+			var doc = CKEDITOR.document.getDocumentElement(),
+				body = CKEDITOR.document.getBody();
+
+			if ( doc.$.scrollTop ) {
+				doc.$.scrollTop = 0;
+			}
+
+			if ( body.$.scrollTop ) {
+				body.$.scrollTop = 0;
+			}
 		},
 
 		tearDown: function() {
@@ -60,10 +69,12 @@
 				// Mock view pane size to prevent that.
 				viewPaneMock = mockWindowViewPaneSize( { width: 1000, height: 1000 } ),
 				scrollTop,
-				balloonToolbarRect;
+				balloonToolbarRect,
+				rectTop;
 
 			balloonToolbar.attach( markerElement );
 			balloonToolbarRect = balloonToolbar.parts.panel.getClientRect();
+			rectTop = CKEDITOR.env.ie || !CKEDITOR.env.edge ? Math.round( balloonToolbarRect.top ) : balloonToolbarRect.top;
 
 			viewPaneMock.restore();
 
@@ -75,7 +86,7 @@
 			assert.areEqual( expectedLeft, balloonToolbarRect.left.toFixed( 2 ), 'left align' );
 			// We have to add 1px because of border.
 			assert.areEqual( ( frame.top + frame.height - scrollTop ).toFixed( 2 ),
-				( balloonToolbarRect.top + balloonToolbar.height + balloonToolbar.triangleHeight + 1 ).toFixed( 2 ), 'top align' );
+				( rectTop + balloonToolbar.height + balloonToolbar.triangleHeight + 1 ).toFixed( 2 ), 'top align' );
 			balloonToolbar.destroy();
 			balloonToolbar = null;
 		},
@@ -94,19 +105,23 @@
 				frame = editor.editable().isInline() ? editor.editable().getClientRect() : editor.window.getFrame().getClientRect(),
 				elementFrame = markerElement.getClientRect(),
 				scrollTop,
-				balloonToolbarRect;
+				balloonToolbarRect,
+				rectTop,
+				expectedLeft;
 
 			markerElement.getParent().getNext().scrollIntoView( true );
 			balloonToolbar.attach( markerElement );
 			balloonToolbarRect = balloonToolbar.parts.panel.getClientRect();
+			rectTop = CKEDITOR.env.ie || !CKEDITOR.env.edge ? Math.round( balloonToolbarRect.top ) : balloonToolbarRect.top;
 
 			// When browser window is so small that panel doesn't fit, window will be scrolled into panel view.
 			// We need to use scroll position to adjust expected result.
 			scrollTop = CKEDITOR.document.getWindow().getScrollPosition().y;
 
-			var expectedLeft = makeExpectedLeft( frame.left + elementFrame.left + elementFrame.width / 2 - 50 );
+			expectedLeft = makeExpectedLeft( frame.left + elementFrame.left + elementFrame.width / 2 - 50 );
+
 			assert.areEqual( expectedLeft, balloonToolbarRect.left.toFixed( 2 ), 'left align' );
-			assert.areEqual( ( frame.top - scrollTop ).toFixed( 2 ), ( balloonToolbarRect.top - balloonToolbar.triangleHeight ).toFixed( 2 ), 'top align' );
+			assert.areEqual( ( frame.top - scrollTop ).toFixed( 2 ), ( rectTop - balloonToolbar.triangleHeight ).toFixed( 2 ), 'top align' );
 			balloonToolbar.destroy();
 			balloonToolbar = null;
 		},

--- a/tests/plugins/balloontoolbar/positioning.js
+++ b/tests/plugins/balloontoolbar/positioning.js
@@ -27,19 +27,14 @@
 
 	var parentFrame = window.frameElement,
 		originalHeight = parentFrame && parentFrame.style.height;
-	function makeExpectedLeft( data ) {
-		if ( CKEDITOR.env.ie && CKEDITOR.env.version <= 9 ) {
-			return data.toFixed( 0 ) + '.00';
-		} else {
-			return data.toFixed( 2 );
-		}
-	}
 
 	var tests = {
 		setUp: function() {
 			if ( parentFrame ) {
 				parentFrame.style.height = '900px';
 			}
+
+			CKEDITOR.document.$.documentElement.scrollTop = 0;
 		},
 
 		tearDown: function() {
@@ -49,10 +44,6 @@
 		},
 
 		'test divaera - out of view - bottom center': function( editor ) {
-			// Due to a high instability of this test, that fails on mobile devices, small screens
-			// and when devtools are open, it's disabled for 4.8.0 release (#1295).
-			assert.ignore();
-
 			if ( editor.name == 'divarea' ) {
 				// divarea tests are failing, it's an upstream issue from balloonpanel (#1064).
 				assert.ignore();
@@ -65,25 +56,31 @@
 				markerElement = editor.editable().findOne( '#marker' ),
 				frame = editor.editable().isInline() ? editor.editable().getClientRect() : editor.window.getFrame().getClientRect(),
 				elementFrame = markerElement.getClientRect(),
+				// When window is so small editor is out of view panel might be rendered below editor.
+				// Mock view pane size to prevent that.
+				viewPaneMock = mockWindowViewPaneSize( { width: 1000, height: 1000 } ),
+				scrollTop,
 				balloonToolbarRect;
 
 			balloonToolbar.attach( markerElement );
 			balloonToolbarRect = balloonToolbar.parts.panel.getClientRect();
 
+			viewPaneMock.restore();
+
+			// When browser window is so small that panel doesn't fit, window will be scrolled into panel view.
+			// Use scroll position to adjust expected result.
+			scrollTop = CKEDITOR.document.getWindow().getScrollPosition().y.toFixed( 2 );
+
 			var expectedLeft = makeExpectedLeft( frame.left + elementFrame.left + elementFrame.width / 2 - 50 );
 			assert.areEqual( expectedLeft, balloonToolbarRect.left.toFixed( 2 ), 'left align' );
 			// We have to add 1px because of border.
-			assert.areEqual( ( balloonToolbarRect.top + balloonToolbar.height + balloonToolbar.triangleHeight + 1 ).toFixed( 2 ),
-				( frame.top + frame.height ).toFixed( 2 ), 'top align' );
+			assert.areEqual( ( frame.top + frame.height - scrollTop ).toFixed( 2 ),
+				( balloonToolbarRect.top + balloonToolbar.height + balloonToolbar.triangleHeight + 1 ).toFixed( 2 ), 'top align' );
 			balloonToolbar.destroy();
 			balloonToolbar = null;
 		},
 
 		'test divaera - out of view - hcenter top': function( editor ) {
-			// Due to a high instability of this test, that fails on mobile devices, small screens
-			// and when devtools are open, it's disabled for 4.8.0 release (#1295).
-			assert.ignore();
-
 			if ( editor.name == 'divarea' ) {
 				// divarea tests are failing, it's an upstream issue from balloonpanel (#1064).
 				assert.ignore();
@@ -96,15 +93,20 @@
 				markerElement = editor.editable().findOne( '#marker' ),
 				frame = editor.editable().isInline() ? editor.editable().getClientRect() : editor.window.getFrame().getClientRect(),
 				elementFrame = markerElement.getClientRect(),
+				scrollTop,
 				balloonToolbarRect;
 
 			markerElement.getParent().getNext().scrollIntoView( true );
 			balloonToolbar.attach( markerElement );
 			balloonToolbarRect = balloonToolbar.parts.panel.getClientRect();
 
+			// When browser window is so small that panel doesn't fit, window will be scrolled into panel view.
+			// We need to use scroll position to adjust expected result.
+			scrollTop = CKEDITOR.document.getWindow().getScrollPosition().y;
+
 			var expectedLeft = makeExpectedLeft( frame.left + elementFrame.left + elementFrame.width / 2 - 50 );
 			assert.areEqual( expectedLeft, balloonToolbarRect.left.toFixed( 2 ), 'left align' );
-			assert.areEqual( frame.top.toFixed( 2 ), ( balloonToolbarRect.top - balloonToolbar.triangleHeight ).toFixed( 2 ), 'top align' );
+			assert.areEqual( ( frame.top - scrollTop ).toFixed( 2 ), ( balloonToolbarRect.top - balloonToolbar.triangleHeight ).toFixed( 2 ), 'top align' );
 			balloonToolbar.destroy();
 			balloonToolbar = null;
 		},
@@ -166,4 +168,28 @@
 	tests = bender.tools.createTestsForEditors( CKEDITOR.tools.objectKeys( bender.editors ), tests );
 	ignoreUnsupportedEnvironment( tests );
 	bender.test( tests );
+
+
+	function makeExpectedLeft( data ) {
+		if ( CKEDITOR.env.ie && CKEDITOR.env.version <= 9 ) {
+			return data.toFixed( 0 ) + '.00';
+		} else {
+			return data.toFixed( 2 );
+		}
+	}
+
+	function mockWindowViewPaneSize( size ) {
+		var window = CKEDITOR.document.getWindow(),
+			winSpy = sinon.stub( CKEDITOR.document, 'getWindow' ),
+			viewPaneSpy = sinon.stub( window, 'getViewPaneSize' );
+
+		winSpy.returns( window );
+		viewPaneSpy.returns( size );
+		return {
+			restore: function() {
+				winSpy.restore();
+				viewPaneSpy.restore();
+			}
+		};
+	}
 } )();


### PR DESCRIPTION
## What is the purpose of this pull request?

Fix for failing test.

## Does your PR contain necessary tests?

All patches which change the editor code must include tests. You can always read more
on [PR testing](https://ckeditor.com/docs/ckeditor4/latest/guide/dev_contributing_code.html#tests),
[how to set the testing environment](https://ckeditor.com/docs/ckeditor4/latest/guide/dev_tests.html) and
[how to create tests](https://ckeditor.com/docs/ckeditor4/latest/guide/dev_tests.html#creating-your-own-test)
in the official CKEditor documentation.

### This PR contains

- [ ] Unit tests
- [ ] Manual tests

## What changes did you make?

- Unignored failing test.
- Mocked window viewPaneSize.
- Included scroll position in assertions.
- Restored scroll position in setUp.
- Rounded balloon toolbar top rect on IE.
- Removed `divarea` from test names, as editor name is dynamically added to test case by `bender.tools.createTestsForEditors`.

Closes #1076 