### PR TITLE
Fix for: Sublist order is reversed when higher level list is removed

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -5,7 +5,7 @@
 
 Fixed Issues:
 
-* [#2721](https://github.com/ckeditor/ckeditor-dev/issues/2721): Fixed: Sublist items are reversed when higher order list is removed.
+* [#2721](https://github.com/ckeditor/ckeditor-dev/issues/2721): Fixed: Sublist items are reversed when higher level list item is removed.
 
 ## CKEditor 4.11.2
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -3,6 +3,10 @@
 
 ## CKEditor 4.11.3
 
+Fixed Issues:
+
+* [#2721](https://github.com/ckeditor/ckeditor-dev/issues/2721): Fixed: Sublist items are reversed when higher order list is removed.
+
 ## CKEditor 4.11.2
 
 Fixed Issues:

--- a/plugins/list/plugin.js
+++ b/plugins/list/plugin.js
@@ -533,6 +533,7 @@
 			child.remove();
 
 			refNode ? child[ forward ? 'insertBefore' : 'insertAfter' ]( refNode ) : into.append( child, forward );
+			refNode = child;
 		}
 	}
 

--- a/plugins/list/plugin.js
+++ b/plugins/list/plugin.js
@@ -533,7 +533,6 @@
 			child.remove();
 
 			refNode ? child[ forward ? 'insertBefore' : 'insertAfter' ]( refNode ) : into.append( child, forward );
-			refNode = child;
 		}
 	}
 

--- a/tests/plugins/list/list.js
+++ b/tests/plugins/list/list.js
@@ -212,5 +212,18 @@ bender.test( {
 		bot.setHtmlWithSelection( '<ul><li><table><tr><td>^foo</td></tr></table></li></ul>' );
 		var bList = ed.getCommand( 'bulletedlist' );
 		assert.areSame( CKEDITOR.TRISTATE_OFF, bList.state, 'check numbered list inactive' );
+	},
+
+	// #2721
+	'test sublist order after removing higher order sublist': function() {
+		var bot = this.editorBots.editor1,
+			editor = bot.editor;
+
+		bot.setHtmlWithSelection( '<ol><li>test<ol><li>^<ol><li>a</li><li>b</li><li>c</li></ol></li></ol></li></ol>' );
+		editor.fire( 'key', {
+			domEvent: new CKEDITOR.dom.event( { keyCode: 8 } )
+		} );
+
+		assert.areSame( '<ol><li>test<ol><li>a</li><li>b</li><li>c</li></ol></li></ol>', bender.tools.compatHtml( editor.getData() ) );
 	}
 } );

--- a/tests/plugins/list/manual/sublistreverse.html
+++ b/tests/plugins/list/manual/sublistreverse.html
@@ -1,0 +1,19 @@
+<textarea id="editor">
+	<ol>
+		<li>test
+		<ol>
+			<li>$
+			<ol>
+				<li>a</li>
+				<li>b</li>
+				<li>c</li>
+			</ol>
+			</li>
+		</ol>
+		</li>
+	</ol>
+</textarea>
+
+<script>
+	CKEDITOR.replace( 'editor' );
+</script>

--- a/tests/plugins/list/manual/sublistreverse.html
+++ b/tests/plugins/list/manual/sublistreverse.html
@@ -15,5 +15,9 @@
 </textarea>
 
 <script>
+	// Ignore until #2737 is resolved.
+	if ( CKEDITOR.env.edge ) {
+		bender.ignore();
+	}
 	CKEDITOR.replace( 'editor' );
 </script>

--- a/tests/plugins/list/manual/sublistreverse.md
+++ b/tests/plugins/list/manual/sublistreverse.md
@@ -1,9 +1,9 @@
 @bender-tags: bug, 2721, 4.11.3
 @bender-ui: collapsed
-@bender-ckeditor-plugins: wysiwygarea, toolbar, list,sourcearea, undo, elementspath
+@bender-ckeditor-plugins: wysiwygarea, toolbar, list, sourcearea, undo, elementspath
 
 1. Place caret in list after dollar symbol (`$`).
-1. Press backspace two times (once in IE).
+1. Press <kbd>Backspace</kbd> two times (once in IE).
 
 ## Expected
 
@@ -26,3 +26,7 @@ Sublist order is reversed:
 	2. b
 	3. a
 ```
+
+## Note
+
+There is known upstream issue on IE [#2774](https://github.com/ckeditor/ckeditor-dev/issues/2774) when after pressing <kbd>Backspace</kbd> only `li` element is removed and `ol` is preserved. This results in incorrect markup `ol > li > ol > ol > li`.

--- a/tests/plugins/list/manual/sublistreverse.md
+++ b/tests/plugins/list/manual/sublistreverse.md
@@ -1,0 +1,26 @@
+@bender-tags: bug, 2721
+@bender-ui: collapsed
+@bender-ckeditor-plugins: wysiwygarea, toolbar, list,sourcearea, undo, elementspath
+
+1. Place caret in list after dollar symbol (`$`).
+1. Press backspace two times.
+
+## Expected
+
+Sublist is ordered alphabetically:
+```
+1. Test
+	1. a
+	2. b
+	3. c
+```
+
+## Unexpected
+
+Sublist order is reversed:
+```
+1. Test
+	1. c
+	2. b
+	3. a
+```

--- a/tests/plugins/list/manual/sublistreverse.md
+++ b/tests/plugins/list/manual/sublistreverse.md
@@ -1,4 +1,4 @@
-@bender-tags: bug, 2721
+@bender-tags: bug, 2721, 4.11.3
 @bender-ui: collapsed
 @bender-ckeditor-plugins: wysiwygarea, toolbar, list,sourcearea, undo, elementspath
 

--- a/tests/plugins/list/manual/sublistreverse.md
+++ b/tests/plugins/list/manual/sublistreverse.md
@@ -3,8 +3,7 @@
 @bender-ckeditor-plugins: wysiwygarea, toolbar, list,sourcearea, undo, elementspath
 
 1. Place caret in list after dollar symbol (`$`).
-1. Press backspace two times.
-
+1. Press backspace two times (once in IE).
 ## Expected
 
 Sublist is ordered alphabetically:

--- a/tests/plugins/list/manual/sublistreverse.md
+++ b/tests/plugins/list/manual/sublistreverse.md
@@ -4,9 +4,11 @@
 
 1. Place caret in list after dollar symbol (`$`).
 1. Press backspace two times (once in IE).
+
 ## Expected
 
 Sublist is ordered alphabetically:
+
 ```
 1. Test
 	1. a
@@ -17,6 +19,7 @@ Sublist is ordered alphabetically:
 ## Unexpected
 
 Sublist order is reversed:
+
 ```
 1. Test
 	1. c


### PR DESCRIPTION
## What is the purpose of this pull request?

Bug fix

## Does your PR contain necessary tests?

All patches which change the editor code must include tests. You can always read more
on [PR testing](https://ckeditor.com/docs/ckeditor4/latest/guide/dev_contributing_code.html#tests),
[how to set the testing environment](https://ckeditor.com/docs/ckeditor4/latest/guide/dev_tests.html) and
[how to create tests](https://ckeditor.com/docs/ckeditor4/latest/guide/dev_tests.html#creating-your-own-test)
in the official CKEditor documentation.

### This PR contains

- [X] Unit tests
- [X] Manual tests

## What changes did you make?

Using last added child (list) item as `refNode` in `mergeChildren` helper.

Closes #2721