### PR TITLE
API Docs: removed duplicated link to dialogDefinition in CKEDITOR.dialog.add

### DIFF
--- a/plugins/dialog/plugin.js
+++ b/plugins/dialog/plugin.js
@@ -1562,7 +1562,6 @@ CKEDITOR.DIALOG_STATE_BUSY = 2;
 		 * A function returning the dialog's definition, or the URL to the `.js` file holding the function.
 		 * The function should accept an argument `editor` which is the current editor instance, and
 		 * return an object conforming to {@link CKEDITOR.dialog.definition}.
-		 * @see CKEDITOR.dialog.definition
 		 */
 		add: function( name, dialogDefinition ) {
 			// Avoid path registration from multiple instances override definition.


### PR DESCRIPTION
## What is the purpose of this pull request?

Task

## Does your PR contain necessary tests?

All patches which change the editor code must include tests. You can always read more
on [PR testing](https://ckeditor.com/docs/ckeditor4/latest/guide/dev_contributing_code.html#tests),
[how to set the testing environment](https://ckeditor.com/docs/ckeditor4/latest/guide/dev_tests.html) and
[how to create tests](https://ckeditor.com/docs/ckeditor4/latest/guide/dev_tests.html#creating-your-own-test)
in the official CKEditor documentation.

### This PR contains

- [ ] Unit tests
- [ ] Manual tests

## What changes did you make?

Removed `@see` tag from `CKEDITOR.dialog.add` docs which duplicates link from `@param`.

Closes #2769 