### PR TITLE
Add information about used left button to open menu or panel with bot

### DIFF
--- a/tests/_benderjs/ckeditor/static/bot.js
+++ b/tests/_benderjs/ckeditor/static/bot.js
@@ -123,7 +123,8 @@
 			var editor = this.editor,
 				btn = editor.ui.get( name ),
 				tc = this.testCase,
-				btnEl;
+				btnEl,
+				leftButtonNumber = CKEDITOR.env.ie && CKEDITOR.env.version < 9 ? 1 : 0;
 
 			editor.once( 'panelShow', function() {
 				// Make sure resume comes after wait.
@@ -137,7 +138,8 @@
 			} );
 
 			btnEl = CKEDITOR.document.getById( btn._.id );
-			btnEl.$[ CKEDITOR.env.ie ? 'onmouseup' : 'onclick' ]( { button: CKEDITOR.MOUSE_BUTTON_LEFT } );
+
+			bender.tools.fireElementEventHandler( btnEl, CKEDITOR.env.ie ? 'onmouseup' : 'onclick', { button: leftButtonNumber } );
 
 			// combo panel opening is synchronous.
 			tc.wait();

--- a/tests/_benderjs/ckeditor/static/bot.js
+++ b/tests/_benderjs/ckeditor/static/bot.js
@@ -124,7 +124,7 @@
 				btn = editor.ui.get( name ),
 				tc = this.testCase,
 				btnEl,
-				leftButtonNumber = CKEDITOR.env.ie && CKEDITOR.env.version < 9 ? 1 : 0;
+				leftMouseButton = CKEDITOR.env.ie && CKEDITOR.env.version < 9 ? 1 : 0;
 
 			editor.once( 'panelShow', function() {
 				// Make sure resume comes after wait.
@@ -139,7 +139,7 @@
 
 			btnEl = CKEDITOR.document.getById( btn._.id );
 
-			bender.tools.fireElementEventHandler( btnEl, CKEDITOR.env.ie ? 'onmouseup' : 'onclick', { button: leftButtonNumber } );
+			bender.tools.fireElementEventHandler( btnEl, CKEDITOR.env.ie ? 'onmouseup' : 'onclick', { button: leftMouseButton } );
 
 			// combo panel opening is synchronous.
 			tc.wait();

--- a/tests/_benderjs/ckeditor/static/bot.js
+++ b/tests/_benderjs/ckeditor/static/bot.js
@@ -124,7 +124,7 @@
 				btn = editor.ui.get( name ),
 				tc = this.testCase,
 				btnEl,
-				leftMouseButton = CKEDITOR.env.ie && CKEDITOR.env.version < 9 ? 1 : 0;
+				leftMouseButton = CKEDITOR.env.ie && CKEDITOR.env.version < 9 ? 1 : CKEDITOR.MOUSE_LEFT_BUTTON;
 
 			editor.once( 'panelShow', function() {
 				// Make sure resume comes after wait.

--- a/tests/_benderjs/ckeditor/static/bot.js
+++ b/tests/_benderjs/ckeditor/static/bot.js
@@ -137,7 +137,7 @@
 			} );
 
 			btnEl = CKEDITOR.document.getById( btn._.id );
-			btnEl.$[ CKEDITOR.env.ie ? 'onmouseup' : 'onclick' ]();
+			btnEl.$[ CKEDITOR.env.ie ? 'onmouseup' : 'onclick' ]( { button: CKEDITOR.MOUSE_BUTTON_LEFT } );
 
 			// combo panel opening is synchronous.
 			tc.wait();

--- a/tests/_benderjs/ckeditor/static/tools.js
+++ b/tests/_benderjs/ckeditor/static/tools.js
@@ -1176,7 +1176,36 @@
 
 			// Add random string to be sure that the image will be downloaded, not taken from cache.
 			img.setAttribute( 'src', src + '?' + Math.random().toString( 16 ).substring( 2 ) );
+		},
+
+		/*
+		* Fires element event handler attribute e.g.
+		* ```html
+		* <button onkeydown="return customFn( event )">x</button>
+		* ```
+		*
+		* @param {CKEDITOR.dom.element/HTMLElement} element Element with attached event handler attribute.
+		* @param {String} eventName Event handler attribute name.
+		* @param {Object} evt Event payload.
+		*/
+		fireElementEventHandler: function( element, eventName, evt ) {
+			if ( element.$ ) {
+				element = element.$;
+			}
+
+			if ( CKEDITOR.env.ie && CKEDITOR.env.version < 9 ) {
+				var nativeEvent = CKEDITOR.document.$.createEventObject();
+
+				for ( var key in evt ) {
+					nativeEvent[ key ] = evt[ key ];
+				}
+
+				element.fireEvent( eventName, nativeEvent );
+			} else {
+				element[ eventName ]( evt );
+			}
 		}
+
 	};
 
 	bender.tools.range = {


### PR DESCRIPTION
## What is the purpose of this pull request?

Bug fix

## Does your PR contain necessary tests?

All patches which change the editor code must include tests. You can always read more
on [PR testing](https://ckeditor.com/docs/ckeditor4/latest/guide/dev_contributing_code.html#tests),
[how to set the testing environment](https://ckeditor.com/docs/ckeditor4/latest/guide/dev_tests.html) and
[how to create tests](https://ckeditor.com/docs/ckeditor4/latest/guide/dev_tests.html#creating-your-own-test)
in the official CKEditor documentation.

### This PR contains

- [ ] Unit tests
- [ ] Manual tests

## What changes did you make?

* fix failing tests - opening menu and panel simulation require information about used mouse button
* add helper to fire elements events

Close #2826, close #2827 