### PR TITLE
Force removal of color dialog in tests/plugins/tabletools/manual/allowedcontent

### DIFF
--- a/tests/plugins/tabletools/manual/allowedcontent.html
+++ b/tests/plugins/tabletools/manual/allowedcontent.html
@@ -54,8 +54,10 @@
 			}
 		},
 		extraPlugins = '',
+		removePlugins = 'colordialog',
 		editor = CKEDITOR.replace( 'editor1', {
-			allowedContent: allowedContent
+			allowedContent: allowedContent,
+			removePlugins: removePlugins
 		} ),
 		// 'change' event doesn't work in IE8.
 		eventName = CKEDITOR.env.ie && CKEDITOR.env.version === 8 ? 'click' : 'change';
@@ -100,6 +102,7 @@
 				break;
 			case 'colordialog':
 				extraPlugins = state ? 'colordialog' : '';
+				removePlugins = state ? '' : 'colordialog';
 				break;
 			default:
 				addRemoveRule( rule, state, styles );
@@ -109,7 +112,8 @@
 			setTimeout( function() {
 				editor = CKEDITOR.replace( 'editor1', {
 					allowedContent: allowedContent,
-					extraPlugins: extraPlugins
+					extraPlugins: extraPlugins,
+					removePlugins: removePlugins
 				} );
 
 				// Calling destroy on editor removes listener.

--- a/tests/plugins/tabletools/manual/allowedcontent.html
+++ b/tests/plugins/tabletools/manual/allowedcontent.html
@@ -53,14 +53,9 @@
 				attributes: []
 			}
 		},
-		extraPlugins = '',
-		removePlugins = 'colordialog',
-		editor = CKEDITOR.replace( 'editor1', {
-			allowedContent: allowedContent,
-			removePlugins: removePlugins
-		} ),
 		// 'change' event doesn't work in IE8.
-		eventName = CKEDITOR.env.ie && CKEDITOR.env.version === 8 ? 'click' : 'change';
+		eventName = CKEDITOR.env.ie && CKEDITOR.env.version === 8 ? 'click' : 'change',
+		editor;
 
 	for ( var key in cellPropMap ) {
 		var name = cellPropMap[ key ];
@@ -76,7 +71,23 @@
 		);
 	}
 
+	editor = createEditor();
+
 	options.on( eventName, inputListener );
+
+	function createEditor() {
+		var config = {
+			allowedContent: allowedContent,
+			plugins: 'wysiwygarea,toolbar,table,tabletools,sourcearea',
+			extraPlugins: []
+		};
+
+		if ( CKEDITOR.document.findOne( 'input[name="colordialog"]' ).$.checked ) {
+			config.extraPlugins.push( 'colordialog' );
+		}
+
+		return CKEDITOR.replace( 'editor1', config );
+	}
 
 	function inputListener( e ) {
 		var target = e.data.getTarget(),
@@ -100,21 +111,13 @@
 			case 'colspan':
 				addRemoveRule( rule, state, attributes );
 				break;
-			case 'colordialog':
-				extraPlugins = state ? 'colordialog' : '';
-				removePlugins = state ? '' : 'colordialog';
-				break;
 			default:
 				addRemoveRule( rule, state, styles );
 		}
 
 		editor.once( 'destroy', function() {
 			setTimeout( function() {
-				editor = CKEDITOR.replace( 'editor1', {
-					allowedContent: allowedContent,
-					extraPlugins: extraPlugins,
-					removePlugins: removePlugins
-				} );
+				editor = createEditor();
 
 				// Calling destroy on editor removes listener.
 				options.on( eventName, inputListener );

--- a/tests/plugins/tabletools/manual/allowedcontent.html
+++ b/tests/plugins/tabletools/manual/allowedcontent.html
@@ -58,7 +58,8 @@
 		editor;
 
 	for ( var key in cellPropMap ) {
-		var name = cellPropMap[ key ];
+		var name = cellPropMap[ key ],
+			additionalInfo = name === 'colordialog' ? '<br> Adds button for picking color next to border and background color options.' : '';
 
 		if ( key === 'Color Dialog' ) {
 			options.appendHtml(
@@ -67,7 +68,7 @@
 		}
 
 		options.appendHtml(
-			'<label><input type="checkbox" name="' + name + '">' + key + '</label>'
+			'<label><input type="checkbox" name="' + name + '">' + key + additionalInfo + '</label>'
 		);
 	}
 

--- a/tests/plugins/tabletools/manual/allowedcontent.md
+++ b/tests/plugins/tabletools/manual/allowedcontent.md
@@ -1,6 +1,5 @@
 @bender-tags: 4.11.3, 1986, bug
 @bender-ui: collapsed
-@bender-ckeditor-plugins: wysiwygarea, toolbar, table, tabletools, sourcearea
 
 # Test scenario
 


### PR DESCRIPTION
## What is the purpose of this pull request?

Task

## Does your PR contain necessary tests?

All patches which change the editor code must include tests. You can always read more
on [PR testing](https://ckeditor.com/docs/ckeditor4/latest/guide/dev_contributing_code.html#tests),
[how to set the testing environment](https://ckeditor.com/docs/ckeditor4/latest/guide/dev_tests.html) and
[how to create tests](https://ckeditor.com/docs/ckeditor4/latest/guide/dev_tests.html#creating-your-own-test)
in the official CKEditor documentation.

### This PR contains

- [ ] Unit tests
- [x] Manual tests

## What changes did you make?

Added `removePlugins` option in config. Tested it by adding `colordialog` plugin in corresponding `.md` file, seems to work ok.
Edit: it works on built version too.