### PR TITLE
Preserve multiple class names when converting to list elements

### DIFF
--- a/plugins/list/plugin.js
+++ b/plugins/list/plugin.js
@@ -192,7 +192,7 @@
 
 							inheritInlineStyles( li, child );
 
-							className && child.addClass( className );
+							className && child.setAttribute( 'class', className );
 
 							// Close the block which we started for inline content.
 							block = null;


### PR DESCRIPTION
## What is the purpose of this pull request?

Bug fix #2709

## Does your PR contain necessary tests?

No.

### This PR contains

- [ ] Unit tests
- [ ] Manual tests

## What changes did you make?

Use setAttribute for class names, because addClass will throw an exception if there are multiple space-separated class names.
