### PR TITLE
Fix for: Autolink throws an error in Source Mode

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -10,7 +10,7 @@ Fixed Issues:
 * [#2572](https://github.com/ckeditor/ckeditor-dev/issues/2572): Fixed: Icons in [Emoji](https://ckeditor.com/cke4/addon/emoji) dropdown navigation groups are not centered.
 * [#1191](https://github.com/ckeditor/ckeditor-dev/issues/1191): Fixed: Items in the [elements path](https://ckeditor.com/cke4/addon/elementspath) are draggable.
 * [#2292](https://github.com/ckeditor/ckeditor-dev/issues/2292): Fixed: Dropping list with link on editor's margin cause console error and removing dragged text from editor.
-* [2756](https://github.com/ckeditor/ckeditor-dev/issues/2756): Fixed: The [Auto Link](https://ckeditor.com/cke4/addon/autolink) plugin causes an error when typing in [Source Editing Mode](https://ckeditor.com/docs/ckeditor4/latest/guide/dev_sourcearea.html).
+* [#2756](https://github.com/ckeditor/ckeditor-dev/issues/2756): Fixed: The [Auto Link](https://ckeditor.com/cke4/addon/autolink) plugin causes an error when typing in [Source Editing Mode](https://ckeditor.com/docs/ckeditor4/latest/guide/dev_sourcearea.html).
 
 ## CKEditor 4.11.2
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -10,6 +10,7 @@ Fixed Issues:
 * [#2572](https://github.com/ckeditor/ckeditor-dev/issues/2572): Fixed: Icons in [Emoji](https://ckeditor.com/cke4/addon/emoji) dropdown navigation groups are not centered.
 * [#1191](https://github.com/ckeditor/ckeditor-dev/issues/1191): Fixed: Items in the [elements path](https://ckeditor.com/cke4/addon/elementspath) are draggable.
 * [#2292](https://github.com/ckeditor/ckeditor-dev/issues/2292): Fixed: Dropping list with link on editor's margin cause console error and removing dragged text from editor.
+* [2756](https://github.com/ckeditor/ckeditor-dev/issues/2756): Fixed: The [Auto Link](https://ckeditor.com/cke4/addon/autolink) plugin causes an error when typing in [Source Editing Mode](https://ckeditor.com/docs/ckeditor4/latest/guide/dev_sourcearea.html).
 
 ## CKEditor 4.11.2
 

--- a/plugins/autolink/plugin.js
+++ b/plugins/autolink/plugin.js
@@ -41,7 +41,7 @@
 			editor.on( 'contentDom', function() {
 				var commitKeystrokes = editor.config.autolink_commitKeystrokes || CKEDITOR.config.autolink_commitKeystrokes;
 				editor.on( 'key', function( evt ) {
-					if ( CKEDITOR.tools.indexOf( commitKeystrokes, evt.data.keyCode ) == -1 ) {
+					if ( editor.mode === 'source' || CKEDITOR.tools.indexOf( commitKeystrokes, evt.data.keyCode ) == -1 ) {
 						return;
 					}
 

--- a/plugins/autolink/plugin.js
+++ b/plugins/autolink/plugin.js
@@ -41,7 +41,7 @@
 			editor.on( 'contentDom', function() {
 				var commitKeystrokes = editor.config.autolink_commitKeystrokes || CKEDITOR.config.autolink_commitKeystrokes;
 				editor.on( 'key', function( evt ) {
-					if ( editor.mode === 'source' || CKEDITOR.tools.indexOf( commitKeystrokes, evt.data.keyCode ) == -1 ) {
+					if ( editor.mode !== 'wysiwyg' || CKEDITOR.tools.indexOf( commitKeystrokes, evt.data.keyCode ) == -1 ) {
 						return;
 					}
 

--- a/plugins/autolink/plugin.js
+++ b/plugins/autolink/plugin.js
@@ -38,20 +38,18 @@
 				return;
 			}
 
-			editor.on( 'contentDom', function() {
-				var commitKeystrokes = editor.config.autolink_commitKeystrokes || CKEDITOR.config.autolink_commitKeystrokes;
-				editor.on( 'key', function( evt ) {
-					if ( editor.mode !== 'wysiwyg' || CKEDITOR.tools.indexOf( commitKeystrokes, evt.data.keyCode ) == -1 ) {
-						return;
-					}
+			var commitKeystrokes = editor.config.autolink_commitKeystrokes || CKEDITOR.config.autolink_commitKeystrokes;
+			editor.on( 'key', function( evt ) {
+				if ( editor.mode !== 'wysiwyg' || CKEDITOR.tools.indexOf( commitKeystrokes, evt.data.keyCode ) == -1 ) {
+					return;
+				}
 
-					var matched = CKEDITOR.plugins.textMatch.match( editor.getSelection().getRanges()[ 0 ], matchCallback );
+				var matched = CKEDITOR.plugins.textMatch.match( editor.getSelection().getRanges()[ 0 ], matchCallback );
 
-					if ( matched ) {
-						insertLink( matched );
-					}
+				if ( matched ) {
+					insertLink( matched );
+				}
 
-				} );
 			} );
 
 			function insertLink( match ) {

--- a/tests/plugins/autolink/autolink.js
+++ b/tests/plugins/autolink/autolink.js
@@ -1,5 +1,5 @@
 /* bender-tags: editor */
-/* bender-ckeditor-plugins: autolink,clipboard,link */
+/* bender-ckeditor-plugins: autolink,clipboard,link,sourcearea */
 /* bender-include: ../clipboard/_helpers/pasting.js */
 /* global assertPasteEvent */
 
@@ -276,6 +276,25 @@
 				assert.areEqual( 'html', data.type );
 				assert.areEqual( expected, bender.tools.compatHtml( data.dataValue ) );
 			} );
+		},
+
+		// (#2756)
+		'test commit keys inactive in source mode': function() {
+			var editor = this.editors.classic;
+
+			editor.setMode( 'source', function() {
+				resume( function() {
+					try {
+						editor.fire( 'key', { keyCode: CKEDITOR.config.autolink_commitKeystrokes[ 0 ] } );
+					} catch ( e ) {
+						assert.fail( 'Error thrown' );
+					} finally {
+						assert.pass( 'Passed without errors' );
+					}
+				} );
+			} );
+
+			wait();
 		}
 	} );
 

--- a/tests/plugins/autolink/autolink.js
+++ b/tests/plugins/autolink/autolink.js
@@ -284,13 +284,8 @@
 
 			editor.setMode( 'source', function() {
 				resume( function() {
-					try {
-						editor.fire( 'key', { keyCode: CKEDITOR.config.autolink_commitKeystrokes[ 0 ] } );
-					} catch ( e ) {
-						assert.fail( 'Error thrown' );
-					} finally {
-						assert.pass( 'Passed without errors' );
-					}
+					editor.fire( 'key', { keyCode: CKEDITOR.config.autolink_commitKeystrokes[ 0 ] } );
+					assert.pass( 'Passed without errors' );
 				} );
 			} );
 

--- a/tests/plugins/autolink/autolink.js
+++ b/tests/plugins/autolink/autolink.js
@@ -284,7 +284,15 @@
 
 			editor.setMode( 'source', function() {
 				resume( function() {
-					editor.fire( 'key', { keyCode: CKEDITOR.config.autolink_commitKeystrokes[ 0 ] } );
+					var keyCode = CKEDITOR.config.autolink_commitKeystrokes[ 0 ];
+					editor.fire( 'key', {
+						keyCode: keyCode,
+						domEvent: {
+							getKey: function() {
+								return keyCode;
+							}
+						}
+					} );
 					assert.pass( 'Passed without errors' );
 				} );
 			} );

--- a/tests/plugins/autolink/manual/sourcemode.html
+++ b/tests/plugins/autolink/manual/sourcemode.html
@@ -1,0 +1,7 @@
+<textarea id="editor">Test editor</textarea>
+<script>
+	if ( bender.env.mobile ) {
+		bender.ignore();
+	}
+	CKEDITOR.replace( 'editor' );
+</script>

--- a/tests/plugins/autolink/manual/sourcemode.md
+++ b/tests/plugins/autolink/manual/sourcemode.md
@@ -1,0 +1,14 @@
+@bender-ui: collapsed
+@bender-tags: 4.11.3, bug, 2756
+@bender-ckeditor-plugins: autolink,sourcearea,wysiwygarea
+
+1. Open editor console.
+1. Focus editor source and press <kbd>Enter</kbd>.
+
+## Expected
+
+Nothing is logged in console.
+
+## Unexpected
+
+Console throws an error.

--- a/tests/plugins/autolink/manual/sourcemode.md
+++ b/tests/plugins/autolink/manual/sourcemode.md
@@ -3,7 +3,8 @@
 @bender-ckeditor-plugins: autolink,sourcearea,wysiwygarea
 
 1. Open editor console.
-1. Focus editor source and press <kbd>Enter</kbd>.
+1. Go to source mode.
+1. Focus editor and press <kbd>Enter</kbd>.
 
 ## Expected
 

--- a/tests/plugins/autolink/manual/sourcemode.md
+++ b/tests/plugins/autolink/manual/sourcemode.md
@@ -2,7 +2,7 @@
 @bender-tags: 4.11.3, bug, 2756
 @bender-ckeditor-plugins: autolink,sourcearea,wysiwygarea
 
-1. Open editor console.
+1. Open browser console.
 1. Go to source mode.
 1. Focus editor and press <kbd>Enter</kbd>.
 

--- a/tests/plugins/autolink/manual/sourcemode.md
+++ b/tests/plugins/autolink/manual/sourcemode.md
@@ -1,6 +1,6 @@
 @bender-ui: collapsed
 @bender-tags: 4.11.3, bug, 2756
-@bender-ckeditor-plugins: autolink,sourcearea,wysiwygarea
+@bender-ckeditor-plugins: autolink,link,sourcearea,wysiwygarea
 
 1. Open browser console.
 1. Go to source mode.


### PR DESCRIPTION
## What is the purpose of this pull request?

Bug fix

## Does your PR contain necessary tests?

All patches which change the editor code must include tests. You can always read more
on [PR testing](https://ckeditor.com/docs/ckeditor4/latest/guide/dev_contributing_code.html#tests),
[how to set the testing environment](https://ckeditor.com/docs/ckeditor4/latest/guide/dev_tests.html) and
[how to create tests](https://ckeditor.com/docs/ckeditor4/latest/guide/dev_tests.html#creating-your-own-test)
in the official CKEditor documentation.

### This PR contains

- [X] Unit tests
- [X] Manual tests

## What changes did you make?

Prevented on `key` listener in `sourcemode`.

Closes #2756