### PR TITLE
Enhance error messages for creators

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -6,6 +6,7 @@
 New Features:
 
 * [#2598](https://github.com/ckeditor/ckeditor-dev/issues/2598): [Page Break](https://ckeditor.com/cke4/addon/pagebreak) feature support for [Paste from Word](https://ckeditor.com/cke4/addon/pastefromword) plugin.
+* [#2748](https://github.com/ckeditor/ckeditor-dev/issues/2748): Enhance errors thrown while creating editor on a nonexistent element or while trying to instantiate second editor on the same element. Thanks to [Byran Zaugg](https://github.com/blzaugg)!
 
 API Changes:
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -6,7 +6,6 @@
 New Features:
 
 * [#2598](https://github.com/ckeditor/ckeditor-dev/issues/2598): [Page Break](https://ckeditor.com/cke4/addon/pagebreak) feature support for [Paste from Word](https://ckeditor.com/cke4/addon/pastefromword) plugin.
-* [#2748](https://github.com/ckeditor/ckeditor-dev/issues/2748): Enhance errors thrown while creating editor on a nonexistent element or while trying to instantiate second editor on the same element. Thanks to [Byran Zaugg](https://github.com/blzaugg)!
 
 API Changes:
 
@@ -14,6 +13,7 @@ API Changes:
 * [#2021](https://github.com/ckeditor/ckeditor-dev/issues/2021): Add [`CKEDITOR.dom.documentFragment.find`](https://ckeditor.com/docs/ckeditor4/latest/api/CKEDITOR_dom_documentFragment.html#method-find) and [`CKEDITOR.dom.documentFragment.findOne`](https://ckeditor.com/docs/ckeditor4/latest/api/CKEDITOR_dom_documentFragment.html#method-findOne) methods.
 * [#2700](https://github.com/ckeditor/ckeditor-dev/issues/2700): Added the [`CKEDITOR.tools.array.find`](https://ckeditor.com/docs/ckeditor4/latest/api/CKEDITOR_tools_array.html#method-find) function.
 * [#2598](https://github.com/ckeditor/ckeditor-dev/issues/2598): Added [`CKEDITOR.plugins.pagebreak.createElement`](https://ckeditor.com/docs/ckeditor4/latest/api/CKEDITOR_plugins_pagebreak.html#method-createElement) method allowing to create [Page Break](https://ckeditor.com/cke4/addon/pagebreak) plugin [`CKEDITOR.dom.element`](https://ckeditor.com/docs/ckeditor4/latest/api/CKEDITOR_dom_element.html) instance.
+* [#2748](https://github.com/ckeditor/ckeditor-dev/issues/2748): Enhance errors thrown while creating editor on a nonexistent element or while trying to instantiate second editor on the same element. Thanks to [Byran Zaugg](https://github.com/blzaugg)!
 
 ## CKEditor 4.11.3
 

--- a/core/ckeditor.js
+++ b/core/ckeditor.js
@@ -34,6 +34,35 @@ CKEDITOR.instances = {};
 CKEDITOR.document = new CKEDITOR.dom.document( document );
 
 /**
+ * Gets the element from DOM and checks if the editor can be instantiated on it.
+ * This function is available for internal use only.
+ *
+ * @private
+ * @since 4.12.0
+ */
+CKEDITOR.getEditorElement = function( elementOrId ) {
+	var element;
+
+	if ( !CKEDITOR.env.isCompatible ) {
+		return null;
+	}
+
+	element = CKEDITOR.dom.element.get( elementOrId );
+
+	// Throw error on missing target element.
+	if ( !element ) {
+		throw 'The provided element, "' + elementOrId + '", is missing from the DOM.';
+	}
+
+	// Avoid multiple inline editor instances on the same element.
+	if ( element.getEditor() ) {
+		throw 'The editor instance "' + element.getEditor().name + '" is already attached to the provided element.';
+	}
+
+	return element;
+};
+
+/**
  * Adds an editor instance to the global {@link CKEDITOR} object. This function
  * is available for internal use mainly.
  *

--- a/core/ckeditor.js
+++ b/core/ckeditor.js
@@ -51,12 +51,20 @@ CKEDITOR.getEditorElement = function( elementOrId ) {
 
 	// Throw error on missing target element.
 	if ( !element ) {
-		throw 'The provided element, "' + elementOrId + '", is missing from the DOM.';
+		CKEDITOR.error( 'editor-incorrect-element', {
+			element: elementOrId
+		} );
+
+		return;
 	}
 
 	// Avoid multiple inline editor instances on the same element.
 	if ( element.getEditor() ) {
-		throw 'The editor instance "' + element.getEditor().name + '" is already attached to the provided element.';
+		CKEDITOR.error( 'editor-element-conflict', {
+			editorName: element.getEditor().name
+		} );
+
+		return;
 	}
 
 	return element;

--- a/core/ckeditor.js
+++ b/core/ckeditor.js
@@ -39,6 +39,7 @@ CKEDITOR.document = new CKEDITOR.dom.document( document );
  *
  * @private
  * @since 4.12.0
+ * @returns {CKEDITOR.dom.element/null}
  */
 CKEDITOR.getEditorElement = function( elementOrId ) {
 	var element;
@@ -55,7 +56,7 @@ CKEDITOR.getEditorElement = function( elementOrId ) {
 			element: elementOrId
 		} );
 
-		return;
+		return null;
 	}
 
 	// Avoid multiple inline editor instances on the same element.
@@ -64,7 +65,7 @@ CKEDITOR.getEditorElement = function( elementOrId ) {
 			editorName: element.getEditor().name
 		} );
 
-		return;
+		return null;
 	}
 
 	return element;

--- a/core/ckeditor.js
+++ b/core/ckeditor.js
@@ -34,44 +34,6 @@ CKEDITOR.instances = {};
 CKEDITOR.document = new CKEDITOR.dom.document( document );
 
 /**
- * Gets the element from DOM and checks if the editor can be instantiated on it.
- * This function is available for internal use only.
- *
- * @private
- * @since 4.12.0
- * @returns {CKEDITOR.dom.element/null}
- */
-CKEDITOR.getEditorElement = function( elementOrId ) {
-	var element;
-
-	if ( !CKEDITOR.env.isCompatible ) {
-		return null;
-	}
-
-	element = CKEDITOR.dom.element.get( elementOrId );
-
-	// Throw error on missing target element.
-	if ( !element ) {
-		CKEDITOR.error( 'editor-incorrect-element', {
-			element: elementOrId
-		} );
-
-		return null;
-	}
-
-	// Avoid multiple inline editor instances on the same element.
-	if ( element.getEditor() ) {
-		CKEDITOR.error( 'editor-element-conflict', {
-			editorName: element.getEditor().name
-		} );
-
-		return null;
-	}
-
-	return element;
-};
-
-/**
  * Adds an editor instance to the global {@link CKEDITOR} object. This function
  * is available for internal use mainly.
  *

--- a/core/creators/inline.js
+++ b/core/creators/inline.js
@@ -31,7 +31,13 @@
 		if ( !CKEDITOR.env.isCompatible )
 			return null;
 
+		var elementArg = element;
+
 		element = CKEDITOR.dom.element.get( element );
+
+		// Throw error on missing target element.
+		if ( !element )
+			throw 'The provided element, "' + elementArg + '", is missing from the DOM.';
 
 		// Avoid multiple inline editor instances on the same element.
 		if ( element.getEditor() )

--- a/core/creators/inline.js
+++ b/core/creators/inline.js
@@ -30,6 +30,10 @@
 	CKEDITOR.inline = function( element, instanceConfig ) {
 		element = CKEDITOR.getEditorElement( element );
 
+		if ( !element ) {
+			return null;
+		}
+
 		var editor = new CKEDITOR.editor( instanceConfig, element, CKEDITOR.ELEMENT_MODE_INLINE ),
 			textarea = element.is( 'textarea' ) ? element : null;
 

--- a/core/creators/inline.js
+++ b/core/creators/inline.js
@@ -28,7 +28,7 @@
 	 * @returns {CKEDITOR.editor} The editor instance created.
 	 */
 	CKEDITOR.inline = function( element, instanceConfig ) {
-		element = CKEDITOR.getEditorElement( element );
+		element = CKEDITOR.editor._getEditorElement( element );
 
 		if ( !element ) {
 			return null;

--- a/core/creators/inline.js
+++ b/core/creators/inline.js
@@ -28,20 +28,7 @@
 	 * @returns {CKEDITOR.editor} The editor instance created.
 	 */
 	CKEDITOR.inline = function( element, instanceConfig ) {
-		if ( !CKEDITOR.env.isCompatible )
-			return null;
-
-		var elementArg = element;
-
-		element = CKEDITOR.dom.element.get( element );
-
-		// Throw error on missing target element.
-		if ( !element )
-			throw 'The provided element, "' + elementArg + '", is missing from the DOM.';
-
-		// Avoid multiple inline editor instances on the same element.
-		if ( element.getEditor() )
-			throw 'The editor instance "' + element.getEditor().name + '" is already attached to the provided element.';
+		element = CKEDITOR.getEditorElement( element );
 
 		var editor = new CKEDITOR.editor( instanceConfig, element, CKEDITOR.ELEMENT_MODE_INLINE ),
 			textarea = element.is( 'textarea' ) ? element : null;

--- a/core/creators/themedui.js
+++ b/core/creators/themedui.js
@@ -320,20 +320,7 @@ CKEDITOR.replaceClass = 'ckeditor';
 	};
 
 	function createInstance( element, config, data, mode ) {
-		if ( !CKEDITOR.env.isCompatible )
-			return null;
-
-		var elementArg = element;
-
-		element = CKEDITOR.dom.element.get( element );
-
-		// Throw error on missing target element.
-		if ( !element )
-			throw 'The provided element, "' + elementArg + '", is missing from the DOM.';
-
-		// Avoid multiple inline editor instances on the same element.
-		if ( element.getEditor() )
-			throw 'The editor instance "' + element.getEditor().name + '" is already attached to the provided element.';
+		element = CKEDITOR.getEditorElement( element );
 
 		// Create the editor instance.
 		var editor = new CKEDITOR.editor( config, element, mode );

--- a/core/creators/themedui.js
+++ b/core/creators/themedui.js
@@ -322,6 +322,10 @@ CKEDITOR.replaceClass = 'ckeditor';
 	function createInstance( element, config, data, mode ) {
 		element = CKEDITOR.getEditorElement( element );
 
+		if ( !element ) {
+			return null;
+		}
+
 		// Create the editor instance.
 		var editor = new CKEDITOR.editor( config, element, mode );
 

--- a/core/creators/themedui.js
+++ b/core/creators/themedui.js
@@ -323,7 +323,13 @@ CKEDITOR.replaceClass = 'ckeditor';
 		if ( !CKEDITOR.env.isCompatible )
 			return null;
 
+		var elementArg = element;
+
 		element = CKEDITOR.dom.element.get( element );
+
+		// Throw error on missing target element.
+		if ( !element )
+			throw 'The provided element, "' + elementArg + '", is missing from the DOM.';
 
 		// Avoid multiple inline editor instances on the same element.
 		if ( element.getEditor() )

--- a/core/creators/themedui.js
+++ b/core/creators/themedui.js
@@ -320,7 +320,7 @@ CKEDITOR.replaceClass = 'ckeditor';
 	};
 
 	function createInstance( element, config, data, mode ) {
-		element = CKEDITOR.getEditorElement( element );
+		element = CKEDITOR.editor._getEditorElement( element );
 
 		if ( !element ) {
 			return null;

--- a/core/editor.js
+++ b/core/editor.js
@@ -1586,6 +1586,7 @@
 	 * @private
 	 * @since 4.12.0
 	 * @static
+	 * @param {String/CKEDITOR.dom.element} elementOrId
 	 * @member CKEDITOR.editor
 	 * @returns {CKEDITOR.dom.element/null}
 	 */

--- a/core/editor.js
+++ b/core/editor.js
@@ -1578,6 +1578,44 @@
 			alert( message ); // jshint ignore:line
 		}
 	} );
+
+	/**
+	 * Gets the element from DOM and checks if the editor can be instantiated on it.
+	 * This function is available for internal use only.
+	 *
+	 * @private
+	 * @since 4.12.0
+	 * @static
+	 * @member CKEDITOR.editor
+	 * @returns {CKEDITOR.dom.element/null}
+	 */
+	CKEDITOR.editor._getEditorElement = function( elementOrId ) {
+		if ( !CKEDITOR.env.isCompatible ) {
+			return null;
+		}
+
+		var element = CKEDITOR.dom.element.get( elementOrId );
+
+		// Throw error on missing target element.
+		if ( !element ) {
+			CKEDITOR.error( 'editor-incorrect-element', {
+				element: elementOrId
+			} );
+
+			return null;
+		}
+
+		// Avoid multiple inline editor instances on the same element.
+		if ( element.getEditor() ) {
+			CKEDITOR.error( 'editor-element-conflict', {
+				editorName: element.getEditor().name
+			} );
+
+			return null;
+		}
+
+		return element;
+	};
 } )();
 
 /**

--- a/tests/core/ckeditor/ckeditor.js
+++ b/tests/core/ckeditor/ckeditor.js
@@ -35,13 +35,6 @@ bender.test( {
 		assert.areSame( document.getElementById( 'editor5' ), CKEDITOR.instances.editor5.element.$, 'instance element doesn\'t match' );
 	},
 
-
-	test_replaceError: function() {
-		assert.throwsError( Error, function() {
-			CKEDITOR.replace( 'error' );
-		} );
-	},
-
 	test_replaceAll_Class: function() {
 		CKEDITOR.replaceAll( 'myclass' );
 

--- a/tests/core/creators/creators.js
+++ b/tests/core/creators/creators.js
@@ -162,6 +162,31 @@ bender.test( {
 		wait();
 	},
 
+	'test creator replace on bogus DOM element': function() {
+		try {
+			CKEDITOR.replace( 'editorBogus', {
+				on: {
+					instanceReady: function() {
+						resume( function() {
+							assert.fail( 'Creation should fail on bogus DOM elements.' );
+						} );
+					}
+				}
+			} );
+		} catch ( e ) {
+			resume( function() {
+				if ( e.toString().indexOf( 'The provided element' ) >= 0 ) {
+					assert.isTrue( true );
+				}
+				else {
+					assert.fail( 'Error message should be friendly and helpful.' );
+				}
+			} );
+		}
+
+		wait();
+	},
+
 	'test creator appendTo': function() {
 		var tc = this,
 			container = CKEDITOR.dom.element.createFromHtml( '<div id="foo"></div>' );
@@ -223,6 +248,31 @@ bender.test( {
 
 		var checkEvents = this.checkEditorEvents( editor, [ 'configLoaded', 'langLoaded', 'pluginsLoaded', 'loaded', 'stylesSet', 'uiReady', 'setData', 'contentDom', 'mode', 'instanceReady' ] ),
 			checkStatuses = this.checkEditorStatuses( editor );
+
+		wait();
+	},
+
+	'test creator inline on bogus DOM element': function() {
+		try {
+			CKEDITOR.inline( 'editorBogus', {
+				on: {
+					instanceReady: function() {
+						resume( function() {
+							assert.fail( 'Creation should fail on bogus DOM elements.' );
+						} );
+					}
+				}
+			} );
+		} catch ( e ) {
+			resume( function() {
+				if ( e.toString().indexOf( 'The provided element' ) >= 0 ) {
+					assert.isTrue( true );
+				}
+				else {
+					assert.fail( 'Error message should be friendly and helpful.' );
+				}
+			} );
+		}
 
 		wait();
 	},

--- a/tests/core/creators/creators.js
+++ b/tests/core/creators/creators.js
@@ -1,312 +1,281 @@
 /* bender-tags: editor */
 /* bender-ckeditor-plugins: wysiwygarea */
+( function() {
+	'use strict';
 
-'use strict';
+	bender.test( {
+		// Check modes switching support. (themedui creator only)
+		checkEditorModes: function( editor, callback ) {
+			assert.isFunction( editor.setMode );
+			assert.isFunction( editor.addMode );
 
-bender.test( {
-	// Check modes switching support. (themedui creator only)
-	checkEditorModes: function( editor, callback ) {
-		assert.isFunction( editor.setMode );
-		assert.isFunction( editor.addMode );
-
-		// Check mode provider.
-		editor.addMode( 'foo', function( callback ) {
-			callback();
-		} );
-
-		// Check mode event fired.
-		editor.on( 'mode', function( evt ) {
-			evt.removeListener();
-			assert.areSame( editor.mode, 'foo' );
-		} );
-
-		// Check mode switch succeed.
-		editor.setMode( 'foo', function() {
-			resume( function() {
-				assert.areSame( editor.mode, 'foo' );
+			// Check mode provider.
+			editor.addMode( 'foo', function( callback ) {
 				callback();
 			} );
-		} );
 
-		wait();
-	},
+			// Check mode event fired.
+			editor.on( 'mode', function( evt ) {
+				evt.removeListener();
+				assert.areSame( editor.mode, 'foo' );
+			} );
 
-	/**
-	 * Check events fired on editor instance.
-	 * @param editor
-	 * @param events Expected editor events in firing order.
-	 */
-	checkEditorEvents: function( editor, events ) {
-		var firedEvents = [];
+			// Check mode switch succeed.
+			editor.setMode( 'foo', function() {
+				resume( function() {
+					assert.areSame( editor.mode, 'foo' );
+					callback();
+				} );
+			} );
 
-		function eventChecker( evt ) {
-			firedEvents.push( evt.name );
-		}
+			wait();
+		},
 
-		for ( var i = 0, evt, length = events.length; evt = events[ i ], i < length; i++ )
-			editor.on( evt, eventChecker, null, null, -1 );
+		/**
+		 * Check events fired on editor instance.
+		 * @param editor
+		 * @param events Expected editor events in firing order.
+		 */
+		checkEditorEvents: function( editor, events ) {
+			var firedEvents = [];
 
-		return function() {
-			arrayAssert.itemsAreEqual( events, firedEvents, 'events sequence doesn\'t match' );
-		};
-	},
+			function eventChecker( evt ) {
+				firedEvents.push( evt.name );
+			}
 
-	// Check theme related functionality. (themedui creator only)
-	checkEditorTheme: function( editor ) {
-		// Check API availability.
-		assert.isFunction( editor.addMode );
-		assert.isFunction( editor.setMode );
-		assert.isFunction( editor.resize );
-		assert.isFunction( editor.getResizable );
+			for ( var i = 0, evt, length = events.length; evt = events[ i ], i < length; i++ )
+				editor.on( evt, eventChecker, null, null, -1 );
 
-		assert.areSame( 'foo', editor.name, 'editor.name' );
-		assert.areSame( CKEDITOR.config.startupMode, editor.mode, 'editor.mode should matches startup mode config.' );
-		assert.areSame( CKEDITOR.instances.foo, editor, 'instance reference is globally available.' );
-		assert.areSame( CKEDITOR.document.getById( 'foo' ).$, editor.element.$, 'editor.element' );
-		assert.areSame( CKEDITOR.document.getById( 'foo' ).$, editor.element.$, 'editor.element' );
-	},
+			return function() {
+				arrayAssert.itemsAreEqual( events, firedEvents, 'events sequence doesn\'t match' );
+			};
+		},
 
-	// Check theme related functionality. (themedui creator only)
-	checkEditorUi: function( editor ) {
-		// Check no "div" used inside of the main ui.
-		if ( CKEDITOR.env.ie ) {
-			var divs = editor.container.getElementsByTag( 'div' );
-			assert.areSame( 0, divs.count() );
-		}
-	},
+		// Check theme related functionality. (themedui creator only)
+		checkEditorTheme: function( editor ) {
+			// Check API availability.
+			assert.isFunction( editor.addMode );
+			assert.isFunction( editor.setMode );
+			assert.isFunction( editor.resize );
+			assert.isFunction( editor.getResizable );
 
-	// Check various editor mandatory fields that are filled by all creators. (all creators)
-	checkEditorProperties: function( editor ) {
-		assert.areSame( CKEDITOR.config.startupMode, editor.mode, 'editor.mode should matches startup mode config.' );
-		assert.areSame( CKEDITOR.instances[ editor.name ], editor, 'instance reference is globally available.' );
-		if ( editor.elementMode != CKEDITOR.ELEMENT_MODE_NONE )
-			assert.isNotNull( editor.element, 'editor.element' );
-		if ( editor.elementMode == CKEDITOR.ELEMENT_MODE_INLINE || editor.elementMode == CKEDITOR.ELEMENT_MODE_REPLACE )
-			assert.areSame( CKEDITOR.document.getById( editor.name ), editor.element, 'editor.name matches id of editor.element.' );
-	},
+			assert.areSame( 'foo', editor.name, 'editor.name' );
+			assert.areSame( CKEDITOR.config.startupMode, editor.mode, 'editor.mode should matches startup mode config.' );
+			assert.areSame( CKEDITOR.instances.foo, editor, 'instance reference is globally available.' );
+			assert.areSame( CKEDITOR.document.getById( 'foo' ).$, editor.element.$, 'editor.element' );
+			assert.areSame( CKEDITOR.document.getById( 'foo' ).$, editor.element.$, 'editor.element' );
+		},
 
-	checkEditorStatuses: function( editor ) {
-		var statuses = [];
+		// Check theme related functionality. (themedui creator only)
+		checkEditorUi: function( editor ) {
+			// Check no "div" used inside of the main ui.
+			if ( CKEDITOR.env.ie ) {
+				var divs = editor.container.getElementsByTag( 'div' );
+				assert.areSame( 0, divs.count() );
+			}
+		},
 
-		statuses.push( editor.status );
+		// Check various editor mandatory fields that are filled by all creators. (all creators)
+		checkEditorProperties: function( editor ) {
+			assert.areSame( CKEDITOR.config.startupMode, editor.mode, 'editor.mode should matches startup mode config.' );
+			assert.areSame( CKEDITOR.instances[ editor.name ], editor, 'instance reference is globally available.' );
+			if ( editor.elementMode != CKEDITOR.ELEMENT_MODE_NONE )
+				assert.isNotNull( editor.element, 'editor.element' );
+			if ( editor.elementMode == CKEDITOR.ELEMENT_MODE_INLINE || editor.elementMode == CKEDITOR.ELEMENT_MODE_REPLACE )
+				assert.areSame( CKEDITOR.document.getById( editor.name ), editor.element, 'editor.name matches id of editor.element.' );
+		},
 
-		editor.on( 'loaded', function() {
+		checkEditorStatuses: function( editor ) {
+			var statuses = [];
+
 			statuses.push( editor.status );
-		}, null, null, 0 ); // Check with the highest priority.
-		editor.on( 'instanceReady', function() {
-			statuses.push( editor.status );
-		}, null, null, 0 );
-		editor.on( 'destroy', function() {
-			statuses.push( editor.status );
-		}, null, null, 0 );
 
-		return function() {
-			arrayAssert.itemsAreEqual( [ 'unloaded', 'loaded', 'ready', 'destroyed' ], statuses, 'Statuses values doesn\'t match' );
-		};
-	},
+			editor.on( 'loaded', function() {
+				statuses.push( editor.status );
+			}, null, null, 0 ); // Check with the highest priority.
+			editor.on( 'instanceReady', function() {
+				statuses.push( editor.status );
+			}, null, null, 0 );
+			editor.on( 'destroy', function() {
+				statuses.push( editor.status );
+			}, null, null, 0 );
 
-	'test APIs availability': function() {
-		// check creation APIs.
-		assert.isFunction( CKEDITOR.replace );
-		assert.isFunction( CKEDITOR.appendTo );
-		assert.isFunction( CKEDITOR.inline );
+			return function() {
+				arrayAssert.itemsAreEqual( [ 'unloaded', 'loaded', 'ready', 'destroyed' ], statuses, 'Statuses values doesn\'t match' );
+			};
+		},
 
-		assert.isFunction( CKEDITOR.replaceAll );
-		assert.isFunction( CKEDITOR.inlineAll );
+		'test APIs availability': function() {
+			// check creation APIs.
+			assert.isFunction( CKEDITOR.replace );
+			assert.isFunction( CKEDITOR.appendTo );
+			assert.isFunction( CKEDITOR.inline );
 
-		// check creation modes enumerations.
-		assert.areSame( CKEDITOR.ELEMENT_MODE_NONE, 0 );
-		assert.areSame( CKEDITOR.ELEMENT_MODE_REPLACE, 1 );
-		assert.areSame( CKEDITOR.ELEMENT_MODE_APPENDTO, 2 );
-		assert.areSame( CKEDITOR.ELEMENT_MODE_INLINE, 3 );
-	},
+			assert.isFunction( CKEDITOR.replaceAll );
+			assert.isFunction( CKEDITOR.inlineAll );
 
-	'test creator replace': function() {
-		var tc = this,
-			target = CKEDITOR.document.getBody().append(
-				CKEDITOR.dom.element.createFromHtml( '<textarea id="foo">&lt;p&gt;foo&lt;/p&gt;</textarea>' ) );
+			// check creation modes enumerations.
+			assert.areSame( CKEDITOR.ELEMENT_MODE_NONE, 0 );
+			assert.areSame( CKEDITOR.ELEMENT_MODE_REPLACE, 1 );
+			assert.areSame( CKEDITOR.ELEMENT_MODE_APPENDTO, 2 );
+			assert.areSame( CKEDITOR.ELEMENT_MODE_INLINE, 3 );
+		},
 
-		var editor = CKEDITOR.replace( 'foo', {
-			on: {
-				instanceReady: function( evt ) {
-					resume( function() {
-						var editor = evt.editor;
-						assert.areSame( 'foo', editor.name, 'editor.name' );
-						assert.areSame( CKEDITOR.ELEMENT_MODE_REPLACE, editor.elementMode, 'editor.elementMode' );
-						assert.areSame( editor.element.getNext().$, editor.container.$, 'editor.container should be the adjacent element of editor.element' );
-						assert.isFalse( editor.element.isVisible(), 'editor.element should be hidden from view.' );
-						checkEvents();
-						tc.checkEditorProperties( editor );
-						tc.checkEditorTheme( editor );
-						tc.checkEditorModes( editor, function() {
+		'test creator replace': function() {
+			var tc = this,
+				target = CKEDITOR.document.getBody().append(
+					CKEDITOR.dom.element.createFromHtml( '<textarea id="foo">&lt;p&gt;foo&lt;/p&gt;</textarea>' ) );
+
+			var editor = CKEDITOR.replace( 'foo', {
+				on: {
+					instanceReady: function( evt ) {
+						resume( function() {
+							var editor = evt.editor;
+							assert.areSame( 'foo', editor.name, 'editor.name' );
+							assert.areSame( CKEDITOR.ELEMENT_MODE_REPLACE, editor.elementMode, 'editor.elementMode' );
+							assert.areSame( editor.element.getNext().$, editor.container.$, 'editor.container should be the adjacent element of editor.element' );
+							assert.isFalse( editor.element.isVisible(), 'editor.element should be hidden from view.' );
+							checkEvents();
+							tc.checkEditorProperties( editor );
+							tc.checkEditorTheme( editor );
+							tc.checkEditorModes( editor, function() {
+								tc.checkEditorUi( editor );
+
+								editor.destroy();
+								checkStatuses();
+
+								target.remove(); // Clean up before next test.
+							} );
+
+							assert.isFalse( true, 'This should not be executed.' );
+							// DO NOT place more tests here - checkEditorModes is asynchronous. Use its callback.
+						} );
+					}
+				}
+			} );
+
+			assert.areSame( '<p>foo</p>', editor.getData(), 'editor initial data doesn\'t match' );
+
+			var checkEvents = this.checkEditorEvents( editor, [ 'configLoaded', 'langLoaded', 'pluginsLoaded', 'loaded', 'stylesSet', 'uiReady', 'setData', 'contentDom', 'mode', 'instanceReady' ] ),
+				checkStatuses = this.checkEditorStatuses( editor );
+
+			wait();
+		},
+
+		// (#2748)
+		'test creator replace on bogus DOM element': createBogusElementTest( 'replace' ),
+
+		'test creator appendTo': function() {
+			var tc = this,
+				container = CKEDITOR.dom.element.createFromHtml( '<div id="foo"></div>' );
+
+			CKEDITOR.document.getBody().append( container );
+
+			var editor = CKEDITOR.appendTo( 'foo', {
+				on: {
+					instanceReady: function() {
+						resume( function() {
+							assert.areSame( 'editor1', editor.name, 'editor.name' );
+							checkEvents();
+							tc.checkEditorProperties( editor );
 							tc.checkEditorUi( editor );
+							assert.areSame( CKEDITOR.ELEMENT_MODE_APPENDTO, editor.elementMode, 'editor.elementMode' );
+							assert.areSame( container.getLast(), editor.container, 'editor.container should be the last child element of editor.element' );
+
+							editor.destroy();
+							checkStatuses();
+							assert.isNull( container.getFirst() );
+
+							container.remove();
+						} );
+					}
+				}
+			} );
+
+			var checkEvents = this.checkEditorEvents( editor, [ 'configLoaded', 'langLoaded', 'pluginsLoaded', 'loaded', 'stylesSet', 'uiReady', 'setData', 'contentDom', 'mode', 'instanceReady' ] ),
+				checkStatuses = this.checkEditorStatuses( editor );
+
+			wait();
+		},
+
+		'test creator inline': function() {
+			var tc = this,
+				target = CKEDITOR.document.getBody().append(
+					CKEDITOR.dom.element.createFromHtml( '<div id="foo" contenteditable="true"><p>foo</p></div>' ) );
+
+			var editor = CKEDITOR.inline( target.$, {
+				on: {
+					instanceReady: function() {
+						resume( function() {
+							assert.areSame( 'foo', editor.name, 'editor.name' );
+							tc.checkEditorProperties( editor );
+							assert.areSame( CKEDITOR.ELEMENT_MODE_INLINE, editor.elementMode, 'editor.elementMode' );
+							assert.areSame( editor.editable().$, editor.element.$, 'editor.editable should be the same with editor.element' );
+							checkEvents( editor );
 
 							editor.destroy();
 							checkStatuses();
 
-							target.remove(); // Clean up before next test.
-						} );
-
-						assert.isFalse( true, 'This should not be executed.' );
-						// DO NOT place more tests here - checkEditorModes is asynchronous. Use its callback.
-					} );
-				}
-			}
-		} );
-
-		assert.areSame( '<p>foo</p>', editor.getData(), 'editor initial data doesn\'t match' );
-
-		var checkEvents = this.checkEditorEvents( editor, [ 'configLoaded', 'langLoaded', 'pluginsLoaded', 'loaded', 'stylesSet', 'uiReady', 'setData', 'contentDom', 'mode', 'instanceReady' ] ),
-			checkStatuses = this.checkEditorStatuses( editor );
-
-		wait();
-	},
-
-	'test creator replace on bogus DOM element': function() {
-		try {
-			CKEDITOR.replace( 'editorBogus', {
-				on: {
-					instanceReady: function() {
-						resume( function() {
-							assert.fail( 'Creation should fail on bogus DOM elements.' );
+							target.remove();
 						} );
 					}
 				}
 			} );
-		} catch ( e ) {
-			resume( function() {
-				if ( e.toString().indexOf( 'The provided element' ) >= 0 ) {
-					assert.isTrue( true );
-				}
-				else {
-					assert.fail( 'Error message should be friendly and helpful.' );
-				}
-			} );
-		}
 
-		wait();
-	},
+			assert.areSame( '<p>foo</p>', bender.tools.compatHtml( editor.getData() ), 'editor initial data doesn\'t match' );
 
-	'test creator appendTo': function() {
-		var tc = this,
-			container = CKEDITOR.dom.element.createFromHtml( '<div id="foo"></div>' );
+			var checkEvents = this.checkEditorEvents( editor, [ 'configLoaded', 'langLoaded', 'pluginsLoaded', 'loaded', 'stylesSet', 'uiReady', 'setData', 'contentDom', 'mode', 'instanceReady' ] ),
+				checkStatuses = this.checkEditorStatuses( editor );
 
-		CKEDITOR.document.getBody().append( container );
+			wait();
+		},
 
-		var editor = CKEDITOR.appendTo( 'foo', {
-			on: {
-				instanceReady: function() {
-					resume( function() {
-						assert.areSame( 'editor1', editor.name, 'editor.name' );
-						checkEvents();
-						tc.checkEditorProperties( editor );
-						tc.checkEditorUi( editor );
-						assert.areSame( CKEDITOR.ELEMENT_MODE_APPENDTO, editor.elementMode, 'editor.elementMode' );
-						assert.areSame( container.getLast(), editor.container, 'editor.container should be the last child element of editor.element' );
+		// (#2748)
+		'test creator inline on bogus DOM element': createBogusElementTest( 'inline' ),
 
-						editor.destroy();
-						checkStatuses();
-						assert.isNull( container.getFirst() );
+		'test creator inline-textarea': function() {
+			var tc = this,
+				target = CKEDITOR.document.getBody().append(
+					CKEDITOR.dom.element.createFromHtml( '<textarea id="foo">&lt;p&gt;foo&lt;/p&gt;</textarea>' ) );
 
-						container.remove();
-					} );
-				}
-			}
-		} );
-
-		var checkEvents = this.checkEditorEvents( editor, [ 'configLoaded', 'langLoaded', 'pluginsLoaded', 'loaded', 'stylesSet', 'uiReady', 'setData', 'contentDom', 'mode', 'instanceReady' ] ),
-			checkStatuses = this.checkEditorStatuses( editor );
-
-		wait();
-	},
-
-	'test creator inline': function() {
-		var tc = this,
-			target = CKEDITOR.document.getBody().append(
-				CKEDITOR.dom.element.createFromHtml( '<div id="foo" contenteditable="true"><p>foo</p></div>' ) );
-
-		var editor = CKEDITOR.inline( target.$, {
-			on: {
-				instanceReady: function() {
-					resume( function() {
-						assert.areSame( 'foo', editor.name, 'editor.name' );
-						tc.checkEditorProperties( editor );
-						assert.areSame( CKEDITOR.ELEMENT_MODE_INLINE, editor.elementMode, 'editor.elementMode' );
-						assert.areSame( editor.editable().$, editor.element.$, 'editor.editable should be the same with editor.element' );
-						checkEvents( editor );
-
-						editor.destroy();
-						checkStatuses();
-
-						target.remove();
-					} );
-				}
-			}
-		} );
-
-		assert.areSame( '<p>foo</p>', bender.tools.compatHtml( editor.getData() ), 'editor initial data doesn\'t match' );
-
-		var checkEvents = this.checkEditorEvents( editor, [ 'configLoaded', 'langLoaded', 'pluginsLoaded', 'loaded', 'stylesSet', 'uiReady', 'setData', 'contentDom', 'mode', 'instanceReady' ] ),
-			checkStatuses = this.checkEditorStatuses( editor );
-
-		wait();
-	},
-
-	'test creator inline on bogus DOM element': function() {
-		try {
-			CKEDITOR.inline( 'editorBogus', {
+			var editor = CKEDITOR.inline( target.$, {
 				on: {
 					instanceReady: function() {
 						resume( function() {
-							assert.fail( 'Creation should fail on bogus DOM elements.' );
+							assert.areSame( 'foo', editor.name, 'editor.name' );
+							tc.checkEditorProperties( editor );
+							assert.areSame( CKEDITOR.ELEMENT_MODE_INLINE, editor.elementMode, 'editor.elementMode' );
+							assert.areSame( editor.element.getNext().$, editor.container.$, 'editor.container should be the adjacent element of editor.element' );
+							checkEvents( editor );
+
+							editor.destroy();
+							checkStatuses();
+
+							target.remove();
 						} );
 					}
 				}
 			} );
-		} catch ( e ) {
-			resume( function() {
-				if ( e.toString().indexOf( 'The provided element' ) >= 0 ) {
-					assert.isTrue( true );
-				}
-				else {
-					assert.fail( 'Error message should be friendly and helpful.' );
-				}
-			} );
+
+			assert.areSame( '<p>foo</p>', bender.tools.compatHtml( editor.getData() ), 'editor initial data doesn\'t match' );
+
+			var checkEvents = this.checkEditorEvents( editor, [ 'configLoaded', 'langLoaded', 'pluginsLoaded', 'loaded', 'stylesSet', 'uiReady', 'setData', 'contentDom', 'mode', 'instanceReady' ] ),
+				checkStatuses = this.checkEditorStatuses( editor );
+
+			wait();
 		}
 
-		wait();
-	},
+	} );
 
-	'test creator inline-textarea': function() {
-		var tc = this,
-			target = CKEDITOR.document.getBody().append(
-				CKEDITOR.dom.element.createFromHtml( '<textarea id="foo">&lt;p&gt;foo&lt;/p&gt;</textarea>' ) );
+	function createBogusElementTest( creator ) {
+		return function() {
+			var spy = sinon.spy( CKEDITOR, 'error' );
 
-		var editor = CKEDITOR.inline( target.$, {
-			on: {
-				instanceReady: function() {
-					resume( function() {
-						assert.areSame( 'foo', editor.name, 'editor.name' );
-						tc.checkEditorProperties( editor );
-						assert.areSame( CKEDITOR.ELEMENT_MODE_INLINE, editor.elementMode, 'editor.elementMode' );
-						assert.areSame( editor.element.getNext().$, editor.container.$, 'editor.container should be the adjacent element of editor.element' );
-						checkEvents( editor );
+			CKEDITOR[ creator ]( 'editorBogus' );
 
-						editor.destroy();
-						checkStatuses();
-
-						target.remove();
-					} );
-				}
-			}
-		} );
-
-		assert.areSame( '<p>foo</p>', bender.tools.compatHtml( editor.getData() ), 'editor initial data doesn\'t match' );
-
-		var checkEvents = this.checkEditorEvents( editor, [ 'configLoaded', 'langLoaded', 'pluginsLoaded', 'loaded', 'stylesSet', 'uiReady', 'setData', 'contentDom', 'mode', 'instanceReady' ] ),
-			checkStatuses = this.checkEditorStatuses( editor );
-
-		wait();
+			spy.restore();
+			assert.areSame( 1, spy.callCount, 'Error was thrown' );
+			assert.areSame( 'editor-incorrect-element', spy.args[ 0 ][ 0 ], 'Appropriate error code was used' );
+		};
 	}
-
-} );
+}() );

--- a/tests/core/creators/creators.js
+++ b/tests/core/creators/creators.js
@@ -275,7 +275,9 @@
 
 			spy.restore();
 			assert.areSame( 1, spy.callCount, 'Error was thrown' );
-			assert.areSame( 'editor-incorrect-element', spy.args[ 0 ][ 0 ], 'Appropriate error code was used' );
+			assert.isTrue( spy.calledWithExactly( 'editor-incorrect-element', sinon.match( {
+				element: 'editorBogus'
+			} ) ), 'Appropriate error code and additional data were used' );
 		};
 	}
 }() );

--- a/tests/core/creators/duplicates.js
+++ b/tests/core/creators/duplicates.js
@@ -7,35 +7,24 @@
 	CKEDITOR.disableAutoInline = true;
 
 	bender.test( {
-		'inline duplicates': function() {
-			var fail = false;
-
-			CKEDITOR.inlineAll();
-
-			wait( function() {
-				try {
-					CKEDITOR.inline( 'editable' );
-					fail = true;
-				} catch ( e ) {}
-
-				assert.isFalse( fail, 'Expected error not thrown.' );
-			}, 100 );
-		},
-
-		'themedui duplicates': function() {
-			var fail = false;
-
-			CKEDITOR.replace( 'editor' );
-
-			wait( function() {
-				try {
-					CKEDITOR.replace( 'editor' );
-					fail = true;
-				} catch ( e ) {}
-
-				assert.isFalse( fail, 'Expected error not thrown.' );
-			}, 100 );
-		}
+		'inline duplicates': createTestCase( 'inline', 'editable' ),
+		'themedui duplicates': createTestCase( 'replace', 'editor' )
 	} );
+
+	function createTestCase( creator, element ) {
+		return function() {
+			var spy = sinon.spy( CKEDITOR, 'error' );
+
+			CKEDITOR[ creator ]( element );
+
+			wait( function() {
+				CKEDITOR[ creator ]( element );
+
+				spy.restore();
+				assert.areSame( 1, spy.callCount, 'Error was thrown' );
+				assert.areSame( 'editor-element-conflict', spy.args[ 0 ][ 0 ], 'Appropriate error code was used' );
+			}, 100 );
+		};
+	}
 
 } )();

--- a/tests/core/creators/duplicates.js
+++ b/tests/core/creators/duplicates.js
@@ -22,7 +22,9 @@
 
 				spy.restore();
 				assert.areSame( 1, spy.callCount, 'Error was thrown' );
-				assert.areSame( 'editor-element-conflict', spy.args[ 0 ][ 0 ], 'Appropriate error code was used' );
+				assert.isTrue( spy.calledWithExactly( 'editor-element-conflict', sinon.match( {
+					editorName: element
+				} ) ), 'Appropriate error code and additional data were used' );
 			}, 100 );
 		};
 	}

--- a/tests/core/creators/inline-textarea.js
+++ b/tests/core/creators/inline-textarea.js
@@ -120,7 +120,9 @@
 
 			spy.restore();
 			assert.areSame( 1, spy.callCount, 'Error was thrown' );
-			assert.areSame( 'editor-element-conflict', spy.args[ 0 ][ 0 ], 'Appropriate error code was used' );
+			assert.isTrue( spy.calledWithExactly( 'editor-element-conflict', sinon.match( {
+				editorName: element
+			} ) ), 'Appropriate error code and additional data were used' );
 		};
 	}
 } )();

--- a/tests/core/creators/inline-textarea.js
+++ b/tests/core/creators/inline-textarea.js
@@ -63,45 +63,9 @@
 			} );
 		},
 
-		'test create concurrent editor: framed on bound textarea': function() {
-			try {
-				CKEDITOR.replace( 'editor1', {
-					on: {
-						instanceReady: function() {
-							resume( function() {
-								assert.fail( 'This textarea is already bound to some instance!' );
-							} );
-						}
-					}
-				} );
-			} catch ( e ) {
-				resume( function() {
-					assert.isTrue( true );
-				} );
-			}
+		'test create concurrent editor: framed on bound textarea': createConcurrentEditorTest( 'replace', 'editor1' ),
 
-			wait();
-		},
-
-		'test create concurrent editor: inline on bound textarea': function() {
-			try {
-				CKEDITOR.inline( 'editor1', {
-					on: {
-						instanceReady: function() {
-							resume( function() {
-								assert.fail( 'This textarea is already bound to some instance!' );
-							} );
-						}
-					}
-				} );
-			} catch ( e ) {
-				resume( function() {
-					assert.isTrue( true );
-				} );
-			}
-
-			wait();
-		},
+		'test create concurrent editor: inline on bound textarea': createConcurrentEditorTest( 'inline', 'editor1' ),
 
 		'test update data on submit': function() {
 			var editor = this.editor,
@@ -147,4 +111,16 @@
 			} );
 		}
 	} );
+
+	function createConcurrentEditorTest( creator, element ) {
+		return function() {
+			var spy = sinon.spy( CKEDITOR, 'error' );
+
+			CKEDITOR[ creator ]( element );
+
+			spy.restore();
+			assert.areSame( 1, spy.callCount, 'Error was thrown' );
+			assert.areSame( 'editor-element-conflict', spy.args[ 0 ][ 0 ], 'Appropriate error code was used' );
+		};
+	}
 } )();


### PR DESCRIPTION
## What is the purpose of this pull request?

New feature

## Does your PR contain necessary tests?

All patches which change the editor code must include tests. You can always read more
on [PR testing](https://ckeditor.com/docs/ckeditor4/latest/guide/dev_contributing_code.html#tests),
[how to set the testing environment](https://ckeditor.com/docs/ckeditor4/latest/guide/dev_tests.html) and
[how to create tests](https://ckeditor.com/docs/ckeditor4/latest/guide/dev_tests.html#creating-your-own-test)
in the official CKEditor documentation.

### This PR contains

- [x] Unit tests
- [ ] Manual tests

## What changes did you make?

I've replaced `throw` statements in our creators with calls to `CKEDITOR.error` with two new error codes:

* `editor-incorrect-element` – logged when user tries to attach editor to nonexistent element,
* `editor-element-conflict` – logged when user tries to attach editor to the element with already attached one.

Additionally I moved the logic for getting element for editor outside creators, into `core/ckeditor.js` under the name `CKEDITOR.getEditorElement`. However I'm not entirely sure if these are the right place and right name.

Finally I had to refactor some tests that were expecting errors to be thrown.

Closes #2748.