### PR TITLE
Fix for failing table tests on built version

### DIFF
--- a/tests/plugins/tabletools/allowedcontent.js
+++ b/tests/plugins/tabletools/allowedcontent.js
@@ -25,7 +25,11 @@
 					rng.select();
 
 					bot.contextmenu( function( menu ) {
-						var items = menu.items[ 0 ].getItems();
+						var tableCellSubmenu = CKEDITOR.tools.array.filter( menu.items, function( item ) {
+								return item.name === 'tablecell';
+							} )[ 0 ],
+							items = tableCellSubmenu.getItems();
+
 						assert[ editor.name === 'editor' ? 'isFalse' : 'isTrue' ]( 'tablecell_properties' in items );
 						menu.hide();
 


### PR DESCRIPTION
## What is the purpose of this pull request?

Failing test

## Does your PR contain necessary tests?

All patches which change the editor code must include tests. You can always read more
on [PR testing](https://ckeditor.com/docs/ckeditor4/latest/guide/dev_contributing_code.html#tests),
[how to set the testing environment](https://ckeditor.com/docs/ckeditor4/latest/guide/dev_tests.html) and
[how to create tests](https://ckeditor.com/docs/ckeditor4/latest/guide/dev_tests.html#creating-your-own-test)
in the official CKEditor documentation.

### This PR contains

- [x] Unit tests
- [ ] Manual tests

## What changes did you make?

I've explicitly get `tablecell` menu item instead of getting the first menu item. Fixes issue with tests after merging #2746.
