### PR TITLE
Improve order of emoji in autocomplete

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -6,6 +6,7 @@
 Fixed Issues:
 
 * [#2721](https://github.com/ckeditor/ckeditor-dev/issues/2721): Fixed: Sublist items are reversed when higher level list item is removed.
+* [#2527](https://github.com/ckeditor/ckeditor-dev/issues/2527): Fixed: [Emoji](https://ckeditor.com/cke4/addon/emoji) autocomplete order now prioritize emojis with name started from used string.
 
 ## CKEditor 4.11.2
 

--- a/plugins/emoji/plugin.js
+++ b/plugins/emoji/plugin.js
@@ -630,17 +630,14 @@
 							// Comparing lowercased strings, because emoji should be case insensitive (#2167).
 							return item.id.toLowerCase().indexOf( emojiName ) !== -1;
 						} ).sort( function( a, b ) {
-							var aIndex = a.id.indexOf( emojiName ),
-								bIndex = b.id.indexOf( emojiName );
+							var aIndex = a.id.substr( 1 ).indexOf( emojiName ),
+								bIndex = b.id.substr( 1 ).indexOf( emojiName );
 
-							if ( aIndex === bIndex ) {
-								if ( a.id > b.id ) {
-									return 1;
-								} else {
-									return -1;
-								}
+							// True when left and right side are oposite.
+							if ( aIndex === 0 ^ bIndex === 0 ) {
+								return aIndex === 0 ? -1 : 1;
 							} else {
-								return aIndex - bIndex;
+								return a.id > b.id ? 1 : -1;
 							}
 						} );
 					callback( data );

--- a/plugins/emoji/plugin.js
+++ b/plugins/emoji/plugin.js
@@ -627,15 +627,14 @@
 				function dataCallback( matchInfo, callback ) {
 					var emojiName = matchInfo.query.substr( 1 ).toLowerCase(),
 						data = arrTools.filter( emojiList, function( item ) {
-							// Comparing lowercased strings, because emoji should be case insensitive (#2167).
+							// Comparing lowercase strings, because emoji should be case insensitive (#2167).
 							return item.id.toLowerCase().indexOf( emojiName ) !== -1;
 						} ).sort( function( a, b ) {
-							var aIndex = a.id.substr( 1 ).indexOf( emojiName ),
-								bIndex = b.id.substr( 1 ).indexOf( emojiName );
+							var aStartsWithEmojiName = !a.id.substr( 1 ).indexOf( emojiName ),
+								bStartsWithEmojiName = !b.id.substr( 1 ).indexOf( emojiName );
 
-							// True when left and right side are oposite.
-							if ( aIndex === 0 ^ bIndex === 0 ) {
-								return aIndex === 0 ? -1 : 1;
+							if ( aStartsWithEmojiName != bStartsWithEmojiName ) {
+								return aStartsWithEmojiName ? -1 : 1;
 							} else {
 								return a.id > b.id ? 1 : -1;
 							}

--- a/plugins/emoji/plugin.js
+++ b/plugins/emoji/plugin.js
@@ -629,6 +629,21 @@
 						data = arrTools.filter( emojiList, function( item ) {
 							// Comparing lowercased strings, because emoji should be case insensitive (#2167).
 							return item.id.toLowerCase().indexOf( emojiName ) !== -1;
+						} ).sort( function( a, b ) {
+							var aIndex = a.id.indexOf( emojiName ),
+								bIndex = b.id.indexOf( emojiName );
+
+							if ( aIndex === bIndex ) {
+								if ( a.id === b.id ) {
+									return 0;
+								} else if ( a.id > b.id ) {
+									return 1;
+								} else {
+									return -1;
+								}
+							} else {
+								return aIndex - bIndex;
+							}
 						} );
 					callback( data );
 				}

--- a/plugins/emoji/plugin.js
+++ b/plugins/emoji/plugin.js
@@ -634,9 +634,7 @@
 								bIndex = b.id.indexOf( emojiName );
 
 							if ( aIndex === bIndex ) {
-								if ( a.id === b.id ) {
-									return 0;
-								} else if ( a.id > b.id ) {
+								if ( a.id > b.id ) {
 									return 1;
 								} else {
 									return -1;

--- a/tests/plugins/emoji/basic.js
+++ b/tests/plugins/emoji/basic.js
@@ -183,6 +183,19 @@
 				assert.areSame( 1, autocomplete.model.data.length, 'Emoji result contains more than one result' );
 				objectAssert.areEqual( { id: ':collision:', symbol: '💥' }, { id: autocomplete.model.data[ 0 ].id, symbol: autocomplete.model.data[ 0 ].symbol }, 'Emoji result contains wrong result' );
 			} );
+		},
+
+		// (#2527)
+		'test emoji autocomplete is sorted in proper order': function( editor, bot ) {
+			emojiTools.runAfterInstanceReady( editor, bot, function( editor, bot ) {
+				var autocomplete = editor._.emoji.autocomplete;
+
+				bot.setHtmlWithSelection( '<p>foo :smiling^</p>' );
+				editor.editable().fire( 'keyup', new CKEDITOR.dom.event( {} ) );
+
+				assert.areSame( ':smiling_cat_face_with_heart-eyes:', autocomplete.model.data[ 0 ].id, 'First element in data should start from "smiling".' );
+				assert.areSame( '😻 :smiling_cat_face_with_heart-eyes:', autocomplete.view.element.getChild( 0 ).getText(), 'First element in view should start from "smiling".' );
+			} );
 		}
 	};
 

--- a/tests/plugins/emoji/basic.js
+++ b/tests/plugins/emoji/basic.js
@@ -188,12 +188,30 @@
 		// (#2527)
 		'test emoji autocomplete is sorted in proper order': function( editor, bot ) {
 			emojiTools.runAfterInstanceReady( editor, bot, function( editor, bot ) {
-				var autocomplete = editor._.emoji.autocomplete;
+				var autocomplete = editor._.emoji.autocomplete,
+					expected = [ ':smiling_cat_face_with_heart-eyes:',
+						':smiling_face:',
+						':smiling_face_with_halo:',
+						':smiling_face_with_heart-eyes:',
+						':smiling_face_with_horns:',
+						':smiling_face_with_smiling_eyes:',
+						':smiling_face_with_sunglasses:',
+						':beaming_face_with_smiling_eyes:',
+						':grinning_cat_face_with_smiling_eyes:',
+						':grinning_face_with_smiling_eyes:',
+						':kissing_face_with_smiling_eyes:',
+						':slightly_smiling_face:'
+					],
+					actual;
 
 				bot.setHtmlWithSelection( '<p>foo :smiling^</p>' );
 				editor.editable().fire( 'keyup', new CKEDITOR.dom.event( {} ) );
 
-				assert.areSame( ':smiling_cat_face_with_heart-eyes:', autocomplete.model.data[ 0 ].id, 'First element in data should start from "smiling".' );
+				actual = CKEDITOR.tools.array.map( autocomplete.model.data, function( el ) {
+					return el.id;
+				} );
+
+				arrayAssert.itemsAreSame( expected, actual );
 				assert.areSame( '😻 :smiling_cat_face_with_heart-eyes:', autocomplete.view.element.getChild( 0 ).getText(), 'First element in view should start from "smiling".' );
 			} );
 		}

--- a/tests/plugins/emoji/manual/sortingorder.html
+++ b/tests/plugins/emoji/manual/sortingorder.html
@@ -1,0 +1,19 @@
+<textarea id="classic">
+	<p>Use autocomplete to insert some emoji.</p>
+</textarea>
+<div id="divarea" contenteditable="true">
+	<p>Use autocomplete to insert some emoji.</p>
+</div>
+
+<script>
+	if ( emojiTools.notSupportedEnvironment ) {
+		bender.ignore();
+	}
+	CKEDITOR.replace( 'classic', {
+		removeButtons: 'EmojiPanel'
+	} );
+	CKEDITOR.replace( 'divarea', {
+		extraPlugins: 'divarea',
+		removeButtons: 'EmojiPanel'
+	} );
+</script>

--- a/tests/plugins/emoji/manual/sortingorder.md
+++ b/tests/plugins/emoji/manual/sortingorder.md
@@ -1,0 +1,13 @@
+@bender-tags: 4.11.2, bug, emoji, 2527
+@bender-ckeditor-plugins: wysiwygarea, sourcearea, emoji
+@bender-ui: collapsed
+@bender-include: ../_helpers/tools.js
+
+## For both editors:
+
+1. Place caret in editor.
+2. Use autocomplete to insert emoji, start typing ( `:smil` ).
+### Expected:
+Emoji started from `:smil` will be displayed first in results.
+### Unexpected:
+Emoji autocomplete results are sorted alphabetically.

--- a/tests/plugins/emoji/manual/sortingorder.md
+++ b/tests/plugins/emoji/manual/sortingorder.md
@@ -1,4 +1,4 @@
-@bender-tags: 4.11.2, bug, emoji, 2527
+@bender-tags: 4.11.3, bug, emoji, 2527
 @bender-ckeditor-plugins: wysiwygarea, sourcearea, emoji
 @bender-ui: collapsed
 @bender-include: ../_helpers/tools.js


### PR DESCRIPTION
## What is the purpose of this pull request?

Bug fix

## Does your PR contain necessary tests?

All patches which change the editor code must include tests. You can always read more
on [PR testing](https://ckeditor.com/docs/ckeditor4/latest/guide/dev_contributing_code.html#tests),
[how to set the testing environment](https://ckeditor.com/docs/ckeditor4/latest/guide/dev_tests.html) and
[how to create tests](https://ckeditor.com/docs/ckeditor4/latest/guide/dev_tests.html#creating-your-own-test)
in the official CKEditor documentation.

### This PR contains

- [x] Unit tests
- [x] Manual tests

## What changes did you make?

* Add sort algorithm, which prioritize emoji which starts from searched string

Close #2527  
