### PR TITLE
Fix for: Editor with enterMode set to ENTER_DIV alters content on paste

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -23,6 +23,7 @@ Fixed Issues:
 * [#3120](https://github.com/ckeditor/ckeditor-dev/issues/3120): [IE8] Fixed: [`CKEDITOR.tools.extend`](https://ckeditor.com/docs/ckeditor4/latest/api/CKEDITOR_tool.html#method-extend) function doesn't work with [`DontEnum`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Data_structures#Properties) object property attribute.
 * [#3098](https://github.com/ckeditor/ckeditor-dev/issues/3098): Fixed: Unit pickers for table cell width and height in [Table Tools](https://ckeditor.com/cke4/addon/tabletools) plugin have different width.
 * [#2813](https://github.com/ckeditor/ckeditor-dev/issues/2813): Fixed: Editor HTML insertion methods ([`editor.insertHtml`](https://ckeditor.com/docs/ckeditor4/latest/api/CKEDITOR_editor.html#method-insertHtml), [`editor.insertHtmlIntoRange`](https://ckeditor.com/docs/ckeditor4/latest/api/CKEDITOR_editor.html#method-insertHtmlIntoRange), [`editor.insertElement`](https://ckeditor.com/docs/ckeditor4/latest/api/CKEDITOR_editor.html#method-insertElement) and [`editor.insertElementIntoRange`](https://ckeditor.com/docs/ckeditor4/latest/api/CKEDITOR_editor.html#method-insertElementIntoRange)) pollutes editable with empty spans.
+* [#2751](https://github.com/ckeditor/ckeditor-dev/issues/2751): Fixed: Editor with [enterMode](https://ckeditor.com/docs/ckeditor4/latest/api/CKEDITOR_config.html#cfg-enterMode) set to [ENTER_DIV](https://ckeditor.com/docs/ckeditor4/latest/api/CKEDITOR.html#property-ENTER_DIV) alters pasted content.
 
 API Changes:
 
@@ -92,7 +93,6 @@ Fixed Issues:
     * [#2780](https://github.com/ckeditor/ckeditor-dev/issues/2780): Fixed: Undo steps disappear after multiple changes of selection.
     * [#2470](https://github.com/ckeditor/ckeditor-dev/issues/2470): [Firefox] Fixed: Widget's nested editable gets blurred upon focus.
     * [#2655](https://github.com/ckeditor/ckeditor-dev/issues/2655): [Chrome, Safari] Fixed: Widget's nested editable cannot be focused under certain circumstances.
-* [#2751](https://github.com/ckeditor/ckeditor-dev/issues/2751): Fixed: Editor with [enterMode](https://ckeditor.com/docs/ckeditor4/latest/api/CKEDITOR_config.html#cfg-enterMode) set to [ENTER_DIV](https://ckeditor.com/docs/ckeditor4/latest/api/CKEDITOR.html#property-ENTER_DIV) alters pasted content.
 
 ## CKEditor 4.11.2
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -92,6 +92,7 @@ Fixed Issues:
     * [#2780](https://github.com/ckeditor/ckeditor-dev/issues/2780): Fixed: Undo steps disappear after multiple changes of selection.
     * [#2470](https://github.com/ckeditor/ckeditor-dev/issues/2470): [Firefox] Fixed: Widget's nested editable gets blurred upon focus.
     * [#2655](https://github.com/ckeditor/ckeditor-dev/issues/2655): [Chrome, Safari] Fixed: Widget's nested editable cannot be focused under certain circumstances.
+* [#2751](https://github.com/ckeditor/ckeditor-dev/issues/2751): Fixed: Editor with [enterMode](https://ckeditor.com/docs/ckeditor4/latest/api/CKEDITOR_config.html#cfg-enterMode) set to [ENTER_DIV](https://ckeditor.com/docs/ckeditor4/latest/api/CKEDITOR.html#property-ENTER_DIV) alters pasted content.
 
 ## CKEditor 4.11.2
 

--- a/core/editable.js
+++ b/core/editable.js
@@ -1652,6 +1652,10 @@
 
 			prepareRangeToDataInsertion( that );
 
+			if ( editor.getData() === '' && editor.enterMode === CKEDITOR.ENTER_DIV ) {
+				clearEditable( editable, range );
+			}
+
 			// DATA PROCESSING
 
 			// Select range and stop execution.
@@ -1666,6 +1670,12 @@
 			// Set final range position and clean up.
 
 			cleanupAfterInsertion( that );
+		}
+
+		function clearEditable( editable, range ) {
+			editable.getFirst().remove();
+			range.setStartAt( editable, CKEDITOR.POSITION_AFTER_START );
+			range.collapse( true );
 		}
 
 		// Prepare range to its data deletion.
@@ -1889,8 +1899,7 @@
 
 					// Find the first ancestor that can contain current node.
 					// This one won't be split.
-					while ( insertionContainer && ( !DTD[ insertionContainer.getName() ][ nodeData.name ] ||
-						preventInsertingDiv( nodeData.name, insertionContainer, that.editor ) ) ) {
+					while ( insertionContainer && !DTD[ insertionContainer.getName() ][ nodeData.name ] ) {
 						if ( insertionContainer.equals( blockLimit ) ) {
 							insertionContainer = null;
 							break;
@@ -2056,7 +2065,7 @@
 						continue;
 					}
 
-					allowed = !!allowedNames[ nodeName ] && !preventInsertingDiv( nodeName, startContainer, that.editor );
+					allowed = !!allowedNames[ nodeName ];
 
 					// Mark <brs data-cke-eol="1"> at the beginning and at the end.
 					if ( nodeName == 'br' && node.data( 'cke-eol' ) && ( !nodeIndex || nodeIndex == nodesCount - 1 ) ) {
@@ -2098,17 +2107,6 @@
 				nodesData[ lastNotAllowed ].lastNotAllowed = 1;
 
 			return nodesData;
-		}
-
-		// Prevent inserting div into div when Editor is in ENTER_DIV mode, and target element is an empty div.
-		function preventInsertingDiv( nodeName, element, editor ) {
-			if ( nodeName !== 'div' || editor.enterMode !== CKEDITOR.ENTER_DIV || element.getName() !== 'div' ) {
-				return false;
-			}
-			if ( element.getHtml() === '' ) {
-				return true;
-			}
-			return element.getChildCount() === 1 && element.getFirst().getName && element.getFirst().getName() === 'br';
 		}
 
 		// TODO: Review content transformation rules on filtering element.

--- a/core/editable.js
+++ b/core/editable.js
@@ -1889,7 +1889,7 @@
 
 					// Find the first ancestor that can contain current node.
 					// This one won't be split.
-					while ( insertionContainer && !DTD[ insertionContainer.getName() ][ nodeData.name ] ) {
+					while ( insertionContainer && ( !DTD[ insertionContainer.getName() ][ nodeData.name ] || preventInsertingDiv( nodeData.name, insertionContainer, that.editor ) ) ) {
 						if ( insertionContainer.equals( blockLimit ) ) {
 							insertionContainer = null;
 							break;
@@ -2055,7 +2055,7 @@
 						continue;
 					}
 
-					allowed = !!allowedNames[ nodeName ];
+					allowed = !!allowedNames[ nodeName ] && !preventInsertingDiv( nodeName, startContainer, that.editor );
 
 					// Mark <brs data-cke-eol="1"> at the beginning and at the end.
 					if ( nodeName == 'br' && node.data( 'cke-eol' ) && ( !nodeIndex || nodeIndex == nodesCount - 1 ) ) {
@@ -2097,6 +2097,17 @@
 				nodesData[ lastNotAllowed ].lastNotAllowed = 1;
 
 			return nodesData;
+		}
+
+		// Prevent inserting div into div when Editor is in ENTER_DIV mode, and target element is an empty div.
+		function preventInsertingDiv( nodeName, element, editor ) {
+			if ( nodeName !== 'div' || editor.enterMode !== CKEDITOR.ENTER_DIV || element.getName() !== 'div' ) {
+				return false;
+			}
+			if ( element.getHtml() === '' ) {
+				return true;
+			}
+			return element.getChildCount() === 1 && element.getFirst().getName && element.getFirst().getName() === 'br';
 		}
 
 		// TODO: Review content transformation rules on filtering element.

--- a/core/editable.js
+++ b/core/editable.js
@@ -1889,7 +1889,8 @@
 
 					// Find the first ancestor that can contain current node.
 					// This one won't be split.
-					while ( insertionContainer && ( !DTD[ insertionContainer.getName() ][ nodeData.name ] || preventInsertingDiv( nodeData.name, insertionContainer, that.editor ) ) ) {
+					while ( insertionContainer && ( !DTD[ insertionContainer.getName() ][ nodeData.name ] ||
+						preventInsertingDiv( nodeData.name, insertionContainer, that.editor ) ) ) {
 						if ( insertionContainer.equals( blockLimit ) ) {
 							insertionContainer = null;
 							break;

--- a/core/editable.js
+++ b/core/editable.js
@@ -1673,7 +1673,8 @@
 		}
 
 		function clearEditable( editable, range ) {
-			editable.getFirst().remove();
+			var first = editable.getFirst();
+			first && first.remove();
 			range.setStartAt( editable, CKEDITOR.POSITION_AFTER_START );
 			range.collapse( true );
 		}

--- a/tests/core/editable/enterdiv.js
+++ b/tests/core/editable/enterdiv.js
@@ -1,0 +1,28 @@
+/* bender-tags: editor */
+
+bender.editor = {
+	config: {
+		enterMode: CKEDITOR.ENTER_DIV
+	}
+};
+
+var tests = {
+	// 2751
+	'insert div': testInsertHtml( '<div>foo</div>' ),
+
+	// 2751
+	'insert two divs': testInsertHtml( '<div>foo</div><div>bar</div>' )
+};
+
+bender.test( tests );
+
+function testInsertHtml( htmlString ) {
+	return function() {
+		this.editorBot.setData( '', function() {
+			var editor = this.editor;
+
+			editor.insertHtml( htmlString );
+			assert.areSame( htmlString, editor.getData() );
+		} );
+	};
+}

--- a/tests/core/editable/enterdiv.js
+++ b/tests/core/editable/enterdiv.js
@@ -7,10 +7,10 @@ bender.editor = {
 };
 
 var tests = {
-	// 2751
+	// (#2751)
 	'insert div': testInsertHtml( '<div>foo</div>' ),
 
-	// 2751
+	// (#2751)
 	'insert two divs': testInsertHtml( '<div>foo</div><div>bar</div>' )
 };
 

--- a/tests/core/editable/enterdiv.js
+++ b/tests/core/editable/enterdiv.js
@@ -1,8 +1,16 @@
 /* bender-tags: editor */
 
-bender.editor = {
-	config: {
-		enterMode: CKEDITOR.ENTER_DIV
+bender.editors = {
+	classic: {
+		config: {
+			enterMode: CKEDITOR.ENTER_DIV
+		}
+	},
+	divarea: {
+		config: {
+			enterMode: CKEDITOR.ENTER_DIV,
+			extraPlugins: 'divarea'
+		}
 	}
 };
 
@@ -11,16 +19,22 @@ var tests = {
 	'insert div': testInsertHtml( '<div>foo</div>' ),
 
 	// (#2751)
-	'insert two divs': testInsertHtml( '<div>foo</div><div>bar</div>' )
+	'insert div wrapped in another div': testInsertHtml( '<div><div>foo</div></div>' ),
+
+	// (#2751)
+	'insert two divs': testInsertHtml( '<div>foo</div><div>bar</div>' ),
+
+	// (#2751)
+	'insert two divs wrapped in another div': testInsertHtml( '<div><div>foo</div><div>bar</div></div>' )
 };
+
+tests = bender.tools.createTestsForEditors( CKEDITOR.tools.object.keys( bender.editors ), tests );
 
 bender.test( tests );
 
 function testInsertHtml( htmlString ) {
-	return function() {
-		this.editorBot.setData( '', function() {
-			var editor = this.editor;
-
+	return function( editor, bot ) {
+		bot.setData( '', function() {
 			editor.insertHtml( htmlString );
 			assert.areSame( htmlString, editor.getData() );
 		} );

--- a/tests/core/editable/manual/enterdiv.html
+++ b/tests/core/editable/manual/enterdiv.html
@@ -1,0 +1,10 @@
+<textarea id="editor">
+	<div>This is some sample text.</div>
+	<div>New line.</div>
+</textarea>
+
+<script>
+	CKEDITOR.replace( 'editor', {
+		enterMode: CKEDITOR.ENTER_DIV
+	} );
+</script>

--- a/tests/core/editable/manual/enterdiv.html
+++ b/tests/core/editable/manual/enterdiv.html
@@ -1,10 +1,18 @@
-<textarea id="editor">
+<textarea id="editor1">
+	<div>This is some sample text.</div>
+	<div>New line.</div>
+</textarea>
+<textarea id="editor2">
 	<div>This is some sample text.</div>
 	<div>New line.</div>
 </textarea>
 
 <script>
-	CKEDITOR.replace( 'editor', {
+	CKEDITOR.replace( 'editor1', {
+		enterMode: CKEDITOR.ENTER_DIV
+	} );
+	CKEDITOR.replace( 'editor2', {
+		extraPlugins: 'divarea',
 		enterMode: CKEDITOR.ENTER_DIV
 	} );
 </script>

--- a/tests/core/editable/manual/enterdiv.html
+++ b/tests/core/editable/manual/enterdiv.html
@@ -3,16 +3,26 @@
 	<div>New line.</div>
 </textarea>
 <textarea id="editor2">
+	<div>
+		<div>This is some sample text.</div>
+		<div>New line.</div>
+	</div>
+</textarea>
+<textarea id="editor3">
 	<div>This is some sample text.</div>
 	<div>New line.</div>
 </textarea>
+<textarea id="editor4">
+	<div>
+		<div>This is some sample text.</div>
+		<div>New line.</div>
+	</div>
+</textarea>
 
 <script>
-	CKEDITOR.replace( 'editor1', {
-		enterMode: CKEDITOR.ENTER_DIV
-	} );
-	CKEDITOR.replace( 'editor2', {
-		extraPlugins: 'divarea',
-		enterMode: CKEDITOR.ENTER_DIV
-	} );
+	for ( var i = 1; i < 5; i++ ) {
+		CKEDITOR.replace( 'editor' + i, {
+			extraPlugins: i > 2 ? 'divarea' : ''
+		} );
+	}
 </script>

--- a/tests/core/editable/manual/enterdiv.html
+++ b/tests/core/editable/manual/enterdiv.html
@@ -21,9 +21,31 @@
 
 <script>
 	for ( var i = 1; i < 5; i++ ) {
+		// Hide editors for which test would fail on Chrome & Safari because of a browser upstream issue
+		// https://github.com/ckeditor/ckeditor-dev/pull/2776#issuecomment-463144905
+		if ( CKEDITOR.env.webkit && !(i%2) ) {
+			CKEDITOR.document.findOne( '#editor' + i ).remove();
+			continue;
+		}
 		CKEDITOR.replace( 'editor' + i, {
 			extraPlugins: i > 2 ? 'divarea' : '',
-			enterMode: CKEDITOR.ENTER_DIV
+			enterMode: CKEDITOR.ENTER_DIV,
+			on: {
+				instanceReady: function() {
+					var textarea = new CKEDITOR.dom.element( 'textarea' );
+					textarea.setValue( this.getData() );
+					textarea.setAttributes( {
+						readonly: true,
+						rows: 2,
+						cols: 80
+					} );
+					textarea.insertBefore( this.element );
+
+					var p = new CKEDITOR.dom.element( 'p' );
+					p.setText( 'Expected editor content:' );
+					p.insertBefore( textarea );
+				}
+			}
 		} );
 	}
 </script>

--- a/tests/core/editable/manual/enterdiv.html
+++ b/tests/core/editable/manual/enterdiv.html
@@ -22,7 +22,8 @@
 <script>
 	for ( var i = 1; i < 5; i++ ) {
 		CKEDITOR.replace( 'editor' + i, {
-			extraPlugins: i > 2 ? 'divarea' : ''
+			extraPlugins: i > 2 ? 'divarea' : '',
+			enterMode: CKEDITOR.ENTER_DIV
 		} );
 	}
 </script>

--- a/tests/core/editable/manual/enterdiv.html
+++ b/tests/core/editable/manual/enterdiv.html
@@ -21,12 +21,15 @@
 
 <script>
 	for ( var i = 1; i < 5; i++ ) {
-		// Hide editors for which test would fail on Chrome & Safari because of a browser upstream issue
+		// Hide editors for which test would fail on Chrome, Safari or IE<9 because of a browser upstream issue
 		// https://github.com/ckeditor/ckeditor-dev/pull/2776#issuecomment-463144905
-		if ( CKEDITOR.env.webkit && !(i%2) ) {
+		var isIgnoredBrowser = ( CKEDITOR.env.ie && CKEDITOR.env.version < 9 ) || CKEDITOR.env.webkit;
+
+		if ( isIgnoredBrowser && !(i%2) ) {
 			CKEDITOR.document.findOne( '#editor' + i ).remove();
 			continue;
 		}
+
 		CKEDITOR.replace( 'editor' + i, {
 			extraPlugins: i > 2 ? 'divarea' : '',
 			enterMode: CKEDITOR.ENTER_DIV,

--- a/tests/core/editable/manual/enterdiv.md
+++ b/tests/core/editable/manual/enterdiv.md
@@ -1,6 +1,6 @@
 @bender-tags: 4.11.3, bug, 2751
 @bender-ui: collapsed
-@bender-ckeditor-plugins: clipboard, toolbar, wysiwygarea, sourcearea, div, selectall
+@bender-ckeditor-plugins: clipboard, toolbar, wysiwygarea, sourcearea, div, selectall, elementspath
 
 1. Select all.
 1. Copy.

--- a/tests/core/editable/manual/enterdiv.md
+++ b/tests/core/editable/manual/enterdiv.md
@@ -1,0 +1,22 @@
+@bender-tags: 4.11.3, bug, 2751
+@bender-ui: collapsed
+@bender-ckeditor-plugins: clipboard, toolbar, wysiwygarea, sourcearea, div, selectall
+
+1. Select all.
+1. Copy.
+1. Paste.
+1. Go to source.
+
+## Expected
+
+Editor content looks same as before pasting which is:
+```
+<div>This is some sample text.</div><div>New line.</div>
+```
+
+## Unexpected
+
+Pasted content is wrapped with an extra div:
+```
+<div><div>This is some sample text.</div><div>New line.</div></div>
+```

--- a/tests/core/editable/manual/enterdiv.md
+++ b/tests/core/editable/manual/enterdiv.md
@@ -2,6 +2,8 @@
 @bender-ui: collapsed
 @bender-ckeditor-plugins: clipboard, toolbar, wysiwygarea, sourcearea, div, selectall, elementspath
 
+## For each editor
+
 1. Select all.
 1. Copy.
 1. Paste.
@@ -9,14 +11,8 @@
 
 ## Expected
 
-Editor content looks same as before pasting which is:
-```
-<div>This is some sample text.</div><div>New line.</div>
-```
+Editor content looks same as before pasting which is listed above editor.
 
 ## Unexpected
 
-Pasted content is wrapped with an extra div:
-```
-<div><div>This is some sample text.</div><div>New line.</div></div>
-```
+Pasted content is wrapped with an extra `div` element.

--- a/tests/core/editable/manual/enterdiv.md
+++ b/tests/core/editable/manual/enterdiv.md
@@ -16,3 +16,12 @@ Editor content looks same as before pasting which is listed above editor.
 ## Unexpected
 
 Pasted content is wrapped with an extra `div` element.
+
+## Note
+
+There is an upstream issue caused by buggy selection. It occurs when div is nested in another div.
+So these cases are excluded from test on following browsers:
+
+- IE8
+- Chrome
+- Safari

--- a/tests/core/editable/manual/enterdiv.md
+++ b/tests/core/editable/manual/enterdiv.md
@@ -1,4 +1,4 @@
-@bender-tags: 4.11.3, bug, 2751
+@bender-tags: 4.12.0, bug, 2751
 @bender-ui: collapsed
 @bender-ckeditor-plugins: clipboard, toolbar, wysiwygarea, sourcearea, div, selectall, elementspath
 

--- a/tests/core/editable/manual/enterdiv.md
+++ b/tests/core/editable/manual/enterdiv.md
@@ -23,5 +23,5 @@ There is an upstream issue caused by buggy selection. It occurs when div is nest
 So these cases are excluded from test on following browsers:
 
 - IE8
-- Chrome
-- Safari
+- [Chrome](https://bugs.chromium.org/p/chromium/issues/detail?id=931285)
+- [Safari](https://bugs.webkit.org/show_bug.cgi?id=198603)


### PR DESCRIPTION
## What is the purpose of this pull request?

Bug fix

## Does your PR contain necessary tests?

All patches which change the editor code must include tests. You can always read more
on [PR testing](https://ckeditor.com/docs/ckeditor4/latest/guide/dev_contributing_code.html#tests),
[how to set the testing environment](https://ckeditor.com/docs/ckeditor4/latest/guide/dev_tests.html) and
[how to create tests](https://ckeditor.com/docs/ckeditor4/latest/guide/dev_tests.html#creating-your-own-test)
in the official CKEditor documentation.

### This PR contains

- [x] Unit tests
- [x] Manual tests

## What changes did you make?
When a `div` is to be inserted in another empty `div` I've forced triggering logic which is normally trigerred when element is not allowed in selection.

Closes #2751 