### PR TITLE
Adjusted the param type for getMosueButton

### DIFF
--- a/core/tools.js
+++ b/core/tools.js
@@ -1464,7 +1464,7 @@
 		 * Detects which mouse button generated a given DOM event.
 		 *
 		 * @since 4.7.3
-		 * @param {CKEDITOR.dom.event/MouseEvent} evt DOM event. Since 4.11.3 native DOM event can be passed.
+		 * @param {CKEDITOR.dom.event/Event} evt DOM event. Since 4.11.3 native `MouseEvent` instance can be passed.
 		 * @returns {Number|Boolean} Returns a number indicating the mouse button or `false`
 		 * if the mouse button cannot be determined.
 		 */


### PR DESCRIPTION
## What is the purpose of this pull request?

Task

## Does your PR contain necessary tests?

All patches which change the editor code must include tests. You can always read more
on [PR testing](https://ckeditor.com/docs/ckeditor4/latest/guide/dev_contributing_code.html#tests),
[how to set the testing environment](https://ckeditor.com/docs/ckeditor4/latest/guide/dev_tests.html) and
[how to create tests](https://ckeditor.com/docs/ckeditor4/latest/guide/dev_tests.html#creating-your-own-test)
in the official CKEditor documentation.

### This PR contains

- [ ] Unit tests
- [ ] Manual tests

👆 no need, it's just a task.

## What changes did you make?

Reason for this is that JSDuck doesn't recognize the MouseEvent type.

For more details see ckeditor/ckeditor-docs#230.