### PR TITLE
Fix for focus issues in nested editables caused by copyformatting plugin

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -9,6 +9,8 @@ Fixed Issues:
 * [#2527](https://github.com/ckeditor/ckeditor-dev/issues/2527): Fixed: [Emoji](https://ckeditor.com/cke4/addon/emoji) autocomplete order now prioritize emojis with name started from used string.
 * [#2572](https://github.com/ckeditor/ckeditor-dev/issues/2572): Fixed: Icons in [Emoji](https://ckeditor.com/cke4/addon/emoji) dropdown navigation groups are not centered.
 * [#1191](https://github.com/ckeditor/ckeditor-dev/issues/1191): Fixed: Elements in elements path are draggable.
+* [#2470](https://github.com/ckeditor/ckeditor-dev/issues/2470): [Firefox] Fixed: Widget's nested editable blurred upon focus.
+* [#2655](https://github.com/ckeditor/ckeditor-dev/issues/2655): [Chrome, Safari] Fixed: Widget's nested editable can't be focused under certain circumstances.
 
 ## CKEditor 4.11.2
 

--- a/plugins/copyformatting/plugin.js
+++ b/plugins/copyformatting/plugin.js
@@ -101,7 +101,7 @@
 					copyFormattingButtonEl;
 
 				editable.attachListener( mouseupHost, 'mouseup', function( evt ) {
-					// Apply formatting only if any styles are copied (#2655).
+					// Apply formatting only if any styles are copied (#2655, #2470).
 					if ( editor.copyFormatting.styles && getMouseButton( evt ) === CKEDITOR.MOUSE_BUTTON_LEFT ) {
 						editor.execCommand( 'applyFormatting' );
 					}

--- a/plugins/copyformatting/plugin.js
+++ b/plugins/copyformatting/plugin.js
@@ -101,7 +101,8 @@
 					copyFormattingButtonEl;
 
 				editable.attachListener( mouseupHost, 'mouseup', function( evt ) {
-					if ( getMouseButton( evt ) === CKEDITOR.MOUSE_BUTTON_LEFT ) {
+					// Apply formatting only if any styles are copied (#2655).
+					if ( editor.copyFormatting.styles && getMouseButton( evt ) === CKEDITOR.MOUSE_BUTTON_LEFT ) {
 						editor.execCommand( 'applyFormatting' );
 					}
 				} );

--- a/tests/plugins/copyformatting/applyformat.js
+++ b/tests/plugins/copyformatting/applyformat.js
@@ -439,7 +439,7 @@
 			assert.areSame( tableConstant, determineContext(), 'Selection within two rows' );
 		},
 
-		// (#2655)
+		// (#2655, #2470)
 		'test applyFormat not fired without copied styles': function() {
 			var editor = this.editor,
 				spy = sinon.spy( editor, 'execCommand' ),

--- a/tests/plugins/copyformatting/applyformat.js
+++ b/tests/plugins/copyformatting/applyformat.js
@@ -437,6 +437,20 @@
 
 			bender.tools.selection.setWithHtml( editor, '<table><tr><td>Ce{ll 1</td></tr><tr><td>Ce}ll 2</td></tr></table>' );
 			assert.areSame( tableConstant, determineContext(), 'Selection within two rows' );
+		},
+
+		// (#2655)
+		'test applyFormat not fired without copied styles': function() {
+			var editor = this.editor,
+				spy = sinon.spy( editor, 'execCommand' ),
+				isIe8 = CKEDITOR.env.ie && CKEDITOR.env.version < 9;
+
+			editor.document.fire( 'mouseup', new CKEDITOR.dom.event( {
+				button: isIe8 ? 1 : CKEDITOR.MOUSE_BUTTON_LEFT
+			} ) );
+			spy.restore();
+
+			assert.areSame( 0, spy.callCount );
 		}
 	} );
 }() );

--- a/tests/plugins/copyformatting/manual/nestededitablefocus.html
+++ b/tests/plugins/copyformatting/manual/nestededitablefocus.html
@@ -1,0 +1,45 @@
+<h2>Classic editor</h2>
+<div id="classic">
+		<div class="test1">x<div class="content">Widget1</div>y</div>
+</div>
+
+<script>
+	if ( !CKEDITOR.env.webkit ) {
+		bender.ignore();
+	}
+
+	CKEDITOR.addCss( '.cke_editable { margin: 0;padding: 50px; }' +
+		'.test1 { border: 1px #000 solid; }' );
+	CKEDITOR.replace( 'classic', {
+		extraPlugins: 'test1'
+	} );
+
+	CKEDITOR.plugins.add( 'test1', {
+		requires: 'widget',
+		init: function( editor ) {
+			editor.widgets.add( 'test1', {
+				button: 'Create autoparagraph test',
+				pathName: 'test-widget',
+
+				template:
+					'<div class="test1">' +
+						'<div class="content"></div>' +
+					'</div>',
+
+				editables: {
+					content: {
+						selector: '.content',
+						allowedContent: 'br'
+					}
+				},
+
+				allowedContent: 'div(test1,content)',
+				requiredContent: 'div(test1)',
+
+				upcast: function( element ) {
+					return element.name == 'div' && element.hasClass( 'test1' );
+				}
+			} );
+		}
+	} );
+</script>

--- a/tests/plugins/copyformatting/manual/nestededitablefocus.html
+++ b/tests/plugins/copyformatting/manual/nestededitablefocus.html
@@ -1,13 +1,20 @@
+<style>
+#square {
+	margin-top: 20px;
+	width: 100px;
+	height: 100px;
+	border: 1px #000 solid;
+	background-color: red;
+}
+</style>
 <h2>Classic editor</h2>
 <div id="classic">
 		<div class="test1">x<div class="content">Widget1</div>y</div>
 </div>
 
-<script>
-	if ( !CKEDITOR.env.webkit ) {
-		bender.ignore();
-	}
+<div id="square"></div>
 
+<script>
 	CKEDITOR.addCss( '.cke_editable { margin: 0;padding: 50px; }' +
 		'.test1 { border: 1px #000 solid; }' );
 	CKEDITOR.replace( 'classic', {
@@ -38,7 +45,19 @@
 
 				upcast: function( element ) {
 					return element.name == 'div' && element.hasClass( 'test1' );
+				},
+
+				init: function() {
+					var square = CKEDITOR.document.getById( 'square' );
+
+					this.editables.content.on( 'focus', function() {
+						square.setStyle( 'background-color', 'green' );
+					} );
+					this.editables.content.on( 'blur', function() {
+						square.setStyle( 'background-color', 'red' );
+					} );
 				}
+
 			} );
 		}
 	} );

--- a/tests/plugins/copyformatting/manual/nestededitablefocus.md
+++ b/tests/plugins/copyformatting/manual/nestededitablefocus.md
@@ -1,0 +1,15 @@
+@bender-tags: bug, 4.11.3, 2655
+@bender-ui: collapsed
+@bender-ckeditor-plugins: widget, wysiwygarea, copyformatting
+
+1. Click inside "Widget 1" text to focus nested editable.
+2. Click above the widget (above the black border).
+3. Click once more inside "Widget 1" text.
+
+## Expected
+
+Focus is moved into nested editable and stays there.
+
+## Unexpected
+
+Focus is moved into nested editable for a fraction of second and then disappears.

--- a/tests/plugins/copyformatting/manual/nestededitablefocus.md
+++ b/tests/plugins/copyformatting/manual/nestededitablefocus.md
@@ -1,4 +1,4 @@
-@bender-tags: bug, 4.11.3, 2655
+@bender-tags: bug, 4.11.3, 2655, 2470
 @bender-ui: collapsed
 @bender-ckeditor-plugins: widget, wysiwygarea, copyformatting
 
@@ -8,8 +8,10 @@
 
 ## Expected
 
-Focus is moved into nested editable and stays there.
+* Focus is moved into nested editable and stays there.
+* Square under the editor is green.
 
 ## Unexpected
 
-Focus is moved into nested editable for a fraction of second and then disappears.
+* Focus is moved into nested editable for a fraction of second and then disappears.
+* Square under the editor is red.


### PR DESCRIPTION
## What is the purpose of this pull request?

Bug fix

## Does your PR contain necessary tests?

All patches which change the editor code must include tests. You can always read more
on [PR testing](https://ckeditor.com/docs/ckeditor4/latest/guide/dev_contributing_code.html#tests),
[how to set the testing environment](https://ckeditor.com/docs/ckeditor4/latest/guide/dev_tests.html) and
[how to create tests](https://ckeditor.com/docs/ckeditor4/latest/guide/dev_tests.html#creating-your-own-test)
in the official CKEditor documentation.

### This PR contains

- [x] Unit tests
- [x] Manual tests

## What changes did you make?

The issue is connected with the fact that every `mouseup` event on editable was connected with executing `applyFormat` command, which required focusing the editor. It obviously was stealing focus from the editable. The simplest solution was to exec `applyFormat` only if there is really some formatting to be applied.

Closes #2655.
Closes #2470.
