### PR TITLE
Added CKEDITOR.config.image2_maxSize

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -21,6 +21,10 @@ New Features:
 
 * [#2048](https://github.com/ckeditor/ckeditor-dev/issues/2048): [Enhanced Image](https://ckeditor.com/cke4/addon/image2) added config option [CKEDITOR.config.image2_maxSize](https://ckeditor.com/docs/ckeditor4/latest/api/CKEDITOR_config.html#cfg-image2_maxSize) that allows seting maximum size that image can be resized to with resizer.
 
+Fixed Issues:
+
+* [#2672](https://github.com/ckeditor/ckeditor-dev/issues/2672): Fixed: When resizing [Enhanced Image](https://ckeditor.com/cke4/addon/image2) to minimum size with resizer imaga dialog doesn't show actual values.
+
 ## CKEditor 4.11.2
 
 Fixed Issues:

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -17,6 +17,10 @@ API Changes:
 
 ## CKEditor 4.11.3
 
+New Features:
+
+* [#2048](https://github.com/ckeditor/ckeditor-dev/issues/2048): [Enhanced Image](https://ckeditor.com/cke4/addon/image2) added config option [CKEDITOR.config.image2_maxSize](https://ckeditor.com/docs/ckeditor4/latest/api/CKEDITOR_config.html#cfg-image2_maxSize) that allows seting maximum size that image can be resized to with resizer.
+
 ## CKEditor 4.11.2
 
 Fixed Issues:

--- a/plugins/image2/plugin.js
+++ b/plugins/image2/plugin.js
@@ -1372,7 +1372,7 @@
 
 			function isAllowedSize( width, height ) {
 				var isTooSmall = width < min.width || height < min.height,
-					isTooBig = max && ( ( max.width && width > max.width ) || ( max.height && height > max.height ) );
+					isTooBig = max && ( width > max.width || height > max.height );
 				return !isTooSmall && !isTooBig;
 			}
 		} );

--- a/plugins/image2/plugin.js
+++ b/plugins/image2/plugin.js
@@ -1371,7 +1371,9 @@
 			}
 
 			function isAllowedSize() {
-				return newWidth >= min.width && newWidth <= max.width && newHeight >= min.height && newHeight <= max.height;
+				var isTooSmall = newWidth < min.width || newHeight < min.height,
+					isTooBig = max && ( ( max.width && newWidth > max.width ) || ( max.height && newHeight > max.height ) );
+				return !isTooSmall && !isTooBig;
 			}
 		} );
 

--- a/plugins/image2/plugin.js
+++ b/plugins/image2/plugin.js
@@ -1324,7 +1324,7 @@
 					}
 				}
 
-				if ( isAllowedSize() ) {
+				if ( isAllowedSize( newWidth, newHeight ) ) {
 					updateData = { width: newWidth, height: newHeight };
 					image.setAttributes( updateData );
 				}
@@ -1364,15 +1364,15 @@
 				maxSize = CKEDITOR.tools.copy( maxSize );
 				natural = CKEDITOR.plugins.image2.getNatural( image );
 
-				maxSize.width = Math.max( maxSize.width === 'naturalWidth' ? natural.width : maxSize.width, min.width );
-				maxSize.height = Math.max( maxSize.height === 'naturalHeight' ? natural.height : maxSize.height, min.width );
+				maxSize.width = Math.max( maxSize.width === 'natural' ? natural.width : maxSize.width, min.width );
+				maxSize.height = Math.max( maxSize.height === 'natural' ? natural.height : maxSize.height, min.width );
 
 				return maxSize;
 			}
 
-			function isAllowedSize() {
-				var isTooSmall = newWidth < min.width || newHeight < min.height,
-					isTooBig = max && ( ( max.width && newWidth > max.width ) || ( max.height && newHeight > max.height ) );
+			function isAllowedSize( width, height ) {
+				var isTooSmall = width < min.width || height < min.height,
+					isTooBig = max && ( ( max.width && width > max.width ) || ( max.height && height > max.height ) );
 				return !isTooSmall && !isTooBig;
 			}
 		} );
@@ -1768,8 +1768,8 @@ CKEDITOR.config.image2_captionedClass = 'image';
  *
  * ```javascript
  *	config.image2_maxSize = {
- *		height: 'naturalHeight',
- *		width: 'naturalWidth'
+ *		height: 'natural',
+ *		width: 'natural'
  *	}
  * ```
  *

--- a/plugins/image2/plugin.js
+++ b/plugins/image2/plugin.js
@@ -1749,3 +1749,33 @@ CKEDITOR.config.image2_captionedClass = 'image';
  * @cfg {Boolean} [image2_altRequired=false]
  * @member CKEDITOR.config
  */
+
+/**
+ * Determines maximum size that image can be resized to with resize handler.
+ *
+ * It holds two properties: `width` and `height`, which can be set with one of two types:
+ *
+ * A number representing value that limits max size in pixel units:
+ *
+ * ```javascript
+ *	config.image2_maxSize = {
+ *		height: 300,
+ *		width: 250
+ *	};
+ * ```
+ *
+ * A string representing image natural size, so each image resize is limited to it's own natural height/width:
+ *
+ * ```javascript
+ *	config.image2_maxSize = {
+ *		height: 'naturalHeight',
+ *		width: 'naturalWidth'
+ *	}
+ * ```
+ *
+ * Note: Image can still be resized to bigger dimensions, when using image dialog.
+ *
+ * @since 4.12.0
+ * @cfg {Object.<String, Number/String>} [image2_maxSize]
+ * @member CKEDITOR.config
+ */

--- a/tests/plugins/image2/manual/dialogafterresize.html
+++ b/tests/plugins/image2/manual/dialogafterresize.html
@@ -1,0 +1,7 @@
+<div id="editor" contenteditable="true">
+	<img src="%BASE_PATH%/_assets/logo.png" />
+</div>
+
+<script>
+	CKEDITOR.replace( 'editor' );
+</script>

--- a/tests/plugins/image2/manual/dialogafterresize.html
+++ b/tests/plugins/image2/manual/dialogafterresize.html
@@ -1,7 +1,21 @@
 <div id="editor" contenteditable="true">
 	<img src="%BASE_PATH%/_assets/logo.png" />
 </div>
-
+<p class="dimensions-preview">Width: <span class="width"></span><br>
+	Height: <span class="height"></span>
+</p>
 <script>
-	CKEDITOR.replace( 'editor' );
+	CKEDITOR.replace( 'editor', {
+		on: {
+			change: function() {
+				var preview = CKEDITOR.document.findOne( '.dimensions-preview' ),
+					image = this.editable().findOne( 'img' ),
+					width = image.getAttribute( 'width' ),
+					height = image.getAttribute( 'height' );
+
+				preview.findOne( '.width' ).setText( width ? width + 'px' : '' );
+				preview.findOne( '.height' ).setText( height ? height + 'px' : '' );
+			}
+		}
+	} );
 </script>

--- a/tests/plugins/image2/manual/dialogafterresize.html
+++ b/tests/plugins/image2/manual/dialogafterresize.html
@@ -5,6 +5,9 @@
 	Height: <span class="height"></span>
 </p>
 <script>
+	if ( bender.env.mobile ) {
+		bender.ignore();
+	}
 	CKEDITOR.replace( 'editor', {
 		on: {
 			change: function() {

--- a/tests/plugins/image2/manual/dialogafterresize.md
+++ b/tests/plugins/image2/manual/dialogafterresize.md
@@ -1,0 +1,15 @@
+@bender-tags: 4.12.0, feature, bug, 2672
+@bender-ui: collapsed
+@bender-ckeditor-plugins: wysiwygarea, toolbar, image2, sourcearea
+
+1. Use resize handler to shrink image to minimum size.
+
+1. Open dialog for this image.
+
+## Expected:
+
+Dialog fields are populated with correct width/height.
+
+## Unexpected:
+
+Dialog fields have wrong values.

--- a/tests/plugins/image2/manual/dialogafterresize.md
+++ b/tests/plugins/image2/manual/dialogafterresize.md
@@ -1,4 +1,4 @@
-@bender-tags: 4.12.0, feature, bug, 2672
+@bender-tags: 4.12.0, bug, 2672
 @bender-ui: collapsed
 @bender-ckeditor-plugins: wysiwygarea, toolbar, image2, sourcearea
 

--- a/tests/plugins/image2/manual/dialogafterresize.md
+++ b/tests/plugins/image2/manual/dialogafterresize.md
@@ -1,15 +1,19 @@
 @bender-tags: 4.12.0, bug, 2672
 @bender-ui: collapsed
-@bender-ckeditor-plugins: wysiwygarea, toolbar, image2, sourcearea
+@bender-ckeditor-plugins: wysiwygarea, toolbar, image2, sourcearea, undo
 
-1. Use resize handler to shrink image to minimum size.
+1. Press and hold resize handler.
+
+1. Shrink image to minimum size.
+
+1. Release resize handler.
 
 1. Open dialog for this image.
 
 ## Expected:
 
-Dialog fields are populated with correct width/height.
+Dialog fields are populated with same values as presented below editor.
 
 ## Unexpected:
 
-Dialog fields have wrong values.
+Dialog fields have other values.

--- a/tests/plugins/image2/manual/maxsize.html
+++ b/tests/plugins/image2/manual/maxsize.html
@@ -4,6 +4,9 @@
 <div id="editor2" contenteditable="true">
 	<img src="%BASE_PATH%/_assets/logo.png" />
 </div>
+<div id="editor3" contenteditable="true">
+	<img src="%BASE_PATH%/_assets/logo.png" />
+</div>
 
 <script>
 	CKEDITOR.replace( 'editor1', {
@@ -19,4 +22,6 @@
 			height: 'naturalHeight'
 		}
 	} );
+
+	CKEDITOR.replace( 'editor3' );
 </script>

--- a/tests/plugins/image2/manual/maxsize.html
+++ b/tests/plugins/image2/manual/maxsize.html
@@ -1,9 +1,24 @@
+<h1>Editor 1:</h1>
+<p>
+	Max width: 350<br>
+	Max height: 350
+</p>
 <div id="editor1" contenteditable="true">
 	<img src="%BASE_PATH%/_assets/logo.png" />
 </div>
+<h1>Editor 2:</h1>
+<p>
+	Max width: 'naturalWidth'<br>
+	Max height: 'naturalHeight'
+</p>
 <div id="editor2" contenteditable="true">
 	<img src="%BASE_PATH%/_assets/logo.png" />
 </div>
+<h1>Editor 3:</h1>
+<p>
+	Max width: unset<br>
+	Max height: unset
+</p>
 <div id="editor3" contenteditable="true">
 	<img src="%BASE_PATH%/_assets/logo.png" />
 </div>

--- a/tests/plugins/image2/manual/maxsize.html
+++ b/tests/plugins/image2/manual/maxsize.html
@@ -1,0 +1,22 @@
+<div id="editor1" contenteditable="true">
+	<img src="%BASE_PATH%/_assets/logo.png" />
+</div>
+<div id="editor2" contenteditable="true">
+	<img src="%BASE_PATH%/_assets/logo.png" />
+</div>
+
+<script>
+	CKEDITOR.replace( 'editor1', {
+		image2_maxSize: {
+			width: 350,
+			height: 350
+		}
+	} );
+
+	CKEDITOR.replace( 'editor2', {
+		image2_maxSize: {
+			width: 'naturalWidth',
+			height: 'naturalHeight'
+		}
+	} );
+</script>

--- a/tests/plugins/image2/manual/maxsize.html
+++ b/tests/plugins/image2/manual/maxsize.html
@@ -8,8 +8,8 @@
 </div>
 <h1>Editor 2:</h1>
 <p>
-	Max width: 'naturalWidth'<br>
-	Max height: 'naturalHeight'
+	Max width: 'natural'<br>
+	Max height: 'natural'
 </p>
 <div id="editor2" contenteditable="true">
 	<img src="%BASE_PATH%/_assets/logo.png" />
@@ -33,8 +33,8 @@
 
 	CKEDITOR.replace( 'editor2', {
 		image2_maxSize: {
-			width: 'naturalWidth',
-			height: 'naturalHeight'
+			width: 'natural',
+			height: 'natural'
 		}
 	} );
 

--- a/tests/plugins/image2/manual/maxsize.md
+++ b/tests/plugins/image2/manual/maxsize.md
@@ -2,30 +2,30 @@
 @bender-ui: collapsed
 @bender-ckeditor-plugins: wysiwygarea, toolbar, image2, sourcearea
 
+# For first editor:
+
 1. Use resize handler to shrink image to minimum size.
 
 1. Open dialog for this image.
 
-	## Expected:
+## Expected:
 
-	Dialog fields are populated with correct width/height.
+Dialog fields are populated with correct width/height.
 
-	## Unexpected:
+## Unexpected:
 
-	Dialog fields have wrong values.
+Dialog fields have wrong values.
 
-1. Close dialog.
+# For each editors
 
 1. Use resize handler to increase image to maximum size.
 
 ## Expected:
 
-- Images can't be resized beyond maximum values:
+- Editor 1, Editor 2: Images can't be resized beyond maximum values.
 
-	- First editor: width/height: `350px`
-
-	- Second editor: width/height: `image natural size`. This means image can't be bigger than it is at start.
+- Editor 3: Image can be resized to any size.
 
 ## Unexpected:
 
-- Images can be resized beyond maximum values.
+- Editor 1, Editor 2: Images can be resized beyond maximum values.

--- a/tests/plugins/image2/manual/maxsize.md
+++ b/tests/plugins/image2/manual/maxsize.md
@@ -1,4 +1,4 @@
-@bender-tags: 4.12.0, feature
+@bender-tags: 4.12.0, feature, bug
 @bender-ui: collapsed
 @bender-ckeditor-plugins: wysiwygarea, toolbar, image2, sourcearea
 

--- a/tests/plugins/image2/manual/maxsize.md
+++ b/tests/plugins/image2/manual/maxsize.md
@@ -1,0 +1,31 @@
+@bender-tags: 4.12.0, feature
+@bender-ui: collapsed
+@bender-ckeditor-plugins: wysiwygarea, toolbar, image2, sourcearea
+
+1. Use resize handler to shrink image to minimum size.
+
+1. Open dialog for this image.
+
+	## Expected:
+
+	Dialog fields are populated with correct width/height.
+
+	## Unexpected:
+
+	Dialog fields have wrong values.
+
+1. Close dialog.
+
+1. Use resize handler to increase image to maximum size.
+
+## Expected:
+
+- Images can't be resized beyond maximum values:
+
+	- First editor: width/height: `350px`
+
+	- Second editor: width/height: `image natural size`. This means image can't be bigger than it is at start.
+
+## Unexpected:
+
+- Images can be resized beyond maximum values.

--- a/tests/plugins/image2/manual/maxsize.md
+++ b/tests/plugins/image2/manual/maxsize.md
@@ -1,20 +1,6 @@
-@bender-tags: 4.12.0, feature, bug
+@bender-tags: 4.12.0, feature, bug, 2048
 @bender-ui: collapsed
 @bender-ckeditor-plugins: wysiwygarea, toolbar, image2, sourcearea
-
-# For first editor:
-
-1. Use resize handler to shrink image to minimum size.
-
-1. Open dialog for this image.
-
-## Expected:
-
-Dialog fields are populated with correct width/height.
-
-## Unexpected:
-
-Dialog fields have wrong values.
 
 # For each editors
 

--- a/tests/plugins/image2/manual/maxsize.md
+++ b/tests/plugins/image2/manual/maxsize.md
@@ -1,4 +1,4 @@
-@bender-tags: 4.12.0, feature, bug, 2048
+@bender-tags: 4.12.0, feature, 2048
 @bender-ui: collapsed
 @bender-ckeditor-plugins: wysiwygarea, toolbar, image2, sourcearea
 

--- a/tests/plugins/image2/resizehandler.js
+++ b/tests/plugins/image2/resizehandler.js
@@ -1,0 +1,133 @@
+/* bender-tags: editor,widget */
+/* bender-ckeditor-plugins: image2,toolbar */
+
+( function() {
+	'use strict';
+
+	bender.editors = {
+		limitedSize: {
+			config: {
+				image2_maxSize: {
+					width: 350,
+					height: 350
+				}
+			}
+		},
+		naturalSize: {
+			config: {
+				image2_maxSize: {
+					width: 'naturalWidth',
+					height: 'naturalHeight'
+				}
+			}
+		}
+	};
+
+	var tests = {
+		//2672
+		'test resize close to minimum size': assertResize( {
+			data: {
+				screenX: 40,
+				screenY: 15
+			},
+			expected: {
+				width: 40,
+				height: 15
+			}
+		} ),
+
+		//2672
+		'test resize lower than minimum size': assertResize( {
+			data: {
+				screenX: 14,
+				screenY: 14
+			},
+			expected: {
+				width: null,
+				height: null
+			}
+		} ),
+
+		//2048
+		'test resize close to maximum size': assertResize( {
+			limitedSize: {
+				data: {
+					screenX: 350,
+					screenY: 131
+				},
+				expected: {
+					width: 350,
+					height: 131
+				}
+			},
+			naturalSize: {
+				data: {
+					screenX: 163,
+					screenY: 61
+				},
+				expected: {
+					width: 163,
+					height: 61
+				}
+			}
+		} ),
+
+		//2048
+		'test resize above maximum size': assertResize( {
+			limitedSize: {
+				data: {
+					screenX: 351,
+					screenY: 132
+				},
+				expected: {
+					width: null,
+					height: null
+				}
+			},
+			naturalSize: {
+				data: {
+					screenX: 165,
+					screenY: 65
+				},
+				expected: {
+					width: null,
+					height: null
+				}
+			}
+		} )
+	};
+
+	bender.test( bender.tools.createTestsForEditors( CKEDITOR.tools.objectKeys( bender.editors ), tests ) );
+
+	function assertResize( options ) {
+		return function( editor, bot ) {
+			bot.setData( '<img src="%BASE_PATH%/_assets/logo.png">', function() {
+				editor.widgets.instances[ editor.widgets._.nextId - 1 ].resizer.fire( 'mousedown', {
+					$: {
+						screenX: 163,
+						screenY: 61
+					}
+				} );
+
+				var doc = CKEDITOR.document,
+					image = editor.editable().findOne( 'img' ),
+					data = options[ editor.name ] ? options[ editor.name ].data : options.data,
+					expected = options[ editor.name ] ? options[ editor.name ].expected : options.expected,
+					actual;
+
+				doc.fire( 'mousemove', {
+					$: data
+				} );
+
+				doc.fire( 'mouseup' );
+
+				actual = {
+					width: image.getAttribute( 'width' ),
+					height: image.getAttribute( 'height' )
+				};
+
+				assert.isTrue( CKEDITOR.tools.objectCompare( actual, expected ) );
+			} );
+		};
+	}
+} )();

--- a/tests/plugins/image2/resizehandler.js
+++ b/tests/plugins/image2/resizehandler.js
@@ -115,7 +115,6 @@
 					} );
 
 					var doc = CKEDITOR.document,
-						image = editor.editable().findOne( 'img' ),
 						data = options[ editor.name ] ? options[ editor.name ].data : options.data,
 						expected = options[ editor.name ] ? options[ editor.name ].expected : options.expected,
 						actual;

--- a/tests/plugins/image2/resizehandler.js
+++ b/tests/plugins/image2/resizehandler.js
@@ -106,13 +106,7 @@
 			bot.setData( '<img src="%BASE_PATH%/_assets/logo.png">', function() {
 				var image = editor.editable().findOne( 'img' );
 
-				if ( CKEDITOR.env.chrome ) {
-					assertResize();
-				} else {
-					waitForImage( image, assertResize );
-				}
-
-				function assertResize() {
+				waitForImage( image, function() {
 					editor.widgets.instances[ editor.widgets._.nextId - 1 ].resizer.fire( 'mousedown', {
 						$: {
 							screenX: 163,
@@ -138,7 +132,7 @@
 					};
 
 					assert.isTrue( CKEDITOR.tools.objectCompare( actual, expected ) );
-				}
+				} );
 			} );
 		};
 	}

--- a/tests/plugins/image2/resizehandler.js
+++ b/tests/plugins/image2/resizehandler.js
@@ -18,8 +18,8 @@
 		naturalSize: {
 			config: {
 				image2_maxSize: {
-					width: 'naturalWidth',
-					height: 'naturalHeight'
+					width: 'natural',
+					height: 'natural'
 				}
 			}
 		}

--- a/tests/plugins/image2/resizehandler.js
+++ b/tests/plugins/image2/resizehandler.js
@@ -26,7 +26,7 @@
 	};
 
 	var tests = {
-		//2672
+		// (#2672)
 		'test resize close to minimum size': testResize( {
 			data: {
 				screenX: 40,
@@ -38,7 +38,7 @@
 			}
 		} ),
 
-		//2672
+		// (#2672)
 		'test resize lower than minimum size': testResize( {
 			data: {
 				screenX: 14,
@@ -50,7 +50,7 @@
 			}
 		} ),
 
-		//2048
+		// (#2048)
 		'test resize close to maximum size': testResize( {
 			limitedSize: {
 				data: {
@@ -74,7 +74,7 @@
 			}
 		} ),
 
-		//2048
+		// (#2048)
 		'test resize above maximum size': testResize( {
 			limitedSize: {
 				data: {

--- a/tests/plugins/uploadfile/_helpers/waitForImage.js
+++ b/tests/plugins/uploadfile/_helpers/waitForImage.js
@@ -4,6 +4,8 @@ function waitForImage( image, callback ) {
 	// IE needs to wait for image to be loaded so it can read width and height of the image.
 	if ( CKEDITOR.env.ie ) {
 		wait( callback, 100 );
+	} else if ( image.$.complete ) {
+		callback();
 	} else {
 		image.once( 'load', function() {
 			resume( callback );

--- a/tests/plugins/uploadfile/_helpers/waitForImage.js
+++ b/tests/plugins/uploadfile/_helpers/waitForImage.js
@@ -4,12 +4,17 @@ function waitForImage( image, callback ) {
 	// IE needs to wait for image to be loaded so it can read width and height of the image.
 	if ( CKEDITOR.env.ie ) {
 		wait( callback, 100 );
-	} else if ( image.$.complete ) {
-		callback();
+		return;
+	}
+
+	if ( image.$.complete ) {
+		setTimeout( function() {
+			resume( callback );
+		} );
 	} else {
 		image.once( 'load', function() {
 			resume( callback );
 		} );
-		wait();
 	}
+	wait();
 }

--- a/tests/plugins/uploadfile/uploadfile.js
+++ b/tests/plugins/uploadfile/uploadfile.js
@@ -226,5 +226,20 @@ bender.test( {
 		loader.abort();
 
 		assert.areSame( 'abort', loader.status, 'Loader status' );
+	},
+
+	'test waitForImage when image is loaded': function() {
+		if ( CKEDITOR.env.ie ) {
+			assert.ignore();
+		}
+
+		var callback = sinon.spy(),
+			imageMock = {
+				$: { complete: true }
+			};
+
+		waitForImage( imageMock, callback );
+
+		assert.isTrue( callback.called );
 	}
 } );

--- a/tests/plugins/uploadfile/uploadfile.js
+++ b/tests/plugins/uploadfile/uploadfile.js
@@ -228,6 +228,7 @@ bender.test( {
 		assert.areSame( 'abort', loader.status, 'Loader status' );
 	},
 
+	// #2714
 	'test waitForImage when image is loaded': function() {
 		if ( CKEDITOR.env.ie ) {
 			assert.ignore();

--- a/tests/plugins/uploadfile/uploadfile.js
+++ b/tests/plugins/uploadfile/uploadfile.js
@@ -226,21 +226,5 @@ bender.test( {
 		loader.abort();
 
 		assert.areSame( 'abort', loader.status, 'Loader status' );
-	},
-
-	// #2714
-	'test waitForImage when image is loaded': function() {
-		if ( CKEDITOR.env.ie ) {
-			assert.ignore();
-		}
-
-		var callback = sinon.spy(),
-			imageMock = {
-				$: { complete: true }
-			};
-
-		waitForImage( imageMock, callback );
-
-		assert.isTrue( callback.called );
 	}
 } );

--- a/tests/utils/testhelpers.js
+++ b/tests/utils/testhelpers.js
@@ -11,13 +11,20 @@ bender.test( {
 			assert.ignore();
 		}
 
-		var callback = sinon.spy(),
+		var called = false,
 			imageMock = {
 				$: { complete: true }
 			};
 
-		waitForImage( imageMock, callback );
+		setTimeout( function() {
+			resume( function() {
+				assert.isTrue( called, 'waitForImage callback called' );
+			} );
+		}, 100 );
 
-		assert.isTrue( callback.called );
+		waitForImage( imageMock, function() {
+			called = true;
+			wait();
+		} );
 	}
 } );

--- a/tests/utils/testhelpers.js
+++ b/tests/utils/testhelpers.js
@@ -1,0 +1,23 @@
+/* bender-tags: editor */
+/* bender-include: %BASE_PATH%/plugins/uploadfile/_helpers/waitForImage.js */
+/* global waitForImage */
+
+'use strict';
+
+bender.test( {
+	// (#2714)
+	'test waitForImage when image is loaded': function() {
+		if ( CKEDITOR.env.ie ) {
+			assert.ignore();
+		}
+
+		var callback = sinon.spy(),
+			imageMock = {
+				$: { complete: true }
+			};
+
+		waitForImage( imageMock, callback );
+
+		assert.isTrue( callback.called );
+	}
+} );


### PR DESCRIPTION
## What is the purpose of this pull request?

New feature + Bugfix

## Does your PR contain necessary tests?

All patches which change the editor code must include tests. You can always read more
on [PR testing](https://ckeditor.com/docs/ckeditor4/latest/guide/dev_contributing_code.html#tests),
[how to set the testing environment](https://ckeditor.com/docs/ckeditor4/latest/guide/dev_tests.html) and
[how to create tests](https://ckeditor.com/docs/ckeditor4/latest/guide/dev_tests.html#creating-your-own-test)
in the official CKEditor documentation.

### This PR contains

- [X] Unit tests
- [X] Manual tests

## What changes did you make?

- Added new config option `CKEDITOR.config.image2_maxSize` that limits maximum size that image can be resized with resizer.
- Fixed resizer `mousemove` listener to update widget data with last correct value which is same as one set on element.

Closes #2048 
Closes #2672
Closes #2714 