### PR TITLE
Fix for failing test tests/plugins/balloontoolbar/positioning

### DIFF
--- a/plugins/balloonpanel/plugin.js
+++ b/plugins/balloonpanel/plugin.js
@@ -455,7 +455,7 @@
 
 				if ( !isInline && CKEDITOR.env.safari ) {
 					// Overwrite frame with editor iframe closest parent, because iframe has wrong rect values in mobile Safari (#1076).
-					frame = this.editor.container.findOne( '.cke_contents' );
+					frame = frame.getParent();
 				}
 
 				var panelWidth = this.getWidth(),

--- a/plugins/balloonpanel/plugin.js
+++ b/plugins/balloonpanel/plugin.js
@@ -453,6 +453,11 @@
 				editable = this.editor.editable();
 				isInline = editable.isInline();
 
+				if ( !isInline && CKEDITOR.env.safari ) {
+					// Overwrite frame with editor iframe closest parent, because iframe has wrong rect values in mobile Safari.
+					frame = this.editor.container.findOne( '.cke_contents' );
+				}
+
 				var panelWidth = this.getWidth(),
 					panelHeight = this.getHeight(),
 

--- a/plugins/balloonpanel/plugin.js
+++ b/plugins/balloonpanel/plugin.js
@@ -454,7 +454,7 @@
 				isInline = editable.isInline();
 
 				if ( !isInline && CKEDITOR.env.safari ) {
-					// Overwrite frame with editor iframe closest parent, because iframe has wrong rect values in mobile Safari.
+					// Overwrite frame with editor iframe closest parent, because iframe has wrong rect values in mobile Safari (#1076).
 					frame = this.editor.container.findOne( '.cke_contents' );
 				}
 

--- a/tests/plugins/balloonpanel/manual/positioning.md
+++ b/tests/plugins/balloonpanel/manual/positioning.md
@@ -1,5 +1,5 @@
 @bender-ui: collapsed
-@bender-tags: 4.9.0, bug, balloonpanel
+@bender-tags: 4.9.0, 4.11.3, bug, balloonpanel
 @bender-ckeditor-plugins: wysiwygarea,toolbar,undo,basicstyles,notification,balloonpanel,sourcearea,list,link,justify
 
 ----

--- a/tests/plugins/balloonpanel/manual/positioning.md
+++ b/tests/plugins/balloonpanel/manual/positioning.md
@@ -1,5 +1,5 @@
 @bender-ui: collapsed
-@bender-tags: 4.9.0, 4.11.3, bug, balloonpanel
+@bender-tags: 4.9.0, 4.11.4, bug, balloonpanel
 @bender-ckeditor-plugins: wysiwygarea,toolbar,undo,basicstyles,notification,balloonpanel,sourcearea,list,link,justify
 
 ----

--- a/tests/plugins/balloonpanel/positioning.js
+++ b/tests/plugins/balloonpanel/positioning.js
@@ -211,8 +211,7 @@
 							{ height: 15, width: 25, left: 130, bottom: 759.34375, right: 140, top: 744.34375 },
 							{ height: 15, width: 25, left: 145, bottom: 759.34375, right: 155, top: 744.34375 }
 						]
-					]
-				};
+					] };
 				this._testBalloonPanelPosition( ranges, 92.5, 422, true );
 			},
 

--- a/tests/plugins/balloonpanel/positioning.js
+++ b/tests/plugins/balloonpanel/positioning.js
@@ -80,19 +80,19 @@
 				if ( !this._getFrameMethodReplaced ) {
 					// The problem is also window.getFrame().getClientRect() as it returns different results from dashboard and directly.
 					this._getFrameMethodReplaced = true;
-					var orig = this.editor.window.getFrame;
+					var editor = this.editor,
+						rect = { height: 300, width: 300, left: 1, bottom: 643, right: 301, top: 343 },
+						orig;
 
-					this.editor.window.getFrame = function() {
-						var ret = orig.call( this );
+					orig = CKEDITOR.env.safari ? editor.container.findOne( '.cke_contents' ) : editor.window.getFrame();
 
-						if ( ret ) {
-							ret.getClientRect = function() {
-								return { height: 300, width: 300, left: 1, bottom: 643, right: 301, top: 343 };
-							};
-						}
+					sinon.stub( orig, 'getClientRect' ).returns( rect );
 
-						return ret;
-					};
+					if ( CKEDITOR.env.safari ) {
+						sinon.stub( editor.container, 'findOne' ).withArgs( '.cke_contents' ).returns( orig );
+					} else {
+						sinon.stub( editor.window, 'getFrame' ).returns( orig );
+					}
 				}
 			},
 
@@ -212,7 +212,8 @@
 							{ height: 15, width: 25, left: 130, bottom: 759.34375, right: 140, top: 744.34375 },
 							{ height: 15, width: 25, left: 145, bottom: 759.34375, right: 155, top: 744.34375 }
 						]
-					] };
+					]
+				};
 				this._testBalloonPanelPosition( ranges, 92.5, 422, true );
 			},
 

--- a/tests/plugins/balloonpanel/positioning.js
+++ b/tests/plugins/balloonpanel/positioning.js
@@ -82,16 +82,15 @@
 					this._getFrameMethodReplaced = true;
 					var editor = this.editor,
 						rect = { height: 300, width: 300, left: 1, bottom: 643, right: 301, top: 343 },
-						orig;
+						frame = editor.window.getFrame(),
+						container = frame.getParent();
 
-					orig = CKEDITOR.env.safari ? editor.container.findOne( '.cke_contents' ) : editor.window.getFrame();
-
-					sinon.stub( orig, 'getClientRect' ).returns( rect );
+					sinon.stub( editor.window, 'getFrame' ).returns( frame );
+					sinon.stub( CKEDITOR.env.safari ? container : frame, 'getClientRect' ).returns( rect );
 
 					if ( CKEDITOR.env.safari ) {
-						sinon.stub( editor.container, 'findOne' ).withArgs( '.cke_contents' ).returns( orig );
-					} else {
-						sinon.stub( editor.window, 'getFrame' ).returns( orig );
+						// Override container because iframe has wrong rect values in mobile Safari (#1076).
+						sinon.stub( frame, 'getParent' ).returns( container );
 					}
 				}
 			},

--- a/tests/plugins/balloontoolbar/manual/positioning.html
+++ b/tests/plugins/balloontoolbar/manual/positioning.html
@@ -1,0 +1,39 @@
+<style>
+	.spacer {
+		margin-top: 300px;
+	}
+</style>
+
+<p class="spacer"></p>
+<textarea id="editor">
+	<p style="margin:500px 0">
+		<span>foo</span>
+	</p>
+</textarea>
+<p class="spacer"></p>
+
+<script>
+	CKEDITOR.replace( 'editor', {
+		extraAllowedContent: 'span;p{margin}',
+		plugins: 'toolbar,wysiwygarea,basicstyles,balloontoolbar',
+		height: 100,
+		on: {
+			instanceReady: function() {
+				var toolbar = new CKEDITOR.ui.balloonToolbar( this, {
+						width: 'auto',
+						height: 40
+					} ),
+					target = this.editable().findOne( 'span' );
+
+				toolbar.addItems( {
+					bold: new CKEDITOR.ui.button( {
+						label: 'test',
+						command: 'bold'
+					} )
+				} );
+
+				toolbar.attach( target );
+			}
+		}
+	} )
+</script>

--- a/tests/plugins/balloontoolbar/manual/positioning.md
+++ b/tests/plugins/balloontoolbar/manual/positioning.md
@@ -11,3 +11,5 @@ The balloon toolbar is located inside the editable.
 ## Unexpected
 
 The balloon toolbar is located outside the editable.
+
+**Note**: When editor is loaded outside of the browser viewport the balloon toolbar may be positioned incorrectly (see [#2978](https://github.com/ckeditor/ckeditor-dev/issues/2978)).

--- a/tests/plugins/balloontoolbar/manual/positioning.md
+++ b/tests/plugins/balloontoolbar/manual/positioning.md
@@ -1,0 +1,13 @@
+@bender-tags: 4.11.4, bug, balloontoolbar, 1076
+@bender-ckeditor-plugins: wysiwygarea,toolbar,basicstyles,balloontoolbar
+@bender-ui: collapsed
+
+Check balloon toolbars initial position in relation to the editors editable.
+
+## Expected
+
+The balloon toolbar is located inside the editable.
+
+## Unexpected
+
+The balloon toolbar is located outside the editable.

--- a/tests/plugins/balloontoolbar/positioning.js
+++ b/tests/plugins/balloontoolbar/positioning.js
@@ -74,13 +74,13 @@
 
 			balloonToolbar.attach( markerElement );
 			balloonToolbarRect = balloonToolbar.parts.panel.getClientRect();
-			rectTop = CKEDITOR.env.ie || !CKEDITOR.env.edge ? Math.round( balloonToolbarRect.top ) : balloonToolbarRect.top;
+			rectTop = CKEDITOR.env.ie && !CKEDITOR.env.edge ? Math.round( balloonToolbarRect.top ) : balloonToolbarRect.top;
 
 			viewPaneMock.restore();
 
 			// When browser window is so small that panel doesn't fit, window will be scrolled into panel view.
 			// Use scroll position to adjust expected result.
-			scrollTop = CKEDITOR.document.getWindow().getScrollPosition().y.toFixed( 2 );
+			scrollTop = CKEDITOR.document.getWindow().getScrollPosition().y;
 
 			var expectedLeft = makeExpectedLeft( frame.left + elementFrame.left + elementFrame.width / 2 - 50 );
 			assert.areEqual( expectedLeft, balloonToolbarRect.left.toFixed( 2 ), 'left align' );
@@ -113,7 +113,7 @@
 			markerElement.getParent().getNext().scrollIntoView( true );
 			balloonToolbar.attach( markerElement );
 			balloonToolbarRect = balloonToolbar.parts.panel.getClientRect();
-			rectTop = CKEDITOR.env.ie || !CKEDITOR.env.edge ? Math.round( balloonToolbarRect.top ) : balloonToolbarRect.top;
+			rectTop = CKEDITOR.env.ie && !CKEDITOR.env.edge ? Math.round( balloonToolbarRect.top ) : balloonToolbarRect.top;
 
 			// When browser window is so small that panel doesn't fit, window will be scrolled into panel view.
 			// We need to use scroll position to adjust expected result.

--- a/tests/plugins/balloontoolbar/positioning.js
+++ b/tests/plugins/balloontoolbar/positioning.js
@@ -210,13 +210,13 @@
 	}
 
 	function getFrameRect( editor ) {
-		var frame;
+		var frame = editor.window.getFrame();
+
 		if ( editor.editable().isInline() ) {
 			frame = editor.editable();
 		} else if ( CKEDITOR.env.safari ) {
-			frame = editor.container.findOne( '.cke_contents' );
-		} else {
-			frame = editor.window.getFrame();
+			// Use container because iframe has wrong rect values in mobile Safari (#1076).
+			frame = frame.getParent();
 		}
 
 		return frame.getClientRect();

--- a/tests/plugins/balloontoolbar/positioning.js
+++ b/tests/plugins/balloontoolbar/positioning.js
@@ -63,7 +63,7 @@
 					height: 200
 				} ),
 				markerElement = editor.editable().findOne( '#marker' ),
-				frame = editor.editable().isInline() ? editor.editable().getClientRect() : editor.window.getFrame().getClientRect(),
+				frame = getFrameRect( editor ),
 				elementFrame = markerElement.getClientRect(),
 				// When window is so small editor is out of view panel might be rendered below editor.
 				// Mock view pane size to prevent that.
@@ -103,7 +103,7 @@
 					height: 200
 				} ),
 				markerElement = editor.editable().findOne( '#marker' ),
-				frame = editor.editable().isInline() ? editor.editable().getClientRect() : editor.window.getFrame().getClientRect(),
+				frame = getFrameRect( editor ),
 				elementFrame = markerElement.getClientRect(),
 				scrollTop,
 				balloonToolbarRect,
@@ -207,5 +207,18 @@
 				viewPaneSpy.restore();
 			}
 		};
+	}
+
+	function getFrameRect( editor ) {
+		var frame;
+		if ( editor.editable().isInline() ) {
+			frame = editor.editable();
+		} else if ( CKEDITOR.env.safari ) {
+			frame = editor.container.findOne( '.cke_contents' );
+		} else {
+			frame = editor.window.getFrame();
+		}
+
+		return frame.getClientRect();
 	}
 } )();

--- a/tests/plugins/balloontoolbar/positioning.js
+++ b/tests/plugins/balloontoolbar/positioning.js
@@ -67,12 +67,10 @@
 				elementFrame = markerElement.getClientRect(),
 				// When window is so small editor is out of view panel might be rendered below editor.
 				// Mock view pane size to prevent that.
-				viewPaneSpy = sinon.stub( CKEDITOR.dom.window.prototype, 'getViewPaneSize' ),
+				viewPaneSpy = sinon.stub( CKEDITOR.dom.window.prototype, 'getViewPaneSize' ).returns( { width: 1000, height: 1000 } ),
 				scrollTop,
 				balloonToolbarRect,
 				rectTop;
-
-			viewPaneSpy.returns( { width: 1000, height: 1000 } );
 
 			balloonToolbar.attach( markerElement );
 			balloonToolbarRect = balloonToolbar.parts.panel.getClientRect();

--- a/tests/plugins/balloontoolbar/positioning.js
+++ b/tests/plugins/balloontoolbar/positioning.js
@@ -129,9 +129,9 @@
 
 		'test panel adds cke_balloontoolbar class': function( editor ) {
 			var balloonToolbar = new CKEDITOR.ui.balloonToolbarView( editor, {
-				width: 100,
-				height: 200
-			} ),
+					width: 100,
+					height: 200
+				} ),
 				markerElement = editor.editable().findOne( '#marker' );
 			balloonToolbar.attach( markerElement );
 
@@ -195,15 +195,11 @@
 	}
 
 	function mockWindowViewPaneSize( size ) {
-		var window = CKEDITOR.document.getWindow(),
-			winSpy = sinon.stub( CKEDITOR.document, 'getWindow' ),
-			viewPaneSpy = sinon.stub( window, 'getViewPaneSize' );
-
-		winSpy.returns( window );
+		var viewPaneSpy = sinon.stub( CKEDITOR.dom.window.prototype, 'getViewPaneSize' );
 		viewPaneSpy.returns( size );
+
 		return {
 			restore: function() {
-				winSpy.restore();
 				viewPaneSpy.restore();
 			}
 		};

--- a/tests/plugins/balloontoolbar/positioning.js
+++ b/tests/plugins/balloontoolbar/positioning.js
@@ -67,16 +67,18 @@
 				elementFrame = markerElement.getClientRect(),
 				// When window is so small editor is out of view panel might be rendered below editor.
 				// Mock view pane size to prevent that.
-				viewPaneMock = mockWindowViewPaneSize( { width: 1000, height: 1000 } ),
+				viewPaneSpy = sinon.stub( CKEDITOR.dom.window.prototype, 'getViewPaneSize' ),
 				scrollTop,
 				balloonToolbarRect,
 				rectTop;
+
+			viewPaneSpy.returns( { width: 1000, height: 1000 } );
 
 			balloonToolbar.attach( markerElement );
 			balloonToolbarRect = balloonToolbar.parts.panel.getClientRect();
 			rectTop = CKEDITOR.env.ie && !CKEDITOR.env.edge ? Math.round( balloonToolbarRect.top ) : balloonToolbarRect.top;
 
-			viewPaneMock.restore();
+			viewPaneSpy.restore();
 
 			// When browser window is so small that panel doesn't fit, window will be scrolled into panel view.
 			// Use scroll position to adjust expected result.
@@ -192,17 +194,6 @@
 		} else {
 			return data.toFixed( 2 );
 		}
-	}
-
-	function mockWindowViewPaneSize( size ) {
-		var viewPaneSpy = sinon.stub( CKEDITOR.dom.window.prototype, 'getViewPaneSize' );
-		viewPaneSpy.returns( size );
-
-		return {
-			restore: function() {
-				viewPaneSpy.restore();
-			}
-		};
 	}
 
 	function getFrameRect( editor ) {


### PR DESCRIPTION
## What is the purpose of this pull request?

Failing tests fix

## Does your PR contain necessary tests?

All patches which change the editor code must include tests. You can always read more
on [PR testing](https://ckeditor.com/docs/ckeditor4/latest/guide/dev_contributing_code.html#tests),
[how to set the testing environment](https://ckeditor.com/docs/ckeditor4/latest/guide/dev_tests.html) and
[how to create tests](https://ckeditor.com/docs/ckeditor4/latest/guide/dev_tests.html#creating-your-own-test)
in the official CKEditor documentation.

### This PR contains

- [ ] Unit tests
- [ ] Manual tests

## What changes did you make?

- Changed some values being rounded too early, corrected ternary operator which rounded values for any browsers instead of only IE.
- iOS has returns wrong rect values for `iframe` see https://github.com/ckeditor/ckeditor-dev/issues/1076#issuecomment-464793119. As a workaround I've used iframe parent to get proper rect. Iframe has `width:100%;height:100%;` styles, so rects matches.
- Updated tests to reflect above change.

Closes #1076