### PR TITLE
Pass a function that returns a template to CKEDITOR.template class

### DIFF
--- a/core/template.js
+++ b/core/template.js
@@ -27,7 +27,7 @@
 	 *
 	 * @class
 	 * @constructor Creates a template class instance.
-	 * @param {String|Function} source The template source - string or callback function that returns a string.
+	 * @param {String/Function} source The template source - string or callback function that returns a string.
 	 */
 	CKEDITOR.template = function( source ) {
 		/**
@@ -35,12 +35,12 @@
 		 *
 		 * @readonly
 		 * @member CKEDITOR.template
-		 * @property {String|Function}
+		 * @property {String/Function}
 		 */
-		if (typeof source === 'function') {
+		if ( typeof source === 'function' ) {
 			this.source = source;
 		} else {
-			this.source = String(source);
+			this.source = String( source );
 		}
 	};
 
@@ -62,8 +62,8 @@
 
 		var template;
 
-		if (typeof this.source === 'function') {
-			template = this.source(data);
+		if ( typeof this.source === 'function' ) {
+			template = this.source( data );
 		} else {
 			template = this.source;
 		}

--- a/core/template.js
+++ b/core/template.js
@@ -35,7 +35,7 @@
 		 *
 		 * @readonly
 		 * @member CKEDITOR.template
-		 * @property {String/Function}
+		 * @property {String/Function} source
 		 */
 		if ( typeof source === 'function' ) {
 			this.source = source;

--- a/core/template.js
+++ b/core/template.js
@@ -18,9 +18,16 @@
 	 *		var tpl = new CKEDITOR.template( '<div class="{cls}">{label}</div>' );
 	 *		alert( tpl.output( { cls: 'cke-label', label: 'foo'} ) ); // '<div class="cke-label">foo</div>'
 	 *
+	 *		// Function that returns a template.
+	 *		var tpl2 = new CKEDITOR.template(function(data) {
+	 *			return data.image ? '<img src="{image}" alt="{label}"/>' : '<div class="{cls}">{label}</div>'
+	 *		});
+	 *		alert( tpl2.output( { cls: 'cke-label', label: 'foo'} ) ); // '<div class="cke-label">foo</div>'
+	 *		alert( tpl2.output( { image: '/some-image.jpg', label: 'foo'} ) ); // <img src="/some-image.jpg" alt="foo"/>
+	 *
 	 * @class
 	 * @constructor Creates a template class instance.
-	 * @param {String} source The template source.
+	 * @param {String|Function} source The template source - string or function that returns a template.
 	 */
 	CKEDITOR.template = function( source ) {
 		/**
@@ -28,9 +35,13 @@
 		 *
 		 * @readonly
 		 * @member CKEDITOR.template
-		 * @property {String}
+		 * @property {String|Function}
 		 */
-		this.source = String( source );
+		if (typeof source === 'function') {
+			this.source = source;
+		} else {
+			this.source = String(source);
+		}
 	};
 
 	/**
@@ -48,7 +59,16 @@
 	 * template output data; otherwise the new length of `buffer`.
 	 */
 	CKEDITOR.template.prototype.output = function( data, buffer ) {
-		var output = this.source.replace( rePlaceholder, function( fullMatch, dataKey ) {
+
+		var template;
+
+		if (typeof this.source === 'function') {
+			template = this.source(data);
+		} else {
+			template = this.source;
+		}
+
+		var output = template.replace( rePlaceholder, function( fullMatch, dataKey ) {
 			return data[ dataKey ] !== undefined ? data[ dataKey ] : fullMatch;
 		} );
 

--- a/core/template.js
+++ b/core/template.js
@@ -18,21 +18,23 @@
 	 *		var tpl = new CKEDITOR.template( '<div class="{cls}">{label}</div>' );
 	 *		alert( tpl.output( { cls: 'cke-label', label: 'foo'} ) ); // '<div class="cke-label">foo</div>'
 	 *
-	 *		// Function that returns a template.
-	 *		var tpl2 = new CKEDITOR.template(function(data) {
-	 *			return data.image ? '<img src="{image}" alt="{label}"/>' : '<div class="{cls}">{label}</div>'
-	 *		});
-	 *		alert( tpl2.output( { cls: 'cke-label', label: 'foo'} ) ); // '<div class="cke-label">foo</div>'
+	 *		// Since 4.12 it is possible to pass a callback Function that returns a template.
+	 * 		var tpl2 = new CKEDITOR.template( function( data ) {
+	 * 			return data.image ? '<img src="{image}" alt="{label}"/>' : '{label}';
+	 * 		} );
+	 *		alert( tpl2.output( { image: null, label: 'foo'} ) ); // 'foo'
 	 *		alert( tpl2.output( { image: '/some-image.jpg', label: 'foo'} ) ); // <img src="/some-image.jpg" alt="foo"/>
 	 *
+	 * @since 4.12
 	 * @class
 	 * @constructor Creates a template class instance.
-	 * @param {String/Function} source The template source - string or callback function that returns a string.
+	 * @param {String/Function} source The template source - string or callback Function that returns a string.
 	 */
 	CKEDITOR.template = function( source ) {
 		/**
 		 * The current template source.
 		 *
+		 * @since 4.12
 		 * @readonly
 		 * @member CKEDITOR.template
 		 * @property {String/Function} source

--- a/core/template.js
+++ b/core/template.js
@@ -27,7 +27,7 @@
 	 *
 	 * @class
 	 * @constructor Creates a template class instance.
-	 * @param {String|Function} source The template source - string or function that returns a template.
+	 * @param {String|Function} source The template source - string or callback function that returns a string.
 	 */
 	CKEDITOR.template = function( source ) {
 		/**

--- a/core/template.js
+++ b/core/template.js
@@ -60,13 +60,7 @@
 	 */
 	CKEDITOR.template.prototype.output = function( data, buffer ) {
 
-		var template;
-
-		if ( typeof this.source === 'function' ) {
-			template = this.source( data );
-		} else {
-			template = this.source;
-		}
+		var template = typeof this.source === 'function' ? this.source( data ) : this.source;
 
 		var output = template.replace( rePlaceholder, function( fullMatch, dataKey ) {
 			return data[ dataKey ] !== undefined ? data[ dataKey ] : fullMatch;

--- a/tests/core/template.js
+++ b/tests/core/template.js
@@ -94,11 +94,11 @@
 		'supports source as a function': function() {
 			// Returns a template for following tests
 			// @param {Object} data
-			function getTemplate(data) {
-				return data.image ? '<img src="{image}" alt="{label}"/>' : '<span>{label}</span>';
+			function getTemplate( data ) {
+				return data.image ? '<img src="{image}" alt="{label}"/>' : '{label}';
 			}
+			this.assertTemplateOutput( 'bar', getTemplate, { image: null, label: 'bar' } );
 			this.assertTemplateOutput( '<img src="/foo.jpg" alt="bar"/>', getTemplate, { image: '/foo.jpg', label: 'bar' } );
-			this.assertTemplateOutput( '<span>bar</span>', getTemplate, { image: null, label: 'bar' } );
 		},
 
 		// Creates a template for given string and checks its output

--- a/tests/core/template.js
+++ b/tests/core/template.js
@@ -91,9 +91,23 @@
 			this.assertTemplateOutput( 'alert("foo!")', '{code}', { code: 'alert("foo!")' } );
 		},
 
+		// Returns a template for following tests
+		// @param {Object} data
+		getTemplate: function(data) {
+			return data.image ? '<img src="{image}" alt="{label}"/>' : '<span>{label}</span>';
+		},
+
+		'callback function case 1': function() {
+			this.assertTemplateOutput( '<img src="/foo.jpg" alt="bar"/>', this.getTemplate, { image: '/foo.jpg', label: 'bar' } );
+		},
+
+		'callback function case 2': function() {
+			this.assertTemplateOutput( '<span>bar</span>', this.getTemplate, { image: null, label: 'bar' } );
+		},
+
 		// Creates a template for given string and checks its output
 		// @param {String} expected Expected template output.
-		// @param {String} templateString Template input string.
+		// @param {String|Function} templateString Template input string or callback function that returns a string.
 		// @param {Object} replacementObject Optional object containing variables.
 		assertTemplateOutput: function( expected, templateString, replacementObject ) {
 			var tpl = new CKEDITOR.template( templateString );

--- a/tests/core/template.js
+++ b/tests/core/template.js
@@ -91,23 +91,19 @@
 			this.assertTemplateOutput( 'alert("foo!")', '{code}', { code: 'alert("foo!")' } );
 		},
 
-		// Returns a template for following tests
-		// @param {Object} data
-		getTemplate: function(data) {
-			return data.image ? '<img src="{image}" alt="{label}"/>' : '<span>{label}</span>';
-		},
-
-		'callback function case 1': function() {
-			this.assertTemplateOutput( '<img src="/foo.jpg" alt="bar"/>', this.getTemplate, { image: '/foo.jpg', label: 'bar' } );
-		},
-
-		'callback function case 2': function() {
-			this.assertTemplateOutput( '<span>bar</span>', this.getTemplate, { image: null, label: 'bar' } );
+		'supports source as a function': function() {
+			// Returns a template for following tests
+			// @param {Object} data
+			function getTemplate(data) {
+				return data.image ? '<img src="{image}" alt="{label}"/>' : '<span>{label}</span>';
+			}
+			this.assertTemplateOutput( '<img src="/foo.jpg" alt="bar"/>', getTemplate, { image: '/foo.jpg', label: 'bar' } );
+			this.assertTemplateOutput( '<span>bar</span>', getTemplate, { image: null, label: 'bar' } );
 		},
 
 		// Creates a template for given string and checks its output
 		// @param {String} expected Expected template output.
-		// @param {String|Function} templateString Template input string or callback function that returns a string.
+		// @param {String/Function} templateString Template input string or callback Function that returns a string.
 		// @param {Object} replacementObject Optional object containing variables.
 		assertTemplateOutput: function( expected, templateString, replacementObject ) {
 			var tpl = new CKEDITOR.template( templateString );


### PR DESCRIPTION
## What is the purpose of this pull request?
New feature

## Does your PR contain necessary tests?
Yes

### This PR contains
- [x] Unit tests
- [ ] Manual tests

## What changes did you make?
I allowed to pass a callback function that returns a template.
The main reason is I want to use it in configuration of 'mentions' plugin
Some of the users I want to mention does not have avatars, in this case I want to display their initials instead of unreachable image.
```
mentions: [
    {
        feed: dataFeed,
        marker: '@',
        itemTemplate: function(data) {
            return '<li data-id="{id}" class="autocomplete-item">' +
                    (data.imageUrl ? '<img class="avatar" src="{imageUrl}"/>' : '<span class="initials">{initials}</span>') +
                    '<span>{label}</span>' +
                '</li>'
        },
        outputTemplate: '[[{type}|{id}|{label}]]<span>&nbsp;</span>',
        minChars: 1
    }
]
```

Closes #2821.