### PR TITLE
Autolink: editor.getSelection(...) null in source view

### DIFF
--- a/plugins/autolink/plugin.js
+++ b/plugins/autolink/plugin.js
@@ -45,7 +45,8 @@
 						return;
 					}
 
-					var matched = CKEDITOR.plugins.textMatch.match( editor.getSelection().getRanges()[ 0 ], matchCallback );
+					var selection = editor.getSelection();
+					var matched = selection && CKEDITOR.plugins.textMatch.match( selection.getRanges()[ 0 ], matchCallback );
 
 					if ( matched ) {
 						insertLink( matched );


### PR DESCRIPTION
## What is the purpose of this pull request?

Fix bug #2756: when typing in source view, autolink throw a null pointer

## Does your PR contain necessary tests?

All patches which change the editor code must include tests. You can always read more
on [PR testing](https://ckeditor.com/docs/ckeditor4/latest/guide/dev_contributing_code.html#tests),
[how to set the testing environment](https://ckeditor.com/docs/ckeditor4/latest/guide/dev_tests.html) and
[how to create tests](https://ckeditor.com/docs/ckeditor4/latest/guide/dev_tests.html#creating-your-own-test)
in the official CKEditor documentation.

### This PR contains

- [ ] Unit tests
- [X] Manual tests

## What changes did you make?

Fix exception
> TypeError: editor.getSelection(...) is null
