### PR TITLE
Fix disappearing undo steps after multiple selection changes

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -14,6 +14,8 @@ Fixed Issues:
 * [#1986](https://github.com/ckeditor/ckeditor-dev/issues/1986): Fixed: Cell Properties dialog from [Table Tools](https://ckeditor.com/cke4/addon/tabletools) plugin shows styles that are not allowed through [`config.allowedContent`](https://ckeditor.com/docs/ckeditor4/latest/api/CKEDITOR_config.html#cfg-allowedContent).
 * [#2565](https://github.com/ckeditor/ckeditor-dev/issues/2565): [IE, Edge] Fixed: Buttons in the [Editor Toolbar](https://ckeditor.com/cke4/addon/toolbar) are activated by clicking them with right mouse button.
 * [#2780](https://github.com/ckeditor/ckeditor-dev/issues/2721): Fixed: Undo steps disappears after multiple change of selection.
+* [#2470](https://github.com/ckeditor/ckeditor-dev/issues/2470): [Firefox] Fixed: Widget's nested editable blurred upon focus.
+* [#2655](https://github.com/ckeditor/ckeditor-dev/issues/2655): [Chrome, Safari] Fixed: Widget's nested editable can't be focused under certain circumstances.
 
 ## CKEditor 4.11.2
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -13,6 +13,7 @@ Fixed Issues:
 * [#2756](https://github.com/ckeditor/ckeditor-dev/issues/2756): Fixed: The [Auto Link](https://ckeditor.com/cke4/addon/autolink) plugin causes an error when typing in [Source Editing Mode](https://ckeditor.com/docs/ckeditor4/latest/guide/dev_sourcearea.html).
 * [#1986](https://github.com/ckeditor/ckeditor-dev/issues/1986): Fixed: Cell Properties dialog from [Table Tools](https://ckeditor.com/cke4/addon/tabletools) plugin shows styles that are not allowed through [`config.allowedContent`](https://ckeditor.com/docs/ckeditor4/latest/api/CKEDITOR_config.html#cfg-allowedContent).
 * [#2565](https://github.com/ckeditor/ckeditor-dev/issues/2565): [IE, Edge] Fixed: Buttons in the [Editor Toolbar](https://ckeditor.com/cke4/addon/toolbar) are activated by clicking them with right mouse button.
+* [#2780](https://github.com/ckeditor/ckeditor-dev/issues/2721): Fixed: Undo steps disappears after multiple change of selection.
 
 ## CKEditor 4.11.2
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -13,7 +13,7 @@ Fixed Issues:
 * [#2756](https://github.com/ckeditor/ckeditor-dev/issues/2756): Fixed: The [Auto Link](https://ckeditor.com/cke4/addon/autolink) plugin causes an error when typing in [Source Editing Mode](https://ckeditor.com/docs/ckeditor4/latest/guide/dev_sourcearea.html).
 * [#1986](https://github.com/ckeditor/ckeditor-dev/issues/1986): Fixed: Cell Properties dialog from [Table Tools](https://ckeditor.com/cke4/addon/tabletools) plugin shows styles that are not allowed through [`config.allowedContent`](https://ckeditor.com/docs/ckeditor4/latest/api/CKEDITOR_config.html#cfg-allowedContent).
 * [#2565](https://github.com/ckeditor/ckeditor-dev/issues/2565): [IE, Edge] Fixed: Buttons in the [Editor Toolbar](https://ckeditor.com/cke4/addon/toolbar) are activated by clicking them with right mouse button.
-* [#2780](https://github.com/ckeditor/ckeditor-dev/issues/2721): Fixed: Undo steps disappears after multiple change of selection.
+* [#2780](https://github.com/ckeditor/ckeditor-dev/issues/2780): Fixed: Undo steps disappears after multiple change of selection.
 * [#2470](https://github.com/ckeditor/ckeditor-dev/issues/2470): [Firefox] Fixed: Widget's nested editable blurred upon focus.
 * [#2655](https://github.com/ckeditor/ckeditor-dev/issues/2655): [Chrome, Safari] Fixed: Widget's nested editable can't be focused under certain circumstances.
 

--- a/plugins/copyformatting/plugin.js
+++ b/plugins/copyformatting/plugin.js
@@ -423,10 +423,7 @@
 						documentElement = CKEDITOR.document.getDocumentElement(),
 						isApplied;
 
-					if ( !isFromKeystroke && cmd.state !== CKEDITOR.TRISTATE_ON ) {
-						return;
-
-					} else if ( isFromKeystroke && !copyFormatting.styles ) {
+					if ( isFromKeystroke && !copyFormatting.styles ) {
 						plugin._putScreenReaderMessage( editor, 'failed' );
 						plugin._detachPasteKeystrokeHandler( editor );
 						return false;

--- a/plugins/copyformatting/plugin.js
+++ b/plugins/copyformatting/plugin.js
@@ -98,17 +98,16 @@
 					// clicking the whole document messes the focus.
 					mouseupHost = editable.isInline() ? editable : editor.document,
 					copyFormattingButton = editor.ui.get( 'CopyFormatting' ),
-					copyFormattingButtonEl;
+					copyFormattingButtonEl,
+					cmd = editor.getCommand( 'copyFormatting' );
 
 				editable.attachListener( mouseupHost, 'mouseup', function( evt ) {
-					if ( getMouseButton( evt ) === CKEDITOR.MOUSE_BUTTON_LEFT ) {
+					if ( getMouseButton( evt ) === CKEDITOR.MOUSE_BUTTON_LEFT && cmd.state === CKEDITOR.TRISTATE_ON ) {
 						editor.execCommand( 'applyFormatting' );
 					}
 				} );
 
 				editable.attachListener( CKEDITOR.document, 'mouseup', function( evt ) {
-					var cmd = editor.getCommand( 'copyFormatting' );
-
 					if ( getMouseButton( evt ) === CKEDITOR.MOUSE_BUTTON_LEFT && cmd.state === CKEDITOR.TRISTATE_ON &&
 						!editable.contains( evt.data.getTarget() ) ) {
 						editor.execCommand( 'copyFormatting' );

--- a/plugins/copyformatting/plugin.js
+++ b/plugins/copyformatting/plugin.js
@@ -91,15 +91,15 @@
 			} );
 
 			editor.on( 'contentDom', function() {
-				var editable = editor.editable(),
+				var cmd = editor.getCommand( 'copyFormatting' ),
+					editable = editor.editable(),
 					// Host element for apply formatting click. In case of classic element it needs to be entire
 					// document, otherwise clicking in body margins would not trigger the event.
 					// Editors with divarea plugin enabled should be treated like inline one – otherwise
 					// clicking the whole document messes the focus.
 					mouseupHost = editable.isInline() ? editable : editor.document,
 					copyFormattingButton = editor.ui.get( 'CopyFormatting' ),
-					copyFormattingButtonEl,
-					cmd = editor.getCommand( 'copyFormatting' );
+					copyFormattingButtonEl;
 
 				editable.attachListener( mouseupHost, 'mouseup', function( evt ) {
 					// Apply formatting only if any styles are copied (#2780, #2655, #2470).

--- a/plugins/copyformatting/plugin.js
+++ b/plugins/copyformatting/plugin.js
@@ -102,6 +102,7 @@
 					cmd = editor.getCommand( 'copyFormatting' );
 
 				editable.attachListener( mouseupHost, 'mouseup', function( evt ) {
+					// Apply formatting only if any styles are copied (#2780, #2655, #2470).
 					if ( getMouseButton( evt ) === CKEDITOR.MOUSE_BUTTON_LEFT && cmd.state === CKEDITOR.TRISTATE_ON ) {
 						editor.execCommand( 'applyFormatting' );
 					}

--- a/tests/plugins/copyformatting/applyformat.js
+++ b/tests/plugins/copyformatting/applyformat.js
@@ -439,7 +439,7 @@
 			assert.areSame( tableConstant, determineContext(), 'Selection within two rows' );
 		},
 
-		// (#2655, #2470)
+		// (#2780, #2655, #2470)
 		'test applyFormat not fired without copied styles': function() {
 			var editor = this.editor,
 				spy = sinon.spy( editor, 'execCommand' ),

--- a/tests/plugins/copyformatting/applyformat.js
+++ b/tests/plugins/copyformatting/applyformat.js
@@ -446,7 +446,8 @@
 				isIe8 = CKEDITOR.env.ie && CKEDITOR.env.version < 9;
 
 			editor.document.fire( 'mouseup', new CKEDITOR.dom.event( {
-				button: isIe8 ? 1 : CKEDITOR.MOUSE_BUTTON_LEFT
+				button: isIe8 ? 1 : CKEDITOR.MOUSE_BUTTON_LEFT,
+				target: editor.editable()
 			} ) );
 			spy.restore();
 

--- a/tests/plugins/copyformatting/applyformat.js
+++ b/tests/plugins/copyformatting/applyformat.js
@@ -439,7 +439,7 @@
 			assert.areSame( tableConstant, determineContext(), 'Selection within two rows' );
 		},
 
-		// (#2655)
+		// (#2655, #2470)
 		'test applyFormat not fired without copied styles': function() {
 			var editor = this.editor,
 				spy = sinon.spy( editor, 'execCommand' ),

--- a/tests/plugins/copyformatting/applyformat.js
+++ b/tests/plugins/copyformatting/applyformat.js
@@ -437,6 +437,20 @@
 
 			bender.tools.selection.setWithHtml( editor, '<table><tr><td>Ce{ll 1</td></tr><tr><td>Ce}ll 2</td></tr></table>' );
 			assert.areSame( tableConstant, determineContext(), 'Selection within two rows' );
+		},
+
+		// (#2655)
+		'test applyFormat not fired without copied styles': function() {
+			var editor = this.editor,
+				spy = sinon.spy( editor, 'execCommand' ),
+				isIe8 = CKEDITOR.env.ie && CKEDITOR.env.version < 9;
+
+			editor.document.fire( 'mouseup', new CKEDITOR.dom.event( {
+				button: isIe8 ? 1 : CKEDITOR.MOUSE_BUTTON_LEFT
+			} ) );
+			spy.restore();
+
+			assert.areSame( 0, spy.callCount );
 		}
 	} );
 }() );

--- a/tests/plugins/copyformatting/manual/nestededitablefocus.html
+++ b/tests/plugins/copyformatting/manual/nestededitablefocus.html
@@ -1,0 +1,45 @@
+<h2>Classic editor</h2>
+<div id="classic">
+		<div class="test1">x<div class="content">Widget1</div>y</div>
+</div>
+
+<script>
+	if ( !CKEDITOR.env.webkit ) {
+		bender.ignore();
+	}
+
+	CKEDITOR.addCss( '.cke_editable { margin: 0;padding: 50px; }' +
+		'.test1 { border: 1px #000 solid; }' );
+	CKEDITOR.replace( 'classic', {
+		extraPlugins: 'test1'
+	} );
+
+	CKEDITOR.plugins.add( 'test1', {
+		requires: 'widget',
+		init: function( editor ) {
+			editor.widgets.add( 'test1', {
+				button: 'Create autoparagraph test',
+				pathName: 'test-widget',
+
+				template:
+					'<div class="test1">' +
+						'<div class="content"></div>' +
+					'</div>',
+
+				editables: {
+					content: {
+						selector: '.content',
+						allowedContent: 'br'
+					}
+				},
+
+				allowedContent: 'div(test1,content)',
+				requiredContent: 'div(test1)',
+
+				upcast: function( element ) {
+					return element.name == 'div' && element.hasClass( 'test1' );
+				}
+			} );
+		}
+	} );
+</script>

--- a/tests/plugins/copyformatting/manual/nestededitablefocus.html
+++ b/tests/plugins/copyformatting/manual/nestededitablefocus.html
@@ -15,7 +15,7 @@
 <div id="square"></div>
 
 <script>
-	CKEDITOR.addCss( '.cke_editable { margin: 0;padding: 50px; }' +
+	CKEDITOR.addCss( '.cke_editable { margin: 0; padding: 50px; }' +
 		'.test1 { border: 1px #000 solid; }' );
 	CKEDITOR.replace( 'classic', {
 		extraPlugins: 'test1'

--- a/tests/plugins/copyformatting/manual/nestededitablefocus.html
+++ b/tests/plugins/copyformatting/manual/nestededitablefocus.html
@@ -1,13 +1,20 @@
+<style>
+#square {
+	margin-top: 20px;
+	width: 100px;
+	height: 100px;
+	border: 1px #000 solid;
+	background-color: red;
+}
+</style>
 <h2>Classic editor</h2>
 <div id="classic">
 		<div class="test1">x<div class="content">Widget1</div>y</div>
 </div>
 
-<script>
-	if ( !CKEDITOR.env.webkit ) {
-		bender.ignore();
-	}
+<div id="square"></div>
 
+<script>
 	CKEDITOR.addCss( '.cke_editable { margin: 0;padding: 50px; }' +
 		'.test1 { border: 1px #000 solid; }' );
 	CKEDITOR.replace( 'classic', {
@@ -38,7 +45,19 @@
 
 				upcast: function( element ) {
 					return element.name == 'div' && element.hasClass( 'test1' );
+				},
+
+				init: function() {
+					var square = CKEDITOR.document.getById( 'square' );
+
+					this.editables.content.on( 'focus', function() {
+						square.setStyle( 'background-color', 'green' );
+					} );
+					this.editables.content.on( 'blur', function() {
+						square.setStyle( 'background-color', 'red' );
+					} );
 				}
+
 			} );
 		}
 	} );

--- a/tests/plugins/copyformatting/manual/nestededitablefocus.md
+++ b/tests/plugins/copyformatting/manual/nestededitablefocus.md
@@ -1,0 +1,15 @@
+@bender-tags: bug, 4.11.3, 2655
+@bender-ui: collapsed
+@bender-ckeditor-plugins: widget, wysiwygarea, copyformatting
+
+1. Click inside "Widget 1" text to focus nested editable.
+2. Click above the widget (above the black border).
+3. Click once more inside "Widget 1" text.
+
+## Expected
+
+Focus is moved into nested editable and stays there.
+
+## Unexpected
+
+Focus is moved into nested editable for a fraction of second and then disappears.

--- a/tests/plugins/copyformatting/manual/nestededitablefocus.md
+++ b/tests/plugins/copyformatting/manual/nestededitablefocus.md
@@ -1,4 +1,4 @@
-@bender-tags: bug, 4.11.3, 2655
+@bender-tags: bug, 4.11.3, 2655, 2470
 @bender-ui: collapsed
 @bender-ckeditor-plugins: widget, wysiwygarea, copyformatting
 
@@ -8,8 +8,10 @@
 
 ## Expected
 
-Focus is moved into nested editable and stays there.
+* Focus is moved into nested editable and stays there.
+* Square under the editor is green.
 
 ## Unexpected
 
-Focus is moved into nested editable for a fraction of second and then disappears.
+* Focus is moved into nested editable for a fraction of second and then disappears.
+* Square under the editor is red.

--- a/tests/plugins/copyformatting/manual/undointegration.html
+++ b/tests/plugins/copyformatting/manual/undointegration.html
@@ -1,18 +1,37 @@
 <h2>First editor</h2>
-
+<p style="border: 1px solid black; padding: 2px;" >Current snapshot index: <strong id="ed1-current">0</strong>.<br><em>(Value is refreshed exclusively on "mouseup" event from editable.)</em></p>
 <div id="editor1" contenteditable="true">
 	<p><strong><u><span style="color: #f00;" class="important">Apollo 11</span></u></strong> <s>was the</s> <span style="color: #f00;" class="important">spaceflight</span> that landed the first humans, Americans <a href="http://en.wikipedia.org/wiki/Neil_Armstrong" title="Neil Armstrong">Neil Armstrong</a> and <a href="http://en.wikipedia.org/wiki/Buzz_Aldrin" title="Buzz Aldrin">Buzz Aldrin</a>, on the Moon on July 20, 1969, at 20:18 UTC. <span style="background-color: #f00;" bogus-attr="2">Armstrong</span> became the first to step onto the lunar surface 6 hours later on July 21 at 02:56 UTC.</p>
 </div>
 
 <h2>Second editor</h2>
-
+<p style="border: 1px solid black; padding: 2px;" >Current snapshot index: <strong id="ed2-current">0</strong>.<br><em>(Value is refreshed exclusively on "mouseup" event from editable.)</em></p>
 <div id="editor2" contenteditable="true">
 	<p><strong><u><span style="color: #f00;" class="important">Apollo 11</span></u></strong> <s>was the</s> <span style="color: #f00;" class="important">spaceflight</span> that landed the first humans, Americans <a href="http://en.wikipedia.org/wiki/Neil_Armstrong" title="Neil Armstrong">Neil Armstrong</a> and <a href="http://en.wikipedia.org/wiki/Buzz_Aldrin" title="Buzz Aldrin">Buzz Aldrin</a>, on the Moon on July 20, 1969, at 20:18 UTC. <span style="background-color: #f00;" bogus-attr="2">Armstrong</span> became the first to step onto the lunar surface 6 hours later on July 21 at 02:56 UTC.</p>
 </div>
 
 <script>
-	CKEDITOR.replace( 'editor1' );
+	CKEDITOR.replace( 'editor1', {
+		on: {
+			instanceReady: function( evt ) {
+				var editor = evt.editor;
+				var currentIndicator = CKEDITOR.document.findOne( '#ed1-current' );
+				editor.editable().on( 'mouseup', function( evt ) {
+					currentIndicator.setText( editor.undoManager.index );
+				} );
+			}
+		}
+	} );
 	CKEDITOR.replace( 'editor2', {
-		extraPlugins: 'divarea'
+		extraPlugins: 'divarea',
+		on: {
+			instanceReady: function( evt ) {
+				var editor = evt.editor;
+				var currentIndicator = CKEDITOR.document.findOne( '#ed2-current' );
+				editor.editable().on( 'mouseup', function( evt ) {
+					currentIndicator.setText( editor.undoManager.index );
+				} );
+			}
+		}
 	} );
 </script>

--- a/tests/plugins/copyformatting/manual/undointegration.html
+++ b/tests/plugins/copyformatting/manual/undointegration.html
@@ -1,0 +1,18 @@
+<h2>First editor</h2>
+
+<div id="editor1" contenteditable="true">
+	<p><strong><u><span style="color: #f00;" class="important">Apollo 11</span></u></strong> <s>was the</s> <span style="color: #f00;" class="important">spaceflight</span> that landed the first humans, Americans <a href="http://en.wikipedia.org/wiki/Neil_Armstrong" title="Neil Armstrong">Neil Armstrong</a> and <a href="http://en.wikipedia.org/wiki/Buzz_Aldrin" title="Buzz Aldrin">Buzz Aldrin</a>, on the Moon on July 20, 1969, at 20:18 UTC. <span style="background-color: #f00;" bogus-attr="2">Armstrong</span> became the first to step onto the lunar surface 6 hours later on July 21 at 02:56 UTC.</p>
+</div>
+
+<h2>Second editor</h2>
+
+<div id="editor2" contenteditable="true">
+	<p><strong><u><span style="color: #f00;" class="important">Apollo 11</span></u></strong> <s>was the</s> <span style="color: #f00;" class="important">spaceflight</span> that landed the first humans, Americans <a href="http://en.wikipedia.org/wiki/Neil_Armstrong" title="Neil Armstrong">Neil Armstrong</a> and <a href="http://en.wikipedia.org/wiki/Buzz_Aldrin" title="Buzz Aldrin">Buzz Aldrin</a>, on the Moon on July 20, 1969, at 20:18 UTC. <span style="background-color: #f00;" bogus-attr="2">Armstrong</span> became the first to step onto the lunar surface 6 hours later on July 21 at 02:56 UTC.</p>
+</div>
+
+<script>
+	CKEDITOR.replace( 'editor1' );
+	CKEDITOR.replace( 'editor2', {
+		extraPlugins: 'divarea'
+	} );
+</script>

--- a/tests/plugins/copyformatting/manual/undointegration.html
+++ b/tests/plugins/copyformatting/manual/undointegration.html
@@ -1,37 +1,35 @@
 <h2>First editor</h2>
-<p style="border: 1px solid black; padding: 2px;" >Current snapshot index: <strong id="ed1-current">0</strong>.<br><em>(Value is refreshed exclusively on "mouseup" event from editable.)</em></p>
+<p style="border: 1px solid black; padding: 2px;" >Current snapshot index: <strong id="ed1-current">0</strong>.<br><em>(Value is refreshed every 200ms.)</em></p>
 <div id="editor1" contenteditable="true">
 	<p><strong><u><span style="color: #f00;" class="important">Apollo 11</span></u></strong> <s>was the</s> <span style="color: #f00;" class="important">spaceflight</span> that landed the first humans, Americans <a href="http://en.wikipedia.org/wiki/Neil_Armstrong" title="Neil Armstrong">Neil Armstrong</a> and <a href="http://en.wikipedia.org/wiki/Buzz_Aldrin" title="Buzz Aldrin">Buzz Aldrin</a>, on the Moon on July 20, 1969, at 20:18 UTC. <span style="background-color: #f00;" bogus-attr="2">Armstrong</span> became the first to step onto the lunar surface 6 hours later on July 21 at 02:56 UTC.</p>
 </div>
 
 <h2>Second editor</h2>
-<p style="border: 1px solid black; padding: 2px;" >Current snapshot index: <strong id="ed2-current">0</strong>.<br><em>(Value is refreshed exclusively on "mouseup" event from editable.)</em></p>
+<p style="border: 1px solid black; padding: 2px;" >Current snapshot index: <strong id="ed2-current">0</strong>.<br><em>(Value is refreshed every 200ms.)</em></p>
 <div id="editor2" contenteditable="true">
 	<p><strong><u><span style="color: #f00;" class="important">Apollo 11</span></u></strong> <s>was the</s> <span style="color: #f00;" class="important">spaceflight</span> that landed the first humans, Americans <a href="http://en.wikipedia.org/wiki/Neil_Armstrong" title="Neil Armstrong">Neil Armstrong</a> and <a href="http://en.wikipedia.org/wiki/Buzz_Aldrin" title="Buzz Aldrin">Buzz Aldrin</a>, on the Moon on July 20, 1969, at 20:18 UTC. <span style="background-color: #f00;" bogus-attr="2">Armstrong</span> became the first to step onto the lunar surface 6 hours later on July 21 at 02:56 UTC.</p>
 </div>
 
 <script>
+	var instanceReadyHandler = function( elementId ) {
+		return function( evt ) {
+			var editor = evt.editor,
+				currentIndicator = CKEDITOR.document.getById( elementId );
+
+			setInterval( function() {
+				currentIndicator.setText( editor.undoManager.index );
+			}, 200 );
+		}
+	};
 	CKEDITOR.replace( 'editor1', {
 		on: {
-			instanceReady: function( evt ) {
-				var editor = evt.editor;
-				var currentIndicator = CKEDITOR.document.findOne( '#ed1-current' );
-				editor.editable().on( 'mouseup', function( evt ) {
-					currentIndicator.setText( editor.undoManager.index );
-				} );
-			}
+			instanceReady: instanceReadyHandler( 'ed1-current' )
 		}
 	} );
 	CKEDITOR.replace( 'editor2', {
 		extraPlugins: 'divarea',
 		on: {
-			instanceReady: function( evt ) {
-				var editor = evt.editor;
-				var currentIndicator = CKEDITOR.document.findOne( '#ed2-current' );
-				editor.editable().on( 'mouseup', function( evt ) {
-					currentIndicator.setText( editor.undoManager.index );
-				} );
-			}
+			instanceReady: instanceReadyHandler( 'ed2-current' )
 		}
 	} );
 </script>

--- a/tests/plugins/copyformatting/manual/undointegration.html
+++ b/tests/plugins/copyformatting/manual/undointegration.html
@@ -1,35 +1,16 @@
 <h2>First editor</h2>
-<p style="border: 1px solid black; padding: 2px;" >Current snapshot index: <strong id="ed1-current">0</strong>.<br><em>(Value is refreshed every 200ms.)</em></p>
 <div id="editor1" contenteditable="true">
 	<p><strong><u><span style="color: #f00;" class="important">Apollo 11</span></u></strong> <s>was the</s> <span style="color: #f00;" class="important">spaceflight</span> that landed the first humans, Americans <a href="http://en.wikipedia.org/wiki/Neil_Armstrong" title="Neil Armstrong">Neil Armstrong</a> and <a href="http://en.wikipedia.org/wiki/Buzz_Aldrin" title="Buzz Aldrin">Buzz Aldrin</a>, on the Moon on July 20, 1969, at 20:18 UTC. <span style="background-color: #f00;" bogus-attr="2">Armstrong</span> became the first to step onto the lunar surface 6 hours later on July 21 at 02:56 UTC.</p>
 </div>
 
 <h2>Second editor</h2>
-<p style="border: 1px solid black; padding: 2px;" >Current snapshot index: <strong id="ed2-current">0</strong>.<br><em>(Value is refreshed every 200ms.)</em></p>
 <div id="editor2" contenteditable="true">
 	<p><strong><u><span style="color: #f00;" class="important">Apollo 11</span></u></strong> <s>was the</s> <span style="color: #f00;" class="important">spaceflight</span> that landed the first humans, Americans <a href="http://en.wikipedia.org/wiki/Neil_Armstrong" title="Neil Armstrong">Neil Armstrong</a> and <a href="http://en.wikipedia.org/wiki/Buzz_Aldrin" title="Buzz Aldrin">Buzz Aldrin</a>, on the Moon on July 20, 1969, at 20:18 UTC. <span style="background-color: #f00;" bogus-attr="2">Armstrong</span> became the first to step onto the lunar surface 6 hours later on July 21 at 02:56 UTC.</p>
 </div>
 
 <script>
-	var instanceReadyHandler = function( elementId ) {
-		return function( evt ) {
-			var editor = evt.editor,
-				currentIndicator = CKEDITOR.document.getById( elementId );
-
-			setInterval( function() {
-				currentIndicator.setText( editor.undoManager.index );
-			}, 200 );
-		}
-	};
-	CKEDITOR.replace( 'editor1', {
-		on: {
-			instanceReady: instanceReadyHandler( 'ed1-current' )
-		}
-	} );
+	CKEDITOR.replace( 'editor1' );
 	CKEDITOR.replace( 'editor2', {
-		extraPlugins: 'divarea',
-		on: {
-			instanceReady: instanceReadyHandler( 'ed2-current' )
-		}
+		extraPlugins: 'divarea'
 	} );
 </script>

--- a/tests/plugins/copyformatting/manual/undointegration.md
+++ b/tests/plugins/copyformatting/manual/undointegration.md
@@ -2,4 +2,12 @@
 @bender-tags: bug, copyformatting, 4.11.3, trac16675
 @bender-ckeditor-plugins: copyformatting, toolbar, wysiwygarea, undo, basicstyles
 
-1. Play with undo
+## Test both editors
+1. Add some content to editor (e.g. new line), to "avctivate" undo step.
+2. Start to click around editor to change selection inside editor (20-25 times). Selection have to differ between adjacent steps.
+
+### Expected:
+Undo UI button is active.
+
+### Unexpected:
+Undo UI became disabled.

--- a/tests/plugins/copyformatting/manual/undointegration.md
+++ b/tests/plugins/copyformatting/manual/undointegration.md
@@ -1,9 +1,9 @@
 @bender-ui: collapsed
-@bender-tags: bug, copyformatting, 4.11.3, trac16675
+@bender-tags: bug, copyformatting, 4.11.3, 2780
 @bender-ckeditor-plugins: copyformatting, toolbar, wysiwygarea, undo, basicstyles
 
 ## Test both editors
-1. Add some content to editor (e.g. new line), to "avctivate" undo step.
+1. Add some content to editor (e.g. new line), to "activate" undo step.
 2. Start to click around editor to change selection inside editor (20-25 times). Selection have to differ between adjacent steps.
 
 ### Expected:

--- a/tests/plugins/copyformatting/manual/undointegration.md
+++ b/tests/plugins/copyformatting/manual/undointegration.md
@@ -5,14 +5,15 @@
 ## Test both editors
 1. Add some content to editor (e.g. new line), to "activate" undo step.
 2. Start to click around editor to change selection inside editor (20-25 times). Selection have to differ between adjacent steps.
+
 ### Expected:
 Undo UI button is active. Current snapshot index does equals 1 and doesn't change with selection change.
 ### Unexpected:
 Undo UI became disabled.
 
-
 3. Click undo button to revert change made in point 1. Make sure that Redo button is activated.
 4. Make new selection inside editor.
+
 ### Expected:
 Redo UI button is active.
 ### Unexpected:

--- a/tests/plugins/copyformatting/manual/undointegration.md
+++ b/tests/plugins/copyformatting/manual/undointegration.md
@@ -5,9 +5,15 @@
 ## Test both editors
 1. Add some content to editor (e.g. new line), to "activate" undo step.
 2. Start to click around editor to change selection inside editor (20-25 times). Selection have to differ between adjacent steps.
-
 ### Expected:
-Undo UI button is active.
-
+Undo UI button is active. Current snapshot index does equals 1 and doesn't change with selection change.
 ### Unexpected:
 Undo UI became disabled.
+
+
+3. Click undo button to revert change made in point 1. Make sure that Redo button is activated.
+4. Make new selection inside editor.
+### Expected:
+Redo UI button is active.
+### Unexpected:
+Redo UI button became disabled.

--- a/tests/plugins/copyformatting/manual/undointegration.md
+++ b/tests/plugins/copyformatting/manual/undointegration.md
@@ -1,0 +1,5 @@
+@bender-ui: collapsed
+@bender-tags: bug, copyformatting, 4.11.3, trac16675
+@bender-ckeditor-plugins: copyformatting, toolbar, wysiwygarea, undo, basicstyles
+
+1. Play with undo

--- a/tests/plugins/copyformatting/manual/undointegration.md
+++ b/tests/plugins/copyformatting/manual/undointegration.md
@@ -4,10 +4,10 @@
 
 ## Test both editors
 1. Add some content to editor (e.g. new line), to "activate" undo step.
-2. Start to click around editor to change selection inside editor (20-25 times). Selection have to differ between adjacent steps.
+2. Start to click around editor to change selection inside editor (20-25 times). Selection **have to differ** between adjacent steps.
 
 ### Expected:
-Undo UI button is active. Current snapshot index does equals 1 and doesn't change with selection change.
+Undo UI button is active.
 ### Unexpected:
 Undo UI became disabled.
 

--- a/tests/plugins/copyformatting/manual/undointegration.md
+++ b/tests/plugins/copyformatting/manual/undointegration.md
@@ -6,15 +6,15 @@
 1. Add some content to editor (e.g. new line), to "activate" undo step.
 2. Start to click around editor to change selection inside editor (20-25 times). Selection **have to differ** between adjacent steps.
 
-### Expected:
-Undo UI button is active.
-### Unexpected:
-Undo UI became disabled.
+  ### Expected:
+  Undo UI button is active.
+  ### Unexpected:
+  Undo UI became disabled.
 
 3. Click undo button to revert change made in point 1. Make sure that Redo button is activated.
 4. Make new selection inside editor.
 
-### Expected:
-Redo UI button is active.
-### Unexpected:
-Redo UI button became disabled.
+  ### Expected:
+  Redo UI button is active.
+  ### Unexpected:
+  Redo UI button became disabled.

--- a/tests/plugins/copyformatting/undointegration.js
+++ b/tests/plugins/copyformatting/undointegration.js
@@ -49,7 +49,8 @@
 			for ( var i = 0; i < editor.undoManager.limit; i++ ) {
 				sel.selectElement( i % 2 ? el1 : el2 );
 				editor.document.fire( 'mouseup', new CKEDITOR.dom.event( {
-					button: CKEDITOR.MOUSE_BUTTON_LEFT
+					button: CKEDITOR.MOUSE_BUTTON_LEFT,
+					target: editor.editable()
 				} ) );
 			}
 
@@ -68,7 +69,8 @@
 
 			sel.selectElement( editor.editable().findOne( '#one' ) );
 			editor.document.fire( 'mouseup', new CKEDITOR.dom.event( {
-				button: CKEDITOR.MOUSE_BUTTON_LEFT
+				button: CKEDITOR.MOUSE_BUTTON_LEFT,
+				target: editor.editable()
 			} ) );
 
 			assert.isTrue( editor.undoManager.redoable(), 'Editor should has possibility to redo.' );

--- a/tests/plugins/copyformatting/undointegration.js
+++ b/tests/plugins/copyformatting/undointegration.js
@@ -13,7 +13,7 @@
 
 	bender.test( {
 		// (#2780)
-		'test undo integration': function() {
+		'test basic undo integration': function() {
 			var editor = this.editor,
 				bot = this.editorBot,
 				sel = editor.getSelection(),
@@ -39,7 +39,21 @@
 
 			assert.areSame( 1, editor.undoManager.index, 'There shouldn\'t be new undo steps.' );
 			assert.isTrue( editor.undoManager.undoable(), 'Editor should has possibility to undo.' );
+		},
+		// (#2780)
+		'test basic redo integration': function() {
+			var editor = this.editor,
+				bot = this.editorBot;
 
+			bot.setHtmlWithSelection( '<p><span id="one">foo</span> []bar <span id="two">baz</span></p>' );
+			editor.insertText( '1' );
+			bot.execCommand( 'undo' );
+
+			editor.document.fire( 'mouseup', new CKEDITOR.dom.event( {
+				button: CKEDITOR.MOUSE_BUTTON_LEFT
+			} ) );
+
+			assert.isTrue( editor.undoManager.redoable(), 'Editor should has possibility to red.' );
 		}
 	} );
 

--- a/tests/plugins/copyformatting/undointegration.js
+++ b/tests/plugins/copyformatting/undointegration.js
@@ -1,0 +1,45 @@
+/* bender-tags: copyformatting */
+/* bender-ckeditor-plugins: wysiwygarea, toolbar, copyformatting, undo */
+/* bender-include: _helpers/tools.js*/
+
+( function() {
+	'use strict';
+
+	bender.editor = {
+		config: {
+			allowedcontent: true
+		}
+	};
+
+	bender.test( {
+		'test undo integration': function() {
+			var editor = this.editor,
+				bot = this.editorBot,
+				sel = editor.getSelection(),
+				el1,
+				el2;
+
+			assert.areSame( 0, editor.undoManager.index, 'There shouldn\'t be any undo steps.' );
+
+			bot.setHtmlWithSelection( '<p><span id="one">foo</span> []bar <span id="two">baz</span></p>' );
+			editor.insertText( '1' );
+
+			assert.areSame( 1, editor.undoManager.index, 'There should be only 1 undo step.' );
+
+			el1 = editor.editable().findOne( '#one' );
+			el2 = editor.editable().findOne( '#two' );
+
+			for ( var i = 0; i < editor.undoManager.limit; i++ ) {
+				sel.selectElement( i % 2 ? el1 : el2 );
+				editor.document.fire( 'mouseup', new CKEDITOR.dom.event( {
+					button: CKEDITOR.MOUSE_BUTTON_LEFT
+				} ) );
+			}
+
+			assert.areSame( 1, editor.undoManager.index, 'There shouldn\'t be new undo steps.' );
+			assert.isTrue( editor.undoManager.undoable(), 'Editor should has possibility to undo.' );
+
+		}
+	} );
+
+} )();

--- a/tests/plugins/copyformatting/undointegration.js
+++ b/tests/plugins/copyformatting/undointegration.js
@@ -12,7 +12,53 @@
 		}
 	};
 
-	function prepareEditor( bot ) {
+
+	bender.test( {
+		// (#2780)
+		'test basic undo integration': function() {
+			var editor = this.editor,
+				bot = this.editorBot,
+				sel = editor.getSelection(),
+				el1,
+				el2;
+
+			resetEditorStatusAndCheckBasicAsserts( bot );
+
+			el1 = editor.editable().findOne( '#one' );
+			el2 = editor.editable().findOne( '#two' );
+
+			for ( var i = 0; i < editor.undoManager.limit; i++ ) {
+				sel.selectElement( i % 2 ? el1 : el2 );
+				editor.document.fire( 'mouseup', new CKEDITOR.dom.event( {
+					button: CKEDITOR.MOUSE_BUTTON_LEFT,
+					target: editor.editable()
+				} ) );
+			}
+
+			assert.areSame( 1, editor.undoManager.index, 'There shouldn\'t be new undo steps and editor should remain on the 1st step.' );
+			assert.isTrue( editor.undoManager.undoable(), 'Editor should have a possibility to undo.' );
+		},
+		// (#2780)
+		'test basic redo integration': function() {
+			var editor = this.editor,
+				bot = this.editorBot,
+				sel = editor.getSelection();
+
+			resetEditorStatusAndCheckBasicAsserts( bot );
+
+			bot.execCommand( 'undo' );
+
+			sel.selectElement( editor.editable().findOne( '#one' ) );
+			editor.document.fire( 'mouseup', new CKEDITOR.dom.event( {
+				button: CKEDITOR.MOUSE_BUTTON_LEFT,
+				target: editor.editable()
+			} ) );
+
+			assert.isTrue( editor.undoManager.redoable(), 'Editor should has possibility to redo.' );
+		}
+	} );
+
+	function resetEditorStatusAndCheckBasicAsserts( bot ) {
 		var editor = bot.editor;
 
 		bot.setHtmlWithSelection( '<p><span id="one">foo</span> []bar <span id="two">baz</span></p>' );
@@ -31,50 +77,5 @@
 		assert.isTrue( editor.undoManager.undoable(), 'Editor should have possibility to undo.' );
 		assert.isFalse( editor.undoManager.redoable(), 'Editor should not have possibility to redo.' );
 	}
-
-	bender.test( {
-		// (#2780)
-		'test basic undo integration': function() {
-			var editor = this.editor,
-				bot = this.editorBot,
-				sel = editor.getSelection(),
-				el1,
-				el2;
-
-			prepareEditor( bot );
-
-			el1 = editor.editable().findOne( '#one' );
-			el2 = editor.editable().findOne( '#two' );
-
-			for ( var i = 0; i < editor.undoManager.limit; i++ ) {
-				sel.selectElement( i % 2 ? el1 : el2 );
-				editor.document.fire( 'mouseup', new CKEDITOR.dom.event( {
-					button: CKEDITOR.MOUSE_BUTTON_LEFT,
-					target: editor.editable()
-				} ) );
-			}
-
-			assert.areSame( 1, editor.undoManager.index, 'There shouldn\'t be new undo steps and editor should remain on 1st step.' );
-			assert.isTrue( editor.undoManager.undoable(), 'Editor should has possibility to undo.' );
-		},
-		// (#2780)
-		'test basic redo integration': function() {
-			var editor = this.editor,
-				bot = this.editorBot,
-				sel = editor.getSelection();
-
-			prepareEditor( bot );
-
-			bot.execCommand( 'undo' );
-
-			sel.selectElement( editor.editable().findOne( '#one' ) );
-			editor.document.fire( 'mouseup', new CKEDITOR.dom.event( {
-				button: CKEDITOR.MOUSE_BUTTON_LEFT,
-				target: editor.editable()
-			} ) );
-
-			assert.isTrue( editor.undoManager.redoable(), 'Editor should has possibility to redo.' );
-		}
-	} );
 
 } )();

--- a/tests/plugins/copyformatting/undointegration.js
+++ b/tests/plugins/copyformatting/undointegration.js
@@ -12,6 +12,7 @@
 	};
 
 	bender.test( {
+		// (#2780)
 		'test undo integration': function() {
 			var editor = this.editor,
 				bot = this.editorBot,

--- a/tests/plugins/copyformatting/undointegration.js
+++ b/tests/plugins/copyformatting/undointegration.js
@@ -6,9 +6,11 @@
 ( function() {
 	'use strict';
 
+	var leftMouseButton = CKEDITOR.env.ie && CKEDITOR.env.version < 9 ? 1 : CKEDITOR.MOUSE_BUTTON_LEFT;
+
 	bender.editor = {
 		config: {
-			allowedcontent: true
+			allowedContent: true
 		}
 	};
 
@@ -30,7 +32,7 @@
 			for ( var i = 0; i < editor.undoManager.limit; i++ ) {
 				sel.selectElement( i % 2 ? el1 : el2 );
 				editor.document.fire( 'mouseup', new CKEDITOR.dom.event( {
-					button: CKEDITOR.MOUSE_BUTTON_LEFT,
+					button: leftMouseButton,
 					target: editor.editable()
 				} ) );
 			}
@@ -50,7 +52,7 @@
 
 			sel.selectElement( editor.editable().findOne( '#one' ) );
 			editor.document.fire( 'mouseup', new CKEDITOR.dom.event( {
-				button: CKEDITOR.MOUSE_BUTTON_LEFT,
+				button: leftMouseButton,
 				target: editor.editable()
 			} ) );
 

--- a/tests/plugins/copyformatting/undointegration.js
+++ b/tests/plugins/copyformatting/undointegration.js
@@ -24,7 +24,7 @@
 				el1,
 				el2;
 
-			resetEditorStatusAndCheckBasicAsserts( bot );
+			resetUndoAndCreateFirstSnapshot( bot );
 
 			el1 = editor.editable().findOne( '#one' );
 			el2 = editor.editable().findOne( '#two' );
@@ -46,7 +46,7 @@
 				bot = this.editorBot,
 				sel = editor.getSelection();
 
-			resetEditorStatusAndCheckBasicAsserts( bot );
+			resetUndoAndCreateFirstSnapshot( bot );
 
 			bot.execCommand( 'undo' );
 
@@ -60,7 +60,7 @@
 		}
 	} );
 
-	function resetEditorStatusAndCheckBasicAsserts( bot ) {
+	function resetUndoAndCreateFirstSnapshot( bot ) {
 		var editor = bot.editor;
 
 		bot.setHtmlWithSelection( '<p><span id="one">foo</span> []bar <span id="two">baz</span></p>' );
@@ -68,16 +68,8 @@
 		editor.undoManager.reset();
 		editor.fire( 'saveSnapshot' );
 
-		assert.areSame( 0, editor.undoManager.index, 'There shouldn\'t be any undo steps.' );
-		assert.isFalse( editor.undoManager.undoable(), 'Editor should not have possibility to undo.' );
-		assert.isFalse( editor.undoManager.redoable(), 'Editor should not have possibility to redo.' );
-
 		editor.insertText( '1' );
 		editor.fire( 'saveSnapshot' );
-
-		assert.areSame( 1, editor.undoManager.index, 'There should be only 1 undo step, which is currently active.' );
-		assert.isTrue( editor.undoManager.undoable(), 'Editor should have possibility to undo.' );
-		assert.isFalse( editor.undoManager.redoable(), 'Editor should not have possibility to redo.' );
 	}
 
 } )();

--- a/tests/plugins/copyformatting/undointegration.js
+++ b/tests/plugins/copyformatting/undointegration.js
@@ -1,6 +1,5 @@
 /* bender-tags: copyformatting */
 /* bender-ckeditor-plugins: wysiwygarea, toolbar, copyformatting, undo */
-/* bender-include: _helpers/tools.js*/
 /* bender-ui: collapsed */
 
 ( function() {
@@ -21,16 +20,13 @@
 			var editor = this.editor,
 				bot = this.editorBot,
 				sel = editor.getSelection(),
-				el1,
-				el2;
+				spans;
 
 			resetUndoAndCreateFirstSnapshot( bot );
 
-			el1 = editor.editable().findOne( '#one' );
-			el2 = editor.editable().findOne( '#two' );
-
+			spans = editor.editable().find( 'span' );
 			for ( var i = 0; i < editor.undoManager.limit; i++ ) {
-				sel.selectElement( i % 2 ? el1 : el2 );
+				sel.selectElement( spans.getItem( i % 2 ) );
 				editor.document.fire( 'mouseup', new CKEDITOR.dom.event( {
 					button: leftMouseButton,
 					target: editor.editable()
@@ -50,7 +46,7 @@
 
 			bot.execCommand( 'undo' );
 
-			sel.selectElement( editor.editable().findOne( '#one' ) );
+			sel.selectElement( editor.editable().find( 'span' ).getItem( 0 ) );
 			editor.document.fire( 'mouseup', new CKEDITOR.dom.event( {
 				button: leftMouseButton,
 				target: editor.editable()
@@ -63,7 +59,7 @@
 	function resetUndoAndCreateFirstSnapshot( bot ) {
 		var editor = bot.editor;
 
-		bot.setHtmlWithSelection( '<p><span id="one">foo</span> []bar <span id="two">baz</span></p>' );
+		bot.setHtmlWithSelection( '<p><span>foo</span> []bar <span>baz</span></p>' );
 
 		editor.undoManager.reset();
 		editor.fire( 'saveSnapshot' );


### PR DESCRIPTION
## What is the purpose of this pull request?

Bug fix

## Does your PR contain necessary tests?

All patches which change the editor code must include tests. You can always read more
on [PR testing](https://ckeditor.com/docs/ckeditor4/latest/guide/dev_contributing_code.html#tests),
[how to set the testing environment](https://ckeditor.com/docs/ckeditor4/latest/guide/dev_tests.html) and
[how to create tests](https://ckeditor.com/docs/ckeditor4/latest/guide/dev_tests.html#creating-your-own-test)
in the official CKEditor documentation.

### This PR contains

- [x] Unit tests
- [x] Manual tests

## What changes did you make?

* Prevent of firing `applyFormat` command after mouse up event, when there is no stored formatting.

Closes #2780.
Closes #2655.
Closes #2470.