### PR TITLE
Restore reverted optimizations of table cell allowed content

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -11,7 +11,7 @@ Fixed Issues:
 * [#1191](https://github.com/ckeditor/ckeditor-dev/issues/1191): Fixed: Items in the [elements path](https://ckeditor.com/cke4/addon/elementspath) are draggable.
 * [#2292](https://github.com/ckeditor/ckeditor-dev/issues/2292): Fixed: Dropping list with link on editor's margin cause console error and removing dragged text from editor.
 * [#2756](https://github.com/ckeditor/ckeditor-dev/issues/2756): Fixed: The [Auto Link](https://ckeditor.com/cke4/addon/autolink) plugin causes an error when typing in [Source Editing Mode](https://ckeditor.com/docs/ckeditor4/latest/guide/dev_sourcearea.html).
-* [#1986](https://github.com/ckeditor/ckeditor-dev/issues/1986): Fixed: cell properties dialog shows styles that are not allowed through allowedContent.
+* [#1986](https://github.com/ckeditor/ckeditor-dev/issues/1986): Fixed: Cell Properties dialog from [Table Tools](https://ckeditor.com/cke4/addon/tabletools) plugin shows styles that are not allowed through [`config.allowedContent`](https://ckeditor.com/docs/ckeditor4/latest/api/CKEDITOR_config.html#cfg-allowedContent).
 
 ## CKEditor 4.11.2
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -11,6 +11,7 @@ Fixed Issues:
 * [#1191](https://github.com/ckeditor/ckeditor-dev/issues/1191): Fixed: Items in the [elements path](https://ckeditor.com/cke4/addon/elementspath) are draggable.
 * [#2292](https://github.com/ckeditor/ckeditor-dev/issues/2292): Fixed: Dropping list with link on editor's margin cause console error and removing dragged text from editor.
 * [#2756](https://github.com/ckeditor/ckeditor-dev/issues/2756): Fixed: The [Auto Link](https://ckeditor.com/cke4/addon/autolink) plugin causes an error when typing in [Source Editing Mode](https://ckeditor.com/docs/ckeditor4/latest/guide/dev_sourcearea.html).
+* [#1986](https://github.com/ckeditor/ckeditor-dev/issues/1986): Fixed: cell properties dialog shows styles that are not allowed through allowedContent.
 
 ## CKEditor 4.11.2
 

--- a/plugins/tabletools/dialogs/tableCell.js
+++ b/plugins/tabletools/dialogs/tableCell.js
@@ -13,7 +13,7 @@ CKEDITOR.dialog.add( 'cellProperties', function( editor ) {
 		colorDialog = editor.plugins.colordialog,
 		firstColumn = {
 			type: 'vbox',
-			requiredContent: [ 'td{width,height}', 'td{white-space}', 'td{text-align}', 'td{vertical-align}' ],
+			requiredContent: [ 'td{width}', 'td{height}', 'td{white-space}', 'td{text-align}', 'td{vertical-align}' ],
 			padding: 0,
 			children: [ {
 				type: 'hbox',
@@ -22,7 +22,7 @@ CKEDITOR.dialog.add( 'cellProperties', function( editor ) {
 					type: 'text',
 					id: 'width',
 					width: '100px',
-					requiredContent: 'td{width,height}',
+					requiredContent: 'td{width}',
 					label: langCommon.width,
 					validate: validate.number( langCell.invalidWidth ),
 
@@ -65,7 +65,7 @@ CKEDITOR.dialog.add( 'cellProperties', function( editor ) {
 					{
 						type: 'select',
 						id: 'widthType',
-						requiredContent: 'td{width,height}',
+						requiredContent: 'td{width}',
 						label: editor.lang.table.widthUnit,
 						labelStyle: 'visibility:hidden',
 						'default': 'px',
@@ -82,7 +82,7 @@ CKEDITOR.dialog.add( 'cellProperties', function( editor ) {
 					children: [ {
 						type: 'text',
 						id: 'height',
-						requiredContent: 'td{width,height}',
+						requiredContent: 'td{height}',
 						label: langCommon.height,
 						width: '100px',
 						'default': '',
@@ -486,7 +486,7 @@ CKEDITOR.dialog.add( 'cellProperties', function( editor ) {
 	function whichColumns() {
 		var columns = 'none';
 
-		if ( editor.filter.check( [ 'td{width,height}', 'td{white-space}', 'td{text-align}', 'td{vertical-align}' ] ) ) {
+		if ( editor.filter.check( [ 'td{width}', 'td{height}', 'td{white-space}', 'td{text-align}', 'td{vertical-align}' ] ) ) {
 			columns = 'first';
 		}
 

--- a/plugins/tabletools/dialogs/tableCell.js
+++ b/plugins/tabletools/dialogs/tableCell.js
@@ -52,10 +52,11 @@ CKEDITOR.dialog.add( 'cellProperties', function( editor ) {
 							// case (https://dev.ckeditor.com/ticket/11439).
 							unit = this.getDialog().getValueOf( 'info', 'widthType' ) || getCellWidthType( element );
 
-						if ( !isNaN( value ) )
+						if ( !isNaN( value ) ) {
 							element.setStyle( 'width', value + unit );
-						else
+						} else {
 							element.removeStyle( 'width' );
+						}
 
 						element.removeAttribute( 'width' );
 					},
@@ -114,10 +115,11 @@ CKEDITOR.dialog.add( 'cellProperties', function( editor ) {
 						commit: function( element ) {
 							var value = parseInt( this.getValue(), 10 );
 
-							if ( !isNaN( value ) )
+							if ( !isNaN( value ) ) {
 								element.setStyle( 'height', CKEDITOR.tools.cssLength( value ) );
-							else
+							} else {
 								element.removeStyle( 'height' );
+							}
 
 							element.removeAttribute( 'height' );
 						}
@@ -149,14 +151,16 @@ CKEDITOR.dialog.add( 'cellProperties', function( editor ) {
 						var wordWrapAttr = element.getAttribute( 'noWrap' ),
 							wordWrapStyle = element.getStyle( 'white-space' );
 
-						if ( wordWrapStyle == 'nowrap' || wordWrapAttr )
+						if ( wordWrapStyle == 'nowrap' || wordWrapAttr ) {
 							return 'no';
+						}
 					} ),
 					commit: function( element ) {
-						if ( this.getValue() == 'no' )
+						if ( this.getValue() == 'no' ) {
 							element.setStyle( 'white-space', 'nowrap' );
-						else
+						} else {
 							element.removeStyle( 'white-space' );
+						}
 
 						element.removeAttribute( 'noWrap' );
 					}
@@ -184,10 +188,11 @@ CKEDITOR.dialog.add( 'cellProperties', function( editor ) {
 					commit: function( selectedCell ) {
 						var value = this.getValue();
 
-						if ( value )
+						if ( value ) {
 							selectedCell.setStyle( 'text-align', value );
-						else
+						} else {
 							selectedCell.removeStyle( 'text-align' );
+						}
 
 						selectedCell.removeAttribute( 'align' );
 					}
@@ -225,10 +230,11 @@ CKEDITOR.dialog.add( 'cellProperties', function( editor ) {
 					commit: function( element ) {
 						var value = this.getValue();
 
-						if ( value )
+						if ( value ) {
 							element.setStyle( 'vertical-align', value );
-						else
+						} else {
 							element.removeStyle( 'vertical-align' );
+						}
 
 						element.removeAttribute( 'vAlign' );
 					}
@@ -266,15 +272,17 @@ CKEDITOR.dialog.add( 'cellProperties', function( editor ) {
 					validate: validate.integer( langCell.invalidRowSpan ),
 					setup: setupCells( function( selectedCell ) {
 						var attrVal = parseInt( selectedCell.getAttribute( 'rowSpan' ), 10 );
-						if ( attrVal && attrVal != 1 )
+						if ( attrVal && attrVal != 1 ) {
 							return attrVal;
+						}
 					} ),
 					commit: function( selectedCell ) {
 						var value = parseInt( this.getValue(), 10 );
-						if ( value && value != 1 )
+						if ( value && value != 1 ) {
 							selectedCell.setAttribute( 'rowSpan', this.getValue() );
-						else
+						} else {
 							selectedCell.removeAttribute( 'rowSpan' );
+						}
 					}
 				},
 				{
@@ -286,15 +294,17 @@ CKEDITOR.dialog.add( 'cellProperties', function( editor ) {
 					validate: validate.integer( langCell.invalidColSpan ),
 					setup: setupCells( function( element ) {
 						var attrVal = parseInt( element.getAttribute( 'colSpan' ), 10 );
-						if ( attrVal && attrVal != 1 )
+						if ( attrVal && attrVal != 1 ) {
 							return attrVal;
+						}
 					} ),
 					commit: function( selectedCell ) {
 						var value = parseInt( this.getValue(), 10 );
-						if ( value && value != 1 )
+						if ( value && value != 1 ) {
 							selectedCell.setAttribute( 'colSpan', this.getValue() );
-						else
+						} else {
 							selectedCell.removeAttribute( 'colSpan' );
+						}
 					}
 				},
 				createSpacer( 'td[colspan]' ),
@@ -318,10 +328,11 @@ CKEDITOR.dialog.add( 'cellProperties', function( editor ) {
 						commit: function( selectedCell ) {
 							var value = this.getValue();
 
-							if ( value )
+							if ( value ) {
 								selectedCell.setStyle( 'background-color', this.getValue() );
-							else
+							} else {
 								selectedCell.removeStyle( 'background-color' );
+							}
 
 							selectedCell.removeAttribute( 'bgColor' );
 						}
@@ -337,8 +348,9 @@ CKEDITOR.dialog.add( 'cellProperties', function( editor ) {
 							},
 							onClick: function() {
 								editor.getColorFromDialog( function( color ) {
-									if ( color )
+									if ( color ) {
 										this.getDialog().getContentElement( 'info', 'bgColor' ).setValue( color );
+									}
 									this.focus();
 								}, this );
 							}
@@ -364,10 +376,11 @@ CKEDITOR.dialog.add( 'cellProperties', function( editor ) {
 						} ),
 						commit: function( selectedCell ) {
 							var value = this.getValue();
-							if ( value )
+							if ( value ) {
 								selectedCell.setStyle( 'border-color', this.getValue() );
-							else
+							} else {
 								selectedCell.removeStyle( 'border-color' );
+							}
 
 							selectedCell.removeAttribute( 'borderColor' );
 						}
@@ -385,8 +398,9 @@ CKEDITOR.dialog.add( 'cellProperties', function( editor ) {
 							},
 							onClick: function() {
 								editor.getColorFromDialog( function( color ) {
-									if ( color )
+									if ( color ) {
 										this.getDialog().getContentElement( 'info', 'borderColor' ).setValue( color );
+									}
 									this.focus();
 								}, this );
 							}
@@ -437,8 +451,9 @@ CKEDITOR.dialog.add( 'cellProperties', function( editor ) {
 			// remains unaltered, i.e. when selected multiple cells and dialog loaded
 			// only the properties of the first cell (https://dev.ckeditor.com/ticket/11439).
 			this.foreach( function( field ) {
-				if ( !field.setup || !field.commit )
+				if ( !field.setup || !field.commit ) {
 					return;
+				}
 
 				// Save field's value every time after "setup" is called.
 				field.setup = CKEDITOR.tools.override( field.setup, function( orgSetup ) {
@@ -451,8 +466,9 @@ CKEDITOR.dialog.add( 'cellProperties', function( editor ) {
 				// Compare saved value with actual value. Update cell only if value has changed.
 				field.commit = CKEDITOR.tools.override( field.commit, function( orgCommit ) {
 					return function() {
-						if ( saved[ field.id ] !== field.getValue() )
+						if ( saved[ field.id ] !== field.getValue() ) {
 							orgCommit.apply( this, arguments );
+						}
 					};
 				} );
 			} );
@@ -531,8 +547,9 @@ CKEDITOR.dialog.add( 'cellProperties', function( editor ) {
 
 				// The only way to have an empty select value in Firefox is
 				// to set a negative selectedIndex.
-				if ( CKEDITOR.env.gecko && this.type == 'select' && !fieldValue )
+				if ( CKEDITOR.env.gecko && this.type == 'select' && !fieldValue ) {
 					this.getInputElement().$.selectedIndex = -1;
+				}
 			}
 		};
 	}
@@ -545,7 +562,8 @@ CKEDITOR.dialog.add( 'cellProperties', function( editor ) {
 		var match = widthPattern.exec(
 			cell.getStyle( 'width' ) || cell.getAttribute( 'width' ) );
 
-		if ( match )
+		if ( match ) {
 			return match[ 2 ];
+		}
 	}
 } );

--- a/plugins/tabletools/dialogs/tableCell.js
+++ b/plugins/tabletools/dialogs/tableCell.js
@@ -63,8 +63,8 @@ CKEDITOR.dialog.add( 'cellProperties', function( editor ) {
 
 	return {
 		title: langCell.title,
-		minWidth: CKEDITOR.env.ie && CKEDITOR.env.quirks ? 450 : 410,
-		minHeight: CKEDITOR.env.ie && ( CKEDITOR.env.ie7Compat || CKEDITOR.env.quirks ) ? 230 : 220,
+		minWidth: 100,
+		minHeight: 50,
 		contents: [ {
 			id: 'info',
 			label: langCell.title,
@@ -74,6 +74,7 @@ CKEDITOR.dialog.add( 'cellProperties', function( editor ) {
 				widths: [ '40%', '5%', '40%' ],
 				children: [ {
 					type: 'vbox',
+					requiredContent: [ 'td{width,height}', 'td{white-space}', 'td{text-align}', 'td{vertical-align}' ],
 					padding: 0,
 					children: [ {
 						type: 'hbox',
@@ -221,7 +222,6 @@ CKEDITOR.dialog.add( 'cellProperties', function( editor ) {
 							element.removeAttribute( 'noWrap' );
 						}
 					},
-					spacer,
 					{
 						type: 'select',
 						id: 'hAlign',
@@ -294,9 +294,9 @@ CKEDITOR.dialog.add( 'cellProperties', function( editor ) {
 						}
 					} ]
 				},
-				spacer,
 				{
 					type: 'vbox',
+					requiredContent: [ 'th', 'td[rowspan]', 'td[colspan]', 'td{background-color}', 'td{border-color}' ],
 					padding: 0,
 					children: [ {
 						type: 'select',
@@ -315,7 +315,6 @@ CKEDITOR.dialog.add( 'cellProperties', function( editor ) {
 							selectedCell.renameNode( this.getValue() );
 						}
 					},
-					spacer,
 					{
 						type: 'text',
 						id: 'rowSpan',
@@ -356,15 +355,14 @@ CKEDITOR.dialog.add( 'cellProperties', function( editor ) {
 								selectedCell.removeAttribute( 'colSpan' );
 						}
 					},
-					spacer,
 					{
 						type: 'hbox',
 						padding: 0,
 						widths: [ '60%', '40%' ],
+						requiredContent: 'td{background-color}',
 						children: [ {
 							type: 'text',
 							id: 'bgColor',
-							requiredContent: 'td{background-color}',
 							label: langCell.bgColor,
 							'default': '',
 							setup: setupCells( function( element ) {
@@ -402,15 +400,14 @@ CKEDITOR.dialog.add( 'cellProperties', function( editor ) {
 							}
 						} : spacer ]
 					},
-					spacer,
 					{
 						type: 'hbox',
 						padding: 0,
 						widths: [ '60%', '40%' ],
+						requiredContent: 'td{border-color}',
 						children: [ {
 							type: 'text',
 							id: 'borderColor',
-							requiredContent: 'td{border-color}',
 							label: langCell.borderColor,
 							'default': '',
 							setup: setupCells( function( element ) {

--- a/plugins/tabletools/dialogs/tableCell.js
+++ b/plugins/tabletools/dialogs/tableCell.js
@@ -9,11 +9,28 @@ CKEDITOR.dialog.add( 'cellProperties', function( editor ) {
 		langCommon = editor.lang.common,
 		validate = CKEDITOR.dialog.validate,
 		widthPattern = /^(\d+(?:\.\d+)?)(px|%)$/,
-		spacer = { type: 'html', html: '&nbsp;' },
 		hiddenSpacer,
 		rtl = editor.lang.dir == 'rtl',
 		colorDialog = editor.plugins.colordialog;
 
+	function createSpacer( requiredContent ) {
+		return {
+			type: 'html',
+			html: '&nbsp;',
+			requiredContent: requiredContent ? requiredContent : undefined
+		};
+	}
+
+	function getColumnsCount() {
+		var columns = 0;
+		if ( editor.filter.check( [ 'th', 'td[rowspan]', 'td[colspan]', 'td{background-color}', 'td{border-color}' ] ) ) {
+			columns++;
+		}
+		if ( editor.filter.check( [ 'td{width,height}', 'td{white-space}', 'td{text-align}', 'td{vertical-align}' ] ) ) {
+			columns++;
+		}
+		return columns;
+	}
 	// Returns a function, which runs regular "setup" for all selected cells to find out
 	// whether the initial value of the field would be the same for all cells. If so,
 	// the value is displayed just as if a regular "setup" was executed. Otherwise,
@@ -63,7 +80,7 @@ CKEDITOR.dialog.add( 'cellProperties', function( editor ) {
 
 	return {
 		title: langCell.title,
-		minWidth: 100,
+		minWidth: getColumnsCount() * 205,
 		minHeight: 50,
 		contents: [ {
 			id: 'info',
@@ -222,6 +239,7 @@ CKEDITOR.dialog.add( 'cellProperties', function( editor ) {
 							element.removeAttribute( 'noWrap' );
 						}
 					},
+					createSpacer( 'td{white-space}' ),
 					{
 						type: 'select',
 						id: 'hAlign',
@@ -294,6 +312,7 @@ CKEDITOR.dialog.add( 'cellProperties', function( editor ) {
 						}
 					} ]
 				},
+				createSpacer( 'td{vertical-align}' ),
 				{
 					type: 'vbox',
 					requiredContent: [ 'th', 'td[rowspan]', 'td[colspan]', 'td{background-color}', 'td{border-color}' ],
@@ -315,6 +334,7 @@ CKEDITOR.dialog.add( 'cellProperties', function( editor ) {
 							selectedCell.renameNode( this.getValue() );
 						}
 					},
+					createSpacer( 'th' ),
 					{
 						type: 'text',
 						id: 'rowSpan',
@@ -355,6 +375,7 @@ CKEDITOR.dialog.add( 'cellProperties', function( editor ) {
 								selectedCell.removeAttribute( 'colSpan' );
 						}
 					},
+					createSpacer( 'td[colspan]' ),
 					{
 						type: 'hbox',
 						padding: 0,
@@ -398,8 +419,9 @@ CKEDITOR.dialog.add( 'cellProperties', function( editor ) {
 									this.focus();
 								}, this );
 							}
-						} : spacer ]
+						} : createSpacer() ]
 					},
+					createSpacer( 'td{background-color}' ),
 					{
 						type: 'hbox',
 						padding: 0,
@@ -444,7 +466,7 @@ CKEDITOR.dialog.add( 'cellProperties', function( editor ) {
 									this.focus();
 								}, this );
 							}
-						} : spacer ]
+						} : createSpacer() ]
 					} ]
 				} ]
 			} ]

--- a/plugins/tabletools/dialogs/tableCell.js
+++ b/plugins/tabletools/dialogs/tableCell.js
@@ -291,95 +291,107 @@ CKEDITOR.dialog.add( 'cellProperties', function( editor ) {
 			padding: 0,
 			widths: colorDialog ? [ '60%', '40%' ] : [ '100%' ],
 			requiredContent: 'td{background-color}',
-			children: [ {
-				type: 'text',
-				id: 'bgColor',
-				label: langCell.bgColor,
-				'default': '',
-				setup: setupCells( function( element ) {
-					var bgColorAttr = element.getAttribute( 'bgColor' ),
-						bgColorStyle = element.getStyle( 'background-color' );
+			children: ( function() {
+				var children = [ {
+					type: 'text',
+					id: 'bgColor',
+					label: langCell.bgColor,
+					'default': '',
+					setup: setupCells( function( element ) {
+						var bgColorAttr = element.getAttribute( 'bgColor' ),
+							bgColorStyle = element.getStyle( 'background-color' );
 
-					return bgColorStyle || bgColorAttr;
-				} ),
-				commit: function( selectedCell ) {
-					var value = this.getValue();
+						return bgColorStyle || bgColorAttr;
+					} ),
+					commit: function( selectedCell ) {
+						var value = this.getValue();
 
-					if ( value ) {
-						selectedCell.setStyle( 'background-color', this.getValue() );
-					} else {
-						selectedCell.removeStyle( 'background-color' );
+						if ( value ) {
+							selectedCell.setStyle( 'background-color', this.getValue() );
+						} else {
+							selectedCell.removeStyle( 'background-color' );
+						}
+
+						selectedCell.removeAttribute( 'bgColor' );
 					}
+				} ];
 
-					selectedCell.removeAttribute( 'bgColor' );
+				if ( colorDialog ) {
+					children.push( {
+						type: 'button',
+						id: 'bgColorChoose',
+						'class': 'colorChooser', // jshint ignore:line
+						label: langCell.chooseColor,
+						onLoad: function() {
+							// Stick the element to the bottom (https://dev.ckeditor.com/ticket/5587)
+							this.getElement().getParent().setStyle( 'vertical-align', 'bottom' );
+						},
+						onClick: function() {
+							editor.getColorFromDialog( function( color ) {
+								if ( color ) {
+									this.getDialog().getContentElement( 'info', 'bgColor' ).setValue( color );
+								}
+								this.focus();
+							}, this );
+						}
+					} );
 				}
-			},
-				colorDialog ? {
-					type: 'button',
-					id: 'bgColorChoose',
-					'class': 'colorChooser', // jshint ignore:line
-					label: langCell.chooseColor,
-					onLoad: function() {
-						// Stick the element to the bottom (https://dev.ckeditor.com/ticket/5587)
-						this.getElement().getParent().setStyle( 'vertical-align', 'bottom' );
-					},
-					onClick: function() {
-						editor.getColorFromDialog( function( color ) {
-							if ( color ) {
-								this.getDialog().getContentElement( 'info', 'bgColor' ).setValue( color );
-							}
-							this.focus();
-						}, this );
-					}
-				} : null ]
+				return children;
+			} )()
 		},
 		{
 			type: 'hbox',
 			padding: 0,
 			widths: colorDialog ? [ '60%', '40%' ] : [ '100%' ],
 			requiredContent: 'td{border-color}',
-			children: [ {
-				type: 'text',
-				id: 'borderColor',
-				label: langCell.borderColor,
-				'default': '',
-				setup: setupCells( function( element ) {
-					var borderColorAttr = element.getAttribute( 'borderColor' ),
-						borderColorStyle = element.getStyle( 'border-color' );
+			children: ( function() {
+				var children = [ {
+					type: 'text',
+					id: 'borderColor',
+					label: langCell.borderColor,
+					'default': '',
+					setup: setupCells( function( element ) {
+						var borderColorAttr = element.getAttribute( 'borderColor' ),
+							borderColorStyle = element.getStyle( 'border-color' );
 
-					return borderColorStyle || borderColorAttr;
-				} ),
-				commit: function( selectedCell ) {
-					var value = this.getValue();
-					if ( value ) {
-						selectedCell.setStyle( 'border-color', this.getValue() );
-					} else {
-						selectedCell.removeStyle( 'border-color' );
-					}
-
-					selectedCell.removeAttribute( 'borderColor' );
-				}
-			},
-
-			colorDialog ? {
-				type: 'button',
-				id: 'borderColorChoose',
-				'class': 'colorChooser', // jshint ignore:line
-				label: langCell.chooseColor,
-				style: ( rtl ? 'margin-right' : 'margin-left' ) + ': 10px',
-				onLoad: function() {
-					// Stick the element to the bottom (https://dev.ckeditor.com/ticket/5587)
-					this.getElement().getParent().setStyle( 'vertical-align', 'bottom' );
-				},
-				onClick: function() {
-					editor.getColorFromDialog( function( color ) {
-						if ( color ) {
-							this.getDialog().getContentElement( 'info', 'borderColor' ).setValue( color );
+						return borderColorStyle || borderColorAttr;
+					} ),
+					commit: function( selectedCell ) {
+						var value = this.getValue();
+						if ( value ) {
+							selectedCell.setStyle( 'border-color', this.getValue() );
+						} else {
+							selectedCell.removeStyle( 'border-color' );
 						}
-						this.focus();
-					}, this );
+
+						selectedCell.removeAttribute( 'borderColor' );
+					}
+				} ];
+
+				if ( colorDialog ) {
+					children.push( {
+						type: 'button',
+						id: 'borderColorChoose',
+						'class': 'colorChooser', // jshint ignore:line
+						label: langCell.chooseColor,
+						style: ( rtl ? 'margin-right' : 'margin-left' ) + ': 10px',
+						onLoad: function() {
+							// Stick the element to the bottom (https://dev.ckeditor.com/ticket/5587)
+							this.getElement().getParent().setStyle( 'vertical-align', 'bottom' );
+						},
+						onClick: function() {
+							editor.getColorFromDialog( function( color ) {
+								if ( color ) {
+									this.getDialog().getContentElement( 'info', 'borderColor' ).setValue( color );
+								}
+								this.focus();
+							}, this );
+						}
+					} );
 				}
-			} : null ]
+
+				return children;
+			} )()
 		} ],
 	itemsCount = 0,
 	index = -1,

--- a/plugins/tabletools/dialogs/tableCell.js
+++ b/plugins/tabletools/dialogs/tableCell.js
@@ -222,7 +222,9 @@ CKEDITOR.dialog.add( 'cellProperties', function( editor ) {
 
 				element.removeAttribute( 'vAlign' );
 			}
-		}, {
+		},
+			createSpacer( [ 'td{text-align}', 'td{vertical-align}' ] ),
+		{
 			type: 'select',
 			id: 'cellType',
 			requiredContent: 'th',
@@ -283,7 +285,7 @@ CKEDITOR.dialog.add( 'cellProperties', function( editor ) {
 				}
 			}
 		},
-		createSpacer( 'td[colspan]' ),
+		createSpacer( [ 'td[colspan]', 'td[rowspan]' ] ),
 		{
 			type: 'hbox',
 			padding: 0,

--- a/plugins/tabletools/dialogs/tableCell.js
+++ b/plugins/tabletools/dialogs/tableCell.js
@@ -11,7 +11,6 @@ CKEDITOR.dialog.add( 'cellProperties', function( editor ) {
 		widthPattern = /^(\d+(?:\.\d+)?)(px|%)$/,
 		rtl = editor.lang.dir == 'rtl',
 		colorDialog = editor.plugins.colordialog,
-
 		firstColumn = {
 			type: 'vbox',
 			requiredContent: [ 'td{width,height}', 'td{white-space}', 'td{text-align}', 'td{vertical-align}' ],
@@ -307,6 +306,7 @@ CKEDITOR.dialog.add( 'cellProperties', function( editor ) {
 					children: [ {
 						type: 'text',
 						id: 'bgColor',
+						requiredContent: 'td{background-color}',
 						label: langCell.bgColor,
 						'default': '',
 						setup: setupCells( function( element ) {
@@ -353,6 +353,7 @@ CKEDITOR.dialog.add( 'cellProperties', function( editor ) {
 					children: [ {
 						type: 'text',
 						id: 'borderColor',
+						requiredContent: 'td{border-color}',
 						label: langCell.borderColor,
 						'default': '',
 						setup: setupCells( function( element ) {
@@ -393,17 +394,10 @@ CKEDITOR.dialog.add( 'cellProperties', function( editor ) {
 				} ]
 		},
 
-		children = [];
+	children = [ firstColumn, secondColumn ];
 
-	switch ( whichColumns() ) {
-		case 'first':
-			children.push( firstColumn );
-			break;
-		case 'second':
-			children.push( secondColumn );
-			break;
-		default:
-			children = [ firstColumn, createSpacer(), secondColumn ];
+	if ( getColumnsCount() === 2 ) {
+		children.splice( 1, 0, createSpacer() );
 	}
 
 	return {
@@ -501,8 +495,9 @@ CKEDITOR.dialog.add( 'cellProperties', function( editor ) {
 	function getWidths() {
 		switch ( whichColumns() ) {
 			case 'first':
+				return [ '100%', '0' ];
 			case 'second':
-				return [ '100%' ];
+				return [ '0', '100%' ];
 			default:
 				return [ '40%', '5%', '40%' ];
 		}

--- a/plugins/tabletools/dialogs/tableCell.js
+++ b/plugins/tabletools/dialogs/tableCell.js
@@ -9,9 +9,461 @@ CKEDITOR.dialog.add( 'cellProperties', function( editor ) {
 		langCommon = editor.lang.common,
 		validate = CKEDITOR.dialog.validate,
 		widthPattern = /^(\d+(?:\.\d+)?)(px|%)$/,
-		hiddenSpacer,
 		rtl = editor.lang.dir == 'rtl',
-		colorDialog = editor.plugins.colordialog;
+		colorDialog = editor.plugins.colordialog,
+
+		firstColumn = {
+			type: 'vbox',
+			requiredContent: [ 'td{width,height}', 'td{white-space}', 'td{text-align}', 'td{vertical-align}' ],
+			padding: 0,
+			children: [ {
+				type: 'hbox',
+				widths: [ '70%', '30%' ],
+				children: [ {
+					type: 'text',
+					id: 'width',
+					width: '100px',
+					requiredContent: 'td{width,height}',
+					label: langCommon.width,
+					validate: validate.number( langCell.invalidWidth ),
+
+					// Extra labelling of width unit type.
+					onLoad: function() {
+						var widthType = this.getDialog().getContentElement( 'info', 'widthType' ),
+							labelElement = widthType.getElement(),
+							inputElement = this.getInputElement(),
+							ariaLabelledByAttr = inputElement.getAttribute( 'aria-labelledby' );
+
+						inputElement.setAttribute( 'aria-labelledby', [ ariaLabelledByAttr, labelElement.$.id ].join( ' ' ) );
+					},
+
+					setup: setupCells( function( element ) {
+						var widthAttr = parseInt( element.getAttribute( 'width' ), 10 ),
+							widthStyle = parseInt( element.getStyle( 'width' ), 10 );
+
+						return !isNaN( widthStyle ) ? widthStyle :
+							!isNaN( widthAttr ) ? widthAttr : '';
+					} ),
+					commit: function( element ) {
+						var value = parseInt( this.getValue(), 10 ),
+
+							// There might be no widthType value, i.e. when multiple cells are
+							// selected but some of them have width expressed in pixels and some
+							// of them in percent. Try to re-read the unit from the cell in such
+							// case (https://dev.ckeditor.com/ticket/11439).
+							unit = this.getDialog().getValueOf( 'info', 'widthType' ) || getCellWidthType( element );
+
+						if ( !isNaN( value ) )
+							element.setStyle( 'width', value + unit );
+						else
+							element.removeStyle( 'width' );
+
+						element.removeAttribute( 'width' );
+					},
+					'default': ''
+				},
+					{
+						type: 'select',
+						id: 'widthType',
+						requiredContent: 'td{width,height}',
+						label: editor.lang.table.widthUnit,
+						labelStyle: 'visibility:hidden',
+						'default': 'px',
+						items: [
+							[ langTable.widthPx, 'px' ],
+							[ langTable.widthPc, '%' ]
+						],
+						setup: setupCells( getCellWidthType )
+					} ]
+			},
+				{
+					type: 'hbox',
+					widths: [ '70%', '30%' ],
+					children: [ {
+						type: 'text',
+						id: 'height',
+						requiredContent: 'td{width,height}',
+						label: langCommon.height,
+						width: '100px',
+						'default': '',
+						validate: validate.number( langCell.invalidHeight ),
+
+						// Extra labelling of height unit type.
+						onLoad: function() {
+							var heightType = this.getDialog().getContentElement( 'info', 'htmlHeightType' ),
+								labelElement = heightType.getElement(),
+								inputElement = this.getInputElement(),
+								ariaLabelledByAttr = inputElement.getAttribute( 'aria-labelledby' );
+
+							if ( this.getDialog().getContentElement( 'info', 'height' ).isVisible() ) {
+								labelElement.setHtml( '<br />' + langTable.widthPx );
+								labelElement.setStyle( 'display', 'block' );
+
+								this.getDialog().getContentElement( 'info', 'hiddenSpacer' ).getElement().setStyle( 'display', 'block' );
+							}
+
+							inputElement.setAttribute( 'aria-labelledby', [ ariaLabelledByAttr, labelElement.$.id ].join( ' ' ) );
+						},
+
+						setup: setupCells( function( element ) {
+							var heightAttr = parseInt( element.getAttribute( 'height' ), 10 ),
+								heightStyle = parseInt( element.getStyle( 'height' ), 10 );
+
+							return !isNaN( heightStyle ) ? heightStyle :
+								!isNaN( heightAttr ) ? heightAttr : '';
+						} ),
+						commit: function( element ) {
+							var value = parseInt( this.getValue(), 10 );
+
+							if ( !isNaN( value ) )
+								element.setStyle( 'height', CKEDITOR.tools.cssLength( value ) );
+							else
+								element.removeStyle( 'height' );
+
+							element.removeAttribute( 'height' );
+						}
+					},
+						{
+							id: 'htmlHeightType',
+							type: 'html',
+							html: '',
+							style: 'display: none'
+						} ]
+				},
+				{
+					type: 'html',
+					id: 'hiddenSpacer',
+					html: '&nbsp;',
+					style: 'display: none'
+				},
+				{
+					type: 'select',
+					id: 'wordWrap',
+					requiredContent: 'td{white-space}',
+					label: langCell.wordWrap,
+					'default': 'yes',
+					items: [
+						[ langCell.yes, 'yes' ],
+						[ langCell.no, 'no' ]
+					],
+					setup: setupCells( function( element ) {
+						var wordWrapAttr = element.getAttribute( 'noWrap' ),
+							wordWrapStyle = element.getStyle( 'white-space' );
+
+						if ( wordWrapStyle == 'nowrap' || wordWrapAttr )
+							return 'no';
+					} ),
+					commit: function( element ) {
+						if ( this.getValue() == 'no' )
+							element.setStyle( 'white-space', 'nowrap' );
+						else
+							element.removeStyle( 'white-space' );
+
+						element.removeAttribute( 'noWrap' );
+					}
+				},
+				createSpacer( 'td{white-space}' ),
+				{
+					type: 'select',
+					id: 'hAlign',
+					requiredContent: 'td{text-align}',
+					label: langCell.hAlign,
+					'default': '',
+					items: [
+						[ langCommon.notSet, '' ],
+						[ langCommon.left, 'left' ],
+						[ langCommon.center, 'center' ],
+						[ langCommon.right, 'right' ],
+						[ langCommon.justify, 'justify' ]
+					],
+					setup: setupCells( function( element ) {
+						var alignAttr = element.getAttribute( 'align' ),
+							textAlignStyle = element.getStyle( 'text-align' );
+
+						return textAlignStyle || alignAttr || '';
+					} ),
+					commit: function( selectedCell ) {
+						var value = this.getValue();
+
+						if ( value )
+							selectedCell.setStyle( 'text-align', value );
+						else
+							selectedCell.removeStyle( 'text-align' );
+
+						selectedCell.removeAttribute( 'align' );
+					}
+				},
+				{
+					type: 'select',
+					id: 'vAlign',
+					requiredContent: 'td{vertical-align}',
+					label: langCell.vAlign,
+					'default': '',
+					items: [
+						[ langCommon.notSet, '' ],
+						[ langCommon.alignTop, 'top' ],
+						[ langCommon.alignMiddle, 'middle' ],
+						[ langCommon.alignBottom, 'bottom' ],
+						[ langCell.alignBaseline, 'baseline' ]
+					],
+					setup: setupCells( function( element ) {
+						var vAlignAttr = element.getAttribute( 'vAlign' ),
+							vAlignStyle = element.getStyle( 'vertical-align' );
+
+						switch ( vAlignStyle ) {
+							// Ignore all other unrelated style values..
+							case 'top':
+							case 'middle':
+							case 'bottom':
+							case 'baseline':
+								break;
+							default:
+								vAlignStyle = '';
+						}
+
+						return vAlignStyle || vAlignAttr || '';
+					} ),
+					commit: function( element ) {
+						var value = this.getValue();
+
+						if ( value )
+							element.setStyle( 'vertical-align', value );
+						else
+							element.removeStyle( 'vertical-align' );
+
+						element.removeAttribute( 'vAlign' );
+					}
+				} ]
+		},
+
+		secondColumn = {
+			type: 'vbox',
+			requiredContent: [ 'th', 'td[rowspan]', 'td[colspan]', 'td{background-color}', 'td{border-color}' ],
+			padding: 0,
+			children: [ {
+				type: 'select',
+				id: 'cellType',
+				requiredContent: 'th',
+				label: langCell.cellType,
+				'default': 'td',
+				items: [
+					[ langCell.data, 'td' ],
+					[ langCell.header, 'th' ]
+				],
+				setup: setupCells( function( selectedCell ) {
+					return selectedCell.getName();
+				} ),
+				commit: function( selectedCell ) {
+					selectedCell.renameNode( this.getValue() );
+				}
+			},
+				createSpacer( 'th' ),
+				{
+					type: 'text',
+					id: 'rowSpan',
+					requiredContent: 'td[rowspan]',
+					label: langCell.rowSpan,
+					'default': '',
+					validate: validate.integer( langCell.invalidRowSpan ),
+					setup: setupCells( function( selectedCell ) {
+						var attrVal = parseInt( selectedCell.getAttribute( 'rowSpan' ), 10 );
+						if ( attrVal && attrVal != 1 )
+							return attrVal;
+					} ),
+					commit: function( selectedCell ) {
+						var value = parseInt( this.getValue(), 10 );
+						if ( value && value != 1 )
+							selectedCell.setAttribute( 'rowSpan', this.getValue() );
+						else
+							selectedCell.removeAttribute( 'rowSpan' );
+					}
+				},
+				{
+					type: 'text',
+					id: 'colSpan',
+					requiredContent: 'td[colspan]',
+					label: langCell.colSpan,
+					'default': '',
+					validate: validate.integer( langCell.invalidColSpan ),
+					setup: setupCells( function( element ) {
+						var attrVal = parseInt( element.getAttribute( 'colSpan' ), 10 );
+						if ( attrVal && attrVal != 1 )
+							return attrVal;
+					} ),
+					commit: function( selectedCell ) {
+						var value = parseInt( this.getValue(), 10 );
+						if ( value && value != 1 )
+							selectedCell.setAttribute( 'colSpan', this.getValue() );
+						else
+							selectedCell.removeAttribute( 'colSpan' );
+					}
+				},
+				createSpacer( 'td[colspan]' ),
+				{
+					type: 'hbox',
+					padding: 0,
+					widths: [ '60%', '40%' ],
+					requiredContent: 'td{background-color}',
+					children: [ {
+						type: 'text',
+						id: 'bgColor',
+						label: langCell.bgColor,
+						'default': '',
+						setup: setupCells( function( element ) {
+							var bgColorAttr = element.getAttribute( 'bgColor' ),
+								bgColorStyle = element.getStyle( 'background-color' );
+
+							return bgColorStyle || bgColorAttr;
+						} ),
+						commit: function( selectedCell ) {
+							var value = this.getValue();
+
+							if ( value )
+								selectedCell.setStyle( 'background-color', this.getValue() );
+							else
+								selectedCell.removeStyle( 'background-color' );
+
+							selectedCell.removeAttribute( 'bgColor' );
+						}
+					},
+						colorDialog ? {
+							type: 'button',
+							id: 'bgColorChoose',
+							'class': 'colorChooser', // jshint ignore:line
+							label: langCell.chooseColor,
+							onLoad: function() {
+								// Stick the element to the bottom (https://dev.ckeditor.com/ticket/5587)
+								this.getElement().getParent().setStyle( 'vertical-align', 'bottom' );
+							},
+							onClick: function() {
+								editor.getColorFromDialog( function( color ) {
+									if ( color )
+										this.getDialog().getContentElement( 'info', 'bgColor' ).setValue( color );
+									this.focus();
+								}, this );
+							}
+						} : createSpacer() ]
+				},
+				createSpacer( 'td{background-color}' ),
+				{
+					type: 'hbox',
+					padding: 0,
+					widths: [ '60%', '40%' ],
+					requiredContent: 'td{border-color}',
+					children: [ {
+						type: 'text',
+						id: 'borderColor',
+						label: langCell.borderColor,
+						'default': '',
+						setup: setupCells( function( element ) {
+							var borderColorAttr = element.getAttribute( 'borderColor' ),
+								borderColorStyle = element.getStyle( 'border-color' );
+
+							return borderColorStyle || borderColorAttr;
+						} ),
+						commit: function( selectedCell ) {
+							var value = this.getValue();
+							if ( value )
+								selectedCell.setStyle( 'border-color', this.getValue() );
+							else
+								selectedCell.removeStyle( 'border-color' );
+
+							selectedCell.removeAttribute( 'borderColor' );
+						}
+					},
+
+						colorDialog ? {
+							type: 'button',
+							id: 'borderColorChoose',
+							'class': 'colorChooser', // jshint ignore:line
+							label: langCell.chooseColor,
+							style: ( rtl ? 'margin-right' : 'margin-left' ) + ': 10px',
+							onLoad: function() {
+								// Stick the element to the bottom (https://dev.ckeditor.com/ticket/5587)
+								this.getElement().getParent().setStyle( 'vertical-align', 'bottom' );
+							},
+							onClick: function() {
+								editor.getColorFromDialog( function( color ) {
+									if ( color )
+										this.getDialog().getContentElement( 'info', 'borderColor' ).setValue( color );
+									this.focus();
+								}, this );
+							}
+						} : createSpacer() ]
+				} ]
+		},
+
+		children = [];
+
+	switch ( whichColumns() ) {
+		case 'first':
+			children.push( firstColumn );
+			break;
+		case 'second':
+			children.push( secondColumn );
+			break;
+		default:
+			children = [ firstColumn, createSpacer(), secondColumn ];
+	}
+
+	return {
+		title: langCell.title,
+		minWidth: getColumnsCount() * 205,
+		minHeight: 50,
+		contents: [ {
+			id: 'info',
+			label: langCell.title,
+			accessKey: 'I',
+			elements: [ {
+				type: 'hbox',
+				widths: getWidths(),
+				children: children
+			} ]
+		} ],
+		onShow: function() {
+			this.cells = CKEDITOR.plugins.tabletools.getSelectedCells( this._.editor.getSelection() );
+			this.setupContent( this.cells );
+		},
+		onOk: function() {
+			var selection = this._.editor.getSelection(),
+				bookmarks = selection.createBookmarks();
+
+			var cells = this.cells;
+			for ( var i = 0; i < cells.length; i++ )
+				this.commitContent( cells[ i ] );
+
+			this._.editor.forceNextSelectionCheck();
+			selection.selectBookmarks( bookmarks );
+			this._.editor.selectionChange();
+		},
+		onLoad: function() {
+			var saved = {};
+
+			// Prevent from changing cell properties when the field's value
+			// remains unaltered, i.e. when selected multiple cells and dialog loaded
+			// only the properties of the first cell (https://dev.ckeditor.com/ticket/11439).
+			this.foreach( function( field ) {
+				if ( !field.setup || !field.commit )
+					return;
+
+				// Save field's value every time after "setup" is called.
+				field.setup = CKEDITOR.tools.override( field.setup, function( orgSetup ) {
+					return function() {
+						orgSetup.apply( this, arguments );
+						saved[ field.id ] = field.getValue();
+					};
+				} );
+
+				// Compare saved value with actual value. Update cell only if value has changed.
+				field.commit = CKEDITOR.tools.override( field.commit, function( orgCommit ) {
+					return function() {
+						if ( saved[ field.id ] !== field.getValue() )
+							orgCommit.apply( this, arguments );
+					};
+				} );
+			} );
+		}
+	};
 
 	function createSpacer( requiredContent ) {
 		return {
@@ -21,15 +473,39 @@ CKEDITOR.dialog.add( 'cellProperties', function( editor ) {
 		};
 	}
 
-	function getColumnsCount() {
-		var columns = 0;
-		if ( editor.filter.check( [ 'th', 'td[rowspan]', 'td[colspan]', 'td{background-color}', 'td{border-color}' ] ) ) {
-			columns++;
-		}
+	function whichColumns() {
+		var columns = 'none';
+
 		if ( editor.filter.check( [ 'td{width,height}', 'td{white-space}', 'td{text-align}', 'td{vertical-align}' ] ) ) {
-			columns++;
+			columns = 'first';
 		}
+
+		if ( editor.filter.check( [ 'th', 'td[rowspan]', 'td[colspan]', 'td{background-color}', 'td{border-color}' ] ) ) {
+			columns = columns === 'first' ? 'both' : 'second';
+		}
+
 		return columns;
+	}
+
+	function getColumnsCount() {
+		switch ( whichColumns() ) {
+			case 'none':
+				return 0;
+			case 'both':
+				return 2;
+			default:
+				return 1;
+		}
+	}
+
+	function getWidths() {
+		switch ( whichColumns() ) {
+			case 'first':
+			case 'second':
+				return [ '100%' ];
+			default:
+				return [ '40%', '5%', '40%' ];
+		}
 	}
 	// Returns a function, which runs regular "setup" for all selected cells to find out
 	// whether the initial value of the field would be the same for all cells. If so,
@@ -77,442 +553,4 @@ CKEDITOR.dialog.add( 'cellProperties', function( editor ) {
 		if ( match )
 			return match[ 2 ];
 	}
-
-	return {
-		title: langCell.title,
-		minWidth: getColumnsCount() * 205,
-		minHeight: 50,
-		contents: [ {
-			id: 'info',
-			label: langCell.title,
-			accessKey: 'I',
-			elements: [ {
-				type: 'hbox',
-				widths: [ '40%', '5%', '40%' ],
-				children: [ {
-					type: 'vbox',
-					requiredContent: [ 'td{width,height}', 'td{white-space}', 'td{text-align}', 'td{vertical-align}' ],
-					padding: 0,
-					children: [ {
-						type: 'hbox',
-						widths: [ '70%', '30%' ],
-						children: [ {
-							type: 'text',
-							id: 'width',
-							width: '100px',
-							requiredContent: 'td{width,height}',
-							label: langCommon.width,
-							validate: validate.number( langCell.invalidWidth ),
-
-							// Extra labelling of width unit type.
-							onLoad: function() {
-								var widthType = this.getDialog().getContentElement( 'info', 'widthType' ),
-									labelElement = widthType.getElement(),
-									inputElement = this.getInputElement(),
-									ariaLabelledByAttr = inputElement.getAttribute( 'aria-labelledby' );
-
-								inputElement.setAttribute( 'aria-labelledby', [ ariaLabelledByAttr, labelElement.$.id ].join( ' ' ) );
-							},
-
-							setup: setupCells( function( element ) {
-								var widthAttr = parseInt( element.getAttribute( 'width' ), 10 ),
-									widthStyle = parseInt( element.getStyle( 'width' ), 10 );
-
-								return !isNaN( widthStyle ) ? widthStyle :
-									!isNaN( widthAttr ) ? widthAttr : '';
-							} ),
-							commit: function( element ) {
-								var value = parseInt( this.getValue(), 10 ),
-
-									// There might be no widthType value, i.e. when multiple cells are
-									// selected but some of them have width expressed in pixels and some
-									// of them in percent. Try to re-read the unit from the cell in such
-									// case (https://dev.ckeditor.com/ticket/11439).
-									unit = this.getDialog().getValueOf( 'info', 'widthType' ) || getCellWidthType( element );
-
-								if ( !isNaN( value ) )
-									element.setStyle( 'width', value + unit );
-								else
-									element.removeStyle( 'width' );
-
-								element.removeAttribute( 'width' );
-							},
-							'default': ''
-						},
-						{
-							type: 'select',
-							id: 'widthType',
-							requiredContent: 'td{width,height}',
-							label: editor.lang.table.widthUnit,
-							labelStyle: 'visibility:hidden',
-							'default': 'px',
-							items: [
-								[ langTable.widthPx, 'px' ],
-								[ langTable.widthPc, '%' ]
-							],
-							setup: setupCells( getCellWidthType )
-						} ]
-					},
-					{
-						type: 'hbox',
-						widths: [ '70%', '30%' ],
-						children: [ {
-							type: 'text',
-							id: 'height',
-							requiredContent: 'td{width,height}',
-							label: langCommon.height,
-							width: '100px',
-							'default': '',
-							validate: validate.number( langCell.invalidHeight ),
-
-							// Extra labelling of height unit type.
-							onLoad: function() {
-								var heightType = this.getDialog().getContentElement( 'info', 'htmlHeightType' ),
-									labelElement = heightType.getElement(),
-									inputElement = this.getInputElement(),
-									ariaLabelledByAttr = inputElement.getAttribute( 'aria-labelledby' );
-
-								if ( this.getDialog().getContentElement( 'info', 'height' ).isVisible() ) {
-									labelElement.setHtml( '<br />' + langTable.widthPx );
-									labelElement.setStyle( 'display', 'block' );
-
-									this.getDialog().getContentElement( 'info', 'hiddenSpacer' ).getElement().setStyle( 'display', 'block' );
-								}
-
-								inputElement.setAttribute( 'aria-labelledby', [ ariaLabelledByAttr, labelElement.$.id ].join( ' ' ) );
-							},
-
-							setup: setupCells( function( element ) {
-								var heightAttr = parseInt( element.getAttribute( 'height' ), 10 ),
-									heightStyle = parseInt( element.getStyle( 'height' ), 10 );
-
-								return !isNaN( heightStyle ) ? heightStyle :
-									!isNaN( heightAttr ) ? heightAttr : '';
-							} ),
-							commit: function( element ) {
-								var value = parseInt( this.getValue(), 10 );
-
-								if ( !isNaN( value ) )
-									element.setStyle( 'height', CKEDITOR.tools.cssLength( value ) );
-								else
-									element.removeStyle( 'height' );
-
-								element.removeAttribute( 'height' );
-							}
-						},
-						{
-							id: 'htmlHeightType',
-							type: 'html',
-							html: '',
-							style: 'display: none'
-						} ]
-					},
-					hiddenSpacer = {
-						type: 'html',
-						id: 'hiddenSpacer',
-						html: '&nbsp;',
-						style: 'display: none'
-					},
-					{
-						type: 'select',
-						id: 'wordWrap',
-						requiredContent: 'td{white-space}',
-						label: langCell.wordWrap,
-						'default': 'yes',
-						items: [
-							[ langCell.yes, 'yes' ],
-							[ langCell.no, 'no' ]
-						],
-						setup: setupCells( function( element ) {
-							var wordWrapAttr = element.getAttribute( 'noWrap' ),
-								wordWrapStyle = element.getStyle( 'white-space' );
-
-							if ( wordWrapStyle == 'nowrap' || wordWrapAttr )
-								return 'no';
-						} ),
-						commit: function( element ) {
-							if ( this.getValue() == 'no' )
-								element.setStyle( 'white-space', 'nowrap' );
-							else
-								element.removeStyle( 'white-space' );
-
-							element.removeAttribute( 'noWrap' );
-						}
-					},
-					createSpacer( 'td{white-space}' ),
-					{
-						type: 'select',
-						id: 'hAlign',
-						requiredContent: 'td{text-align}',
-						label: langCell.hAlign,
-						'default': '',
-						items: [
-							[ langCommon.notSet, '' ],
-							[ langCommon.left, 'left' ],
-							[ langCommon.center, 'center' ],
-							[ langCommon.right, 'right' ],
-							[ langCommon.justify, 'justify' ]
-						],
-						setup: setupCells( function( element ) {
-							var alignAttr = element.getAttribute( 'align' ),
-								textAlignStyle = element.getStyle( 'text-align' );
-
-							return textAlignStyle || alignAttr || '';
-						} ),
-						commit: function( selectedCell ) {
-							var value = this.getValue();
-
-							if ( value )
-								selectedCell.setStyle( 'text-align', value );
-							else
-								selectedCell.removeStyle( 'text-align' );
-
-							selectedCell.removeAttribute( 'align' );
-						}
-					},
-					{
-						type: 'select',
-						id: 'vAlign',
-						requiredContent: 'td{vertical-align}',
-						label: langCell.vAlign,
-						'default': '',
-						items: [
-							[ langCommon.notSet, '' ],
-							[ langCommon.alignTop, 'top' ],
-							[ langCommon.alignMiddle, 'middle' ],
-							[ langCommon.alignBottom, 'bottom' ],
-							[ langCell.alignBaseline, 'baseline' ]
-						],
-						setup: setupCells( function( element ) {
-							var vAlignAttr = element.getAttribute( 'vAlign' ),
-								vAlignStyle = element.getStyle( 'vertical-align' );
-
-							switch ( vAlignStyle ) {
-								// Ignore all other unrelated style values..
-								case 'top':
-								case 'middle':
-								case 'bottom':
-								case 'baseline':
-									break;
-								default:
-									vAlignStyle = '';
-							}
-
-							return vAlignStyle || vAlignAttr || '';
-						} ),
-						commit: function( element ) {
-							var value = this.getValue();
-
-							if ( value )
-								element.setStyle( 'vertical-align', value );
-							else
-								element.removeStyle( 'vertical-align' );
-
-							element.removeAttribute( 'vAlign' );
-						}
-					} ]
-				},
-				createSpacer( 'td{vertical-align}' ),
-				{
-					type: 'vbox',
-					requiredContent: [ 'th', 'td[rowspan]', 'td[colspan]', 'td{background-color}', 'td{border-color}' ],
-					padding: 0,
-					children: [ {
-						type: 'select',
-						id: 'cellType',
-						requiredContent: 'th',
-						label: langCell.cellType,
-						'default': 'td',
-						items: [
-							[ langCell.data, 'td' ],
-							[ langCell.header, 'th' ]
-						],
-						setup: setupCells( function( selectedCell ) {
-							return selectedCell.getName();
-						} ),
-						commit: function( selectedCell ) {
-							selectedCell.renameNode( this.getValue() );
-						}
-					},
-					createSpacer( 'th' ),
-					{
-						type: 'text',
-						id: 'rowSpan',
-						requiredContent: 'td[rowspan]',
-						label: langCell.rowSpan,
-						'default': '',
-						validate: validate.integer( langCell.invalidRowSpan ),
-						setup: setupCells( function( selectedCell ) {
-							var attrVal = parseInt( selectedCell.getAttribute( 'rowSpan' ), 10 );
-							if ( attrVal && attrVal != 1 )
-								return attrVal;
-						} ),
-						commit: function( selectedCell ) {
-							var value = parseInt( this.getValue(), 10 );
-							if ( value && value != 1 )
-								selectedCell.setAttribute( 'rowSpan', this.getValue() );
-							else
-								selectedCell.removeAttribute( 'rowSpan' );
-						}
-					},
-					{
-						type: 'text',
-						id: 'colSpan',
-						requiredContent: 'td[colspan]',
-						label: langCell.colSpan,
-						'default': '',
-						validate: validate.integer( langCell.invalidColSpan ),
-						setup: setupCells( function( element ) {
-							var attrVal = parseInt( element.getAttribute( 'colSpan' ), 10 );
-							if ( attrVal && attrVal != 1 )
-								return attrVal;
-						} ),
-						commit: function( selectedCell ) {
-							var value = parseInt( this.getValue(), 10 );
-							if ( value && value != 1 )
-								selectedCell.setAttribute( 'colSpan', this.getValue() );
-							else
-								selectedCell.removeAttribute( 'colSpan' );
-						}
-					},
-					createSpacer( 'td[colspan]' ),
-					{
-						type: 'hbox',
-						padding: 0,
-						widths: [ '60%', '40%' ],
-						requiredContent: 'td{background-color}',
-						children: [ {
-							type: 'text',
-							id: 'bgColor',
-							label: langCell.bgColor,
-							'default': '',
-							setup: setupCells( function( element ) {
-								var bgColorAttr = element.getAttribute( 'bgColor' ),
-									bgColorStyle = element.getStyle( 'background-color' );
-
-								return bgColorStyle || bgColorAttr;
-							} ),
-							commit: function( selectedCell ) {
-								var value = this.getValue();
-
-								if ( value )
-									selectedCell.setStyle( 'background-color', this.getValue() );
-								else
-									selectedCell.removeStyle( 'background-color' );
-
-								selectedCell.removeAttribute( 'bgColor' );
-							}
-						},
-						colorDialog ? {
-							type: 'button',
-							id: 'bgColorChoose',
-							'class': 'colorChooser', // jshint ignore:line
-							label: langCell.chooseColor,
-							onLoad: function() {
-								// Stick the element to the bottom (https://dev.ckeditor.com/ticket/5587)
-								this.getElement().getParent().setStyle( 'vertical-align', 'bottom' );
-							},
-							onClick: function() {
-								editor.getColorFromDialog( function( color ) {
-									if ( color )
-										this.getDialog().getContentElement( 'info', 'bgColor' ).setValue( color );
-									this.focus();
-								}, this );
-							}
-						} : createSpacer() ]
-					},
-					createSpacer( 'td{background-color}' ),
-					{
-						type: 'hbox',
-						padding: 0,
-						widths: [ '60%', '40%' ],
-						requiredContent: 'td{border-color}',
-						children: [ {
-							type: 'text',
-							id: 'borderColor',
-							label: langCell.borderColor,
-							'default': '',
-							setup: setupCells( function( element ) {
-								var borderColorAttr = element.getAttribute( 'borderColor' ),
-									borderColorStyle = element.getStyle( 'border-color' );
-
-								return borderColorStyle || borderColorAttr;
-							} ),
-							commit: function( selectedCell ) {
-								var value = this.getValue();
-								if ( value )
-									selectedCell.setStyle( 'border-color', this.getValue() );
-								else
-									selectedCell.removeStyle( 'border-color' );
-
-								selectedCell.removeAttribute( 'borderColor' );
-							}
-						},
-
-						colorDialog ? {
-							type: 'button',
-							id: 'borderColorChoose',
-							'class': 'colorChooser', // jshint ignore:line
-							label: langCell.chooseColor,
-							style: ( rtl ? 'margin-right' : 'margin-left' ) + ': 10px',
-							onLoad: function() {
-								// Stick the element to the bottom (https://dev.ckeditor.com/ticket/5587)
-								this.getElement().getParent().setStyle( 'vertical-align', 'bottom' );
-							},
-							onClick: function() {
-								editor.getColorFromDialog( function( color ) {
-									if ( color )
-										this.getDialog().getContentElement( 'info', 'borderColor' ).setValue( color );
-									this.focus();
-								}, this );
-							}
-						} : createSpacer() ]
-					} ]
-				} ]
-			} ]
-		} ],
-		onShow: function() {
-			this.cells = CKEDITOR.plugins.tabletools.getSelectedCells( this._.editor.getSelection() );
-			this.setupContent( this.cells );
-		},
-		onOk: function() {
-			var selection = this._.editor.getSelection(),
-				bookmarks = selection.createBookmarks();
-
-			var cells = this.cells;
-			for ( var i = 0; i < cells.length; i++ )
-				this.commitContent( cells[ i ] );
-
-			this._.editor.forceNextSelectionCheck();
-			selection.selectBookmarks( bookmarks );
-			this._.editor.selectionChange();
-		},
-		onLoad: function() {
-			var saved = {};
-
-			// Prevent from changing cell properties when the field's value
-			// remains unaltered, i.e. when selected multiple cells and dialog loaded
-			// only the properties of the first cell (https://dev.ckeditor.com/ticket/11439).
-			this.foreach( function( field ) {
-				if ( !field.setup || !field.commit )
-					return;
-
-				// Save field's value every time after "setup" is called.
-				field.setup = CKEDITOR.tools.override( field.setup, function( orgSetup ) {
-					return function() {
-						orgSetup.apply( this, arguments );
-						saved[ field.id ] = field.getValue();
-					};
-				} );
-
-				// Compare saved value with actual value. Update cell only if value has changed.
-				field.commit = CKEDITOR.tools.override( field.commit, function( orgCommit ) {
-					return function() {
-						if ( saved[ field.id ] !== field.getValue() )
-							orgCommit.apply( this, arguments );
-					};
-				} );
-			} );
-		}
-	};
 } );

--- a/plugins/tabletools/dialogs/tableCell.js
+++ b/plugins/tabletools/dialogs/tableCell.js
@@ -11,412 +11,424 @@ CKEDITOR.dialog.add( 'cellProperties', function( editor ) {
 		widthPattern = /^(\d+(?:\.\d+)?)(px|%)$/,
 		rtl = editor.lang.dir == 'rtl',
 		colorDialog = editor.plugins.colordialog,
-		firstColumn = {
-			type: 'vbox',
-			requiredContent: [ 'td{width}', 'td{height}', 'td{white-space}', 'td{text-align}', 'td{vertical-align}' ],
-			padding: 0,
+		items = [ {
+			requiredContent: 'td{width}',
+			type: 'hbox',
+			widths: [ '70%', '30%' ],
 			children: [ {
-				type: 'hbox',
-				widths: [ '70%', '30%' ],
-				children: [ {
-					type: 'text',
-					id: 'width',
-					width: '100px',
-					requiredContent: 'td{width}',
-					label: langCommon.width,
-					validate: validate.number( langCell.invalidWidth ),
+				type: 'text',
+				id: 'width',
+				width: '100px',
+				label: langCommon.width,
+				validate: validate.number( langCell.invalidWidth ),
 
-					// Extra labelling of width unit type.
-					onLoad: function() {
-						var widthType = this.getDialog().getContentElement( 'info', 'widthType' ),
-							labelElement = widthType.getElement(),
-							inputElement = this.getInputElement(),
-							ariaLabelledByAttr = inputElement.getAttribute( 'aria-labelledby' );
+				// Extra labelling of width unit type.
+				onLoad: function() {
+					var widthType = this.getDialog().getContentElement( 'info', 'widthType' ),
+						labelElement = widthType.getElement(),
+						inputElement = this.getInputElement(),
+						ariaLabelledByAttr = inputElement.getAttribute( 'aria-labelledby' );
 
-						inputElement.setAttribute( 'aria-labelledby', [ ariaLabelledByAttr, labelElement.$.id ].join( ' ' ) );
-					},
-
-					setup: setupCells( function( element ) {
-						var widthAttr = parseInt( element.getAttribute( 'width' ), 10 ),
-							widthStyle = parseInt( element.getStyle( 'width' ), 10 );
-
-						return !isNaN( widthStyle ) ? widthStyle :
-							!isNaN( widthAttr ) ? widthAttr : '';
-					} ),
-					commit: function( element ) {
-						var value = parseInt( this.getValue(), 10 ),
-
-							// There might be no widthType value, i.e. when multiple cells are
-							// selected but some of them have width expressed in pixels and some
-							// of them in percent. Try to re-read the unit from the cell in such
-							// case (https://dev.ckeditor.com/ticket/11439).
-							unit = this.getDialog().getValueOf( 'info', 'widthType' ) || getCellWidthType( element );
-
-						if ( !isNaN( value ) ) {
-							element.setStyle( 'width', value + unit );
-						} else {
-							element.removeStyle( 'width' );
-						}
-
-						element.removeAttribute( 'width' );
-					},
-					'default': ''
+					inputElement.setAttribute( 'aria-labelledby', [ ariaLabelledByAttr, labelElement.$.id ].join( ' ' ) );
 				},
-					{
-						type: 'select',
-						id: 'widthType',
-						requiredContent: 'td{width}',
-						label: editor.lang.table.widthUnit,
-						labelStyle: 'visibility:hidden',
-						'default': 'px',
-						items: [
-							[ langTable.widthPx, 'px' ],
-							[ langTable.widthPc, '%' ]
-						],
-						setup: setupCells( getCellWidthType )
-					} ]
-			},
-				{
-					type: 'hbox',
-					widths: [ '70%', '30%' ],
-					children: [ {
-						type: 'text',
-						id: 'height',
-						requiredContent: 'td{height}',
-						label: langCommon.height,
-						width: '100px',
-						'default': '',
-						validate: validate.number( langCell.invalidHeight ),
 
-						// Extra labelling of height unit type.
-						onLoad: function() {
-							var heightType = this.getDialog().getContentElement( 'info', 'htmlHeightType' ),
-								labelElement = heightType.getElement(),
-								inputElement = this.getInputElement(),
-								ariaLabelledByAttr = inputElement.getAttribute( 'aria-labelledby' );
+				setup: setupCells( function( element ) {
+					var widthAttr = parseInt( element.getAttribute( 'width' ), 10 ),
+						widthStyle = parseInt( element.getStyle( 'width' ), 10 );
 
-							if ( this.getDialog().getContentElement( 'info', 'height' ).isVisible() ) {
-								labelElement.setHtml( '<br />' + langTable.widthPx );
-								labelElement.setStyle( 'display', 'block' );
+					return !isNaN( widthStyle ) ? widthStyle :
+						!isNaN( widthAttr ) ? widthAttr : '';
+				} ),
+				commit: function( element ) {
+					var value = parseInt( this.getValue(), 10 ),
 
-								this.getDialog().getContentElement( 'info', 'hiddenSpacer' ).getElement().setStyle( 'display', 'block' );
-							}
+						// There might be no widthType value, i.e. when multiple cells are
+						// selected but some of them have width expressed in pixels and some
+						// of them in percent. Try to re-read the unit from the cell in such
+						// case (https://dev.ckeditor.com/ticket/11439).
+						unit = this.getDialog().getValueOf( 'info', 'widthType' ) || getCellWidthType( element );
 
-							inputElement.setAttribute( 'aria-labelledby', [ ariaLabelledByAttr, labelElement.$.id ].join( ' ' ) );
-						},
-
-						setup: setupCells( function( element ) {
-							var heightAttr = parseInt( element.getAttribute( 'height' ), 10 ),
-								heightStyle = parseInt( element.getStyle( 'height' ), 10 );
-
-							return !isNaN( heightStyle ) ? heightStyle :
-								!isNaN( heightAttr ) ? heightAttr : '';
-						} ),
-						commit: function( element ) {
-							var value = parseInt( this.getValue(), 10 );
-
-							if ( !isNaN( value ) ) {
-								element.setStyle( 'height', CKEDITOR.tools.cssLength( value ) );
-							} else {
-								element.removeStyle( 'height' );
-							}
-
-							element.removeAttribute( 'height' );
-						}
-					},
-						{
-							id: 'htmlHeightType',
-							type: 'html',
-							html: '',
-							style: 'display: none'
-						} ]
-				},
-				{
-					type: 'html',
-					id: 'hiddenSpacer',
-					html: '&nbsp;',
-					style: 'display: none'
-				},
-				{
-					type: 'select',
-					id: 'wordWrap',
-					requiredContent: 'td{white-space}',
-					label: langCell.wordWrap,
-					'default': 'yes',
-					items: [
-						[ langCell.yes, 'yes' ],
-						[ langCell.no, 'no' ]
-					],
-					setup: setupCells( function( element ) {
-						var wordWrapAttr = element.getAttribute( 'noWrap' ),
-							wordWrapStyle = element.getStyle( 'white-space' );
-
-						if ( wordWrapStyle == 'nowrap' || wordWrapAttr ) {
-							return 'no';
-						}
-					} ),
-					commit: function( element ) {
-						if ( this.getValue() == 'no' ) {
-							element.setStyle( 'white-space', 'nowrap' );
-						} else {
-							element.removeStyle( 'white-space' );
-						}
-
-						element.removeAttribute( 'noWrap' );
+					if ( !isNaN( value ) ) {
+						element.setStyle( 'width', value + unit );
+					} else {
+						element.removeStyle( 'width' );
 					}
+
+					element.removeAttribute( 'width' );
 				},
-				createSpacer( 'td{white-space}' ),
-				{
-					type: 'select',
-					id: 'hAlign',
-					requiredContent: 'td{text-align}',
-					label: langCell.hAlign,
-					'default': '',
-					items: [
-						[ langCommon.notSet, '' ],
-						[ langCommon.left, 'left' ],
-						[ langCommon.center, 'center' ],
-						[ langCommon.right, 'right' ],
-						[ langCommon.justify, 'justify' ]
-					],
-					setup: setupCells( function( element ) {
-						var alignAttr = element.getAttribute( 'align' ),
-							textAlignStyle = element.getStyle( 'text-align' );
-
-						return textAlignStyle || alignAttr || '';
-					} ),
-					commit: function( selectedCell ) {
-						var value = this.getValue();
-
-						if ( value ) {
-							selectedCell.setStyle( 'text-align', value );
-						} else {
-							selectedCell.removeStyle( 'text-align' );
-						}
-
-						selectedCell.removeAttribute( 'align' );
-					}
-				},
-				{
-					type: 'select',
-					id: 'vAlign',
-					requiredContent: 'td{vertical-align}',
-					label: langCell.vAlign,
-					'default': '',
-					items: [
-						[ langCommon.notSet, '' ],
-						[ langCommon.alignTop, 'top' ],
-						[ langCommon.alignMiddle, 'middle' ],
-						[ langCommon.alignBottom, 'bottom' ],
-						[ langCell.alignBaseline, 'baseline' ]
-					],
-					setup: setupCells( function( element ) {
-						var vAlignAttr = element.getAttribute( 'vAlign' ),
-							vAlignStyle = element.getStyle( 'vertical-align' );
-
-						switch ( vAlignStyle ) {
-							// Ignore all other unrelated style values..
-							case 'top':
-							case 'middle':
-							case 'bottom':
-							case 'baseline':
-								break;
-							default:
-								vAlignStyle = '';
-						}
-
-						return vAlignStyle || vAlignAttr || '';
-					} ),
-					commit: function( element ) {
-						var value = this.getValue();
-
-						if ( value ) {
-							element.setStyle( 'vertical-align', value );
-						} else {
-							element.removeStyle( 'vertical-align' );
-						}
-
-						element.removeAttribute( 'vAlign' );
-					}
-				} ]
-		},
-
-		secondColumn = {
-			type: 'vbox',
-			requiredContent: [ 'th', 'td[rowspan]', 'td[colspan]', 'td{background-color}', 'td{border-color}' ],
-			padding: 0,
-			children: [ {
+				'default': ''
+			}, {
 				type: 'select',
-				id: 'cellType',
-				requiredContent: 'th',
-				label: langCell.cellType,
-				'default': 'td',
+				id: 'widthType',
+				label: editor.lang.table.widthUnit,
+				labelStyle: 'visibility:hidden',
+				'default': 'px',
 				items: [
-					[ langCell.data, 'td' ],
-					[ langCell.header, 'th' ]
+					[ langTable.widthPx, 'px' ],
+					[ langTable.widthPc, '%' ]
 				],
-				setup: setupCells( function( selectedCell ) {
-					return selectedCell.getName();
+				setup: setupCells( getCellWidthType )
+			} ]
+		}, {
+			requiredContent: 'td{height}',
+			type: 'hbox',
+			widths: [ '70%', '30%' ],
+			children: [ {
+				type: 'text',
+				id: 'height',
+				label: langCommon.height,
+				width: '100px',
+				'default': '',
+				validate: validate.number( langCell.invalidHeight ),
+
+				// Extra labelling of height unit type.
+				onLoad: function() {
+					var heightType = this.getDialog().getContentElement( 'info', 'htmlHeightType' ),
+						labelElement = heightType.getElement(),
+						inputElement = this.getInputElement(),
+						ariaLabelledByAttr = inputElement.getAttribute( 'aria-labelledby' );
+
+					if ( this.getDialog().getContentElement( 'info', 'height' ).isVisible() ) {
+						labelElement.setHtml( '<br />' + langTable.widthPx );
+						labelElement.setStyle( 'display', 'block' );
+					}
+
+					inputElement.setAttribute( 'aria-labelledby', [ ariaLabelledByAttr, labelElement.$.id ].join( ' ' ) );
+				},
+
+				setup: setupCells( function( element ) {
+					var heightAttr = parseInt( element.getAttribute( 'height' ), 10 ),
+						heightStyle = parseInt( element.getStyle( 'height' ), 10 );
+
+					return !isNaN( heightStyle ) ? heightStyle :
+						!isNaN( heightAttr ) ? heightAttr : '';
+				} ),
+				commit: function( element ) {
+					var value = parseInt( this.getValue(), 10 );
+
+					if ( !isNaN( value ) ) {
+						element.setStyle( 'height', CKEDITOR.tools.cssLength( value ) );
+					} else {
+						element.removeStyle( 'height' );
+					}
+
+					element.removeAttribute( 'height' );
+				}
+			}, {
+				id: 'htmlHeightType',
+				type: 'html',
+				html: '',
+				style: 'display: none'
+			} ]
+		},
+		createSpacer( [ 'td{width}', 'td{height}' ] ),
+		{
+			type: 'select',
+			id: 'wordWrap',
+			requiredContent: 'td{white-space}',
+			label: langCell.wordWrap,
+			'default': 'yes',
+			items: [
+				[ langCell.yes, 'yes' ],
+				[ langCell.no, 'no' ]
+			],
+			setup: setupCells( function( element ) {
+				var wordWrapAttr = element.getAttribute( 'noWrap' ),
+					wordWrapStyle = element.getStyle( 'white-space' );
+
+				if ( wordWrapStyle == 'nowrap' || wordWrapAttr ) {
+					return 'no';
+				}
+			} ),
+			commit: function( element ) {
+				if ( this.getValue() == 'no' ) {
+					element.setStyle( 'white-space', 'nowrap' );
+				} else {
+					element.removeStyle( 'white-space' );
+				}
+
+				element.removeAttribute( 'noWrap' );
+			}
+		},
+		createSpacer( 'td{white-space}' ),
+		{
+			type: 'select',
+			id: 'hAlign',
+			requiredContent: 'td{text-align}',
+			label: langCell.hAlign,
+			'default': '',
+			items: [
+				[ langCommon.notSet, '' ],
+				[ langCommon.left, 'left' ],
+				[ langCommon.center, 'center' ],
+				[ langCommon.right, 'right' ],
+				[ langCommon.justify, 'justify' ]
+			],
+			setup: setupCells( function( element ) {
+				var alignAttr = element.getAttribute( 'align' ),
+					textAlignStyle = element.getStyle( 'text-align' );
+
+				return textAlignStyle || alignAttr || '';
+			} ),
+			commit: function( selectedCell ) {
+				var value = this.getValue();
+
+				if ( value ) {
+					selectedCell.setStyle( 'text-align', value );
+				} else {
+					selectedCell.removeStyle( 'text-align' );
+				}
+
+				selectedCell.removeAttribute( 'align' );
+			}
+		}, {
+			type: 'select',
+			id: 'vAlign',
+			requiredContent: 'td{vertical-align}',
+			label: langCell.vAlign,
+			'default': '',
+			items: [
+				[ langCommon.notSet, '' ],
+				[ langCommon.alignTop, 'top' ],
+				[ langCommon.alignMiddle, 'middle' ],
+				[ langCommon.alignBottom, 'bottom' ],
+				[ langCell.alignBaseline, 'baseline' ]
+			],
+			setup: setupCells( function( element ) {
+				var vAlignAttr = element.getAttribute( 'vAlign' ),
+					vAlignStyle = element.getStyle( 'vertical-align' );
+
+				switch ( vAlignStyle ) {
+					// Ignore all other unrelated style values..
+					case 'top':
+					case 'middle':
+					case 'bottom':
+					case 'baseline':
+						break;
+					default:
+						vAlignStyle = '';
+				}
+
+				return vAlignStyle || vAlignAttr || '';
+			} ),
+			commit: function( element ) {
+				var value = this.getValue();
+
+				if ( value ) {
+					element.setStyle( 'vertical-align', value );
+				} else {
+					element.removeStyle( 'vertical-align' );
+				}
+
+				element.removeAttribute( 'vAlign' );
+			}
+		}, {
+			type: 'select',
+			id: 'cellType',
+			requiredContent: 'th',
+			label: langCell.cellType,
+			'default': 'td',
+			items: [
+				[ langCell.data, 'td' ],
+				[ langCell.header, 'th' ]
+			],
+			setup: setupCells( function( selectedCell ) {
+				return selectedCell.getName();
+			} ),
+			commit: function( selectedCell ) {
+				selectedCell.renameNode( this.getValue() );
+			}
+		},
+		createSpacer( 'th' ),
+		{
+			type: 'text',
+			id: 'rowSpan',
+			requiredContent: 'td[rowspan]',
+			label: langCell.rowSpan,
+			'default': '',
+			validate: validate.integer( langCell.invalidRowSpan ),
+			setup: setupCells( function( selectedCell ) {
+				var attrVal = parseInt( selectedCell.getAttribute( 'rowSpan' ), 10 );
+				if ( attrVal && attrVal != 1 ) {
+					return attrVal;
+				}
+			} ),
+			commit: function( selectedCell ) {
+				var value = parseInt( this.getValue(), 10 );
+				if ( value && value != 1 ) {
+					selectedCell.setAttribute( 'rowSpan', this.getValue() );
+				} else {
+					selectedCell.removeAttribute( 'rowSpan' );
+				}
+			}
+		}, {
+			type: 'text',
+			id: 'colSpan',
+			requiredContent: 'td[colspan]',
+			label: langCell.colSpan,
+			'default': '',
+			validate: validate.integer( langCell.invalidColSpan ),
+			setup: setupCells( function( element ) {
+				var attrVal = parseInt( element.getAttribute( 'colSpan' ), 10 );
+				if ( attrVal && attrVal != 1 ) {
+					return attrVal;
+				}
+			} ),
+			commit: function( selectedCell ) {
+				var value = parseInt( this.getValue(), 10 );
+				if ( value && value != 1 ) {
+					selectedCell.setAttribute( 'colSpan', this.getValue() );
+				} else {
+					selectedCell.removeAttribute( 'colSpan' );
+				}
+			}
+		},
+		createSpacer( 'td[colspan]' ),
+		{
+			type: 'hbox',
+			padding: 0,
+			widths: [ '60%', '40%' ],
+			requiredContent: 'td{background-color}',
+			children: [ {
+				type: 'text',
+				id: 'bgColor',
+				label: langCell.bgColor,
+				'default': '',
+				setup: setupCells( function( element ) {
+					var bgColorAttr = element.getAttribute( 'bgColor' ),
+						bgColorStyle = element.getStyle( 'background-color' );
+
+					return bgColorStyle || bgColorAttr;
 				} ),
 				commit: function( selectedCell ) {
-					selectedCell.renameNode( this.getValue() );
+					var value = this.getValue();
+
+					if ( value ) {
+						selectedCell.setStyle( 'background-color', this.getValue() );
+					} else {
+						selectedCell.removeStyle( 'background-color' );
+					}
+
+					selectedCell.removeAttribute( 'bgColor' );
 				}
 			},
-				createSpacer( 'th' ),
-				{
-					type: 'text',
-					id: 'rowSpan',
-					requiredContent: 'td[rowspan]',
-					label: langCell.rowSpan,
-					'default': '',
-					validate: validate.integer( langCell.invalidRowSpan ),
-					setup: setupCells( function( selectedCell ) {
-						var attrVal = parseInt( selectedCell.getAttribute( 'rowSpan' ), 10 );
-						if ( attrVal && attrVal != 1 ) {
-							return attrVal;
-						}
-					} ),
-					commit: function( selectedCell ) {
-						var value = parseInt( this.getValue(), 10 );
-						if ( value && value != 1 ) {
-							selectedCell.setAttribute( 'rowSpan', this.getValue() );
-						} else {
-							selectedCell.removeAttribute( 'rowSpan' );
-						}
-					}
-				},
-				{
-					type: 'text',
-					id: 'colSpan',
-					requiredContent: 'td[colspan]',
-					label: langCell.colSpan,
-					'default': '',
-					validate: validate.integer( langCell.invalidColSpan ),
-					setup: setupCells( function( element ) {
-						var attrVal = parseInt( element.getAttribute( 'colSpan' ), 10 );
-						if ( attrVal && attrVal != 1 ) {
-							return attrVal;
-						}
-					} ),
-					commit: function( selectedCell ) {
-						var value = parseInt( this.getValue(), 10 );
-						if ( value && value != 1 ) {
-							selectedCell.setAttribute( 'colSpan', this.getValue() );
-						} else {
-							selectedCell.removeAttribute( 'colSpan' );
-						}
-					}
-				},
-				createSpacer( 'td[colspan]' ),
-				{
-					type: 'hbox',
-					padding: 0,
-					widths: [ '60%', '40%' ],
-					requiredContent: 'td{background-color}',
-					children: [ {
-						type: 'text',
-						id: 'bgColor',
-						requiredContent: 'td{background-color}',
-						label: langCell.bgColor,
-						'default': '',
-						setup: setupCells( function( element ) {
-							var bgColorAttr = element.getAttribute( 'bgColor' ),
-								bgColorStyle = element.getStyle( 'background-color' );
-
-							return bgColorStyle || bgColorAttr;
-						} ),
-						commit: function( selectedCell ) {
-							var value = this.getValue();
-
-							if ( value ) {
-								selectedCell.setStyle( 'background-color', this.getValue() );
-							} else {
-								selectedCell.removeStyle( 'background-color' );
-							}
-
-							selectedCell.removeAttribute( 'bgColor' );
-						}
+				colorDialog ? {
+					type: 'button',
+					id: 'bgColorChoose',
+					'class': 'colorChooser', // jshint ignore:line
+					label: langCell.chooseColor,
+					onLoad: function() {
+						// Stick the element to the bottom (https://dev.ckeditor.com/ticket/5587)
+						this.getElement().getParent().setStyle( 'vertical-align', 'bottom' );
 					},
-						colorDialog ? {
-							type: 'button',
-							id: 'bgColorChoose',
-							'class': 'colorChooser', // jshint ignore:line
-							label: langCell.chooseColor,
-							onLoad: function() {
-								// Stick the element to the bottom (https://dev.ckeditor.com/ticket/5587)
-								this.getElement().getParent().setStyle( 'vertical-align', 'bottom' );
-							},
-							onClick: function() {
-								editor.getColorFromDialog( function( color ) {
-									if ( color ) {
-										this.getDialog().getContentElement( 'info', 'bgColor' ).setValue( color );
-									}
-									this.focus();
-								}, this );
+					onClick: function() {
+						editor.getColorFromDialog( function( color ) {
+							if ( color ) {
+								this.getDialog().getContentElement( 'info', 'bgColor' ).setValue( color );
 							}
-						} : createSpacer() ]
-				},
-				createSpacer( 'td{background-color}' ),
-				{
-					type: 'hbox',
-					padding: 0,
-					widths: [ '60%', '40%' ],
-					requiredContent: 'td{border-color}',
-					children: [ {
-						type: 'text',
-						id: 'borderColor',
-						requiredContent: 'td{border-color}',
-						label: langCell.borderColor,
-						'default': '',
-						setup: setupCells( function( element ) {
-							var borderColorAttr = element.getAttribute( 'borderColor' ),
-								borderColorStyle = element.getStyle( 'border-color' );
-
-							return borderColorStyle || borderColorAttr;
-						} ),
-						commit: function( selectedCell ) {
-							var value = this.getValue();
-							if ( value ) {
-								selectedCell.setStyle( 'border-color', this.getValue() );
-							} else {
-								selectedCell.removeStyle( 'border-color' );
-							}
-
-							selectedCell.removeAttribute( 'borderColor' );
-						}
-					},
-
-						colorDialog ? {
-							type: 'button',
-							id: 'borderColorChoose',
-							'class': 'colorChooser', // jshint ignore:line
-							label: langCell.chooseColor,
-							style: ( rtl ? 'margin-right' : 'margin-left' ) + ': 10px',
-							onLoad: function() {
-								// Stick the element to the bottom (https://dev.ckeditor.com/ticket/5587)
-								this.getElement().getParent().setStyle( 'vertical-align', 'bottom' );
-							},
-							onClick: function() {
-								editor.getColorFromDialog( function( color ) {
-									if ( color ) {
-										this.getDialog().getContentElement( 'info', 'borderColor' ).setValue( color );
-									}
-									this.focus();
-								}, this );
-							}
-						} : createSpacer() ]
-				} ]
+							this.focus();
+						}, this );
+					}
+				} : createSpacer() ]
 		},
+		{
+			type: 'hbox',
+			padding: 0,
+			widths: [ '60%', '40%' ],
+			requiredContent: 'td{border-color}',
+			children: [ {
+				type: 'text',
+				id: 'borderColor',
+				label: langCell.borderColor,
+				'default': '',
+				setup: setupCells( function( element ) {
+					var borderColorAttr = element.getAttribute( 'borderColor' ),
+						borderColorStyle = element.getStyle( 'border-color' );
 
-	children = [ firstColumn, secondColumn ];
+					return borderColorStyle || borderColorAttr;
+				} ),
+				commit: function( selectedCell ) {
+					var value = this.getValue();
+					if ( value ) {
+						selectedCell.setStyle( 'border-color', this.getValue() );
+					} else {
+						selectedCell.removeStyle( 'border-color' );
+					}
 
-	if ( getColumnsCount() === 2 ) {
-		children.splice( 1, 0, createSpacer() );
+					selectedCell.removeAttribute( 'borderColor' );
+				}
+			},
+
+			colorDialog ? {
+				type: 'button',
+				id: 'borderColorChoose',
+				'class': 'colorChooser', // jshint ignore:line
+				label: langCell.chooseColor,
+				style: ( rtl ? 'margin-right' : 'margin-left' ) + ': 10px',
+				onLoad: function() {
+					// Stick the element to the bottom (https://dev.ckeditor.com/ticket/5587)
+					this.getElement().getParent().setStyle( 'vertical-align', 'bottom' );
+				},
+				onClick: function() {
+					editor.getColorFromDialog( function( color ) {
+						if ( color ) {
+							this.getDialog().getContentElement( 'info', 'borderColor' ).setValue( color );
+						}
+						this.focus();
+					}, this );
+				}
+			} : createSpacer() ]
+		} ],
+	itemsCount = 0,
+	index = -1,
+	children = [ createColumn() ];
+
+	items = CKEDITOR.tools.array.filter( items, function( item ) {
+		var requiredContent = item.requiredContent,
+			ret;
+
+		// Remove it, as there is no need to filter again.
+		delete item.requiredContent;
+
+		ret = editor.filter.check( requiredContent );
+
+		if ( ret && !item.isSpacer ) {
+			itemsCount++;
+		}
+
+		return ret;
+	} );
+
+	if ( itemsCount > 5 ) {
+		children = children.concat( [ createSpacer(), createColumn() ] );
 	}
+
+	CKEDITOR.tools.array.forEach( items, function( item ) {
+		if ( !item.isSpacer ) {
+			index++;
+		}
+		if ( itemsCount > 5 && index >= itemsCount / 2 ) {
+			children[ 2 ].children.push( item );
+		} else {
+			children[ 0 ].children.push( item );
+		}
+	} );
+
+	CKEDITOR.tools.array.forEach( children, function( item ) {
+		if ( item.isSpacer ) {
+			return;
+		}
+
+		var children = item.children;
+
+		if ( children[ children.length - 1 ].isSpacer ) {
+			children.pop();
+		}
+	} );
 
 	return {
 		title: langCell.title,
-		minWidth: getColumnsCount() * 205,
+		minWidth: children.length === 1 ? 205 : 410,
 		minHeight: 50,
 		contents: [ {
 			id: 'info',
@@ -424,7 +436,7 @@ CKEDITOR.dialog.add( 'cellProperties', function( editor ) {
 			accessKey: 'I',
 			elements: [ {
 				type: 'hbox',
-				widths: getWidths(),
+				widths: children.length === 1 ? [ '100%' ] : [ '40%', '5%', '40%' ],
 				children: children
 			} ]
 		} ],
@@ -477,47 +489,21 @@ CKEDITOR.dialog.add( 'cellProperties', function( editor ) {
 
 	function createSpacer( requiredContent ) {
 		return {
+			isSpacer: true,
 			type: 'html',
 			html: '&nbsp;',
 			requiredContent: requiredContent ? requiredContent : undefined
 		};
 	}
 
-	function whichColumns() {
-		var columns = 'none';
-
-		if ( editor.filter.check( [ 'td{width}', 'td{height}', 'td{white-space}', 'td{text-align}', 'td{vertical-align}' ] ) ) {
-			columns = 'first';
-		}
-
-		if ( editor.filter.check( [ 'th', 'td[rowspan]', 'td[colspan]', 'td{background-color}', 'td{border-color}' ] ) ) {
-			columns = columns === 'first' ? 'both' : 'second';
-		}
-
-		return columns;
+	function createColumn() {
+		return {
+			type: 'vbox',
+			padding: 0,
+			children: []
+		};
 	}
 
-	function getColumnsCount() {
-		switch ( whichColumns() ) {
-			case 'none':
-				return 0;
-			case 'both':
-				return 2;
-			default:
-				return 1;
-		}
-	}
-
-	function getWidths() {
-		switch ( whichColumns() ) {
-			case 'first':
-				return [ '100%', '0' ];
-			case 'second':
-				return [ '0', '100%' ];
-			default:
-				return [ '40%', '5%', '40%' ];
-		}
-	}
 	// Returns a function, which runs regular "setup" for all selected cells to find out
 	// whether the initial value of the field would be the same for all cells. If so,
 	// the value is displayed just as if a regular "setup" was executed. Otherwise,

--- a/plugins/tabletools/dialogs/tableCell.js
+++ b/plugins/tabletools/dialogs/tableCell.js
@@ -198,6 +198,7 @@ CKEDITOR.dialog.add( 'cellProperties', function( editor ) {
 					{
 						type: 'select',
 						id: 'wordWrap',
+						requiredContent: 'td{white-space}',
 						label: langCell.wordWrap,
 						'default': 'yes',
 						items: [
@@ -224,6 +225,7 @@ CKEDITOR.dialog.add( 'cellProperties', function( editor ) {
 					{
 						type: 'select',
 						id: 'hAlign',
+						requiredContent: 'td{text-align}',
 						label: langCell.hAlign,
 						'default': '',
 						items: [
@@ -253,6 +255,7 @@ CKEDITOR.dialog.add( 'cellProperties', function( editor ) {
 					{
 						type: 'select',
 						id: 'vAlign',
+						requiredContent: 'td{vertical-align}',
 						label: langCell.vAlign,
 						'default': '',
 						items: [
@@ -298,6 +301,7 @@ CKEDITOR.dialog.add( 'cellProperties', function( editor ) {
 					children: [ {
 						type: 'select',
 						id: 'cellType',
+						requiredContent: 'th',
 						label: langCell.cellType,
 						'default': 'td',
 						items: [
@@ -315,6 +319,7 @@ CKEDITOR.dialog.add( 'cellProperties', function( editor ) {
 					{
 						type: 'text',
 						id: 'rowSpan',
+						requiredContent: 'td[rowspan]',
 						label: langCell.rowSpan,
 						'default': '',
 						validate: validate.integer( langCell.invalidRowSpan ),
@@ -334,6 +339,7 @@ CKEDITOR.dialog.add( 'cellProperties', function( editor ) {
 					{
 						type: 'text',
 						id: 'colSpan',
+						requiredContent: 'td[colspan]',
 						label: langCell.colSpan,
 						'default': '',
 						validate: validate.integer( langCell.invalidColSpan ),
@@ -358,6 +364,7 @@ CKEDITOR.dialog.add( 'cellProperties', function( editor ) {
 						children: [ {
 							type: 'text',
 							id: 'bgColor',
+							requiredContent: 'td{background-color}',
 							label: langCell.bgColor,
 							'default': '',
 							setup: setupCells( function( element ) {
@@ -403,6 +410,7 @@ CKEDITOR.dialog.add( 'cellProperties', function( editor ) {
 						children: [ {
 							type: 'text',
 							id: 'borderColor',
+							requiredContent: 'td{border-color}',
 							label: langCell.borderColor,
 							'default': '',
 							setup: setupCells( function( element ) {

--- a/plugins/tabletools/dialogs/tableCell.js
+++ b/plugins/tabletools/dialogs/tableCell.js
@@ -287,7 +287,7 @@ CKEDITOR.dialog.add( 'cellProperties', function( editor ) {
 		{
 			type: 'hbox',
 			padding: 0,
-			widths: [ '60%', '40%' ],
+			widths: colorDialog ? [ '60%', '40%' ] : [ '100%' ],
 			requiredContent: 'td{background-color}',
 			children: [ {
 				type: 'text',
@@ -329,12 +329,12 @@ CKEDITOR.dialog.add( 'cellProperties', function( editor ) {
 							this.focus();
 						}, this );
 					}
-				} : createSpacer() ]
+				} : null ]
 		},
 		{
 			type: 'hbox',
 			padding: 0,
-			widths: [ '60%', '40%' ],
+			widths: colorDialog ? [ '60%', '40%' ] : [ '100%' ],
 			requiredContent: 'td{border-color}',
 			children: [ {
 				type: 'text',
@@ -377,7 +377,7 @@ CKEDITOR.dialog.add( 'cellProperties', function( editor ) {
 						this.focus();
 					}, this );
 				}
-			} : createSpacer() ]
+			} : null ]
 		} ],
 	itemsCount = 0,
 	index = -1,

--- a/plugins/tabletools/plugin.js
+++ b/plugins/tabletools/plugin.js
@@ -769,7 +769,10 @@
 
 		init: function( editor ) {
 			var lang = editor.lang.table,
-				styleParse = CKEDITOR.tools.style.parse;
+				styleParse = CKEDITOR.tools.style.parse,
+				requiredContent = [
+					'td{width}', 'td{height}', 'td{border-color}', 'td{background-color}', 'td{white-space}', 'td{vertical-align}', 'td{text-align}',
+					'td[colspan]', 'td[rowspan]', 'th' ];
 
 			function createDef( def ) {
 				return CKEDITOR.tools.extend( def || {}, {
@@ -786,7 +789,7 @@
 
 			addCmd( 'cellProperties', new CKEDITOR.dialogCommand( 'cellProperties', createDef( {
 				allowedContent: 'td th{width,height,border-color,background-color,white-space,vertical-align,text-align}[colspan,rowspan]',
-				requiredContent: 'table',
+				requiredContent: requiredContent,
 				contentTransformations: [ [ {
 						element: 'td',
 						left: function( element ) {
@@ -988,18 +991,23 @@
 						order: 1,
 						getItems: function() {
 							var selection = editor.getSelection(),
-								cells = getSelectedCells( selection );
-							return {
-								tablecell_insertBefore: CKEDITOR.TRISTATE_OFF,
-								tablecell_insertAfter: CKEDITOR.TRISTATE_OFF,
-								tablecell_delete: CKEDITOR.TRISTATE_OFF,
-								tablecell_merge: mergeCells( selection, null, true ) ? CKEDITOR.TRISTATE_OFF : CKEDITOR.TRISTATE_DISABLED,
-								tablecell_merge_right: mergeCells( selection, 'right', true ) ? CKEDITOR.TRISTATE_OFF : CKEDITOR.TRISTATE_DISABLED,
-								tablecell_merge_down: mergeCells( selection, 'down', true ) ? CKEDITOR.TRISTATE_OFF : CKEDITOR.TRISTATE_DISABLED,
-								tablecell_split_vertical: verticalSplitCell( selection, true ) ? CKEDITOR.TRISTATE_OFF : CKEDITOR.TRISTATE_DISABLED,
-								tablecell_split_horizontal: horizontalSplitCell( selection, true ) ? CKEDITOR.TRISTATE_OFF : CKEDITOR.TRISTATE_DISABLED,
-								tablecell_properties: cells.length > 0 ? CKEDITOR.TRISTATE_OFF : CKEDITOR.TRISTATE_DISABLED
-							};
+								cells = getSelectedCells( selection ),
+								items = {
+									tablecell_insertBefore: CKEDITOR.TRISTATE_OFF,
+									tablecell_insertAfter: CKEDITOR.TRISTATE_OFF,
+									tablecell_delete: CKEDITOR.TRISTATE_OFF,
+									tablecell_merge: mergeCells( selection, null, true ) ? CKEDITOR.TRISTATE_OFF : CKEDITOR.TRISTATE_DISABLED,
+									tablecell_merge_right: mergeCells( selection, 'right', true ) ? CKEDITOR.TRISTATE_OFF : CKEDITOR.TRISTATE_DISABLED,
+									tablecell_merge_down: mergeCells( selection, 'down', true ) ? CKEDITOR.TRISTATE_OFF : CKEDITOR.TRISTATE_DISABLED,
+									tablecell_split_vertical: verticalSplitCell( selection, true ) ? CKEDITOR.TRISTATE_OFF : CKEDITOR.TRISTATE_DISABLED,
+									tablecell_split_horizontal: horizontalSplitCell( selection, true ) ? CKEDITOR.TRISTATE_OFF : CKEDITOR.TRISTATE_DISABLED
+								};
+
+							if ( editor.filter.check( requiredContent ) ) {
+								items.tablecell_properties = cells.length > 0 ? CKEDITOR.TRISTATE_OFF : CKEDITOR.TRISTATE_DISABLED;
+							}
+
+							return items;
 						}
 					},
 

--- a/plugins/tabletools/plugin.js
+++ b/plugins/tabletools/plugin.js
@@ -771,7 +771,7 @@
 			var lang = editor.lang.table,
 				styleParse = CKEDITOR.tools.style.parse,
 				requiredContent = [
-					'td{width,height}', 'td{border-color}', 'td{background-color}', 'td{white-space}', 'td{vertical-align}', 'td{text-align}',
+					'td{width}', 'td{height}', 'td{border-color}', 'td{background-color}', 'td{white-space}', 'td{vertical-align}', 'td{text-align}',
 					'td[colspan]', 'td[rowspan]', 'th' ];
 
 			function createDef( def ) {

--- a/plugins/tabletools/plugin.js
+++ b/plugins/tabletools/plugin.js
@@ -771,7 +771,7 @@
 			var lang = editor.lang.table,
 				styleParse = CKEDITOR.tools.style.parse,
 				requiredContent = [
-					'td{width}', 'td{height}', 'td{border-color}', 'td{background-color}', 'td{white-space}', 'td{vertical-align}', 'td{text-align}',
+					'td{width,height}', 'td{border-color}', 'td{background-color}', 'td{white-space}', 'td{vertical-align}', 'td{text-align}',
 					'td[colspan]', 'td[rowspan]', 'th' ];
 
 			function createDef( def ) {

--- a/tests/plugins/tabletools/allowedcontent.js
+++ b/tests/plugins/tabletools/allowedcontent.js
@@ -113,13 +113,12 @@
 			}
 		} );
 
-		bender.editors[ 'editor_' + index ] = {
+		bender.editors[ 'editor_' + index + '_allowed:' + array.join( ',' ) ] = {
 			config: {
 				allowedContent: bender.editors.editor.config.allowedContent,
 				extraAllowedContent: extraAllowedContent
 			}
 		};
 	} );
-
 	bender.test( bender.tools.createTestsForEditors( CKEDITOR.tools.objectKeys( bender.editors ), tests ) );
 } )();

--- a/tests/plugins/tabletools/allowedcontent.js
+++ b/tests/plugins/tabletools/allowedcontent.js
@@ -25,18 +25,18 @@
 				bot.dialog( 'cellProperties', function( dialog ) {
 					for ( var key in filterMap ) {
 						if ( key !== editor.name ) {
-							assert.isTrue( getNotAllowed( key ), 'Dialog ' + key + ' should be disallowed.' );
+							assert.isTrue( isNotAllowed( key ), 'Dialog ' + key + ' should be disallowed.' );
 							if ( key === 'width' ) {
-								assert.isTrue( getNotAllowed( 'height' ), 'Dialog height should be disallowed.' );
+								assert.isTrue( isNotAllowed( 'height' ), 'Dialog height should be disallowed.' );
 							}
 						} else {
-							assert.isUndefined( getNotAllowed( key ), 'Dialog ' + key + ' shouldn\'t be disallowed.' );
+							assert.isUndefined( isNotAllowed( key ), 'Dialog ' + key + ' shouldn\'t be disallowed.' );
 							if ( key === 'width' ) {
-								assert.isUndefined( getNotAllowed( 'height' ), 'Dialog height shouldn\'t be disallowed.' );
+								assert.isUndefined( isNotAllowed( 'height' ), 'Dialog height shouldn\'t be disallowed.' );
 							}
 						}
 					}
-					function getNotAllowed( key ) {
+					function isNotAllowed( key ) {
 						return dialog._.contents.info[ key ].notAllowed;
 					}
 				} );

--- a/tests/plugins/tabletools/allowedcontent.js
+++ b/tests/plugins/tabletools/allowedcontent.js
@@ -5,7 +5,8 @@
 	'use strict';
 
 	var filterMap = {
-		width: 'td{width,height}',
+		width: 'td{width}',
+		height: 'td{height}',
 		wordWrap: 'td{white-space}',
 		hAlign: 'td{text-align}',
 		vAlign: 'td{vertical-align}',
@@ -26,14 +27,8 @@
 					for ( var key in filterMap ) {
 						if ( key !== editor.name ) {
 							assert.isTrue( isNotAllowed( key ), 'Dialog ' + key + ' should be disallowed.' );
-							if ( key === 'width' ) {
-								assert.isTrue( isNotAllowed( 'height' ), 'Dialog height should be disallowed.' );
-							}
 						} else {
 							assert.isUndefined( isNotAllowed( key ), 'Dialog ' + key + ' shouldn\'t be disallowed.' );
-							if ( key === 'width' ) {
-								assert.isUndefined( isNotAllowed( 'height' ), 'Dialog height shouldn\'t be disallowed.' );
-							}
 						}
 					}
 					function isNotAllowed( key ) {

--- a/tests/plugins/tabletools/allowedcontent.js
+++ b/tests/plugins/tabletools/allowedcontent.js
@@ -1,0 +1,59 @@
+/* bender-tags: editor */
+/* bender-ckeditor-plugins: dialog,tabletools,toolbar */
+
+( function() {
+	'use strict';
+
+	var filterMap = {
+		width: 'td{width,height}',
+		wordWrap: 'td{white-space}',
+		hAlign: 'td{text-align}',
+		vAlign: 'td{vertical-align}',
+		cellType: 'th',
+		rowSpan: 'td[rowspan]',
+		colSpan: 'td[colspan]',
+		bgColor: 'td{background-color}',
+		borderColor: 'td{border-color}'
+	},
+	tests = {
+		'test dialog required content': function( editor, bot ) {
+			bot.setData( '<table><tbody><tr><td>Cell</td></tr></tbody></table>', function() {
+				var rng = new CKEDITOR.dom.range( editor.document );
+				rng.setStart( editor.editable().findOne( 'td' ), CKEDITOR.POSITION_AFTER_START );
+				rng.select();
+
+				bot.dialog( 'cellProperties', function( dialog ) {
+					for ( var key in filterMap ) {
+						if ( key !== editor.name ) {
+							assert.isTrue( getNotAllowed( key ), 'Dialog ' + key + ' should be disallowed.' );
+							if ( key === 'width' ) {
+								assert.isTrue( getNotAllowed( 'height' ), 'Dialog height should be disallowed.' );
+							}
+						} else {
+							assert.isUndefined( getNotAllowed( key ), 'Dialog ' + key + ' shouldn\'t be disallowed.' );
+							if ( key === 'width' ) {
+								assert.isUndefined( getNotAllowed( 'height' ), 'Dialog height shouldn\'t be disallowed.' );
+							}
+						}
+					}
+					function getNotAllowed( key ) {
+						return dialog._.contents.info[ key ].notAllowed;
+					}
+				} );
+			} );
+		}
+	};
+
+	bender.editors = {};
+
+	for ( var key in filterMap ) {
+		bender.editors[ key ] = {
+			config: {
+				allowedContent: 'table;tbody;thead;tr;td;',
+				extraAllowedContent: filterMap[ key ]
+			}
+		};
+	}
+
+	bender.test( bender.tools.createTestsForEditors( CKEDITOR.tools.objectKeys( bender.editors ), tests ) );
+} )();

--- a/tests/plugins/tabletools/allowedcontent.js
+++ b/tests/plugins/tabletools/allowedcontent.js
@@ -31,6 +31,9 @@
 							assert.isUndefined( isNotAllowed( key ), 'Dialog ' + key + ' shouldn\'t be disallowed.' );
 						}
 					}
+
+					dialog.hide();
+
 					function isNotAllowed( key ) {
 						return dialog._.contents.info[ key ].notAllowed;
 					}

--- a/tests/plugins/tabletools/allowedcontent.js
+++ b/tests/plugins/tabletools/allowedcontent.js
@@ -47,7 +47,7 @@
 										shouldBeAllowed = shouldBeAllowed[ propertyName ];
 
 										if ( shouldBeAllowed ) {
-											shouldBeAllowed = shouldBeAllowed.indexOf( allowedStyleOrAttribute ) !== -1;
+											shouldBeAllowed = CKEDITOR.tools.indexOf( shouldBeAllowed, allowedStyleOrAttribute ) !== -1;
 										} else {
 											shouldBeAllowed = false;
 										}

--- a/tests/plugins/tabletools/allowedcontent.js
+++ b/tests/plugins/tabletools/allowedcontent.js
@@ -5,53 +5,120 @@
 	'use strict';
 
 	var filterMap = {
-		width: 'td{width}',
-		height: 'td{height}',
-		wordWrap: 'td{white-space}',
-		hAlign: 'td{text-align}',
-		vAlign: 'td{vertical-align}',
-		cellType: 'th',
-		rowSpan: 'td[rowspan]',
-		colSpan: 'td[colspan]',
-		bgColor: 'td{background-color}',
-		borderColor: 'td{border-color}'
-	},
-	tests = {
-		'test dialog required content': function( editor, bot ) {
-			bot.setData( '<table><tbody><tr><td>Cell</td></tr></tbody></table>', function() {
-				var rng = new CKEDITOR.dom.range( editor.document );
-				rng.setStart( editor.editable().findOne( 'td' ), CKEDITOR.POSITION_AFTER_START );
-				rng.select();
+			width: [ 'td', 'styles', 'width' ],
+			height: [ 'td', 'styles', 'height' ],
+			wordWrap: [ 'td', 'styles', 'white-space' ],
+			hAlign: [ 'td', 'styles', 'text-align' ],
+			vAlign: [ 'td', 'styles', 'vertical-align' ],
+			cellType: [ 'th' ],
+			rowSpan: [ 'td', 'attributes', 'rowspan' ],
+			colSpan: [ 'td', 'attributes', 'colspan' ],
+			bgColor: [ 'td', 'styles', 'background-color' ],
+			borderColor: [ 'td', 'styles', 'border-color' ]
+		},
+		extraAllowedContentList = [],
+		tests = {
+			'test dialog required content': function( editor, bot ) {
+				bot.setData( '<table><tbody><tr><td>Cell</td></tr></tbody></table>', function() {
+					var rng = new CKEDITOR.dom.range( editor.document );
+					rng.setStart( editor.editable().findOne( 'td' ), CKEDITOR.POSITION_AFTER_START );
+					rng.select();
 
-				bot.dialog( 'cellProperties', function( dialog ) {
-					for ( var key in filterMap ) {
-						if ( key !== editor.name ) {
-							assert.isTrue( isNotAllowed( key ), 'Dialog ' + key + ' should be disallowed.' );
+					bot.contextmenu( function( menu ) {
+						var items = menu.items[ 0 ].getItems();
+						assert[ editor.name === 'editor' ? 'isFalse' : 'isTrue' ]( 'tablecell_properties' in items );
+						menu.hide();
+
+						if ( editor.name === 'editor' ) {
+							assert.areSame( CKEDITOR.TRISTATE_DISABLED, editor.getCommand( 'cellProperties' ).state );
 						} else {
-							assert.isUndefined( isNotAllowed( key ), 'Dialog ' + key + ' shouldn\'t be disallowed.' );
+							bot.dialog( 'cellProperties', function( dialog ) {
+								for ( var key in filterMap ) {
+									var filterArray = filterMap[ key ],
+										elementName = filterArray[ 0 ],
+										propertyName = filterArray[ 1 ],
+										allowedStyleOrAttribute = filterArray[ 2 ],
+										extraAllowedContent = editor.config.extraAllowedContent,
+										shouldBeAllowed = extraAllowedContent[ elementName ];
+
+									if ( filterArray.length === 1 ) {
+										shouldBeAllowed = elementName in extraAllowedContent;
+									} else if ( shouldBeAllowed ) {
+										shouldBeAllowed = shouldBeAllowed[ propertyName ];
+
+										if ( shouldBeAllowed ) {
+											shouldBeAllowed = shouldBeAllowed.indexOf( allowedStyleOrAttribute ) !== -1;
+										} else {
+											shouldBeAllowed = false;
+										}
+									} else {
+										shouldBeAllowed = false;
+									}
+
+									shouldBeAllowed = !!shouldBeAllowed;
+
+									assert[ shouldBeAllowed ? 'isUndefined' : 'isTrue' ]( isNotAllowed( key ), 'Dialog ' + key );
+								}
+
+								dialog.hide();
+
+								function isNotAllowed( key ) {
+									return dialog._.contents.info[ key ].notAllowed;
+								}
+							} );
 						}
-					}
-
-					dialog.hide();
-
-					function isNotAllowed( key ) {
-						return dialog._.contents.info[ key ].notAllowed;
-					}
+					} );
 				} );
-			} );
-		}
-	};
+			}
+		};
 
 	bender.editors = {};
 
 	for ( var key in filterMap ) {
-		bender.editors[ key ] = {
+		if ( extraAllowedContentList.length ) {
+			extraAllowedContentList.push( extraAllowedContentList[ extraAllowedContentList.length - 1 ].concat( [ key ] ) );
+		}
+		extraAllowedContentList.unshift( [ key ] );
+	}
+
+	bender.editors = {
+		editor: {
 			config: {
-				allowedContent: 'table;tbody;thead;tr;td;',
-				extraAllowedContent: filterMap[ key ]
+				allowedContent: 'table;tbody;thead;tr;td;'
+			}
+		}
+	};
+
+	CKEDITOR.tools.array.forEach( extraAllowedContentList, function( array, index ) {
+		var extraAllowedContent = {};
+
+		CKEDITOR.tools.array.forEach( array, function( key ) {
+			var filterArray = filterMap[ key ],
+				elementName = filterArray[ 0 ],
+				propertyName = filterArray[ 1 ],
+				allowedStyleOrAttribute = filterArray[ 2 ];
+
+			if ( filterArray.length === 1 ) {
+				extraAllowedContent[ elementName ] = true;
+				return;
+			} else if ( !extraAllowedContent[ filterArray [ 0 ] ] ) {
+				extraAllowedContent[ elementName ] = {};
+			}
+
+			if ( !extraAllowedContent[ elementName ][ propertyName ] ) {
+				extraAllowedContent[ elementName ][ propertyName ] = [ allowedStyleOrAttribute ];
+			} else {
+				extraAllowedContent[ elementName ][ propertyName ].push( allowedStyleOrAttribute );
+			}
+		} );
+
+		bender.editors[ 'editor_' + index ] = {
+			config: {
+				allowedContent: bender.editors.editor.config.allowedContent,
+				extraAllowedContent: extraAllowedContent
 			}
 		};
-	}
+	} );
 
 	bender.test( bender.tools.createTestsForEditors( CKEDITOR.tools.objectKeys( bender.editors ), tests ) );
 } )();

--- a/tests/plugins/tabletools/allowedcontent.js
+++ b/tests/plugins/tabletools/allowedcontent.js
@@ -63,7 +63,8 @@
 								dialog.hide();
 
 								function isNotAllowed( key ) {
-									return dialog._.contents.info[ key ].notAllowed;
+									var item = dialog._.contents.info[ key ];
+									return item === undefined || item.notAllowed;
 								}
 							} );
 						}

--- a/tests/plugins/tabletools/cellproperties.js
+++ b/tests/plugins/tabletools/cellproperties.js
@@ -141,10 +141,9 @@
 			}, function( bot ) {
 				bot.setHtmlWithSelection( '<table><tr><td>Te^st</td></tr></table>' );
 				bot.dialog( 'cellProperties', function( dialog ) {
-					assert.isFalse( dialog.getContentElement( 'info', 'width' ).isVisible() );
-					assert.isFalse( dialog.getContentElement( 'info', 'height' ).isVisible() );
-					assert.isFalse( dialog.getContentElement( 'info', 'htmlHeightType' ).isVisible() );
-					assert.isFalse( dialog.getContentElement( 'info', 'hiddenSpacer' ).isVisible() );
+					assert.isUndefined( dialog.getContentElement( 'info', 'width' ) );
+					assert.isUndefined( dialog.getContentElement( 'info', 'height' ) );
+					assert.isUndefined( dialog.getContentElement( 'info', 'htmlHeightType' ) );
 				} );
 			} );
 		},
@@ -159,7 +158,6 @@
 					assert.isTrue( dialog.getContentElement( 'info', 'width' ).isVisible() );
 					assert.isTrue( dialog.getContentElement( 'info', 'height' ).isVisible() );
 					assert.isTrue( dialog.getContentElement( 'info', 'htmlHeightType' ).isVisible() );
-					assert.isTrue( dialog.getContentElement( 'info', 'hiddenSpacer' ).isVisible() );
 				} );
 			} );
 		}

--- a/tests/plugins/tabletools/cellproperties.js
+++ b/tests/plugins/tabletools/cellproperties.js
@@ -160,6 +160,27 @@
 					assert.isTrue( dialog.getContentElement( 'info', 'htmlHeightType' ).isVisible() );
 				} );
 			} );
+		},
+
+		'test dialog definition': function() {
+			bender.editorBot.create( {
+				name: 'definition',
+				removePlugins: 'colordialog'
+			}, function( bot ) {
+				bot.setHtmlWithSelection( '<table><tr><td>Te^st</td></tr></table>' );
+				bot.dialog( 'cellProperties', function( dialog ) {
+					assertChildren( dialog.definition.contents[ 0 ].elements[ 0 ].children );
+				} );
+			} );
 		}
 	} );
+
+	function assertChildren( children ) {
+		CKEDITOR.tools.array.forEach( children, function( item ) {
+			assert.isObject( item );
+			if ( item.children ) {
+				assertChildren( item.children );
+			}
+		} );
+	}
 } )();

--- a/tests/plugins/tabletools/cellproperties.js
+++ b/tests/plugins/tabletools/cellproperties.js
@@ -162,7 +162,8 @@
 			} );
 		},
 
-		// #1986 and #2732
+		// Changes to cell properties dialog (#1986) caused regression (#2732).
+		// Dialog definition had `null` items. Each item should be an object.
 		'test dialog definition': function() {
 			bender.editorBot.create( {
 				name: 'definition',

--- a/tests/plugins/tabletools/cellproperties.js
+++ b/tests/plugins/tabletools/cellproperties.js
@@ -30,6 +30,14 @@
 			} );
 		},
 
+		tearDown: function() {
+			var dialog = CKEDITOR.dialog.getCurrent();
+
+			if ( dialog ) {
+				dialog.hide();
+			}
+		},
+
 		'test cell properties dialog (text selection)': function() {
 			this.doTest( 'table-1', function( dialog ) {
 				dialog.setValueOf( 'info', 'width', 100 );

--- a/tests/plugins/tabletools/cellproperties.js
+++ b/tests/plugins/tabletools/cellproperties.js
@@ -171,6 +171,7 @@
 		},
 
 		// Changes to cell properties dialog (#1986) caused regression (#2732).
+		// Opening dialog shouldn't cause an error.
 		// Dialog definition had `null` items. Each item should be an object.
 		'test dialog definition': function() {
 			bender.editorBot.create( {
@@ -178,9 +179,13 @@
 				removePlugins: 'colordialog'
 			}, function( bot ) {
 				bot.setHtmlWithSelection( '<table><tr><td>Te^st</td></tr></table>' );
-				bot.dialog( 'cellProperties', function( dialog ) {
-					assertChildren( dialog.definition.contents[ 0 ].elements[ 0 ].children );
-				} );
+				try {
+					bot.dialog( 'cellProperties', function( dialog ) {
+						assertChildren( dialog.definition.contents[ 0 ].elements[ 0 ].children );
+					} );
+				} catch ( err ) {
+					assert.fail( err );
+				}
 			} );
 		}
 	} );

--- a/tests/plugins/tabletools/cellproperties.js
+++ b/tests/plugins/tabletools/cellproperties.js
@@ -162,6 +162,7 @@
 			} );
 		},
 
+		// #1986 and #2732
 		'test dialog definition': function() {
 			bender.editorBot.create( {
 				name: 'definition',

--- a/tests/plugins/tabletools/cellproperties.js
+++ b/tests/plugins/tabletools/cellproperties.js
@@ -172,7 +172,7 @@
 
 		// Changes to cell properties dialog (#1986) caused regression (#2732).
 		// Dialog definition had `null` items. Each item should be an object.
-		'test dialog definition doesn\'t have empty contnets': function() {
+		'test dialog definition doesn\'t have empty contents': function() {
 			bender.editorBot.create( {
 				name: 'nocolordialog',
 				config: {

--- a/tests/plugins/tabletools/cellproperties.js
+++ b/tests/plugins/tabletools/cellproperties.js
@@ -180,9 +180,16 @@
 				}
 			}, function( bot ) {
 				bot.setHtmlWithSelection( '<table><tr><td>Te^st</td></tr></table>' );
-				bot.dialog( 'cellProperties', function( dialog ) {
-					assertChildren( dialog.definition.contents[ 0 ].elements[ 0 ].children );
-				} );
+
+				CKEDITOR.once( 'dialogDefinition', function( evt ) {
+					resume( function() {
+						assertChildren( evt.data.definition.contents[ 0 ].elements[ 0 ].children );
+					} );
+				}, null, null, 0 );
+
+				bot.editor.execCommand( 'cellProperties' );
+
+				wait();
 			} );
 		},
 
@@ -223,7 +230,7 @@
 
 	function assertChildren( children ) {
 		CKEDITOR.tools.array.forEach( children, function( item ) {
-			if ( item.children ) {
+			if ( item && item.children ) {
 				assertChildren( item.children );
 			} else {
 				assert.isObject( item );

--- a/tests/plugins/tabletools/cellproperties.js
+++ b/tests/plugins/tabletools/cellproperties.js
@@ -179,9 +179,10 @@
 
 	function assertChildren( children ) {
 		CKEDITOR.tools.array.forEach( children, function( item ) {
-			assert.isObject( item );
 			if ( item.children ) {
 				assertChildren( item.children );
+			} else {
+				assert.isObject( item );
 			}
 		} );
 	}

--- a/tests/plugins/tabletools/cellproperties.js
+++ b/tests/plugins/tabletools/cellproperties.js
@@ -214,7 +214,7 @@
 							listener.apply( null, args );
 							assert.pass( 'Passed with no errors.' );
 						} catch ( err ) {
-							assert.fail( err );
+							assert.fail( 'Error occured.' );
 						} finally {
 							listeners[ 0 ] = listener;
 						}

--- a/tests/plugins/tabletools/manual/allowedcontent.html
+++ b/tests/plugins/tabletools/manual/allowedcontent.html
@@ -1,0 +1,32 @@
+<textarea id="editor1">
+	<table>
+		<tbody>
+			<tr>
+				<td>Ths is cell</td>
+			</tr>
+		</tbody>
+	</table>
+</textarea>
+<textarea id="editor2">
+	<table>
+		<tbody>
+			<tr>
+				<td>Ths is cell</td>
+			</tr>
+		</tbody>
+	</table>
+</textarea>
+
+<script>
+	CKEDITOR.replace( 'editor1', {
+		allowedContent:
+			'p;' +
+			'div;' +
+			'table;' +
+			'thead;' +
+			'tbody;' +
+			'tr;' +
+			'td;'
+	} );
+	CKEDITOR.replace( 'editor2' );
+</script>

--- a/tests/plugins/tabletools/manual/allowedcontent.html
+++ b/tests/plugins/tabletools/manual/allowedcontent.html
@@ -37,7 +37,8 @@
 			'Rows Span': 'rowspan',
 			'Cols Span': 'colspan',
 			'Background Color': 'background-color',
-			'Border Color': 'border-color'
+			'Border Color': 'border-color',
+			'Color Dialog': 'colordialog'
 		},
 		options = CKEDITOR.document.findOne( '.options' ),
 		allowedContent = {
@@ -60,6 +61,13 @@
 
 	for ( var key in cellPropMap ) {
 		var name = cellPropMap[ key ];
+
+		if ( key === 'Color Dialog' ) {
+			options.appendHtml(
+				'<p>Extra plugins:</p>'
+			);
+		}
+
 		options.appendHtml(
 			'<label><input type="checkbox" name="' + name + '">' + key + '</label>'
 		);
@@ -72,7 +80,8 @@
 			state = target.$.checked,
 			rule = target.getAttribute( 'name' ),
 			attributes = allowedContent.td.attributes,
-			styles = allowedContent.td.styles;
+			styles = allowedContent.td.styles,
+			extraPlugins;
 
 		if ( !rule ) {
 			return;
@@ -89,6 +98,9 @@
 			case 'colspan':
 				addRemoveRule( rule, state, attributes );
 				break;
+			case 'colordialog':
+				extraPlugins = state ? 'colordialog' : '';
+				break;
 			default:
 				addRemoveRule( rule, state, styles );
 		}
@@ -96,7 +108,8 @@
 		editor.once( 'destroy', function() {
 			setTimeout( function() {
 				editor = CKEDITOR.replace( 'editor1', {
-					allowedContent: allowedContent
+					allowedContent: allowedContent,
+					extraPlugins: extraPlugins
 				} );
 
 				// Calling destroy on editor removes listener.

--- a/tests/plugins/tabletools/manual/allowedcontent.html
+++ b/tests/plugins/tabletools/manual/allowedcontent.html
@@ -1,13 +1,22 @@
+<style>
+	.options {
+		line-height: 24px;
+	}
+
+	.options label {
+		display: block;
+	}
+
+	.options input {
+		margin-right: 8px;
+	}
+</style>
+
+<div class="options"><p>
+	Allowed content:
+</p></div>
+
 <textarea id="editor1">
-	<table>
-		<tbody>
-			<tr>
-				<td>Ths is cell</td>
-			</tr>
-		</tbody>
-	</table>
-</textarea>
-<textarea id="editor2">
 	<table>
 		<tbody>
 			<tr>
@@ -18,15 +27,88 @@
 </textarea>
 
 <script>
-	CKEDITOR.replace( 'editor1', {
-		allowedContent:
-			'p;' +
-			'div;' +
-			'table;' +
-			'thead;' +
-			'tbody;' +
-			'tr;' +
-			'td;'
+	var cellPropMap = {
+			'Width': 'width',
+			'Height': 'height',
+			'Word Wrap': 'white-space',
+			'Horizontal Align': 'text-align',
+			'Vertical Align': 'vertical-align',
+			'Cell Type': 'th',
+			'Rows Span': 'rowspan',
+			'Cols Span': 'colspan',
+			'Background Color': 'background-color',
+			'Border Color': 'border-color'
+		},
+		options = CKEDITOR.document.findOne( '.options' ),
+		allowedContent = {
+			p: true,
+			div: true,
+			table: true,
+			thead: true,
+			tbody: true,
+			tr: true,
+			td: {
+				styles: [],
+				attributes: []
+			}
+		},
+		editor = CKEDITOR.replace( 'editor1', {
+			allowedContent: allowedContent
+		} );
+
+	for ( var key in cellPropMap ) {
+		var name = cellPropMap[ key ];
+		options.appendHtml(
+			'<label><input type="checkbox" name="' + name + '">' + key + '</label>'
+		);
+	}
+
+	// Calling destroy on editor removes listener, so use native.
+	options.$.addEventListener( 'input', function( e ) {
+		var target = new CKEDITOR.dom.element( e.target ),
+			state = target.$.checked,
+			rule = target.getAttribute( 'name' ),
+			attributes = allowedContent.td.attributes,
+			styles = allowedContent.td.styles;
+
+		switch ( rule ) {
+			case 'th':
+				if ( state ) {
+					allowedContent.th = true;
+				} else {
+					delete allowedContent.th;
+				}
+			case 'rowspan':
+			case 'colspan':
+				addRemoveRule( rule, state, attributes );
+				// rule = 'td[' + rule + ']';
+				break;
+			default:
+				addRemoveRule( rule, state, styles );
+				// rule = 'td{' + rule + '}';
+		}
+
+
+		editor.once( 'destroy', function() {
+			setTimeout( function() {
+				editor = CKEDITOR.replace( 'editor1', {
+					allowedContent: allowedContent
+				} );
+			} );
+		} );
+
+		// We need to recreate editor, because filter is caching checks.
+		editor.destroy();
+
+		function addRemoveRule( rule, state, arr ) {
+			var index = CKEDITOR.tools.array.indexOf( arr, rule );
+
+			if ( state && index === -1 ) {
+				arr.push( rule );
+			} else if ( !state && index >= 0 ) {
+				arr.splice( index, 1 );
+			}
+		}
+
 	} );
-	CKEDITOR.replace( 'editor2' );
 </script>

--- a/tests/plugins/tabletools/manual/allowedcontent.html
+++ b/tests/plugins/tabletools/manual/allowedcontent.html
@@ -53,6 +53,7 @@
 				attributes: []
 			}
 		},
+		extraPlugins = '',
 		editor = CKEDITOR.replace( 'editor1', {
 			allowedContent: allowedContent
 		} ),
@@ -80,8 +81,7 @@
 			state = target.$.checked,
 			rule = target.getAttribute( 'name' ),
 			attributes = allowedContent.td.attributes,
-			styles = allowedContent.td.styles,
-			extraPlugins;
+			styles = allowedContent.td.styles;
 
 		if ( !rule ) {
 			return;

--- a/tests/plugins/tabletools/manual/allowedcontent.html
+++ b/tests/plugins/tabletools/manual/allowedcontent.html
@@ -54,7 +54,9 @@
 		},
 		editor = CKEDITOR.replace( 'editor1', {
 			allowedContent: allowedContent
-		} );
+		} ),
+		// Change event doesn't work in IE8.
+		eventName = CKEDITOR.env.ie && CKEDITOR.env.version === 8 ? 'click' : 'change';
 
 	for ( var key in cellPropMap ) {
 		var name = cellPropMap[ key ];
@@ -63,7 +65,7 @@
 		);
 	}
 
-	options.on( 'input', inputListener );
+	options.on( eventName, inputListener );
 
 	function inputListener( e ) {
 		var target = e.data.getTarget(),
@@ -71,6 +73,10 @@
 			rule = target.getAttribute( 'name' ),
 			attributes = allowedContent.td.attributes,
 			styles = allowedContent.td.styles;
+
+		if ( !rule ) {
+			return;
+		}
 
 		switch ( rule ) {
 			case 'th':
@@ -94,7 +100,7 @@
 				} );
 
 				// Calling destroy on editor removes listener.
-				options.on( 'input', inputListener );
+				options.on( eventName, inputListener );
 			} );
 		} );
 

--- a/tests/plugins/tabletools/manual/allowedcontent.html
+++ b/tests/plugins/tabletools/manual/allowedcontent.html
@@ -82,11 +82,9 @@
 			case 'rowspan':
 			case 'colspan':
 				addRemoveRule( rule, state, attributes );
-				// rule = 'td[' + rule + ']';
 				break;
 			default:
 				addRemoveRule( rule, state, styles );
-			// rule = 'td{' + rule + '}';
 		}
 
 		editor.once( 'destroy', function() {

--- a/tests/plugins/tabletools/manual/allowedcontent.html
+++ b/tests/plugins/tabletools/manual/allowedcontent.html
@@ -55,7 +55,7 @@
 		editor = CKEDITOR.replace( 'editor1', {
 			allowedContent: allowedContent
 		} ),
-		// Change event doesn't work in IE8.
+		// 'change' event doesn't work in IE8.
 		eventName = CKEDITOR.env.ie && CKEDITOR.env.version === 8 ? 'click' : 'change';
 
 	for ( var key in cellPropMap ) {

--- a/tests/plugins/tabletools/manual/allowedcontent.html
+++ b/tests/plugins/tabletools/manual/allowedcontent.html
@@ -20,7 +20,7 @@
 	<table>
 		<tbody>
 			<tr>
-				<td>Ths is cell</td>
+				<td>This is cell</td>
 			</tr>
 		</tbody>
 	</table>
@@ -63,9 +63,10 @@
 		);
 	}
 
-	// Calling destroy on editor removes listener, so use native.
-	options.$.addEventListener( 'input', function( e ) {
-		var target = new CKEDITOR.dom.element( e.target ),
+	options.on( 'input', inputListener );
+
+	function inputListener( e ) {
+		var target = e.data.getTarget(),
 			state = target.$.checked,
 			rule = target.getAttribute( 'name' ),
 			attributes = allowedContent.td.attributes,
@@ -85,30 +86,31 @@
 				break;
 			default:
 				addRemoveRule( rule, state, styles );
-				// rule = 'td{' + rule + '}';
+			// rule = 'td{' + rule + '}';
 		}
-
 
 		editor.once( 'destroy', function() {
 			setTimeout( function() {
 				editor = CKEDITOR.replace( 'editor1', {
 					allowedContent: allowedContent
 				} );
+
+				// Calling destroy on editor removes listener.
+				options.on( 'input', inputListener );
 			} );
 		} );
 
 		// We need to recreate editor, because filter is caching checks.
 		editor.destroy();
+	}
 
-		function addRemoveRule( rule, state, arr ) {
-			var index = CKEDITOR.tools.array.indexOf( arr, rule );
+	function addRemoveRule( rule, state, arr ) {
+		var index = CKEDITOR.tools.array.indexOf( arr, rule );
 
-			if ( state && index === -1 ) {
-				arr.push( rule );
-			} else if ( !state && index >= 0 ) {
-				arr.splice( index, 1 );
-			}
+		if ( state && index === -1 ) {
+			arr.push( rule );
+		} else if ( !state && index >= 0 ) {
+			arr.splice( index, 1 );
 		}
-
-	} );
+	}
 </script>

--- a/tests/plugins/tabletools/manual/allowedcontent.md
+++ b/tests/plugins/tabletools/manual/allowedcontent.md
@@ -4,34 +4,19 @@
 
 # Test scenario
 
-For each editor:
-1. Open context menu for table cell.
-1. Choose cell properties from context menu.
+1. Use checkboxes to select allowed cell properties.
+1. Use context menu on editor to open cell properties.
 
 ## Expected
 
-#### First editor:
-
-Dialog is empty.
-
-#### Second editor:
-
-Dialog has all listed options:
-- Width,
-- Height,
-- Word Wrap,
-- Horizontal Align,
-- Vertical Align,
-- Cell Type,
-- Rows Span,
-- Cols Span,
-- Background Color,
-- Border Color
-
-It is possible to change any of cell property via dialog.
+- Cell properties dialog options are matching selected checkboxes.
+- If none is selected then cell properties is not displayed in context menu.
 
 ## Unexpected
 
-First editor has any option in dialog,
-Second editor has any missing option in dialog,
-It is impossible to change any property via dialog in second editor.
+- Dialog options are different than selected checkboxes.
+
+## Note:
+
+- Selecting/unselecting checkboxes destroys and creates new editor, so visible flickering may occur.
+- To change width or height of cell both properties needs to be allowed.

--- a/tests/plugins/tabletools/manual/allowedcontent.md
+++ b/tests/plugins/tabletools/manual/allowedcontent.md
@@ -1,0 +1,37 @@
+@bender-tags: 4.10.0, 1986, bug
+@bender-ui: collapsed
+@bender-ckeditor-plugins: wysiwygarea, toolbar, table, tabletools, sourcearea
+
+# Test scenario
+
+For each editor:
+1. Open context menu for table cell.
+1. Choose cell properties from context menu.
+
+## Expected
+
+#### First editor:
+
+Dialog is empty.
+
+#### Second editor:
+
+Dialog has all listed options:
+- Width,
+- Height,
+- Word Wrap,
+- Horizontal Align,
+- Vertical Align,
+- Cell Type,
+- Rows Span,
+- Cols Span,
+- Background Color,
+- Border Color
+
+It is possible to change any of cell property via dialog.
+
+## Unexpected
+
+First editor has any option in dialog,
+Second editor has any missing option in dialog,
+It is impossible to change any property via dialog in second editor.

--- a/tests/plugins/tabletools/manual/allowedcontent.md
+++ b/tests/plugins/tabletools/manual/allowedcontent.md
@@ -1,4 +1,4 @@
-@bender-tags: 4.10.0, 1986, bug
+@bender-tags: 4.10.1, 1986, bug
 @bender-ui: collapsed
 @bender-ckeditor-plugins: wysiwygarea, toolbar, table, tabletools, sourcearea
 

--- a/tests/plugins/tabletools/manual/allowedcontent.md
+++ b/tests/plugins/tabletools/manual/allowedcontent.md
@@ -1,4 +1,4 @@
-@bender-tags: 4.10.1, 1986, bug
+@bender-tags: 4.11.0, 1986, bug
 @bender-ui: collapsed
 @bender-ckeditor-plugins: wysiwygarea, toolbar, table, tabletools, sourcearea
 

--- a/tests/plugins/tabletools/manual/allowedcontent.md
+++ b/tests/plugins/tabletools/manual/allowedcontent.md
@@ -19,4 +19,3 @@
 ## Note:
 
 - Selecting/unselecting checkboxes destroys and creates new editor, so visible flickering may occur.
-- To change width or height of cell both properties needs to be allowed.

--- a/tests/plugins/tabletools/manual/allowedcontent.md
+++ b/tests/plugins/tabletools/manual/allowedcontent.md
@@ -1,4 +1,4 @@
-@bender-tags: 4.11.0, 1986, bug
+@bender-tags: 4.11.2, 1986, bug
 @bender-ui: collapsed
 @bender-ckeditor-plugins: wysiwygarea, toolbar, table, tabletools, sourcearea
 

--- a/tests/plugins/tabletools/manual/allowedcontent.md
+++ b/tests/plugins/tabletools/manual/allowedcontent.md
@@ -1,4 +1,4 @@
-@bender-tags: 4.11.2, 1986, bug
+@bender-tags: 4.11.3, 1986, bug
 @bender-ui: collapsed
 @bender-ckeditor-plugins: wysiwygarea, toolbar, table, tabletools, sourcearea
 

--- a/tests/plugins/tabletools/manual/filebrowserintegration.html
+++ b/tests/plugins/tabletools/manual/filebrowserintegration.html
@@ -1,0 +1,18 @@
+<textarea id="editor"><table border="1">
+	<tbody>
+		<tr>
+			<td>Table cell</td>
+		</tr>
+	</tbody>
+</table>
+</textarea>
+
+<script>
+	if ( bender.tools.env.mobile ) {
+		bender.ignore();
+	}
+
+	CKEDITOR.replace( 'editor', {
+		removePlugins: 'colorDialog'
+	} );
+</script>

--- a/tests/plugins/tabletools/manual/filebrowserintegration.md
+++ b/tests/plugins/tabletools/manual/filebrowserintegration.md
@@ -1,0 +1,15 @@
+@bender-tags: 4.11.3, bug, 2656, 2732
+@bender-ui: collapsed
+@bender-ckeditor-plugins: wysiwygarea, toolbar, table, tabletools, contextmenu, filebrowser
+
+1. Open console.
+1. Right click on table cell.
+1. Open cell properties from context menu.
+
+## Expected
+
+Dialog opens without any errors.
+
+## Unexpected
+
+Console logs an error.


### PR DESCRIPTION
## What is the purpose of this pull request?

Bug fix

## Does your PR contain necessary tests?

All patches which change the editor code must include tests. You can always read more
on [PR testing](https://ckeditor.com/docs/ckeditor4/latest/guide/dev_contributing_code.html#tests),
[how to set the testing environment](https://ckeditor.com/docs/ckeditor4/latest/guide/dev_tests.html) and
[how to create tests](https://ckeditor.com/docs/ckeditor4/latest/guide/dev_tests.html#creating-your-own-test)
in the official CKEditor documentation.

### This PR contains

- [x] Unit tests
- [x] Manual tests

## What changes did you make?

Changes from #2086 were reverted by #2735 because of nasty regression #2732.

Problem comes from here:
https://github.com/ckeditor/ckeditor-dev/blob/abd2465fd64ae9e9f84c275210f73d2fec54c219/plugins/tabletools/dialogs/tableCell.js#L317-L334
And repeated in [L364-382](https://github.com/ckeditor/ckeditor-dev/blob/abd2465fd64ae9e9f84c275210f73d2fec54c219/plugins/tabletools/dialogs/tableCell.js#L364-L382)

Originally I didn't want to move part of definition to conditional variable, as it would make reading whole definition harder, so I inlined which leaded to item being `null` when `colorDialog` plugin is absent. Resulting in an error when `filebrowser` plugin tried to access property of `null`.

To fix the error I wrapped linked above conditional with IIFE, so it returns one or two elements, but none of them is `null`.

New commits starts from: `5d1c1ac`

Closes #1986 