### PR TITLE
Fix Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ dist: trusty
 language: node_js
 
 node_js:
-  - 8
+  - 10
 
 env:
   - BUILD=0 BROWSER=Chrome
@@ -14,17 +14,14 @@ env:
 
 addons:
   firefox: "latest"
-  apt:
-    sources:
-      - google-chrome
-    packages:
-      - google-chrome-stable
+  chrome: stable
 
 before_script:
   # Prepare environment.
   - 'npm install benderjs-cli -g'
-  - 'sh -e /etc/init.d/xvfb start'
   - 'export DISPLAY=:99.0'
+  - 'sh -e /etc/init.d/xvfb start'
+  - 'sleep 3'
 
   # The $TRAVIS_BRANCH points to target branch for PRs and for other branches it is the current branch name.
   - 'BUILD_PATH=0'

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ dist: trusty
 language: node_js
 
 node_js:
-  - 4
+  - 8
 
 env:
   - BUILD=0 BROWSER=Chrome

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,12 +9,16 @@ node_js:
 env:
   - BUILD=0 BROWSER=Chrome
   - BUILD=1 BROWSER=Chrome
-  - BUILD=0 BROWSER=Firefox
-  - BUILD=1 BROWSER=Firefox
+  - BUILD=0 BROWSER=Firefox MOZ_HEADLESS=1
+  - BUILD=1 BROWSER=Firefox MOZ_HEADLESS=1
 
 addons:
   firefox: "latest"
   chrome: stable
+
+before_install:
+  - # start your web application and listen on `localhost`
+  - google-chrome-stable --headless --disable-gpu --remote-debugging-port=9222 http://localhost &
 
 before_script:
   # Prepare environment.

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,15 +17,11 @@ addons:
   chrome: stable
 
 before_install:
-  - # start your web application and listen on `localhost`
-  - google-chrome-stable --headless --disable-gpu --remote-debugging-port=9222 http://localhost &
+  - google-chrome-stable --headless --disable-gpu &
 
 before_script:
   # Prepare environment.
   - 'npm install benderjs-cli -g'
-  - 'export DISPLAY=:99.0'
-  - 'sh -e /etc/init.d/xvfb start'
-  - 'sleep 3'
 
   # The $TRAVIS_BRANCH points to target branch for PRs and for other branches it is the current branch name.
   - 'BUILD_PATH=0'

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,9 +16,6 @@ addons:
   firefox: "latest"
   chrome: stable
 
-before_install:
-  - google-chrome-stable --headless --disable-gpu &
-
 before_script:
   # Prepare environment.
   - 'npm install benderjs-cli -g'

--- a/.travis.yml
+++ b/.travis.yml
@@ -22,6 +22,9 @@ before_install:
 before_script:
   # Prepare environment.
   - 'npm install benderjs-cli -g'
+  - 'export DISPLAY=:99.0'
+  - 'sh -e /etc/init.d/xvfb start'
+  - 'sleep 3'
 
   # The $TRAVIS_BRANCH points to target branch for PRs and for other branches it is the current branch name.
   - 'BUILD_PATH=0'

--- a/bender.ci.js
+++ b/bender.ci.js
@@ -5,5 +5,6 @@ var config = require( './bender' );
 
 config.startBrowser = process.env.BROWSER || 'Chrome';
 config.mathJaxLibPath = 'https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.4/MathJax.js?config=TeX-AMS_HTML';
+config.isTravis = true;
 
 module.exports = config;

--- a/bender.ci.js
+++ b/bender.ci.js
@@ -5,5 +5,9 @@ var config = require( './bender' );
 
 config.startBrowser = process.env.BROWSER || 'Chrome';
 config.isTravis = true;
+config.startBrowserOptions = {
+	Chrome: '--headless --disable-gpu',
+	Firefox: '-headless'
+};
 
 module.exports = config;

--- a/bender.ci.js
+++ b/bender.ci.js
@@ -4,7 +4,6 @@
 var config = require( './bender' );
 
 config.startBrowser = process.env.BROWSER || 'Chrome';
-config.mathJaxLibPath = 'https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.4/MathJax.js?config=TeX-AMS_HTML';
 config.isTravis = true;
 
 module.exports = config;

--- a/bender.js
+++ b/bender.js
@@ -1,5 +1,30 @@
 /* jshint browser: false, node: true */
 
+/**
+ * Bender configuration file
+ *
+ * @param {Object}   applications       Applications used in current project
+ * @param {Array}    browsers           List of browsers used for testing
+ * @param {Number}   captureTimeout     Timeout before which a launched browser should connect to the server
+ * @param {String}   certificate        Location of the certificate file
+ * @param {Boolean}  debug              Enable debug logs
+ * @param {Number}   defermentTimeout   Timeout before which a plugin should finish initializing on a test page
+ * @param {String}   framework          Default framework used for the tests
+ * @param {String}   hostname           Host on which the HTTP and WebSockets servers will listen
+ * @param {Array}    manualBrowsers     List of browsers accepting manual tests
+ * @param {Number}   manualTestTimeout  Timeout after which a manual test is marked as failed
+ * @param {Array}    plugins            List of Bender plugins to load at startup (Required)
+ * @param {Number}   port               Port on which the HTTP and WebSockets servers will listen
+ * @param {String}   privateKey         Location of the private key file
+ * @param {Boolean}  secure             Flag telling whether to serve contents over HTTPS and WSS
+ * @param {Number}   slowAvgThreshold   Average test case duration threshold above which a test is marked as slow
+ * @param {Number}   slowThreshold      Test duration threshold above which a test is marked as slow
+ * @param {String}   startBrowser       Name of a browser to start when executing bender run command
+ * @param {Number}   testRetries        Number of retries to perform before marking a test as failed
+ * @param {Object}   tests              Test groups for the project (Required)
+ * @param {Number}   testTimeout        Timeout after which a test will be fetched again
+ */
+
 'use strict';
 
 var config = {
@@ -123,7 +148,8 @@ var config = {
 		indent_handlebars: false,
 		end_with_newline: true,
 		extra_liners: 'head, body, div, p, /html'
-	}
+	},
+	mathJaxLibPath: 'https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.4/MathJax.js?config=TeX-AMS_HTML'
 };
 
 module.exports = config;

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
 	"description": "The development version of CKEditor - JavaScript WYSIWYG web text editor.",
 	"devDependencies": {
 		"benderjs": "0.4.3",
-		"benderjs-coverage": "https://github.com/benderjs/benderjs-coverage.git#t/ci-fix",
+		"benderjs-coverage": "https://github.com/benderjs/benderjs-coverage.git#master",
 		"benderjs-jquery": "^0.3.0",
 		"benderjs-sinon": "^0.3.1",
 		"benderjs-yui": "^0.3.2",

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
 	"version": "4.11.3",
 	"description": "The development version of CKEditor - JavaScript WYSIWYG web text editor.",
 	"devDependencies": {
-		"benderjs": "^0.4.2",
+		"benderjs": "^0.4.3",
 		"benderjs-coverage": "^0.2.1",
 		"benderjs-jquery": "^0.3.0",
 		"benderjs-sinon": "^0.3.1",

--- a/package.json
+++ b/package.json
@@ -3,8 +3,8 @@
 	"version": "4.11.3",
 	"description": "The development version of CKEditor - JavaScript WYSIWYG web text editor.",
 	"devDependencies": {
-		"benderjs": "^0.4.3",
-		"benderjs-coverage": "^0.2.1",
+		"benderjs": "0.4.3",
+		"benderjs-coverage": "https://github.com/benderjs/benderjs-coverage.git#t/ci-fix",
 		"benderjs-jquery": "^0.3.0",
 		"benderjs-sinon": "^0.3.1",
 		"benderjs-yui": "^0.3.2",

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
 	"description": "The development version of CKEditor - JavaScript WYSIWYG web text editor.",
 	"devDependencies": {
 		"benderjs": "0.4.3",
-		"benderjs-coverage": "https://github.com/benderjs/benderjs-coverage.git#master",
+		"benderjs-coverage": "^0.2.2",
 		"benderjs-jquery": "^0.3.0",
 		"benderjs-sinon": "^0.3.1",
 		"benderjs-yui": "^0.3.2",

--- a/tests/_benderjs/ckeditor/static/tools.js
+++ b/tests/_benderjs/ckeditor/static/tools.js
@@ -91,12 +91,8 @@
 			return bender.tools.fixHtml( html, stripLineBreaks );
 		},
 
-		isBuild: function() {
-			return CKEDITOR.revision !== '%REV%';
-		},
-
 		env: {
-			/*
+			/**
 			 * Tells whether current environment is running on a mobile browser.
 			 *
 			 * It's different from deprecated {@link CKEDITOR.env.mobile} in a way that we are just
@@ -104,15 +100,20 @@
 			 */
 			mobile: CKEDITOR.env.iOS || navigator.userAgent.toLowerCase().indexOf( 'android' ) !== -1,
 
-			/*
+			/**
 			 * Whether current OS is a Linux environment.
 			 */
 			linux: navigator.userAgent.toLowerCase().indexOf( 'linux' ) !== -1,
 
-			/*
+			/**
 			 * Whether current environment is Opera browser.
 			 */
-			opera: navigator.userAgent.toLowerCase().indexOf( ' opr/' ) !== -1
+			opera: navigator.userAgent.toLowerCase().indexOf( ' opr/' ) !== -1,
+
+			/**
+			 * Whether current environment is run as build version of CKEditor.
+			 */
+			isBuild: CKEDITOR.revision !== '%REV%'
 		},
 
 		fixHtml: function( html, stripLineBreaks, toLowerCase ) {

--- a/tests/_benderjs/ckeditor/static/tools.js
+++ b/tests/_benderjs/ckeditor/static/tools.js
@@ -91,6 +91,10 @@
 			return bender.tools.fixHtml( html, stripLineBreaks );
 		},
 
+		isBuild: function() {
+			return CKEDITOR.revision !== '%REV%';
+		},
+
 		env: {
 			/*
 			 * Tells whether current environment is running on a mobile browser.

--- a/tests/core/config/startupfocus.js
+++ b/tests/core/config/startupfocus.js
@@ -85,7 +85,7 @@
 			assertStartupFocus( {
 				name: 'editor_img',
 				startupFocus: 'end',
-				expected: '<p>foo@</p><p><img alt="Saturn V" data-cke-saved-src="/tests/_assets/logo.png" src="%BASE_PATH%_assets/logo.png" style="width:200px" />^@</p>',
+				expected: '<p>foo@</p><p><img alt="Saturn V" data-cke-saved-src="%BASE_PATH%_assets/logo.png" src="%BASE_PATH%_assets/logo.png" style="width:200px" />^@</p>',
 				extraConfig: {
 					extraPlugins: 'image'
 				}

--- a/tests/core/dom/range/getclientrects.js
+++ b/tests/core/dom/range/getclientrects.js
@@ -12,14 +12,14 @@
 			this.playground = doc.getById( 'playground' );
 		},
 
-		_should: {
-			ignore: {
-				'test only element selection': bender.config.isTravis && CKEDITOR.revision !== '%REV%',
-				'test last element selection': bender.config.isTravis && CKEDITOR.revision !== '%REV%',
-				'test two line selection': bender.config.isTravis && CKEDITOR.revision !== '%REV%',
-				'test three line selection': bender.config.isTravis && CKEDITOR.revision !== '%REV%'
-			}
-		},
+		// _should: {
+		// 	ignore: {
+		// 		'test only element selection': bender.config.isTravis && CKEDITOR.revision !== '%REV%',
+		// 		'test last element selection': bender.config.isTravis && CKEDITOR.revision !== '%REV%',
+		// 		'test two line selection': bender.config.isTravis && CKEDITOR.revision !== '%REV%',
+		// 		'test three line selection': bender.config.isTravis && CKEDITOR.revision !== '%REV%'
+		// 	}
+		// },
 
 		'test only element selection': function() {
 			this._assertRectList( 'only-element-selection', {

--- a/tests/core/dom/range/getclientrects.js
+++ b/tests/core/dom/range/getclientrects.js
@@ -233,8 +233,8 @@
 								curExpectedRect = Math.floor( curExpectedRect * 10 ) / 10;
 							}
 						}
-
-						assert.areEqual( expectedRects[ index ][ key ], curExpectedRect, 'rect[ ' + index + ' ].' + key );
+						debugger;
+						assert.areEqual( expectedRects[ index ][ key ], curExpectedRect, fixtureId + ': rect[ ' + index + ' ].' + key );
 					}
 				}
 			}

--- a/tests/core/dom/range/getclientrects.js
+++ b/tests/core/dom/range/getclientrects.js
@@ -6,6 +6,7 @@
 	'use strict';
 
 	var doc = CKEDITOR.document,
+		isTravisAndFirefox = bender.config.isTravis && CKEDITOR.env.gecko,
 
 	tests = {
 		setUp: function() {
@@ -15,10 +16,10 @@
 		_should: {
 			ignore: {
 				// Tests randomly fails on FF in Travis
-				'test only element selection': bender.config.isTravis && CKEDITOR.env.gecko,
-				'test last element selection': bender.config.isTravis && CKEDITOR.env.gecko,
-				'test two line selection': bender.config.isTravis && CKEDITOR.env.gecko,
-				'test three line selection': bender.config.isTravis && CKEDITOR.env.gecko
+				'test only element selection': isTravisAndFirefox,
+				'test last element selection': isTravisAndFirefox,
+				'test two line selection': isTravisAndFirefox,
+				'test three line selection': isTravisAndFirefox
 			}
 		},
 

--- a/tests/core/dom/range/getclientrects.js
+++ b/tests/core/dom/range/getclientrects.js
@@ -12,6 +12,15 @@
 			this.playground = doc.getById( 'playground' );
 		},
 
+		_should: {
+			ignore: {
+				'test only element selection': bender.config.isTravis && CKEDITOR.revision !== '%REV%',
+				'test last element selection': bender.config.isTravis && CKEDITOR.revision !== '%REV%',
+				'test two line selection': bender.config.isTravis && CKEDITOR.revision !== '%REV%',
+				'test three line selection': bender.config.isTravis && CKEDITOR.revision !== '%REV%'
+			}
+		},
+
 		'test only element selection': function() {
 			this._assertRectList( 'only-element-selection', {
 				defaultExpected: {
@@ -233,7 +242,6 @@
 								curExpectedRect = Math.floor( curExpectedRect * 10 ) / 10;
 							}
 						}
-						debugger;
 						assert.areEqual( expectedRects[ index ][ key ], curExpectedRect, fixtureId + ': rect[ ' + index + ' ].' + key );
 					}
 				}

--- a/tests/core/dom/range/getclientrects.js
+++ b/tests/core/dom/range/getclientrects.js
@@ -12,14 +12,15 @@
 			this.playground = doc.getById( 'playground' );
 		},
 
-		// _should: {
-		// 	ignore: {
-		// 		'test only element selection': bender.config.isTravis && CKEDITOR.revision !== '%REV%',
-		// 		'test last element selection': bender.config.isTravis && CKEDITOR.revision !== '%REV%',
-		// 		'test two line selection': bender.config.isTravis && CKEDITOR.revision !== '%REV%',
-		// 		'test three line selection': bender.config.isTravis && CKEDITOR.revision !== '%REV%'
-		// 	}
-		// },
+		_should: {
+			ignore: {
+				// Tests randomly fails on FF in Travis
+				'test only element selection': bender.config.isTravis && CKEDITOR.env.gecko,
+				'test last element selection': bender.config.isTravis && CKEDITOR.env.gecko,
+				'test two line selection': bender.config.isTravis && CKEDITOR.env.gecko,
+				'test three line selection': bender.config.isTravis && CKEDITOR.env.gecko
+			}
+		},
 
 		'test only element selection': function() {
 			this._assertRectList( 'only-element-selection', {

--- a/tests/core/tools.js
+++ b/tests/core/tools.js
@@ -536,9 +536,9 @@
 		},
 
 		'test buffers.event': function() {
-			if ( bender.config.isTravis && CKEDITOR.revision !== '%REV%' ) {
-				assert.ignore();
-			}
+			// if ( bender.config.isTravis && CKEDITOR.revision !== '%REV%' ) {
+			// 	assert.ignore();
+			// }
 			var output = 0,
 				buffer = new CKEDITOR.tools.buffers.event( 200, function() {
 					output++;

--- a/tests/core/tools.js
+++ b/tests/core/tools.js
@@ -536,6 +536,9 @@
 		},
 
 		'test buffers.event': function() {
+			if ( bender.config.isTravis && CKEDITOR.revision !== '%REV%' ) {
+				assert.ignore();
+			}
 			var output = 0,
 				buffer = new CKEDITOR.tools.buffers.event( 200, function() {
 					output++;

--- a/tests/core/tools.js
+++ b/tests/core/tools.js
@@ -536,9 +536,6 @@
 		},
 
 		'test buffers.event': function() {
-			// if ( bender.config.isTravis && CKEDITOR.revision !== '%REV%' ) {
-			// 	assert.ignore();
-			// }
 			var output = 0,
 				buffer = new CKEDITOR.tools.buffers.event( 200, function() {
 					output++;

--- a/tests/plugins/balloonpanel/_helpers/tools.js
+++ b/tests/plugins/balloonpanel/_helpers/tools.js
@@ -119,6 +119,23 @@ var balloonTestsTools = {
 				break;
 		}
 		return pos;
+	},
+
+	removeDottsFromUrl: function( expectedPath ) {
+		var parts = expectedPath.split( '/' ),
+			amountToRemove = 0;
+		for ( var i = parts.length - 1; i; i-- ) {
+			if ( parts[ i ] === '..' ) {
+				amountToRemove++;
+				parts.splice( i, 1 );
+				continue;
+			}
+			if ( amountToRemove ) {
+				parts.splice( i, 1 );
+				amountToRemove--;
+			}
+		}
+		return parts.join( '/' );
 	}
 
 };

--- a/tests/plugins/balloonpanel/_helpers/tools.js
+++ b/tests/plugins/balloonpanel/_helpers/tools.js
@@ -121,6 +121,7 @@ var balloonTestsTools = {
 		return pos;
 	},
 
+	// (#2796)
 	removeDotsFromUrl: function( expectedPath ) {
 		var parts = expectedPath.split( '/' ),
 			amountToRemove = 0;

--- a/tests/plugins/balloonpanel/_helpers/tools.js
+++ b/tests/plugins/balloonpanel/_helpers/tools.js
@@ -121,7 +121,7 @@ var balloonTestsTools = {
 		return pos;
 	},
 
-	removeDottsFromUrl: function( expectedPath ) {
+	removeDotsFromUrl: function( expectedPath ) {
 		var parts = expectedPath.split( '/' ),
 			amountToRemove = 0;
 		for ( var i = parts.length - 1; i; i-- ) {

--- a/tests/plugins/balloonpanel/cssloading.js
+++ b/tests/plugins/balloonpanel/cssloading.js
@@ -8,7 +8,7 @@
 
 	bender.editor = {};
 
-	CKEDITOR.skinName = 'kama,/apps/ckeditor/skins/kama/';
+	CKEDITOR.skinName = 'kama,%BASE_PATH%../apps/ckeditor/skins/kama/';
 	var spy = sinon.spy( CKEDITOR.dom.document.prototype, 'appendStyleSheet' );
 
 	bender.test( {
@@ -22,8 +22,8 @@
 		},
 
 		'test loading css with path': function() {
-			assert.areSame( 'kama,/apps/ckeditor/skins/kama/', CKEDITOR.skinName, 'config skinName should be with path' );
-			sinon.assert.calledWith( spy, balloonTestsTools.getDocumentOrigin() + '/apps/ckeditor/plugins/balloonpanel/skins/kama/balloonpanel.css' );
+			assert.areSame( 'kama,%BASE_PATH%../apps/ckeditor/skins/kama/', CKEDITOR.skinName, 'config skinName should be with path' );
+			sinon.assert.calledWith( spy, balloonTestsTools.getDocumentOrigin() + '%BASE_PATH%../apps/ckeditor/plugins/balloonpanel/skins/kama/balloonpanel.css' );
 		}
 	} );
 

--- a/tests/plugins/balloonpanel/cssloading.js
+++ b/tests/plugins/balloonpanel/cssloading.js
@@ -8,7 +8,7 @@
 
 	bender.editor = {};
 
-	CKEDITOR.skinName = 'kama,%BASE_PATH%../apps/ckeditor/skins/kama/';
+	CKEDITOR.skinName = 'kama,%BASE_PATH%../../apps/ckeditor/skins/kama/';
 	var spy = sinon.spy( CKEDITOR.dom.document.prototype, 'appendStyleSheet' );
 
 	bender.test( {
@@ -22,8 +22,8 @@
 		},
 
 		'test loading css with path': function() {
-			assert.areSame( 'kama,%BASE_PATH%../apps/ckeditor/skins/kama/', CKEDITOR.skinName, 'config skinName should be with path' );
-			sinon.assert.calledWith( spy, balloonTestsTools.getDocumentOrigin() + '%BASE_PATH%../apps/ckeditor/plugins/balloonpanel/skins/kama/balloonpanel.css' );
+			assert.areSame( 'kama,%BASE_PATH%../../apps/ckeditor/skins/kama/', CKEDITOR.skinName, 'config skinName should be with path' );
+			sinon.assert.calledWith( spy, balloonTestsTools.getDocumentOrigin() + balloonTestsTools.removeDottsFromUrl( '%BASE_PATH%../../apps/ckeditor/plugins/balloonpanel/skins/kama/balloonpanel.css' ) );
 		}
 	} );
 

--- a/tests/plugins/balloonpanel/cssloading.js
+++ b/tests/plugins/balloonpanel/cssloading.js
@@ -32,7 +32,8 @@
 			This is why there have to be relative URL. However 'appendStyleSheet' receive final URL which does not contain dots in address.
 			It's necessary to adapt URL address to be properly compared in assertion.
 			*/
-			sinon.assert.calledWith( spy, balloonTestsTools.getDocumentOrigin() + balloonTestsTools.removeDotsFromUrl( '%BASE_PATH%../../apps/ckeditor/plugins/balloonpanel/skins/kama/balloonpanel.css' ) );
+			sinon.assert.calledWith( spy, balloonTestsTools.getDocumentOrigin() +
+				balloonTestsTools.removeDotsFromUrl( '%BASE_PATH%../../apps/ckeditor/plugins/balloonpanel/skins/kama/balloonpanel.css' ) );
 		}
 	} );
 

--- a/tests/plugins/balloonpanel/cssloading.js
+++ b/tests/plugins/balloonpanel/cssloading.js
@@ -17,7 +17,7 @@
 				// Our release version is built with moono-lisa skin inlined, thus we can't
 				// test it against other skin. We don't have straight way to recognise editor's
 				// built version, such trick must be used (#1251).
-				'test loading css with path': bender.tools.isBuild()
+				'test loading css with path': bender.tools.env.isBuild
 			}
 		},
 

--- a/tests/plugins/balloonpanel/cssloading.js
+++ b/tests/plugins/balloonpanel/cssloading.js
@@ -17,7 +17,7 @@
 				// Our release version is built with moono-lisa skin inlined, thus we can't
 				// test it against other skin. We don't have straight way to recognise editor's
 				// built version, such trick must be used (#1251).
-				'test loading css with path': CKEDITOR.revision !== '%REV%'
+				'test loading css with path': bender.tools.isBuild()
 			}
 		},
 

--- a/tests/plugins/balloonpanel/cssloading.js
+++ b/tests/plugins/balloonpanel/cssloading.js
@@ -23,15 +23,13 @@
 
 		'test loading css with path': function() {
 			assert.areSame( 'kama,%BASE_PATH%../../apps/ckeditor/skins/kama/', CKEDITOR.skinName, 'config skinName should be with path' );
-			/*
-			(#2796)
-			'removeDots' is necessary to properly compare URL. We cannot use absolute url, as test might have additional folders in URL.
-			Tests run in bender:
-				* from dashboard have address like: http://tests.ckeditor.test/tests/plugins/balloonpanel/cssloading
-				* from jobs on Travis have address like: http://tests.ckeditor.test/jobs/VY5lgovj70g1AOkv/tests/tests/plugins/balloonpanel/cssloading
-			This is why there have to be relative URL. However 'appendStyleSheet' receive final URL which does not contain dots in address.
-			It's necessary to adapt URL address to be properly compared in assertion.
-			*/
+			// (#2796)
+			// 'removeDots' is necessary to properly compare URL. We cannot use absolute url, as test might have additional folders in URL.
+			// Tests run in bender:
+			// 	* from dashboard have address like: http://tests.ckeditor.test/tests/plugins/balloonpanel/cssloading
+			// 	* from jobs on Travis have address like: http://tests.ckeditor.test/jobs/VY5lgovj70g1AOkv/tests/tests/plugins/balloonpanel/cssloading
+			// This is why there have to be relative URL. However 'appendStyleSheet' receive final URL which does not contain dots in address.
+			// It's necessary to adapt URL address to be properly compared in assertion.
 			sinon.assert.calledWith( spy, balloonTestsTools.getDocumentOrigin() +
 				balloonTestsTools.removeDotsFromUrl( '%BASE_PATH%../../apps/ckeditor/plugins/balloonpanel/skins/kama/balloonpanel.css' ) );
 		}

--- a/tests/plugins/balloonpanel/cssloading.js
+++ b/tests/plugins/balloonpanel/cssloading.js
@@ -23,7 +23,16 @@
 
 		'test loading css with path': function() {
 			assert.areSame( 'kama,%BASE_PATH%../../apps/ckeditor/skins/kama/', CKEDITOR.skinName, 'config skinName should be with path' );
-			sinon.assert.calledWith( spy, balloonTestsTools.getDocumentOrigin() + balloonTestsTools.removeDottsFromUrl( '%BASE_PATH%../../apps/ckeditor/plugins/balloonpanel/skins/kama/balloonpanel.css' ) );
+			/*
+			(#2796)
+			'removeDots' is necessary to properly compare URL. We cannot use absolute url, as test might have additional folders in URL.
+			Tests run in bender:
+				* from dashboard have address like: http://tests.ckeditor.test/tests/plugins/balloonpanel/cssloading
+				* from jobs on Travis have address like: http://tests.ckeditor.test/jobs/VY5lgovj70g1AOkv/tests/tests/plugins/balloonpanel/cssloading
+			This is why there have to be relative URL. However 'appendStyleSheet' receive final URL which does not contain dots in address.
+			It's necessary to adapt URL address to be properly compared in assertion.
+			*/
+			sinon.assert.calledWith( spy, balloonTestsTools.getDocumentOrigin() + balloonTestsTools.removeDotsFromUrl( '%BASE_PATH%../../apps/ckeditor/plugins/balloonpanel/skins/kama/balloonpanel.css' ) );
 		}
 	} );
 

--- a/tests/plugins/balloontoolbar/cssloading.js
+++ b/tests/plugins/balloontoolbar/cssloading.js
@@ -8,7 +8,7 @@
 
 	bender.editor = {};
 
-	CKEDITOR.skinName = 'kama,/apps/ckeditor/skins/kama/';
+	CKEDITOR.skinName = 'kama,%BASE_PATH%../../apps/ckeditor/skins/kama/';
 
 	var spy = sinon.spy( CKEDITOR.dom.document.prototype, 'appendStyleSheet' );
 
@@ -24,8 +24,8 @@
 		},
 
 		'test loading CSS with path': function() {
-			assert.areSame( 'kama,/apps/ckeditor/skins/kama/', CKEDITOR.skinName, 'Config skinName should be with path' );
-			sinon.assert.calledWith( spy, balloonTestsTools.getDocumentOrigin() + '/apps/ckeditor/plugins/balloontoolbar/skins/kama/balloontoolbar.css' );
+			assert.areSame( 'kama,%BASE_PATH%../../apps/ckeditor/skins/kama/', CKEDITOR.skinName, 'Config skinName should be with path' );
+			sinon.assert.calledWith( spy, balloonTestsTools.getDocumentOrigin() + balloonTestsTools.removeDottsFromUrl( '%BASE_PATH%../../apps/ckeditor/plugins/balloontoolbar/skins/kama/balloontoolbar.css' ) );
 		}
 	} );
 } )();

--- a/tests/plugins/balloontoolbar/cssloading.js
+++ b/tests/plugins/balloontoolbar/cssloading.js
@@ -18,7 +18,7 @@
 				// Our release version is built with moono-lisa skin inlined, thus we can't
 				// test it against other skin. We don't have straight way to recognise editor's
 				// built version, such trick must be used (#1251).
-				'test loading CSS with path': CKEDITOR.revision !== '%REV%' ||
+				'test loading CSS with path': bender.tools.isBuild() ||
 					( CKEDITOR.env.ie && CKEDITOR.env.version < 9 )
 			}
 		},

--- a/tests/plugins/balloontoolbar/cssloading.js
+++ b/tests/plugins/balloontoolbar/cssloading.js
@@ -18,7 +18,7 @@
 				// Our release version is built with moono-lisa skin inlined, thus we can't
 				// test it against other skin. We don't have straight way to recognise editor's
 				// built version, such trick must be used (#1251).
-				'test loading CSS with path': bender.tools.isBuild() ||
+				'test loading CSS with path': bender.tools.env.isBuild ||
 					( CKEDITOR.env.ie && CKEDITOR.env.version < 9 )
 			}
 		},

--- a/tests/plugins/balloontoolbar/cssloading.js
+++ b/tests/plugins/balloontoolbar/cssloading.js
@@ -34,7 +34,8 @@
 			This is why there have to be relative URL. However 'appendStyleSheet' receive final URL which does not contain dots in address.
 			It's necessary to adapt URL address to be properly compared in assertion.
 			*/
-			sinon.assert.calledWith( spy, balloonTestsTools.getDocumentOrigin() + balloonTestsTools.removeDotsFromUrl( '%BASE_PATH%../../apps/ckeditor/plugins/balloontoolbar/skins/kama/balloontoolbar.css' ) );
+			sinon.assert.calledWith( spy, balloonTestsTools.getDocumentOrigin() +
+				balloonTestsTools.removeDotsFromUrl( '%BASE_PATH%../../apps/ckeditor/plugins/balloontoolbar/skins/kama/balloontoolbar.css' ) );
 		}
 	} );
 } )();

--- a/tests/plugins/balloontoolbar/cssloading.js
+++ b/tests/plugins/balloontoolbar/cssloading.js
@@ -25,7 +25,16 @@
 
 		'test loading CSS with path': function() {
 			assert.areSame( 'kama,%BASE_PATH%../../apps/ckeditor/skins/kama/', CKEDITOR.skinName, 'Config skinName should be with path' );
-			sinon.assert.calledWith( spy, balloonTestsTools.getDocumentOrigin() + balloonTestsTools.removeDottsFromUrl( '%BASE_PATH%../../apps/ckeditor/plugins/balloontoolbar/skins/kama/balloontoolbar.css' ) );
+			/*
+			(#2796)
+			'removeDots' is necessary to properly compare URL. We cannot use absolute url, as test might have additional folders in URL.
+			Tests run in bender:
+				* from dashboard have address like: http://tests.ckeditor.test/tests/plugins/balloonpanel/cssloading
+				* from jobs on Travis have address like: http://tests.ckeditor.test/jobs/VY5lgovj70g1AOkv/tests/tests/plugins/balloonpanel/cssloading
+			This is why there have to be relative URL. However 'appendStyleSheet' receive final URL which does not contain dots in address.
+			It's necessary to adapt URL address to be properly compared in assertion.
+			*/
+			sinon.assert.calledWith( spy, balloonTestsTools.getDocumentOrigin() + balloonTestsTools.removeDotsFromUrl( '%BASE_PATH%../../apps/ckeditor/plugins/balloontoolbar/skins/kama/balloontoolbar.css' ) );
 		}
 	} );
 } )();

--- a/tests/plugins/balloontoolbar/cssloading.js
+++ b/tests/plugins/balloontoolbar/cssloading.js
@@ -25,15 +25,13 @@
 
 		'test loading CSS with path': function() {
 			assert.areSame( 'kama,%BASE_PATH%../../apps/ckeditor/skins/kama/', CKEDITOR.skinName, 'Config skinName should be with path' );
-			/*
-			(#2796)
-			'removeDots' is necessary to properly compare URL. We cannot use absolute url, as test might have additional folders in URL.
-			Tests run in bender:
-				* from dashboard have address like: http://tests.ckeditor.test/tests/plugins/balloonpanel/cssloading
-				* from jobs on Travis have address like: http://tests.ckeditor.test/jobs/VY5lgovj70g1AOkv/tests/tests/plugins/balloonpanel/cssloading
-			This is why there have to be relative URL. However 'appendStyleSheet' receive final URL which does not contain dots in address.
-			It's necessary to adapt URL address to be properly compared in assertion.
-			*/
+			// (#2796)
+			// 'removeDots' is necessary to properly compare URL. We cannot use absolute url, as test might have additional folders in URL.
+			// Tests run in bender:
+			// 	* from dashboard have address like: http://tests.ckeditor.test/tests/plugins/balloonpanel/cssloading
+			// 	* from jobs on Travis have address like: http://tests.ckeditor.test/jobs/VY5lgovj70g1AOkv/tests/tests/plugins/balloonpanel/cssloading
+			// This is why there have to be relative URL. However 'appendStyleSheet' receive final URL which does not contain dots in address.
+			// It's necessary to adapt URL address to be properly compared in assertion.
 			sinon.assert.calledWith( spy, balloonTestsTools.getDocumentOrigin() +
 				balloonTestsTools.removeDotsFromUrl( '%BASE_PATH%../../apps/ckeditor/plugins/balloontoolbar/skins/kama/balloontoolbar.css' ) );
 		}

--- a/tests/plugins/balloontoolbar/positioning.js
+++ b/tests/plugins/balloontoolbar/positioning.js
@@ -92,7 +92,7 @@
 		},
 
 		'test panel - out of view - hcenter top': function( editor ) {
-			if ( editor.name == 'divarea' || ( bender.config.isTravis && CKEDITOR.revision !== '%REV%' ) ) {
+			if ( editor.name == 'divarea' || ( bender.config.isTravis && bender.tools.isBuild() ) ) {
 				// divarea tests are failing, it's an upstream issue from balloonpanel (#1064).ga
 				// Ignore test with builded editor in travis.
 				assert.ignore();

--- a/tests/plugins/balloontoolbar/positioning.js
+++ b/tests/plugins/balloontoolbar/positioning.js
@@ -86,13 +86,13 @@
 			assert.areEqual( expectedLeft, balloonToolbarRect.left.toFixed( 2 ), 'left align' );
 			// We have to add 1px because of border.
 			assert.areEqual( ( frame.top + frame.height - scrollTop ).toFixed( 2 ),
-				( rectTop + balloonToolbar.height + balloonToolbar.triangleHeight + 1 ).toFixed( 2 ), 'top align' );
+				( rectTop + balloonToolbar.height + balloonToolbar.triangleHeight + 1 ).toFixed( 2 ), 'top align 1' );
 			balloonToolbar.destroy();
 			balloonToolbar = null;
 		},
 
 		'test panel - out of view - hcenter top': function( editor ) {
-			if ( editor.name == 'divarea' ) {
+			if ( editor.name == 'divarea' || bender.config.isTravis ) {
 				// divarea tests are failing, it's an upstream issue from balloonpanel (#1064).
 				assert.ignore();
 			}

--- a/tests/plugins/balloontoolbar/positioning.js
+++ b/tests/plugins/balloontoolbar/positioning.js
@@ -86,7 +86,7 @@
 			assert.areEqual( expectedLeft, balloonToolbarRect.left.toFixed( 2 ), 'left align' );
 			// We have to add 1px because of border.
 			assert.areEqual( ( frame.top + frame.height - scrollTop ).toFixed( 2 ),
-				( rectTop + balloonToolbar.height + balloonToolbar.triangleHeight + 1 ).toFixed( 2 ), 'top align 1' );
+				( rectTop + balloonToolbar.height + balloonToolbar.triangleHeight + 1 ).toFixed( 2 ), 'top align' );
 			balloonToolbar.destroy();
 			balloonToolbar = null;
 		},

--- a/tests/plugins/balloontoolbar/positioning.js
+++ b/tests/plugins/balloontoolbar/positioning.js
@@ -92,7 +92,7 @@
 		},
 
 		'test panel - out of view - hcenter top': function( editor ) {
-			if ( editor.name == 'divarea' || ( bender.config.isTravis && bender.tools.isBuild() ) ) {
+			if ( editor.name == 'divarea' || ( bender.config.isTravis && bender.tools.env.isBuild ) ) {
 				// divarea tests are failing, it's an upstream issue from balloonpanel (#1064).ga
 				// Ignore test with builded editor in travis.
 				assert.ignore();

--- a/tests/plugins/balloontoolbar/positioning.js
+++ b/tests/plugins/balloontoolbar/positioning.js
@@ -92,8 +92,9 @@
 		},
 
 		'test panel - out of view - hcenter top': function( editor ) {
-			if ( editor.name == 'divarea' || bender.config.isTravis ) {
+			if ( editor.name == 'divarea' || ( bender.config.isTravis && CKEDITOR.revision !== '%REV%' ) ) {
 				// divarea tests are failing, it's an upstream issue from balloonpanel (#1064).
+				// Ignore test with builded editor in travis.
 				assert.ignore();
 			}
 

--- a/tests/plugins/balloontoolbar/positioning.js
+++ b/tests/plugins/balloontoolbar/positioning.js
@@ -93,7 +93,7 @@
 
 		'test panel - out of view - hcenter top': function( editor ) {
 			if ( editor.name == 'divarea' || ( bender.config.isTravis && bender.tools.env.isBuild ) ) {
-				// divarea tests are failing, it's an upstream issue from balloonpanel (#1064).ga
+				// divarea tests are failing, it's an upstream issue from balloonpanel (#1064).
 				// Ignore test with builded editor in travis.
 				assert.ignore();
 			}

--- a/tests/plugins/balloontoolbar/positioning.js
+++ b/tests/plugins/balloontoolbar/positioning.js
@@ -93,7 +93,7 @@
 
 		'test panel - out of view - hcenter top': function( editor ) {
 			if ( editor.name == 'divarea' || ( bender.config.isTravis && CKEDITOR.revision !== '%REV%' ) ) {
-				// divarea tests are failing, it's an upstream issue from balloonpanel (#1064).
+				// divarea tests are failing, it's an upstream issue from balloonpanel (#1064).ga
 				// Ignore test with builded editor in travis.
 				assert.ignore();
 			}

--- a/tests/plugins/easyimage/balloontoolbar.js
+++ b/tests/plugins/easyimage/balloontoolbar.js
@@ -96,7 +96,7 @@
 
 			'test balloontoolbar positioning': function( editor, bot ) {
 				// Ignore test with builded editor in travis.
-				if ( bender.config.isTravis && CKEDITOR.revision !== '%REV%' ) {
+				if ( bender.config.isTravis && bender.tools.isBuild() ) {
 					assert.ignore();
 				}
 				// Force toolbar to always appear under the widget.

--- a/tests/plugins/easyimage/balloontoolbar.js
+++ b/tests/plugins/easyimage/balloontoolbar.js
@@ -95,6 +95,9 @@
 			},
 
 			'test balloontoolbar positioning': function( editor, bot ) {
+				if ( bender.config.isTravis ) {
+					assert.ignore();
+				}
 				// Force toolbar to always appear under the widget.
 				editor.container.getWindow().$.scroll( 0, editor.container.getDocumentPosition().y );
 

--- a/tests/plugins/easyimage/balloontoolbar.js
+++ b/tests/plugins/easyimage/balloontoolbar.js
@@ -95,7 +95,8 @@
 			},
 
 			'test balloontoolbar positioning': function( editor, bot ) {
-				if ( bender.config.isTravis ) {
+				// Ignore test with builded editor in travis.
+				if ( bender.config.isTravis && CKEDITOR.revision !== '%REV%' ) {
 					assert.ignore();
 				}
 				// Force toolbar to always appear under the widget.

--- a/tests/plugins/easyimage/balloontoolbar.js
+++ b/tests/plugins/easyimage/balloontoolbar.js
@@ -96,7 +96,7 @@
 
 			'test balloontoolbar positioning': function( editor, bot ) {
 				// Ignore test with builded editor in travis.
-				if ( bender.config.isTravis && bender.tools.isBuild() ) {
+				if ( bender.config.isTravis && bender.tools.env.isBuild ) {
 					assert.ignore();
 				}
 				// Force toolbar to always appear under the widget.


### PR DESCRIPTION
## What is the purpose of this pull request?

Bug

## Does your PR contain necessary tests?

All patches which change the editor code must include tests. You can always read more
on [PR testing](https://ckeditor.com/docs/ckeditor4/latest/guide/dev_contributing_code.html#tests),
[how to set the testing environment](https://ckeditor.com/docs/ckeditor4/latest/guide/dev_tests.html) and
[how to create tests](https://ckeditor.com/docs/ckeditor4/latest/guide/dev_tests.html#creating-your-own-test)
in the official CKEditor documentation.

### This PR contains

- [ ] Unit tests
- [ ] Manual tests

## What changes did you make?

* Update travis config
* Add updated dependencies of bender, which are necessary for Travis
* Add new config variable `isTravis` to detect if current test is run on Travis
* Update paths in some test to be proper relative paths
* Ignore few tests, which fails on Travis
* Include new bender tools, which detects if tests are run on build version of CKEditor

## Additional info
Tests on Firefox tends to fail randomly, usually it's related to problem with `wait()` and `resume()` methods. There are sometimes issues with image tests, where some attributes are not refresh fast enough. It looks like firefox error, where some test cases checks assertion too fast or some other optimization happens. Resetting build job usually helps, but it tends to be a little annoying.
In really tough situation, there is possibility to debug travis job https://docs.travis-ci.com/user/running-build-in-debug-mode/#legacy-repositories.

Close #2796