### PR TITLE
Remove redundant code from emoji plugin

### DIFF
--- a/plugins/emoji/plugin.js
+++ b/plugins/emoji/plugin.js
@@ -266,7 +266,7 @@
 								}
 							} );
 
-							this.clearSearchAndMoveFocus( event );
+							this.clearSearchAndMoveFocus( activeElement );
 
 							event.data.preventDefault();
 						}
@@ -507,13 +507,9 @@
 					this.elements.statusDescription.setText( '' );
 					this.elements.statusName.setText( '' );
 				},
-				clearSearchAndMoveFocus: function( event ) {
-					var element = event.data.getTarget().getAscendant( 'li', true );
-					if ( !element ) {
-						return;
-					}
+				clearSearchAndMoveFocus: function( activeElement ) {
 					this.clearSearchInput();
-					this.moveFocus( element.data( 'cke-emoji-group' ) );
+					this.moveFocus( activeElement.data( 'cke-emoji-group' ) );
 				},
 				moveFocus: function( groupName ) {
 					var firstSectionItem = this.blockElement.findOne( 'a[data-cke-emoji-group="' + htmlEncode( groupName ) + '"]' ),

--- a/plugins/emoji/skins/default.css
+++ b/plugins/emoji/skins/default.css
@@ -54,7 +54,6 @@
 	height: auto;
 	margin: 0 6px;
 	text-align: center;
-	cursor: pointer;
 }
 
 .cke_browser_ie .cke_emoji-inner_panel > nav li {
@@ -159,7 +158,6 @@
 	font-family: "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol";
 	list-style-type: none;
 	display: inline-table;
-	cursor: pointer;
 	width: 36px;
 	height: 36px;
 	font-size: 1.8em;

--- a/tests/plugins/emoji/manual/dropdown/pointercursorinnavigation.html
+++ b/tests/plugins/emoji/manual/dropdown/pointercursorinnavigation.html
@@ -1,0 +1,13 @@
+<h1>Classic editor</h1>
+
+<textarea id="editor1" cols="10" rows="10">
+	<p>Insert here some emoji from toolbar.</p>
+</textarea>
+
+<script>
+	if ( emojiTools.notSupportedEnvironment || bender.tools.env.mobile ) {
+		bender.ignore();
+	}
+
+	CKEDITOR.replace( 'editor1' );
+</script>

--- a/tests/plugins/emoji/manual/dropdown/pointercursorinnavigation.md
+++ b/tests/plugins/emoji/manual/dropdown/pointercursorinnavigation.md
@@ -1,9 +1,7 @@
-@bender-tags: 4.11.2, bug, emoji, 2592
+@bender-tags: 4.11.3, bug, emoji, 2592
 @bender-ckeditor-plugins: wysiwygarea, toolbar, elementspath, sourcearea, emoji, clipboard, undo, stylescombo, format
 @bender-ui: collapsed
 @bender-include: ../../_helpers/tools.js
-
-## Test Case 1:
 
 1. Open emoji dropdown.
 2. Move cursor over group navigation at top of dropdown.
@@ -12,10 +10,3 @@ Cursor is changed to pointer, which indicates that element is a link.
 3. Move cursor over emoji in main section.
 ### Expected:
 Cursor is changed to pointer, which indicates that element is a link.
-
-## Test Case 2:
-
-1. Open emoji dropdown.
-2. Click into navigation group.
-### Expected:
-Emoji list is scrolled to proper position. First element of clicked group is selected.

--- a/tests/plugins/emoji/manual/dropdown/pointercursorinnavigation.md
+++ b/tests/plugins/emoji/manual/dropdown/pointercursorinnavigation.md
@@ -5,8 +5,10 @@
 
 1. Open emoji dropdown.
 2. Move cursor over group navigation at top of dropdown.
-### Expected:
-Cursor is changed to pointer, which indicates that element is a link.
-3. Move cursor over emoji in main section.
-### Expected:
-Cursor is changed to pointer, which indicates that element is a link.
+
+	### Expected
+	Cursor is changed to pointer, which indicates that element is a link.
+3. Move cursor over an emoji in the main section.
+
+	### Expected
+	Cursor is changed to pointer, which indicates that element is a link.

--- a/tests/plugins/emoji/manual/dropdown/scrollpagebug.html
+++ b/tests/plugins/emoji/manual/dropdown/scrollpagebug.html
@@ -10,7 +10,7 @@ body {
 </textarea>
 
 <script>
-	if ( emojiTools.notSupportedEnvironment) {
+	if ( emojiTools.notSupportedEnvironment ) {
 		bender.ignore();
 	}
 

--- a/tests/plugins/emoji/manual/dropdown/scrollpagebug.md
+++ b/tests/plugins/emoji/manual/dropdown/scrollpagebug.md
@@ -1,4 +1,4 @@
-@bender-tags: 4.11.1, bug, emoji, 2571
+@bender-tags: 4.11.1, bug, emoji, 2571, 4.11.3, 2592
 @bender-ckeditor-plugins: wysiwygarea, toolbar, emoji
 @bender-ui: collapsed
 @bender-include: ../../_helpers/tools.js

--- a/tests/plugins/emoji/manual/dropdown/scrollpagebug.md
+++ b/tests/plugins/emoji/manual/dropdown/scrollpagebug.md
@@ -5,7 +5,7 @@
 
 1. Open emoji dropdown.
 2. Click into emoji group.
-### Expected
-Page is not scrolled down.
 ### Unexpected
-Page scrolls down.
+Page is not scrolled down.
+### Expected
+Page scrolls down. First emoji in group is selected.

--- a/tests/plugins/emoji/manual/dropdown/scrollpagebug.md
+++ b/tests/plugins/emoji/manual/dropdown/scrollpagebug.md
@@ -5,7 +5,11 @@
 
 1. Open emoji dropdown.
 2. Click into emoji group.
-### Unexpected
-Page is not scrolled down.
+
 ### Expected
+
 Page scrolls down. First emoji in group is selected.
+
+### Unexpected
+
+Page is not scrolled down.

--- a/tests/plugins/emoji/manual/dropdown/smallrefactoring.md
+++ b/tests/plugins/emoji/manual/dropdown/smallrefactoring.md
@@ -1,0 +1,21 @@
+@bender-tags: 4.11.2, bug, emoji, 2592
+@bender-ckeditor-plugins: wysiwygarea, toolbar, elementspath, sourcearea, emoji, clipboard, undo, stylescombo, format
+@bender-ui: collapsed
+@bender-include: ../../_helpers/tools.js
+
+## Test Case 1:
+
+1. Open emoji dropdown.
+2. Move cursor over group navigation at top of dropdown.
+### Expected:
+Cursor is changed to pointer, which indicates that element is a link.
+3. Move cursor over emoji in main section.
+### Expected:
+Cursor is changed to pointer, which indicates that element is a link.
+
+## Test Case 2:
+
+1. Open emoji dropdown.
+2. Click into navigation group.
+### Expected:
+Emoji list is scrolled to proper position. First element of clicked group is selected.


### PR DESCRIPTION
## What is the purpose of this pull request?

Task.

## Does your PR contain necessary tests?

All patches which change the editor code must include tests. You can always read more
on [PR testing](https://ckeditor.com/docs/ckeditor4/latest/guide/dev_contributing_code.html#tests),
[how to set the testing environment](https://ckeditor.com/docs/ckeditor4/latest/guide/dev_tests.html) and
[how to create tests](https://ckeditor.com/docs/ckeditor4/latest/guide/dev_tests.html#creating-your-own-test)
in the official CKEditor documentation.

### This PR contains

- [ ] Unit tests
- [x] Manual tests

## What changes did you make?

- remove unnecessary css for emoji
- pass element to function instead of reading it twice

Close #2592 