### PR TITLE
Fixes #2748 Throw friendly error for invalid/missing id's on editor creation

### DIFF
--- a/core/creators/inline.js
+++ b/core/creators/inline.js
@@ -31,7 +31,13 @@
 		if ( !CKEDITOR.env.isCompatible )
 			return null;
 
+		var elementArg = element;
+
 		element = CKEDITOR.dom.element.get( element );
+
+		// Throw error on missing target element.
+		if ( !element )
+			throw 'The provided element, "' + elementArg + '", is missing from the DOM.';
 
 		// Avoid multiple inline editor instances on the same element.
 		if ( element.getEditor() )

--- a/core/creators/themedui.js
+++ b/core/creators/themedui.js
@@ -323,7 +323,13 @@ CKEDITOR.replaceClass = 'ckeditor';
 		if ( !CKEDITOR.env.isCompatible )
 			return null;
 
+		var elementArg = element;
+
 		element = CKEDITOR.dom.element.get( element );
+
+		// Throw error on missing target element.
+		if ( !element )
+			throw 'The provided element, "' + elementArg + '", is missing from the DOM.';
 
 		// Avoid multiple inline editor instances on the same element.
 		if ( element.getEditor() )

--- a/tests/core/creators/creators.js
+++ b/tests/core/creators/creators.js
@@ -162,6 +162,31 @@ bender.test( {
 		wait();
 	},
 
+	'test creator replace on bogus DOM element': function() {
+		try {
+			CKEDITOR.replace( 'editorBogus', {
+				on: {
+					instanceReady: function() {
+						resume( function() {
+							assert.fail( 'Creation should fail on bogus DOM elements.' );
+						} );
+					}
+				}
+			} );
+		} catch ( e ) {
+			resume( function() {
+				if ( e.toString().indexOf( 'The provided element' ) >= 0 ) {
+					assert.isTrue( true );
+				}
+				else {
+					assert.fail( 'Error message should be friendly and helpful.' );
+				}
+			} );
+		}
+
+		wait();
+	},
+
 	'test creator appendTo': function() {
 		var tc = this,
 			container = CKEDITOR.dom.element.createFromHtml( '<div id="foo"></div>' );
@@ -223,6 +248,31 @@ bender.test( {
 
 		var checkEvents = this.checkEditorEvents( editor, [ 'configLoaded', 'langLoaded', 'pluginsLoaded', 'loaded', 'stylesSet', 'uiReady', 'setData', 'contentDom', 'mode', 'instanceReady' ] ),
 			checkStatuses = this.checkEditorStatuses( editor );
+
+		wait();
+	},
+
+	'test creator inline on bogus DOM element': function() {
+		try {
+			CKEDITOR.inline( 'editorBogus', {
+				on: {
+					instanceReady: function() {
+						resume( function() {
+							assert.fail( 'Creation should fail on bogus DOM elements.' );
+						} );
+					}
+				}
+			} );
+		} catch ( e ) {
+			resume( function() {
+				if ( e.toString().indexOf( 'The provided element' ) >= 0 ) {
+					assert.isTrue( true );
+				}
+				else {
+					assert.fail( 'Error message should be friendly and helpful.' );
+				}
+			} );
+		}
 
 		wait();
 	},


### PR DESCRIPTION
## What is the purpose of this pull request?
bug fix

## Does your PR contain necessary tests?
All patches which change the editor code must include tests. You can always read more
on [PR testing](https://ckeditor.com/docs/ckeditor4/latest/guide/dev_contributing_code.html#tests),
[how to set the testing environment](https://ckeditor.com/docs/ckeditor4/latest/guide/dev_tests.html) and
[how to create tests](https://ckeditor.com/docs/ckeditor4/latest/guide/dev_tests.html#creating-your-own-test)
in the official CKEditor documentation.

### This PR contains
* [x]  Unit tests
* [ ]  Manual tests

## What changes did you make?
Throw helpful error when bogus DOM element is passes to `inline()`, `appendTo()`, or `replace()`.

Closes #2748