### PR TITLE
Fix for activating various UI items via right click

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -10,11 +10,17 @@ Fixed Issues:
 * [#941](https://github.com/ckeditor/ckeditor-dev/issues/941): Fixed: Error is thrown after styling the text table cell selected using native selection when [Table Selection](https://ckeditor.com/cke4/addon/tableselection) is enabled.
 * [#3261](https://github.com/ckeditor/ckeditor-dev/issues/3261): Fixed: [Widget](https://ckeditor.com/cke4/addon/widget) initialized using dialog has incorrect owner document.
 * [#3198](https://github.com/ckeditor/ckeditor-dev/issues/3198): Fixed: Blurring and focusing editor when [widget](https://ckeditor.com/cke4/addon/widget) is focused creates additional undo step.
+* [#2859](https://github.com/ckeditor/ckeditor-dev/pull/2859): [IE, Edge] Fixed: Various editor's UI elements react to right mouse button click:
+	* [#2845](https://github.com/ckeditor/ckeditor-dev/issues/2845): [Rich Combo](https://ckeditor.com/cke4/addon/richcombo).
+	* [#2857](https://github.com/ckeditor/ckeditor-dev/issues/2857): [List Block](https://ckeditor.com/cke4/addon/listblock).
+	* [#2858](https://github.com/ckeditor/ckeditor-dev/issues/2858): [Menu](https://ckeditor.com/cke4/addon/menu).
 
 API Changes:
 
 * [#3154](https://github.com/ckeditor/ckeditor-dev/issues/3154): Added the [`CKEDITOR.tools.array.some()`](https://ckeditor.com/docs/ckeditor4/latest/api/CKEDITOR_tools_array.html#method-some) method.
 * [#3245](https://github.com/ckeditor/ckeditor-dev/issues/3245): Added the [`CKEDITOR.plugins.undo.UndoManager.addFilterRule()`](https://ckeditor.com/docs/ckeditor4/latest/api/CKEDITOR_plugins_undo_UndoManager.html#method-addFilterRule) method which allows filtering undo snapshots contents.
+* [#2845](https://github.com/ckeditor/ckeditor-dev/issues/2845): Added the [`CKEDITOR.tools.normalizeMouseButton()`](https://ckeditor.com/docs/ckeditor4/latest/api/CKEDITOR_tools.html#method-normalizeMouseButton) method.
+* [#2975](https://github.com/ckeditor/ckeditor-dev/issues/2975): Added the [`CKEDITOR.dom.element#fireEventHandler()`](https://ckeditor.com/docs/ckeditor4/latest/api/CKEDITOR_dom_element.html#method-fireEventHandler) method.
 
 ## CKEditor 4.12.1
 

--- a/core/dom/element.js
+++ b/core/dom/element.js
@@ -2113,6 +2113,41 @@ CKEDITOR.dom.element.clearMarkers = function( database, element, removeFromDatab
 				else if ( !type || node.type == type )
 					callback( node );
 			}
+		},
+
+		/**
+		 * Fires element event handler attribute e.g.
+		 *
+		 * ```html
+		 * <button onkeydown="return customFn( event )">x</button>
+		 * ```
+		 *
+		 * ```javascript
+		 * buttonEl.fireEventHandler( 'keydown', {
+		 * 	keyCode: 13 // Enter
+		 * } );
+		 * ```
+		 *
+		 * @since 4.11.4
+		 * @param {CKEDITOR.dom.element/HTMLElement} element Element with attached event handler attribute.
+		 * @param {String} eventName Event name.
+		 * @param {Object} evt Event payload.
+		 */
+		fireEventHandler: function( eventName, evt ) {
+			var handlerName = 'on' + eventName,
+				element = this.$;
+
+			if ( CKEDITOR.env.ie && CKEDITOR.env.version < 9 ) {
+				var nativeEvent = element.ownerDocument.createEventObject();
+
+				for ( var key in evt ) {
+					nativeEvent[ key ] = evt[ key ];
+				}
+
+				element.fireEvent( handlerName, nativeEvent );
+			} else {
+				element[ handlerName ]( evt );
+			}
 		}
 	} );
 

--- a/core/dom/element.js
+++ b/core/dom/element.js
@@ -2146,7 +2146,7 @@ CKEDITOR.dom.element.clearMarkers = function( database, element, removeFromDatab
 
 				element.fireEvent( handlerName, nativeEvent );
 			} else {
-				element[ handlerName ]( evt );
+				element[ element[ eventName ] ? eventName : handlerName ]( evt );
 			}
 		}
 	} );

--- a/core/dom/element.js
+++ b/core/dom/element.js
@@ -2128,7 +2128,7 @@ CKEDITOR.dom.element.clearMarkers = function( database, element, removeFromDatab
 		 * } );
 		 * ```
 		 *
-		 * @since 4.11.4
+		 * @since 4.12.0
 		 * @param {CKEDITOR.dom.element/HTMLElement} element Element with attached event handler attribute.
 		 * @param {String} eventName Event name.
 		 * @param {Object} evt Event payload.

--- a/core/dom/element.js
+++ b/core/dom/element.js
@@ -2128,7 +2128,7 @@ CKEDITOR.dom.element.clearMarkers = function( database, element, removeFromDatab
 		 * } );
 		 * ```
 		 *
-		 * @since 4.12.0
+		 * @since 4.13.0
 		 * @param {CKEDITOR.dom.element/HTMLElement} element Element with attached event handler attribute.
 		 * @param {String} eventName Event name.
 		 * @param {Object} evt Event payload.

--- a/core/dom/element.js
+++ b/core/dom/element.js
@@ -2135,18 +2135,18 @@ CKEDITOR.dom.element.clearMarkers = function( database, element, removeFromDatab
 		 */
 		fireEventHandler: function( eventName, evt ) {
 			var handlerName = 'on' + eventName,
-				element = this.$;
+				nativeElement = this.$;
 
 			if ( CKEDITOR.env.ie && CKEDITOR.env.version < 9 ) {
-				var nativeEvent = element.ownerDocument.createEventObject();
+				var nativeEvent = nativeElement.ownerDocument.createEventObject();
 
 				for ( var key in evt ) {
 					nativeEvent[ key ] = evt[ key ];
 				}
 
-				element.fireEvent( handlerName, nativeEvent );
+				nativeElement.fireEvent( handlerName, nativeEvent );
 			} else {
-				element[ element[ eventName ] ? eventName : handlerName ]( evt );
+				nativeElement[ nativeElement[ eventName ] ? eventName : handlerName ]( evt );
 			}
 		}
 	} );

--- a/core/tools.js
+++ b/core/tools.js
@@ -1459,7 +1459,7 @@
 		 * @since 4.7.3
 		 * @param {CKEDITOR.dom.event/Event} evt DOM event. Since 4.11.3 a native `MouseEvent` instance can be passed.
 		 * @returns {Number|Boolean} Returns a number indicating the mouse button or `false`
-		 * if the mouse button cannot be determined. The mouse button is normalizes using {@link CKEDITOR.tools.normalizeMouseButton}.
+		 * if the mouse button cannot be determined. The mouse button is normalized using {@link CKEDITOR.tools#normalizeMouseButton}.
 		 */
 		getMouseButton: function( evt ) {
 			var domEvent = evt && evt.data ? evt.data.$ : evt;
@@ -1474,12 +1474,12 @@
 		/**
 		 * Normalizes mouse buttons across browsers.
 		 *
-		 * Notably only Internet Explorer < 9 has different buttons mappings
-		 * than other browsers:
+		 * Noticeably only Internet Explorer 8 and IE 9 in Quirks Mode/Compatibility View have different
+		 * buttons mappings than other browsers:
 		 *
 		 * ```
 		 * +--------------+------+----------------+
-		 * | Mouse button | IE 8 | Other browsers |
+		 * | Mouse button |  IE  | Other browsers |
 		 * +--------------+------+----------------+
 		 * | Left         |   1  |        0       |
 		 * +--------------+------+----------------+
@@ -1489,8 +1489,15 @@
 		 * +--------------+------+----------------+
 		 * ```
 		 *
-		 * Thererore value returned by IE 8 is converted to value present in other browsers,
-		 * unless second parameter is set to `true`.
+		 * Therefore value returned by IE < 9 is converted to value present in other browsers,
+		 * unless second parameter is set to `true`. In such case the normalization is reversed.
+		 * The normalization is conducted only in browsers that use non-standard button mappings,
+		 * returning passed parameter in every other browser;
+		 *
+		 * ```javascript
+		 * console.log( CKEDITOR.tools.normalizeMouseButton( 1 ) ); // Returns 0 in IE8, 1 in all other browsers.
+		 * console.log( CKEDITOR.tools.normalizeMouseButton( 0, true ) ); // Returns 1 in IE8, 0 in all other browsers.
+		 * ```
 		 *
 		 * @since 4.11.4
 		 * @param {Number} button Mouse button identifier.

--- a/core/tools.js
+++ b/core/tools.js
@@ -1459,7 +1459,7 @@
 		 * @since 4.7.3
 		 * @param {CKEDITOR.dom.event/Event} evt DOM event. Since 4.11.3 a native `MouseEvent` instance can be passed.
 		 * @returns {Number|Boolean} Returns a number indicating the mouse button or `false`
-		 * if the mouse button cannot be determined. The mouse button is normalized using {@link CKEDITOR.tools#normalizeMouseButton}.
+		 * if the mouse button cannot be determined.
 		 */
 		getMouseButton: function( evt ) {
 			var domEvent = evt && evt.data ? evt.data.$ : evt;
@@ -1478,15 +1478,15 @@
 		 * buttons mappings than other browsers:
 		 *
 		 * ```
-		 * +--------------+------+----------------+
-		 * | Mouse button |  IE  | Other browsers |
-		 * +--------------+------+----------------+
-		 * | Left         |   1  |        0       |
-		 * +--------------+------+----------------+
-		 * | Middle       |   4  |        1       |
-		 * +--------------+------+----------------+
-		 * | Right        |   2  |        2       |
-		 * +--------------+------+----------------+
+		 * +--------------+--------------------------+----------------+
+		 * | Mouse button | IE 8 / IE 9 CM / IE 9 QM | Other browsers |
+		 * +--------------+--------------------------+----------------+
+		 * | Left         |             1            |        0       |
+		 * +--------------+--------------------------+----------------+
+		 * | Middle       |             4            |        1       |
+		 * +--------------+--------------------------+----------------+
+		 * | Right        |             2            |        2       |
+		 * +--------------+--------------------------+----------------+
 		 * ```
 		 *
 		 * Therefore value returned by IE < 9 is converted to value present in other browsers,

--- a/core/tools.js
+++ b/core/tools.js
@@ -1459,7 +1459,7 @@
 		 * @since 4.7.3
 		 * @param {CKEDITOR.dom.event/Event} evt DOM event. Since 4.11.3 a native `MouseEvent` instance can be passed.
 		 * @returns {Number|Boolean} Returns a number indicating the mouse button or `false`
-		 * if the mouse button cannot be determined.
+		 * if the mouse button cannot be determined. The mouse button is normalizes using {@link CKEDITOR.tools.normalizeMouseButton}.
 		 */
 		getMouseButton: function( evt ) {
 			var domEvent = evt && evt.data ? evt.data.$ : evt;
@@ -1468,17 +1468,45 @@
 				return false;
 			}
 
+			return CKEDITOR.tools.normalizeMouseButton( domEvent.button );
+		},
+
+		/**
+		 * Normalizes mouse buttons across browsers.
+		 *
+		 * Notably only Internet Explorer < 9 has different buttons mappings
+		 * than other browsers:
+		 *
+		 * ```
+		 * +--------------+------+----------------+
+		 * | Mouse button | IE 8 | Other browsers |
+		 * +--------------+------+----------------+
+		 * | Left         |   1  |        0       |
+		 * +--------------+------+----------------+
+		 * | Middle       |   4  |        1       |
+		 * +--------------+------+----------------+
+		 * | Right        |   2  |        2       |
+		 * +--------------+------+----------------+
+		 * ```
+		 *
+		 * Thererore value returned by IE 8 is converted to value present in other browsers.
+		 *
+		 * @since 4.11.4
+		 * @param {Number} button Mouse button identifier.
+		 * @returns {Number} Normalized mouse button identifier.
+		 */
+		normalizeMouseButton: function( button ) {
 			if ( CKEDITOR.env.ie && ( CKEDITOR.env.version < 9 || CKEDITOR.env.ie6Compat ) ) {
-				if ( domEvent.button === 4 ) {
+				if ( button === 4 ) {
 					return CKEDITOR.MOUSE_BUTTON_MIDDLE;
-				} else if ( domEvent.button === 1 ) {
+				} else if ( button === 1 ) {
 					return CKEDITOR.MOUSE_BUTTON_LEFT;
 				} else {
 					return CKEDITOR.MOUSE_BUTTON_RIGHT;
 				}
 			}
 
-			return domEvent.button;
+			return button;
 		},
 
 		/**

--- a/core/tools.js
+++ b/core/tools.js
@@ -1482,42 +1482,6 @@
 		},
 
 		/**
-		 * Fires element event handler attribute e.g.
-		 *
-		 * ```html
-		 * <button onkeydown="return customFn( event )">x</button>
-		 * ```
-		 *
-		 * ```javascript
-		 * CKEDITOR.tools.fireElementEventHandler( buttonEl, 'onkeydown', {
-		 * 	keyCode: 13 // Enter
-		 * } );
-		 * ```
-		 *
-		 * @since 4.11.4
-		 * @param {CKEDITOR.dom.element/HTMLElement} element Element with attached event handler attribute.
-		 * @param {String} handlerName Event handler attribute name (basically `on` + event name).
-		 * @param {Object} evt Event payload.
-		 */
-		fireElementEventHandler: function( element, handlerName, evt ) {
-			if ( element.$ ) {
-				element = element.$;
-			}
-
-			if ( CKEDITOR.env.ie && CKEDITOR.env.version < 9 ) {
-				var nativeEvent = element.ownerDocument.createEventObject();
-
-				for ( var key in evt ) {
-					nativeEvent[ key ] = evt[ key ];
-				}
-
-				element.fireEvent( handlerName, nativeEvent );
-			} else {
-				element[ handlerName ]( evt );
-			}
-		},
-
-		/**
 		 * Convert hex string to array containing 1 byte in each cell. Bytes are represented as Integer numbers.
 		 *
 		 * @since 4.8.0

--- a/core/tools.js
+++ b/core/tools.js
@@ -1462,7 +1462,7 @@
 		 * if the mouse button cannot be determined.
 		 */
 		getMouseButton: function( evt ) {
-			var domEvent = evt.data ? evt.data.$ : evt;
+			var domEvent = evt && evt.data ? evt.data.$ : evt;
 
 			if ( !domEvent ) {
 				return false;
@@ -1498,7 +1498,7 @@
 			}
 
 			if ( CKEDITOR.env.ie && CKEDITOR.env.version < 9 ) {
-				var nativeEvent = CKEDITOR.document.$.createEventObject();
+				var nativeEvent = element.ownerDocument.createEventObject();
 
 				for ( var key in evt ) {
 					nativeEvent[ key ] = evt[ key ];

--- a/core/tools.js
+++ b/core/tools.js
@@ -1499,7 +1499,7 @@
 		 * console.log( CKEDITOR.tools.normalizeMouseButton( 0, true ) ); // Returns 1 in IE8, 0 in all other browsers.
 		 * ```
 		 *
-		 * @since 4.11.4
+		 * @since 4.12.0
 		 * @param {Number} button Mouse button identifier.
 		 * @param {Boolean} [reverse=false] If set to true, the conversion is reversed: values
 		 * returned by other browsers are converted to IE 8 values.

--- a/core/tools.js
+++ b/core/tools.js
@@ -1491,8 +1491,10 @@
 		 *
 		 * Therefore value returned by IE < 9 is converted to value present in other browsers,
 		 * unless second parameter is set to `true`. In such case the normalization is reversed.
+		 * Reversed normalization allows to use standard buttons value while writing code for IE < 9.
+		 *
 		 * The normalization is conducted only in browsers that use non-standard button mappings,
-		 * returning passed parameter in every other browser;
+		 * returning passed parameter in every other browser:
 		 *
 		 * ```javascript
 		 * console.log( CKEDITOR.tools.normalizeMouseButton( 1 ) ); // Returns 0 in IE8, 1 in all other browsers.

--- a/core/tools.js
+++ b/core/tools.js
@@ -1523,7 +1523,9 @@
 
 				if ( mapping[ 0 ] === button && reverse ) {
 					return mapping[ 1 ];
-				} else if ( !reverse && mapping[ 1 ] === button ) {
+				}
+
+				if ( !reverse && mapping[ 1 ] === button ) {
 					return mapping[ 0 ];
 				}
 			}

--- a/core/tools.js
+++ b/core/tools.js
@@ -1482,6 +1482,35 @@
 		},
 
 		/**
+		 * Fires element event handler attribute e.g.
+		 * ```html
+		 * <button onkeydown="return customFn( event )">x</button>
+		 * ```
+		 *
+		 * @since 4.11.4
+		 * @param {CKEDITOR.dom.element/HTMLElement} element Element with attached event handler attribute.
+		 * @param {String} eventName Event handler attribute name.
+		 * @param {Object} evt Event payload.
+		 */
+		fireElementEventHandler: function( element, eventName, evt ) {
+			if ( element.$ ) {
+				element = element.$;
+			}
+
+			if ( CKEDITOR.env.ie && CKEDITOR.env.version < 9 ) {
+				var nativeEvent = CKEDITOR.document.$.createEventObject();
+
+				for ( var key in evt ) {
+					nativeEvent[ key ] = evt[ key ];
+				}
+
+				element.fireEvent( eventName, nativeEvent );
+			} else {
+				element[ eventName ]( evt );
+			}
+		},
+
+		/**
 		 * Convert hex string to array containing 1 byte in each cell. Bytes are represented as Integer numbers.
 		 *
 		 * @since 4.8.0

--- a/core/tools.js
+++ b/core/tools.js
@@ -1483,16 +1483,23 @@
 
 		/**
 		 * Fires element event handler attribute e.g.
+		 *
 		 * ```html
 		 * <button onkeydown="return customFn( event )">x</button>
 		 * ```
 		 *
+		 * ```javascript
+		 * CKEDITOR.tools.fireElementEventHandler( buttonEl, 'onkeydown', {
+		 * 	keyCode: 13 // Enter
+		 * } );
+		 * ```
+		 *
 		 * @since 4.11.4
 		 * @param {CKEDITOR.dom.element/HTMLElement} element Element with attached event handler attribute.
-		 * @param {String} eventName Event handler attribute name.
+		 * @param {String} handlerName Event handler attribute name (basically `on` + event name).
 		 * @param {Object} evt Event payload.
 		 */
-		fireElementEventHandler: function( element, eventName, evt ) {
+		fireElementEventHandler: function( element, handlerName, evt ) {
 			if ( element.$ ) {
 				element = element.$;
 			}
@@ -1504,9 +1511,9 @@
 					nativeEvent[ key ] = evt[ key ];
 				}
 
-				element.fireEvent( eventName, nativeEvent );
+				element.fireEvent( handlerName, nativeEvent );
 			} else {
-				element[ eventName ]( evt );
+				element[ handlerName ]( evt );
 			}
 		},
 

--- a/core/tools.js
+++ b/core/tools.js
@@ -1512,18 +1512,19 @@
 					[ CKEDITOR.MOUSE_BUTTON_RIGHT, 2 ]
 				];
 
-			if ( CKEDITOR.env.ie && ( CKEDITOR.env.version < 9 || CKEDITOR.env.ie6Compat ) ) {
-				for ( var i = 0; i < mappings.length; i++ ) {
-					var mapping = mappings[ i ];
-					if ( mapping[ 0 ] === button && reverse ) {
-						return mapping[ 1 ];
-					} else if ( !reverse && mapping[ 1 ] === button ) {
-						return mapping[ 0 ];
-					}
-				}
+			if ( !CKEDITOR.env.ie || ( CKEDITOR.env.version >= 9 && !CKEDITOR.env.ie6Compat ) ) {
+				return button;
 			}
 
-			return button;
+			for ( var i = 0; i < mappings.length; i++ ) {
+				var mapping = mappings[ i ];
+
+				if ( mapping[ 0 ] === button && reverse ) {
+					return mapping[ 1 ];
+				} else if ( !reverse && mapping[ 1 ] === button ) {
+					return mapping[ 0 ];
+				}
+			}
 		},
 
 		/**

--- a/core/tools.js
+++ b/core/tools.js
@@ -1489,20 +1489,30 @@
 		 * +--------------+------+----------------+
 		 * ```
 		 *
-		 * Thererore value returned by IE 8 is converted to value present in other browsers.
+		 * Thererore value returned by IE 8 is converted to value present in other browsers,
+		 * unless second parameter is set to `true`.
 		 *
 		 * @since 4.11.4
 		 * @param {Number} button Mouse button identifier.
+		 * @param {Boolean} [reverse=false] If set to true, the conversion is reversed: values
+		 * returned by other browsers are converted to IE 8 values.
 		 * @returns {Number} Normalized mouse button identifier.
 		 */
-		normalizeMouseButton: function( button ) {
+		normalizeMouseButton: function( button, reverse ) {
+			var mappings = [
+					[ CKEDITOR.MOUSE_BUTTON_LEFT, 1 ],
+					[ CKEDITOR.MOUSE_BUTTON_MIDDLE, 4 ],
+					[ CKEDITOR.MOUSE_BUTTON_RIGHT, 2 ]
+				];
+
 			if ( CKEDITOR.env.ie && ( CKEDITOR.env.version < 9 || CKEDITOR.env.ie6Compat ) ) {
-				if ( button === 4 ) {
-					return CKEDITOR.MOUSE_BUTTON_MIDDLE;
-				} else if ( button === 1 ) {
-					return CKEDITOR.MOUSE_BUTTON_LEFT;
-				} else {
-					return CKEDITOR.MOUSE_BUTTON_RIGHT;
+				for ( var i = 0; i < mappings.length; i++ ) {
+					var mapping = mappings[ i ];
+					if ( mapping[ 0 ] === button && reverse ) {
+						return mapping[ 1 ];
+					} else if ( !reverse && mapping[ 1 ] === button ) {
+						return mapping[ 0 ];
+					}
 				}
 			}
 

--- a/core/tools.js
+++ b/core/tools.js
@@ -1474,8 +1474,8 @@
 		/**
 		 * Normalizes mouse buttons across browsers.
 		 *
-		 * Noticeably only Internet Explorer 8 and IE 9 in Quirks Mode/Compatibility View have different
-		 * buttons mappings than other browsers:
+		 * Noticeably only Internet Explorer 8 and Internet Explorer 9 in Quirks Mode / Compatibility View
+		 * have different buttons mappings than other browsers:
 		 *
 		 * ```
 		 * +--------------+--------------------------+----------------+

--- a/core/tools.js
+++ b/core/tools.js
@@ -1519,15 +1519,15 @@
 		 * @returns {Number} Normalized mouse button identifier.
 		 */
 		normalizeMouseButton: function( button, reverse ) {
-			var mappings = [
-					[ CKEDITOR.MOUSE_BUTTON_LEFT, 1 ],
-					[ CKEDITOR.MOUSE_BUTTON_MIDDLE, 4 ],
-					[ CKEDITOR.MOUSE_BUTTON_RIGHT, 2 ]
-				];
-
 			if ( !CKEDITOR.env.ie || ( CKEDITOR.env.version >= 9 && !CKEDITOR.env.ie6Compat ) ) {
 				return button;
 			}
+
+			var mappings = [
+				[ CKEDITOR.MOUSE_BUTTON_LEFT, 1 ],
+				[ CKEDITOR.MOUSE_BUTTON_MIDDLE, 4 ],
+				[ CKEDITOR.MOUSE_BUTTON_RIGHT, 2 ]
+			];
 
 			for ( var i = 0; i < mappings.length; i++ ) {
 				var mapping = mappings[ i ];

--- a/core/tools.js
+++ b/core/tools.js
@@ -1489,17 +1489,28 @@
 		 * +--------------+--------------------------+----------------+
 		 * ```
 		 *
-		 * Therefore value returned by IE < 9 is converted to value present in other browsers,
-		 * unless second parameter is set to `true`. In such case the normalization is reversed.
-		 * Reversed normalization allows to use standard buttons value while writing code for IE < 9.
-		 *
 		 * The normalization is conducted only in browsers that use non-standard button mappings,
-		 * returning passed parameter in every other browser:
+		 * returning passed parameter in every other browser. Therefore values for IE < 9 are mapped
+		 * to values used in the rest of the browsers. For example the below code in IE8 will return results as follows:
 		 *
-		 * ```javascript
-		 * console.log( CKEDITOR.tools.normalizeMouseButton( 1 ) ); // Returns 0 in IE8, 1 in all other browsers.
-		 * console.log( CKEDITOR.tools.normalizeMouseButton( 0, true ) ); // Returns 1 in IE8, 0 in all other browsers.
+		 * ```js
+		 * console.log( CKEDITOR.tools.normalizeMouseButton( 1 ) ); // 0
+		 * console.log( CKEDITOR.tools.normalizeMouseButton( 4 ) ); // 1
+		 * console.log( CKEDITOR.tools.normalizeMouseButton( 2 ) ); // 2
 		 * ```
+		 *
+		 * While for the rest of the browsers it will simply return passed values.
+		 *
+		 * With the `reversed` parameter set to `true` values from the rest of the browsers
+		 * are mapped to IE < 9 values in IE < 9 browsers. This means IE8 will return results as follows:
+		 *
+		 * ```js
+		 * console.log( CKEDITOR.tools.normalizeMouseButton( 0, true ) ); // 1
+		 * console.log( CKEDITOR.tools.normalizeMouseButton( 1, true ) ); // 4
+		 * console.log( CKEDITOR.tools.normalizeMouseButton( 2, true ) ); // 2
+		 * ```
+		 *
+		 * While for the rest of the browsers it will simply return passed values.
 		 *
 		 * @since 4.13.0
 		 * @param {Number} button Mouse button identifier.

--- a/core/tools.js
+++ b/core/tools.js
@@ -1501,7 +1501,7 @@
 		 * console.log( CKEDITOR.tools.normalizeMouseButton( 0, true ) ); // Returns 1 in IE8, 0 in all other browsers.
 		 * ```
 		 *
-		 * @since 4.12.0
+		 * @since 4.13.0
 		 * @param {Number} button Mouse button identifier.
 		 * @param {Boolean} [reverse=false] If set to true, the conversion is reversed: values
 		 * returned by other browsers are converted to IE 8 values.

--- a/plugins/listblock/plugin.js
+++ b/plugins/listblock/plugin.js
@@ -96,6 +96,7 @@ CKEDITOR.plugins.add( 'listblock', {
 					var data = {
 						id: id,
 						val: escapeSingleQuotes( CKEDITOR.tools.htmlEncodeAttr( value ) ),
+						// Add check for left mouse button (#2857).
 						onclick: CKEDITOR.env.ie ?
 							'return false;" onmouseup="CKEDITOR.tools.getMouseButton(event)===CKEDITOR.MOUSE_BUTTON_LEFT&&' : '',
 						clickFn: this._.getClick(),

--- a/plugins/listblock/plugin.js
+++ b/plugins/listblock/plugin.js
@@ -14,7 +14,7 @@ CKEDITOR.plugins.add( 'listblock', {
 					' draggable="false"' +
 					' ondragstart="return false;"' + // Draggable attribute is buggy on Firefox.
 					' href="javascript:void(\'{val}\')" ' +
-					' {onclick}="CKEDITOR.tools.callFunction({clickFn},\'{val}\'); return false;"' + // https://dev.ckeditor.com/ticket/188
+					' onclick="{onclick}CKEDITOR.tools.callFunction({clickFn},\'{val}\'); return false;"' + // https://dev.ckeditor.com/ticket/188
 						' role="option">' +
 					'{text}' +
 				'</a>' +
@@ -96,7 +96,8 @@ CKEDITOR.plugins.add( 'listblock', {
 					var data = {
 						id: id,
 						val: escapeSingleQuotes( CKEDITOR.tools.htmlEncodeAttr( value ) ),
-						onclick: CKEDITOR.env.ie ? 'onclick="return false;" onmouseup' : 'onclick',
+						onclick: CKEDITOR.env.ie ?
+							'return false;" onmouseup="CKEDITOR.tools.getMouseButton(event)===CKEDITOR.MOUSE_BUTTON_LEFT&&' : '',
 						clickFn: this._.getClick(),
 						title: CKEDITOR.tools.htmlEncodeAttr( title || value ),
 						text: html || value

--- a/plugins/menu/plugin.js
+++ b/plugins/menu/plugin.js
@@ -116,8 +116,8 @@ CKEDITOR.plugins.add( 'menu', {
 
 	// https://dev.ckeditor.com/ticket/188
 	menuItemSource += ' onmouseover="CKEDITOR.tools.callFunction({hoverFn},{index});"' +
-			' onmouseout="CKEDITOR.tools.callFunction({moveOutFn},{index});" ' +
-			'onclick="' + specialClickHandler + 'CKEDITOR.tools.callFunction({clickFn},{index}); return false;"' +
+			' onmouseout="CKEDITOR.tools.callFunction({moveOutFn},{index});"' +
+			' onclick="' + specialClickHandler + 'CKEDITOR.tools.callFunction({clickFn},{index}); return false;"' +
 			'>';
 
 	menuItemSource +=

--- a/plugins/menu/plugin.js
+++ b/plugins/menu/plugin.js
@@ -93,7 +93,8 @@ CKEDITOR.plugins.add( 'menu', {
 		' aria-haspopup="{hasPopup}"' +
 		' aria-disabled="{disabled}"' +
 		' {ariaChecked}' +
-		' draggable="false"';
+		' draggable="false"',
+		specialClickHandler = '';
 
 	// Some browsers don't cancel key events in the keydown but in the
 	// keypress.
@@ -108,11 +109,15 @@ CKEDITOR.plugins.add( 'menu', {
 			' ondragstart="return false;"' );
 	}
 
+	// We must block clicking with right mouse button (#2858).
+	if ( CKEDITOR.env.ie ) {
+		specialClickHandler = 'return false;" onmouseup="CKEDITOR.tools.getMouseButton(event)===CKEDITOR.MOUSE_BUTTON_LEFT&&';
+	}
+
 	// https://dev.ckeditor.com/ticket/188
 	menuItemSource += ' onmouseover="CKEDITOR.tools.callFunction({hoverFn},{index});"' +
 			' onmouseout="CKEDITOR.tools.callFunction({moveOutFn},{index});" ' +
-			( CKEDITOR.env.ie ? 'onclick="return false;" onmouseup' : 'onclick' ) +
-				'="CKEDITOR.tools.callFunction({clickFn},{index}); return false;"' +
+			'onclick="' + specialClickHandler + 'CKEDITOR.tools.callFunction({clickFn},{index}); return false;"' +
 			'>';
 
 	menuItemSource +=

--- a/plugins/panel/plugin.js
+++ b/plugins/panel/plugin.js
@@ -444,9 +444,8 @@
 						focusable = index >= 0 && this._.getItems().getItem( index );
 
 						if ( focusable ) {
-							focusable.$[ keyAction ] ? focusable.$[ keyAction ]() :
 							// We must pass info about clicked button (#2857).
-							CKEDITOR.tools.fireElementEventHandler( focusable, 'on' + keyAction, {
+							focusable.fireEventHandler( keyAction, {
 								button: ( CKEDITOR.env.ie && ( CKEDITOR.env.version < 9 || CKEDITOR.env.ie6Compat ) ) ?
 									1 : CKEDITOR.MOUSE_BUTTON_LEFT
 							} );

--- a/plugins/panel/plugin.js
+++ b/plugins/panel/plugin.js
@@ -446,8 +446,7 @@
 						if ( focusable ) {
 							// We must pass info about clicked button (#2857).
 							focusable.fireEventHandler( keyAction, {
-								button: ( CKEDITOR.env.ie && ( CKEDITOR.env.version < 9 || CKEDITOR.env.ie6Compat ) ) ?
-									1 : CKEDITOR.MOUSE_BUTTON_LEFT
+								button: CKEDITOR.tools.normalizeMouseButton( CKEDITOR.MOUSE_BUTTON_LEFT, true )
 							} );
 						}
 

--- a/plugins/panel/plugin.js
+++ b/plugins/panel/plugin.js
@@ -447,7 +447,8 @@
 							focusable.$[ keyAction ] ? focusable.$[ keyAction ]() :
 							// We must pass info about clicked button (#2857).
 							CKEDITOR.tools.fireElementEventHandler( focusable, 'on' + keyAction, {
-								button: CKEDITOR.env.ie && CKEDITOR.env.version < 9 ? 1 : CKEDITOR.MOUSE_BUTTON_LEFT
+								button: ( CKEDITOR.env.ie && ( CKEDITOR.env.version < 9 || CKEDITOR.env.ie6Compat ) ) ?
+									1 : CKEDITOR.MOUSE_BUTTON_LEFT
 							} );
 						}
 

--- a/plugins/panel/plugin.js
+++ b/plugins/panel/plugin.js
@@ -443,8 +443,13 @@
 						index = this._.focusIndex;
 						focusable = index >= 0 && this._.getItems().getItem( index );
 
-						if ( focusable )
-							focusable.$[ keyAction ] ? focusable.$[ keyAction ]() : focusable.$[ 'on' + keyAction ]();
+						if ( focusable ) {
+							focusable.$[ keyAction ] ? focusable.$[ keyAction ]() :
+							// We must pass info about clicked button (#2857).
+							CKEDITOR.tools.fireElementEventHandler( focusable, 'on' + keyAction, {
+								button: CKEDITOR.env.ie && CKEDITOR.env.version < 9 ? 1 : CKEDITOR.MOUSE_BUTTON_LEFT
+							} );
+						}
 
 						return false;
 				}

--- a/plugins/richcombo/plugin.js
+++ b/plugins/richcombo/plugin.js
@@ -21,7 +21,8 @@ CKEDITOR.plugins.add( 'richcombo', {
 			' hidefocus="true"' +
 			' role="button"' +
 			' aria-labelledby="{id}_label"' +
-			' aria-haspopup="listbox"';
+			' aria-haspopup="listbox"',
+		specialClickHandler = '';
 
 	// Some browsers don't cancel key events in the keydown but in the
 	// keypress.
@@ -34,11 +35,15 @@ CKEDITOR.plugins.add( 'richcombo', {
 	if ( CKEDITOR.env.gecko )
 		template += ' onblur="this.style.cssText = this.style.cssText;"';
 
+	// In IE/Edge right click opens rich combo (#2845)
+	if ( CKEDITOR.env.ie ) {
+		specialClickHandler = 'return false;" onmouseup="CKEDITOR.tools.getMouseButton(event)==CKEDITOR.MOUSE_BUTTON_LEFT&&';
+	}
+
 	template +=
 		' onkeydown="return CKEDITOR.tools.callFunction({keydownFn},event,this);"' +
 		' onfocus="return CKEDITOR.tools.callFunction({focusFn},event);" ' +
-			( CKEDITOR.env.ie ? 'onclick="return false;" onmouseup' : 'onclick' ) + // https://dev.ckeditor.com/ticket/188
-				'="CKEDITOR.tools.callFunction({clickFn},this);return false;">' +
+		'onclick="' + specialClickHandler + 'CKEDITOR.tools.callFunction({clickFn},this);return false;">' +
 			'<span id="{id}_text" class="cke_combo_text cke_combo_inlinelabel">{label}</span>' +
 			'<span class="cke_combo_open">' +
 				'<span class="cke_combo_arrow">' +

--- a/plugins/richcombo/plugin.js
+++ b/plugins/richcombo/plugin.js
@@ -35,7 +35,7 @@ CKEDITOR.plugins.add( 'richcombo', {
 	if ( CKEDITOR.env.gecko )
 		template += ' onblur="this.style.cssText = this.style.cssText;"';
 
-	// In IE/Edge right click opens rich combo (#2845)
+	// In IE/Edge right click opens rich combo (#2845).
 	if ( CKEDITOR.env.ie ) {
 		specialClickHandler = 'return false;" onmouseup="CKEDITOR.tools.getMouseButton(event)==CKEDITOR.MOUSE_BUTTON_LEFT&&';
 	}

--- a/plugins/richcombo/plugin.js
+++ b/plugins/richcombo/plugin.js
@@ -42,8 +42,8 @@ CKEDITOR.plugins.add( 'richcombo', {
 
 	template +=
 		' onkeydown="return CKEDITOR.tools.callFunction({keydownFn},event,this);"' +
-		' onfocus="return CKEDITOR.tools.callFunction({focusFn},event);" ' +
-		'onclick="' + specialClickHandler + 'CKEDITOR.tools.callFunction({clickFn},this);return false;">' +
+		' onfocus="return CKEDITOR.tools.callFunction({focusFn},event);"' +
+		' onclick="' + specialClickHandler + 'CKEDITOR.tools.callFunction({clickFn},this);return false;">' +
 			'<span id="{id}_text" class="cke_combo_text cke_combo_inlinelabel">{label}</span>' +
 			'<span class="cke_combo_open">' +
 				'<span class="cke_combo_arrow">' +

--- a/tests/_benderjs/ckeditor/static/bot.js
+++ b/tests/_benderjs/ckeditor/static/bot.js
@@ -155,7 +155,7 @@
 
 			btnEl = CKEDITOR.document.getById( btn._.id );
 
-			CKEDITOR.tools.fireElementEventHandler( btnEl, CKEDITOR.env.ie ? 'onmouseup' : 'onclick', { button: leftMouseButton } );
+			btnEl.fireEventHandler( CKEDITOR.env.ie ? 'mouseup' : 'click', { button: leftMouseButton } );
 
 			// combo panel opening is synchronous.
 			tc.wait();
@@ -243,7 +243,7 @@
 
 			item = CKEDITOR.document.getById( 'cke_' + combo.id );
 			item = item.getElementsByTag( 'a' ).getItem( 0 );
-			CKEDITOR.tools.fireElementEventHandler( item, CKEDITOR.env.ie ? 'onmouseup' : 'onclick', { button: leftMouseButton } );
+			item.fireEventHandler( CKEDITOR.env.ie ? 'mouseup' : 'click', { button: leftMouseButton } );
 
 			// combo panel opening is synchronous.
 			tc.wait();

--- a/tests/_benderjs/ckeditor/static/bot.js
+++ b/tests/_benderjs/ckeditor/static/bot.js
@@ -227,6 +227,7 @@
 			var editor = this.editor,
 				combo = editor.ui.get( name ),
 				tc = this.testCase,
+				leftMouseButton = CKEDITOR.env.ie && CKEDITOR.env.version < 9 ? 1 : CKEDITOR.MOUSE_BUTTON_LEFT,
 				item;
 
 			editor.once( 'panelShow', function() {
@@ -242,7 +243,8 @@
 
 			item = CKEDITOR.document.getById( 'cke_' + combo.id );
 			item = item.getElementsByTag( 'a' ).getItem( 0 );
-			item.$[ CKEDITOR.env.ie ? 'onmouseup' : 'onclick' ]();
+			//item.$[ CKEDITOR.env.ie ? 'onmouseup' : 'onclick' ]();
+			bender.tools.fireElementEventHandler( item, CKEDITOR.env.ie ? 'onmouseup' : 'onclick', { button: leftMouseButton } );
 
 			// combo panel opening is synchronous.
 			tc.wait();

--- a/tests/_benderjs/ckeditor/static/bot.js
+++ b/tests/_benderjs/ckeditor/static/bot.js
@@ -155,7 +155,7 @@
 
 			btnEl = CKEDITOR.document.getById( btn._.id );
 
-			bender.tools.fireElementEventHandler( btnEl, CKEDITOR.env.ie ? 'onmouseup' : 'onclick', { button: leftMouseButton } );
+			CKEDITOR.tools.fireElementEventHandler( btnEl, CKEDITOR.env.ie ? 'onmouseup' : 'onclick', { button: leftMouseButton } );
 
 			// combo panel opening is synchronous.
 			tc.wait();
@@ -244,7 +244,7 @@
 			item = CKEDITOR.document.getById( 'cke_' + combo.id );
 			item = item.getElementsByTag( 'a' ).getItem( 0 );
 			//item.$[ CKEDITOR.env.ie ? 'onmouseup' : 'onclick' ]();
-			bender.tools.fireElementEventHandler( item, CKEDITOR.env.ie ? 'onmouseup' : 'onclick', { button: leftMouseButton } );
+			CKEDITOR.tools.fireElementEventHandler( item, CKEDITOR.env.ie ? 'onmouseup' : 'onclick', { button: leftMouseButton } );
 
 			// combo panel opening is synchronous.
 			tc.wait();

--- a/tests/_benderjs/ckeditor/static/bot.js
+++ b/tests/_benderjs/ckeditor/static/bot.js
@@ -243,7 +243,6 @@
 
 			item = CKEDITOR.document.getById( 'cke_' + combo.id );
 			item = item.getElementsByTag( 'a' ).getItem( 0 );
-			//item.$[ CKEDITOR.env.ie ? 'onmouseup' : 'onclick' ]();
 			CKEDITOR.tools.fireElementEventHandler( item, CKEDITOR.env.ie ? 'onmouseup' : 'onclick', { button: leftMouseButton } );
 
 			// combo panel opening is synchronous.

--- a/tests/_benderjs/ckeditor/static/bot.js
+++ b/tests/_benderjs/ckeditor/static/bot.js
@@ -227,7 +227,7 @@
 			var editor = this.editor,
 				combo = editor.ui.get( name ),
 				tc = this.testCase,
-				leftMouseButton = CKEDITOR.env.ie && CKEDITOR.env.version < 9 ? 1 : CKEDITOR.MOUSE_BUTTON_LEFT,
+				leftMouseButton = CKEDITOR.tools.normalizeMouseButton( CKEDITOR.MOUSE_BUTTON_LEFT, true ),
 				item;
 
 			editor.once( 'panelShow', function() {

--- a/tests/_benderjs/ckeditor/static/tools.js
+++ b/tests/_benderjs/ckeditor/static/tools.js
@@ -1247,6 +1247,39 @@
 		},
 
 		/**
+		 * Creates a promise from the given function. It works in a similar way as a promise constructor
+		 * (https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise),
+		 * with support for IE8 browser.
+		 *
+		 * ```js
+		 *	bender.tools.promise( function( resolve, reject ) {
+		 *		setTimeout( function() {
+		 *			var timestamp;
+		 *			try {
+		 *				timestamp = ( new Date() ).getTime();
+		 *			} catch ( e ) {
+		 *				reject( e );
+		 *			}
+		 *			resolve( timestamp );
+		 *		}, 5000 );
+		 *	} )
+		 * ```
+		 *
+		 * @param {Function} executor Initialization function executed immediately by the Promise implementation.
+		 * @param {Function} executor.resolve Function which should be called when promise is fulfilled.
+		 * @param {Function} executor.reject Function which should be called when promise is rejected.
+		 * @returns {Promise}
+		 */
+
+		promise: function( fn ) {
+			var deferred = Q.defer();
+
+			fn( CKEDITOR.tools.bind( deferred.resolve, deferred ), CKEDITOR.tools.bind( deferred.reject, deferred ) );
+
+			return deferred.promise;
+		},
+
+		/**
 		 * Creates test suite object for `bender.test` method from synchronous and asynchronous test cases.
 		 * Asynchronous test must be a function which returns a promise and cannot poses wait-resume statements.
 		 *
@@ -1280,8 +1313,37 @@
 			}
 
 			return tmp;
-		}
+		},
 
+		/*
+		 * Fires specified mouse event on given element
+		 *
+		 * @param {CKEDITOR.dom.element/HTMLElement} element Element with attached event handler attribute.
+		 * @param {String} eventName Event handler attribute name.
+		 * @param {Number} button Mouse button to be used.
+		*/
+		dispatchMouseEvent: function( element, type, button ) {
+			var ie8ButtonMap = {
+					0: 1, // CKEDITOR.MOUSE_BUTTON_LEFT
+					1: 4, // CKEDITOR.MOUSE_BUTTON_MIDDLE
+					2: 2 // CKEDITOR.MOUSE_BUTTON_RIGHT
+				},
+				mouseEvent;
+			element = element.$;
+
+			// Thanks to http://help.dottoro.com/ljhlvomw.php
+			if ( document.createEventObject ) {
+				mouseEvent = document.createEventObject();
+
+				mouseEvent.button = ie8ButtonMap[ button ];
+				element.fireEvent( 'on' + type, mouseEvent );
+			} else {
+				mouseEvent = document.createEvent( 'MouseEvent' );
+
+				mouseEvent.initMouseEvent( type, true, true, window, 0, 0, 0, 80, 20, false, false, false, false, button, null );
+				element.dispatchEvent( mouseEvent );
+			}
+		}
 	};
 
 	bender.tools.range = {

--- a/tests/_benderjs/ckeditor/static/tools.js
+++ b/tests/_benderjs/ckeditor/static/tools.js
@@ -1219,39 +1219,6 @@
 		},
 
 		/**
-		 * Creates a promise from the given function. It works in a similar way as a promise constructor
-		 * (https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise),
-		 * with support for IE8 browser.
-		 *
-		 * ```js
-		 *	bender.tools.promise( function( resolve, reject ) {
-		 *		setTimeout( function() {
-		 *			var timestamp;
-		 *			try {
-		 *				timestamp = ( new Date() ).getTime();
-		 *			} catch ( e ) {
-		 *				reject( e );
-		 *			}
-		 *			resolve( timestamp );
-		 *		}, 5000 );
-		 *	} )
-		 * ```
-		 *
-		 * @param {Function} executor Initialization function executed immediately by the Promise implementation.
-		 * @param {Function} executor.resolve Function which should be called when promise is fulfilled.
-		 * @param {Function} executor.reject Function which should be called when promise is rejected.
-		 * @returns {Promise}
-		 */
-
-		promise: function( fn ) {
-			var deferred = Q.defer();
-
-			fn( CKEDITOR.tools.bind( deferred.resolve, deferred ), CKEDITOR.tools.bind( deferred.reject, deferred ) );
-
-			return deferred.promise;
-		},
-
-		/**
 		 * Creates test suite object for `bender.test` method from synchronous and asynchronous test cases.
 		 * Asynchronous test must be a function which returns a promise and cannot poses wait-resume statements.
 		 *

--- a/tests/_benderjs/ckeditor/static/tools.js
+++ b/tests/_benderjs/ckeditor/static/tools.js
@@ -1218,34 +1218,6 @@
 			img.setAttribute( 'src', src + '?' + Math.random().toString( 16 ).substring( 2 ) );
 		},
 
-		/*
-		* Fires element event handler attribute e.g.
-		* ```html
-		* <button onkeydown="return customFn( event )">x</button>
-		* ```
-		*
-		* @param {CKEDITOR.dom.element/HTMLElement} element Element with attached event handler attribute.
-		* @param {String} eventName Event handler attribute name.
-		* @param {Object} evt Event payload.
-		*/
-		fireElementEventHandler: function( element, eventName, evt ) {
-			if ( element.$ ) {
-				element = element.$;
-			}
-
-			if ( CKEDITOR.env.ie && CKEDITOR.env.version < 9 ) {
-				var nativeEvent = CKEDITOR.document.$.createEventObject();
-
-				for ( var key in evt ) {
-					nativeEvent[ key ] = evt[ key ];
-				}
-
-				element.fireEvent( eventName, nativeEvent );
-			} else {
-				element[ eventName ]( evt );
-			}
-		},
-
 		/**
 		 * Creates a promise from the given function. It works in a similar way as a promise constructor
 		 * (https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise),

--- a/tests/_benderjs/ckeditor/static/tools.js
+++ b/tests/_benderjs/ckeditor/static/tools.js
@@ -1295,19 +1295,15 @@
 		 * @param {Number} button Mouse button to be used.
 		*/
 		dispatchMouseEvent: function( element, type, button ) {
-			var ie8ButtonMap = {
-					0: 1, // CKEDITOR.MOUSE_BUTTON_LEFT
-					1: 4, // CKEDITOR.MOUSE_BUTTON_MIDDLE
-					2: 2 // CKEDITOR.MOUSE_BUTTON_RIGHT
-				},
-				mouseEvent;
+			var mouseEvent;
+			button = CKEDITOR.tools.normalizeMouseButton( button, true );
 			element = element.$;
 
 			// Thanks to http://help.dottoro.com/ljhlvomw.php
 			if ( document.createEventObject ) {
 				mouseEvent = document.createEventObject();
 
-				mouseEvent.button = ie8ButtonMap[ button ];
+				mouseEvent.button = button;
 				element.fireEvent( 'on' + type, mouseEvent );
 			} else {
 				mouseEvent = document.createEvent( 'MouseEvent' );

--- a/tests/_benderjs/ckeditor/static/tools.js
+++ b/tests/_benderjs/ckeditor/static/tools.js
@@ -1287,8 +1287,8 @@
 			return tmp;
 		},
 
-		/*
-		 * Fires specified mouse event on given element
+		/**
+		 * Fires specified mouse event on the given element.
 		 *
 		 * @param {CKEDITOR.dom.element/HTMLElement} element Element with attached event handler attribute.
 		 * @param {String} eventName Event handler attribute name.

--- a/tests/_benderjs/ckeditor/static/tools.js
+++ b/tests/_benderjs/ckeditor/static/tools.js
@@ -1301,7 +1301,7 @@
 
 			// Thanks to http://help.dottoro.com/ljhlvomw.php
 			if ( document.createEventObject ) {
-				mouseEvent = document.createEventObject();
+				mouseEvent = element.ownerDocument.createEventObject();
 
 				mouseEvent.button = button;
 				element.fireEvent( 'on' + type, mouseEvent );

--- a/tests/core/dom/element/element.js
+++ b/tests/core/dom/element/element.js
@@ -1212,6 +1212,24 @@ bender.test( appendDomObjectTests(
 
 			CKEDITOR.document.getBody().append( iframe );
 			wait();
+		},
+
+		// (#2975)
+		'test fireEventHandler with click on element without onclick': function() {
+			var link = CKEDITOR.dom.element.createFromHtml(
+				'<a href="#">Link</a>' ),
+				leftMouseButton = CKEDITOR.tools.normalizeMouseButton( CKEDITOR.MOUSE_BUTTON_LEFT, true );
+
+			link.once( 'click', function( evt ) {
+				this.setAttribute( 'data-button', evt.data.$.button );
+				evt.data.preventDefault();
+			} );
+			link.fireEventHandler( 'click', {
+				button: leftMouseButton
+			} );
+
+			assert.areSame( String( leftMouseButton ), link.getAttribute( 'data-button' ),
+				'Proper event data was passed' );
 		}
 	}
 ) );

--- a/tests/core/dom/element/element.js
+++ b/tests/core/dom/element/element.js
@@ -1176,13 +1176,15 @@ bender.test( appendDomObjectTests(
 		// (#2975)
 		'test fireEventHandler with mouseup': function() {
 			var link = CKEDITOR.dom.element.createFromHtml(
-				'<a href="#" onmouseup="this.setAttribute(\'data-button\',event.button);return false;">Link</a>' );
+				'<a href="#" onmouseup="this.setAttribute(\'data-button\',event.button);return false;">Link</a>' ),
+				rightMouseButton = CKEDITOR.tools.normalizeMouseButton( CKEDITOR.MOUSE_BUTTON_RIGHT );
 
 			link.fireEventHandler( 'mouseup', {
-				button: 2
+				button: rightMouseButton
 			} );
 
-			assert.areSame( '2', link.getAttribute( 'data-button' ), 'Proper event data was passed' );
+			assert.areSame( String( rightMouseButton ), link.getAttribute( 'data-button' ),
+				'Proper event data was passed' );
 		},
 
 		// (#2975)
@@ -1192,17 +1194,19 @@ bender.test( appendDomObjectTests(
 			iframe.once( 'load', function() {
 				resume( function() {
 					var document = new CKEDITOR.dom.document( iframe.$.contentWindow.document ),
-						link = new CKEDITOR.dom.element( 'a', document );
+						link = new CKEDITOR.dom.element( 'a', document ),
+						rightMouseButton = CKEDITOR.tools.normalizeMouseButton( CKEDITOR.MOUSE_BUTTON_RIGHT );
 
 					link.setAttribute( 'onmouseup',
 						'this.setAttribute(\'data-button\',event.button);return false;' );
 					document.getBody().append( link );
 
 					link.fireEventHandler( 'mouseup', {
-						button: 2
+						button: rightMouseButton
 					} );
 
-					assert.areSame( '2', link.getAttribute( 'data-button' ), 'Proper event data was passed' );
+					assert.areSame( String( rightMouseButton ), link.getAttribute( 'data-button' ),
+						'Proper event data was passed' );
 				} );
 			} );
 

--- a/tests/core/dom/element/element.js
+++ b/tests/core/dom/element/element.js
@@ -1171,6 +1171,43 @@ bender.test( appendDomObjectTests(
 			elem.setSize( 'width', 200, true );
 
 			assert.areSame( expectedWidth, round( parseFloat( elem.$.style.width ) ), 'Computed width' );
+		},
+
+		// (#2975)
+		'test fireEventHandler with mouseup': function() {
+			var link = CKEDITOR.dom.element.createFromHtml(
+				'<a href="#" onmouseup="this.setAttribute(\'data-button\',event.button);return false;">Link</a>' );
+
+			link.fireEventHandler( 'mouseup', {
+				button: 2
+			} );
+
+			assert.areSame( '2', link.getAttribute( 'data-button' ), 'Proper event data was passed' );
+		},
+
+		// (#2975)
+		'test fireEventHandler with mouseup in iframe': function() {
+			var iframe = CKEDITOR.dom.element.createFromHtml( '<iframe src="about:blank"></iframe>' );
+
+			iframe.once( 'load', function() {
+				resume( function() {
+					var document = new CKEDITOR.dom.document( iframe.$.contentWindow.document ),
+						link = new CKEDITOR.dom.element( 'a', document );
+
+					link.setAttribute( 'onmouseup',
+						'this.setAttribute(\'data-button\',event.button);return false;' );
+					document.getBody().append( link );
+
+					link.fireEventHandler( 'mouseup', {
+						button: 2
+					} );
+
+					assert.areSame( '2', link.getAttribute( 'data-button' ), 'Proper event data was passed' );
+				} );
+			} );
+
+			CKEDITOR.document.getBody().append( iframe );
+			wait();
 		}
 	}
 ) );

--- a/tests/core/tools.js
+++ b/tests/core/tools.js
@@ -924,6 +924,18 @@
 			}
 		},
 
+		// (#2857)
+		'test fireElementEventHandler with onmouseup': function() {
+			var link = CKEDITOR.dom.element.createFromHtml(
+				'<a href="#" onmouseup="this.setAttribute(\'data-button\',event.button);return false;">Link</a>' );
+
+			CKEDITOR.tools.fireElementEventHandler( link, 'onmouseup', {
+				button: 2
+			} );
+
+			assert.areSame( '2', link.getAttribute( 'data-button' ), 'Proper event data was passed' );
+		},
+
 		// #662
 		'test hexstring to bytes converter': function() {
 			var testCases = [

--- a/tests/core/tools.js
+++ b/tests/core/tools.js
@@ -924,43 +924,6 @@
 			}
 		},
 
-		// (#2857)
-		'test fireElementEventHandler with onmouseup': function() {
-			var link = CKEDITOR.dom.element.createFromHtml(
-				'<a href="#" onmouseup="this.setAttribute(\'data-button\',event.button);return false;">Link</a>' );
-
-			CKEDITOR.tools.fireElementEventHandler( link, 'onmouseup', {
-				button: 2
-			} );
-
-			assert.areSame( '2', link.getAttribute( 'data-button' ), 'Proper event data was passed' );
-		},
-
-		// (#2857)
-		'test fireElementEventHandler with onmouseup in iframe': function() {
-			var iframe = CKEDITOR.dom.element.createFromHtml( '<iframe src="about:blank"></iframe>' );
-
-			iframe.once( 'load', function() {
-				resume( function() {
-					var document = new CKEDITOR.dom.document( iframe.$.contentWindow.document ),
-						link = new CKEDITOR.dom.element( 'a', document );
-
-					link.setAttribute( 'onmouseup',
-						'this.setAttribute(\'data-button\',event.button);return false;' );
-					document.getBody().append( link );
-
-					CKEDITOR.tools.fireElementEventHandler( link, 'onmouseup', {
-						button: 2
-					} );
-
-					assert.areSame( '2', link.getAttribute( 'data-button' ), 'Proper event data was passed' );
-				} );
-			} );
-
-			CKEDITOR.document.getBody().append( iframe );
-			wait();
-		},
-
 		// #662
 		'test hexstring to bytes converter': function() {
 			var testCases = [

--- a/tests/core/tools.js
+++ b/tests/core/tools.js
@@ -924,6 +924,24 @@
 			}
 		},
 
+		// (#2845)
+		'test normalizeMouseButton': function() {
+			var isIe8 = CKEDITOR.env.ie && CKEDITOR.env.version < 9;
+
+			generateMouseButtonAsserts( [
+				[ CKEDITOR.MOUSE_BUTTON_LEFT, 1 ],
+				[ CKEDITOR.MOUSE_BUTTON_MIDDLE, 4 ],
+				[ CKEDITOR.MOUSE_BUTTON_RIGHT, 2 ]
+			] );
+
+			function generateMouseButtonAsserts( inputs ) {
+				CKEDITOR.tools.array.forEach( inputs, function( input ) {
+					assert.areSame( input[ 0 ],
+						CKEDITOR.tools.normalizeMouseButton( input[ isIe8 ? 1 : 0 ] ) );
+				} );
+			}
+		},
+
 		// #662
 		'test hexstring to bytes converter': function() {
 			var testCases = [

--- a/tests/core/tools.js
+++ b/tests/core/tools.js
@@ -936,6 +936,31 @@
 			assert.areSame( '2', link.getAttribute( 'data-button' ), 'Proper event data was passed' );
 		},
 
+		// (#2857)
+		'test fireElementEventHandler with onmouseup in iframe': function() {
+			var iframe = CKEDITOR.dom.element.createFromHtml( '<iframe src="about:blank"></iframe>' );
+
+			iframe.once( 'load', function() {
+				resume( function() {
+					var document = new CKEDITOR.dom.document( iframe.$.contentWindow.document ),
+						link = new CKEDITOR.dom.element( 'a', document );
+
+					link.setAttribute( 'onmouseup',
+						'this.setAttribute(\'data-button\',event.button);return false;' );
+					document.getBody().append( link );
+
+					CKEDITOR.tools.fireElementEventHandler( link, 'onmouseup', {
+						button: 2
+					} );
+
+					assert.areSame( '2', link.getAttribute( 'data-button' ), 'Proper event data was passed' );
+				} );
+			} );
+
+			CKEDITOR.document.getBody().append( iframe );
+			wait();
+		},
+
 		// #662
 		'test hexstring to bytes converter': function() {
 			var testCases = [

--- a/tests/core/tools.js
+++ b/tests/core/tools.js
@@ -942,6 +942,24 @@
 			}
 		},
 
+		// (#2845)
+		'test reversed normalizeMouseButton': function() {
+			var isIe8 = CKEDITOR.env.ie && CKEDITOR.env.version < 9;
+
+			generateMouseButtonAsserts( [
+				[ CKEDITOR.MOUSE_BUTTON_LEFT, 1 ],
+				[ CKEDITOR.MOUSE_BUTTON_MIDDLE, 4 ],
+				[ CKEDITOR.MOUSE_BUTTON_RIGHT, 2 ]
+			] );
+
+			function generateMouseButtonAsserts( inputs ) {
+				CKEDITOR.tools.array.forEach( inputs, function( input ) {
+					assert.areSame( input[ isIe8 ? 1 : 0 ],
+						CKEDITOR.tools.normalizeMouseButton( input[ 0 ], true ) );
+				} );
+			}
+		},
+
 		// #662
 		'test hexstring to bytes converter': function() {
 			var testCases = [

--- a/tests/plugins/button/button.js
+++ b/tests/plugins/button/button.js
@@ -66,31 +66,8 @@ bender.test( {
 			buttonCmd = editor.getCommand( 'buttonCmd' ),
 			spy = sinon.spy( buttonCmd, 'exec' );
 
-		dispatchMouseEvent( btnEl, 'mouseup', CKEDITOR.MOUSE_BUTTON_RIGHT );
+		bender.tools.dispatchMouseEvent( btnEl, 'mouseup', CKEDITOR.MOUSE_BUTTON_RIGHT );
 
 		assert.areSame( 0, spy.callCount );
 	}
 } );
-
-function dispatchMouseEvent( element, type, button ) {
-	var ie8ButtonMap = {
-			0: 1, // CKEDITOR.MOUSE_BUTTON_LEFT
-			1: 4, // CKEDITOR.MOUSE_BUTTON_MIDDLE
-			2: 2 // CKEDITOR.MOUSE_BUTTON_RIGHT
-		},
-		mouseEvent;
-	element = element.$;
-
-	// Thanks to http://help.dottoro.com/ljhlvomw.php
-	if ( document.createEventObject ) {
-		mouseEvent = document.createEventObject();
-
-		mouseEvent.button = ie8ButtonMap[ button ];
-		element.fireEvent( 'on' + type, mouseEvent );
-	} else {
-		mouseEvent = document.createEvent( 'MouseEvent' );
-
-		mouseEvent.initMouseEvent( type, true, true, window, 0, 0, 0, 80, 20, false, false, false, false, button, null );
-		element.dispatchEvent( mouseEvent );
-	}
-}

--- a/tests/plugins/listblock/listblock.js
+++ b/tests/plugins/listblock/listblock.js
@@ -68,7 +68,7 @@
 					item = block.findOne( 'a' ),
 					spy = sinon.spy( combo, 'onClick' );
 
-				dispatchMouseEvent( item, 'mouseup', CKEDITOR.MOUSE_BUTTON_RIGHT );
+				bender.tools.dispatchMouseEvent( item, 'mouseup', CKEDITOR.MOUSE_BUTTON_RIGHT );
 				spy.restore();
 				combo._.panel.hide();
 				assert.areSame( 0, spy.callCount, 'onClick not fired' );
@@ -130,27 +130,4 @@
 			return str.replace( /\'/g, '\\\'' );
 		}
 	} );
-
-	function dispatchMouseEvent( element, type, button ) {
-		var ie8ButtonMap = {
-				0: 1, // CKEDITOR.MOUSE_BUTTON_LEFT
-				1: 4, // CKEDITOR.MOUSE_BUTTON_MIDDLE
-				2: 2 // CKEDITOR.MOUSE_BUTTON_RIGHT
-			},
-			mouseEvent;
-		element = element.$;
-
-		// Thanks to http://help.dottoro.com/ljhlvomw.php
-		if ( document.createEventObject ) {
-			mouseEvent = document.createEventObject();
-
-			mouseEvent.button = ie8ButtonMap[ button ];
-			element.fireEvent( 'on' + type, mouseEvent );
-		} else {
-			mouseEvent = document.createEvent( 'MouseEvent' );
-
-			mouseEvent.initMouseEvent( type, true, true, window, 0, 0, 0, 80, 20, false, false, false, false, button, null );
-			element.dispatchEvent( mouseEvent );
-		}
-	}
 } )();

--- a/tests/plugins/listblock/listblock.js
+++ b/tests/plugins/listblock/listblock.js
@@ -70,6 +70,7 @@
 
 				dispatchMouseEvent( item, 'mouseup', CKEDITOR.MOUSE_BUTTON_RIGHT );
 				spy.restore();
+				combo._.panel.hide();
 				assert.areSame( 0, spy.callCount, 'onClick not fired' );
 			} );
 		},

--- a/tests/plugins/listblock/listblock.js
+++ b/tests/plugins/listblock/listblock.js
@@ -63,6 +63,25 @@
 			wait();
 		},
 
+		// (#2857)
+		'test right clicking list block elements': function() {
+			if ( !CKEDITOR.env.ie ) {
+				assert.ignore();
+			}
+
+			var bot = this.editorBot;
+
+			bot.combo( 'Styles', function( combo ) {
+				var block = combo._.panel.getBlock( combo.id ).element,
+					item = block.findOne( 'a' ),
+					spy = sinon.spy( combo, 'onClick' );
+
+				dispatchMouseEvent( item, 'mouseup', CKEDITOR.MOUSE_BUTTON_RIGHT );
+				spy.restore();
+				assert.areSame( 0, spy.callCount, 'onClick not fired' );
+			} );
+		},
+
 		// Expects both object to have following structure:
 		// { value: 'foo', html: 'bar', title: 'baz' }
 		//
@@ -119,4 +138,26 @@
 		}
 	} );
 
+	function dispatchMouseEvent( element, type, button ) {
+		var ie8ButtonMap = {
+				0: 1, // CKEDITOR.MOUSE_BUTTON_LEFT
+				1: 4, // CKEDITOR.MOUSE_BUTTON_MIDDLE
+				2: 2 // CKEDITOR.MOUSE_BUTTON_RIGHT
+			},
+			mouseEvent;
+		element = element.$;
+
+		// Thanks to http://help.dottoro.com/ljhlvomw.php
+		if ( document.createEventObject ) {
+			mouseEvent = document.createEventObject();
+
+			mouseEvent.button = ie8ButtonMap[ button ];
+			element.fireEvent( 'on' + type, mouseEvent );
+		} else {
+			mouseEvent = document.createEvent( 'MouseEvent' );
+
+			mouseEvent.initMouseEvent( type, true, true, window, 0, 0, 0, 80, 20, false, false, false, false, button, null );
+			element.dispatchEvent( mouseEvent );
+		}
+	}
 } )();

--- a/tests/plugins/listblock/listblock.js
+++ b/tests/plugins/listblock/listblock.js
@@ -41,26 +41,18 @@
 
 		// (#2430)
 		'test list block elements not draggable': function() {
-			var editor = this.editor,
-				stylesCombo = editor.ui.get( 'Styles' );
+			var bot = this.editorBot;
 
-			editor.once( 'panelShow', function( evt ) {
-				resume( function() {
-					var block = stylesCombo._.panel.getBlock( stylesCombo.id ).element,
-						items = block.find( 'a' ).toArray().concat( block.find( 'h1' ).toArray() );
+			bot.combo( 'Styles', function( combo ) {
+				var block = combo._.panel.getBlock( combo.id ).element,
+					items = block.find( 'a' ).toArray().concat( block.find( 'h1' ).toArray() );
 
-					CKEDITOR.tools.array.forEach( items, function( element ) {
-						assert.areEqual( 'false', element.getAttribute( 'draggable' ), 'Draggable attribute value should be "false".' );
-						assert.areEqual( 'return false;', element.getAttribute( 'ondragstart' ), 'ondragstart value should be "return false;".' );
-					} );
+				combo._.panel.hide();
+				CKEDITOR.tools.array.forEach( items, function( element ) {
+					assert.areEqual( 'false', element.getAttribute( 'draggable' ), 'Draggable attribute value should be "false".' );
+					assert.areEqual( 'return false;', element.getAttribute( 'ondragstart' ), 'ondragstart value should be "return false;".' );
 				} );
-
-				evt.data.hide();
 			} );
-
-			CKEDITOR.document.findOne( '#cke_' + stylesCombo.id ).findOne( 'a' ).$[ CKEDITOR.env.ie ? 'onmouseup' : 'click' ]();
-
-			wait();
 		},
 
 		// (#2857)

--- a/tests/plugins/listblock/manual/rightclick.html
+++ b/tests/plugins/listblock/manual/rightclick.html
@@ -1,0 +1,12 @@
+<h2>Classic editor</h2>
+<div id="classic">
+	<p>I'm CKEditor 4 instance.</p>
+</div>
+
+<script>
+	if ( !CKEDITOR.env.ie ) {
+		bender.ignore();
+	}
+
+	CKEDITOR.replace( 'classic' );
+</script>

--- a/tests/plugins/listblock/manual/rightclick.md
+++ b/tests/plugins/listblock/manual/rightclick.md
@@ -4,13 +4,24 @@
 
 ## Procedure
 
-1. Open "Styles" combo.
-2. Right click any option.
+1. Open console.
+2. Open "Styles" combo.
+3. Right click any option.
 
-### Expected result:
+	### Expected result:
 
-Focus is moved to the clicked option.
+	Focus is moved to the clicked option.
 
-### Unexpected result
+	### Unexpected result:
 
-Clicked style is applied to the editor.
+	Clicked style is applied to the editor.
+4. Press `Space`/`Enter`.
+
+	### Expected result:
+
+	Focused option is applied to the editor.
+
+	### Unexpected result:
+
+	* Nothing happens.
+	* There is error in the console.

--- a/tests/plugins/listblock/manual/rightclick.md
+++ b/tests/plugins/listblock/manual/rightclick.md
@@ -1,0 +1,16 @@
+@bender-ui: collapsed
+@bender-tags: 2857, 4.11.4, bug
+@bender-ckeditor-plugins: wysiwygarea, stylescombo, toolbar
+
+## Procedure
+
+1. Open "Styles" combo.
+2. Right click any option.
+
+### Expected result:
+
+Focus is moved to the clicked option.
+
+### Unexpected result
+
+Clicked style is applied to the editor.

--- a/tests/plugins/listblock/manual/rightclick.md
+++ b/tests/plugins/listblock/manual/rightclick.md
@@ -1,5 +1,5 @@
 @bender-ui: collapsed
-@bender-tags: 2857, 4.11.4, bug
+@bender-tags: 2857, 4.12.0, bug
 @bender-ckeditor-plugins: wysiwygarea, stylescombo, toolbar
 
 ## Procedure

--- a/tests/plugins/listblock/manual/rightclick.md
+++ b/tests/plugins/listblock/manual/rightclick.md
@@ -10,7 +10,9 @@
 
 	### Expected result:
 
-	Focus is moved to the clicked option.
+	Focus remains on the first option.
+
+	WARNING: it's best to check it using arrow keys, as visible focus indicator (background + outline) can be in fact moved to the clicked option.
 
 	### Unexpected result:
 

--- a/tests/plugins/listblock/manual/rightclick.md
+++ b/tests/plugins/listblock/manual/rightclick.md
@@ -1,5 +1,5 @@
 @bender-ui: collapsed
-@bender-tags: 2857, 4.12.0, bug
+@bender-tags: 2857, 4.13.0, bug
 @bender-ckeditor-plugins: wysiwygarea, stylescombo, toolbar
 
 ## Procedure

--- a/tests/plugins/menu/manual/rightclick.html
+++ b/tests/plugins/menu/manual/rightclick.html
@@ -1,0 +1,12 @@
+<h2>Classic editor</h2>
+<div id="classic">
+	<p>I'm CKEditor 4 instance.</p>
+</div>
+
+<script>
+	if ( !CKEDITOR.env.ie ) {
+		bender.ignore();
+	}
+
+	CKEDITOR.replace( 'classic' );
+</script>

--- a/tests/plugins/menu/manual/rightclick.html
+++ b/tests/plugins/menu/manual/rightclick.html
@@ -8,5 +8,33 @@
 		bender.ignore();
 	}
 
-	CKEDITOR.replace( 'classic' );
+	CKEDITOR.replace( 'classic', {
+		on: {
+			instanceReady: function( evt ) {
+				var editor = evt.editor;
+
+				editor.addMenuGroup( 'test' );
+				editor.addMenuItems( {
+					item1: {
+						label: 'Test 1',
+						group: 'test',
+						order: 1
+					},
+
+					item2: {
+						label: 'Test 2',
+						group: 'test',
+						order: 2
+					}
+				} );
+
+				editor.contextMenu.addListener( function() {
+					return {
+						item1: CKEDITOR.TRISTATE_OFF,
+						item2: CKEDITOR.TRISTATE_OFF
+					};
+				} );
+			}
+		}
+	} );
 </script>

--- a/tests/plugins/menu/manual/rightclick.html
+++ b/tests/plugins/menu/manual/rightclick.html
@@ -18,12 +18,18 @@
 					item1: {
 						label: 'Test 1',
 						group: 'test',
+						onClick: function() {
+							alert( 'Test 1' );
+						},
 						order: 1
 					},
 
 					item2: {
 						label: 'Test 2',
 						group: 'test',
+						onClick: function() {
+							alert( 'Test 2' );
+						},
 						order: 2
 					}
 				} );

--- a/tests/plugins/menu/manual/rightclick.md
+++ b/tests/plugins/menu/manual/rightclick.md
@@ -1,0 +1,18 @@
+@bender-ui: collapsed
+@bender-tags: 2858, 4.11.4, bug
+@bender-ckeditor-plugins: wysiwygarea, language, contextmenu, clipboard, toolbar
+
+## Procedure
+
+1. Open editor's context menu.
+2. Right click any menu item.
+
+### Expected result:
+
+Focus is moved to the clicked item.
+
+### Unexpected result:
+
+Action connected with clicked item is applied to the editor.
+
+Repeat the procedure for the menu under "Language" button.

--- a/tests/plugins/menu/manual/rightclick.md
+++ b/tests/plugins/menu/manual/rightclick.md
@@ -5,7 +5,7 @@
 ## Procedure
 
 1. Open console.
-2. Open editor's context menu.
+2. Open editor's context menu by right-clicking its content.
 3. Right click any menu item.
 
 	### Expected result:

--- a/tests/plugins/menu/manual/rightclick.md
+++ b/tests/plugins/menu/manual/rightclick.md
@@ -4,15 +4,25 @@
 
 ## Procedure
 
-1. Open editor's context menu.
-2. Right click any menu item.
+1. Open console.
+2. Open editor's context menu.
+3. Right click any menu item.
 
-### Expected result:
+	### Expected result:
 
-Focus is moved to the clicked item.
+	Focus is moved to the clicked item.
 
-### Unexpected result:
+	### Unexpected result:
 
-Action connected with clicked item is applied to the editor.
+	Action connected with clicked item is applied to the editor.
+4. Press `Space`/`Enter`.
+
+	### Expected result:
+
+	Action connected with clicked item is applied to the editor.
+
+	### Unexpected result:
+
+	Error is thrown.
 
 Repeat the procedure for the menu under "Language" button.

--- a/tests/plugins/menu/manual/rightclick.md
+++ b/tests/plugins/menu/manual/rightclick.md
@@ -10,7 +10,9 @@
 
 	### Expected result:
 
-	Focus is moved to the clicked item.
+	Focus remains on the first option.
+
+	WARNING: it's best to check it using arrow keys, as visible focus indicator (background + outline) can be in fact moved to the clicked option.
 
 	### Unexpected result:
 
@@ -19,7 +21,7 @@
 
 	### Expected result:
 
-	Action connected with clicked item is applied to the editor.
+	Action connected with focused item is applied to the editor.
 
 	### Unexpected result:
 

--- a/tests/plugins/menu/manual/rightclick.md
+++ b/tests/plugins/menu/manual/rightclick.md
@@ -1,5 +1,5 @@
 @bender-ui: collapsed
-@bender-tags: 2858, 4.11.4, bug
+@bender-tags: 2858, 4.12.0, bug
 @bender-ckeditor-plugins: wysiwygarea, language, contextmenu, clipboard, toolbar
 
 ## Procedure

--- a/tests/plugins/menu/manual/rightclick.md
+++ b/tests/plugins/menu/manual/rightclick.md
@@ -1,5 +1,5 @@
 @bender-ui: collapsed
-@bender-tags: 2858, 4.12.0, bug
+@bender-tags: 2858, 4.13.0, bug
 @bender-ckeditor-plugins: wysiwygarea, language, contextmenu, clipboard, toolbar
 
 ## Procedure

--- a/tests/plugins/menu/manual/rightclick.md
+++ b/tests/plugins/menu/manual/rightclick.md
@@ -1,6 +1,6 @@
 @bender-ui: collapsed
 @bender-tags: 2858, 4.13.0, bug
-@bender-ckeditor-plugins: wysiwygarea, language, contextmenu, clipboard, toolbar
+@bender-ckeditor-plugins: wysiwygarea, language, contextmenu, clipboard, toolbar, sourcearea
 
 ## Procedure
 

--- a/tests/plugins/menu/menu.js
+++ b/tests/plugins/menu/menu.js
@@ -38,9 +38,29 @@
 			this.editorBot.menu( 'custom_menubutton', function( menu ) {
 				var panelDoc = menu._.panel._.iframe.getFrameDocument();
 				var menuItemEl = panelDoc.getById( menu.id + 0 );
+				menu.hide();
 				assert.isTrue( menuItemEl.hasClass( 'cke_menubutton' ), 'check ui type class name' );
 				assert.isTrue( menuItemEl.hasClass( 'cke_menubutton__custom_menuitem' ), 'check named ui type class name' );
 				assert.isTrue( menuItemEl.hasClass( customCls ), 'check ui item custom class name' );
+			} );
+		},
+
+		// (#2858)
+		'test right-clicking menu items': function() {
+			if ( !CKEDITOR.env.ie ) {
+				assert.ignore();
+			}
+
+			var bot = this.editorBot;
+
+			bot.menu( 'custom_menubutton', function( menu ) {
+				var item = menu._.element.findOne( 'a' ),
+					spy = sinon.spy( menu._, 'onClick' );
+
+				bender.tools.dispatchMouseEvent( item, 'mouseup', CKEDITOR.MOUSE_BUTTON_RIGHT );
+				spy.restore();
+				menu.hide();
+				assert.areSame( 0, spy.callCount, 'item command was not fired' );
 			} );
 		}
 	} );

--- a/tests/plugins/panel/manual/keydown.html
+++ b/tests/plugins/panel/manual/keydown.html
@@ -1,0 +1,41 @@
+<div id="editor">
+	<p>I'm just a little content lost in the moment. I'm so scared, but I dont' show it…</p>
+</div>
+
+<script>
+	CKEDITOR.replace( 'editor', {
+		on: {
+			instanceReady: function( evt ) {
+				var editor = evt.editor;
+
+				editor.addMenuGroup( 'test' );
+				editor.addMenuItems( {
+					item1: {
+						label: 'Test 1',
+						group: 'test',
+						onClick: function() {
+							alert( 'Test 1' );
+						},
+						order: 1
+					},
+
+					item2: {
+						label: 'Test 2',
+						group: 'test',
+						onClick: function() {
+							alert( 'Test 2' );
+						},
+						order: 2
+					}
+				} );
+
+				editor.contextMenu.addListener( function() {
+					return {
+						item1: CKEDITOR.TRISTATE_OFF,
+						item2: CKEDITOR.TRISTATE_OFF
+					};
+				} );
+			}
+		}
+	} );
+</script>

--- a/tests/plugins/panel/manual/keydown.md
+++ b/tests/plugins/panel/manual/keydown.md
@@ -1,0 +1,23 @@
+@bender-tags: 4.12.0, feature, 2975
+@bender-ui: collapsed
+@bender-ckeditor-plugins: wysiwygarea,toolbar,contextmenu,stylescombo,language
+
+## Test Scenario
+
+1. Open context menu inside the editor and press <kbd>Space</kbd>.
+	### Expected
+
+	* Alert with focused menu item's name is displayed.
+
+	### Unexpected
+
+	* Nothing happens.
+2. Repeat the same procedure for <kbd>Enter</kbd>.
+3. Repeat above steps also for Language button and Styles combo
+	### Expected
+
+	* Options activated via keyboard works correctly.
+
+	### Unexpected
+
+	* Options are not activated via keyboard.

--- a/tests/plugins/panel/manual/keydown.md
+++ b/tests/plugins/panel/manual/keydown.md
@@ -13,6 +13,8 @@
 
 	* Nothing happens.
 2. Repeat the same procedure for <kbd>Enter</kbd>.
+
+	Note: <kbd>Enter</kbd> does not work in Firefox on macOS – [#3271](https://github.com/ckeditor/ckeditor-dev/issues/3271).
 3. Repeat above steps also for Language button and Styles combo
 	### Expected
 

--- a/tests/plugins/panel/manual/keydown.md
+++ b/tests/plugins/panel/manual/keydown.md
@@ -1,4 +1,4 @@
-@bender-tags: 4.12.0, feature, 2975
+@bender-tags: 4.13.0, feature, 2975
 @bender-ui: collapsed
 @bender-ckeditor-plugins: wysiwygarea,toolbar,contextmenu,stylescombo,language
 

--- a/tests/plugins/panel/panel.js
+++ b/tests/plugins/panel/panel.js
@@ -56,19 +56,18 @@
 		// (#2857)
 		'test keydown passes info about click': function() {
 			var block = createClickableBlock(),
-				items = block._.getItems(),
-				leftMouseButton = CKEDITOR.env.ie && CKEDITOR.env.version < 9 ? '1' : '0';
+				items = block._.getItems();
 
 			block._.markFirstDisplayed();
 
 			block.onKeyDown( 13 );
-			assert.areSame( leftMouseButton, items.getItem( block._.focusIndex ).getAttribute( 'data-button' ) );
+			assert.areSame( '0', items.getItem( block._.focusIndex ).getAttribute( 'data-button' ) );
 		}
 	} );
 
 	function createClickableBlock() {
 		var parent = new CKEDITOR.dom.element( 'div' ),
-			clickHandler = 'console.log(\'click\');this.setAttribute(\'data-button\', CKEDITOR.tools.getMouseButton(event));return false;';
+			clickHandler = 'this.setAttribute(\'data-button\', CKEDITOR.tools.getMouseButton(event));return false;';
 		CKEDITOR.document.getBody().append( parent );
 
 		var block = new CKEDITOR.ui.panel.block( parent, { attributes: {} } );

--- a/tests/plugins/panel/panel.js
+++ b/tests/plugins/panel/panel.js
@@ -51,6 +51,34 @@
 
 			block.onKeyDown( 9 );
 			assert.areSame( 'input', items.getItem( block._.focusIndex ).getName() );
+		},
+
+		// (#2857)
+		'test keydown passes info about click': function() {
+			var block = createClickableBlock(),
+				items = block._.getItems(),
+				leftMouseButton = CKEDITOR.env.ie && CKEDITOR.env.version < 9 ? '1' : '0';
+
+			block._.markFirstDisplayed();
+
+			block.onKeyDown( 13 );
+			assert.areSame( leftMouseButton, items.getItem( block._.focusIndex ).getAttribute( 'data-button' ) );
 		}
 	} );
+
+	function createClickableBlock() {
+		var parent = new CKEDITOR.dom.element( 'div' ),
+			clickHandler = 'console.log(\'click\');this.setAttribute(\'data-button\', CKEDITOR.tools.getMouseButton(event));return false;';
+		CKEDITOR.document.getBody().append( parent );
+
+		var block = new CKEDITOR.ui.panel.block( parent, { attributes: {} } );
+
+		block.element.setHtml( '<a href="#" _cke_focus="1" onmouseup="' + clickHandler + '" onclick="' + clickHandler + '">link1</a>' );
+
+		block.keys[ 13 ] = CKEDITOR.env.ie ? 'mouseup' : 'click'; // Enter
+
+		block.show();
+
+		return block;
+	}
 } )();

--- a/tests/plugins/panel/panel.js
+++ b/tests/plugins/panel/panel.js
@@ -60,7 +60,7 @@
 
 			block._.markFirstDisplayed();
 
-			block.onKeyDown( 13 );
+			block.onKeyDown( 13 ); // Enter
 			assert.areSame( '0', items.getItem( block._.focusIndex ).getAttribute( 'data-button' ) );
 		}
 	} );

--- a/tests/plugins/richcombo/manual/rightclick.html
+++ b/tests/plugins/richcombo/manual/rightclick.html
@@ -4,7 +4,7 @@
 </div>
 
 <script>
-	if ( CKEDITOR.env.gecko ) {
+	if ( !CKEDITOR.env.ie ) {
 		bender.ignore();
 	}
 

--- a/tests/plugins/richcombo/manual/rightclick.html
+++ b/tests/plugins/richcombo/manual/rightclick.html
@@ -1,0 +1,12 @@
+<h2>Classic editor</h2>
+<div id="classic">
+	<p>I'm CKEditor 4 instance.</p>
+</div>
+
+<script>
+	if ( CKEDITOR.env.gecko ) {
+		bender.ignore();
+	}
+
+	CKEDITOR.replace( 'classic' );
+</script>

--- a/tests/plugins/richcombo/manual/rightclick.md
+++ b/tests/plugins/richcombo/manual/rightclick.md
@@ -12,5 +12,4 @@ Nothing happens.
 
 ### Unexpected result
 
-* Chrome/Safari: rich combo is highlighted, as after left click.
 * IE/Edge: rich combo becomes open.

--- a/tests/plugins/richcombo/manual/rightclick.md
+++ b/tests/plugins/richcombo/manual/rightclick.md
@@ -12,4 +12,4 @@ Nothing happens.
 
 ### Unexpected result
 
-* IE/Edge: rich combo becomes open.
+Rich combo becomes open.

--- a/tests/plugins/richcombo/manual/rightclick.md
+++ b/tests/plugins/richcombo/manual/rightclick.md
@@ -1,0 +1,16 @@
+@bender-ui: collapsed
+@bender-tags: 2845, 4.11.4, bug
+@bender-ckeditor-plugins: wysiwygarea, stylescombo, toolbar
+
+## Procedure
+
+Right click "Styles" combo.
+
+### Expected result:
+
+Nothing happens.
+
+### Unexpected result
+
+* Chrome/Safari: rich combo is highlighted, as after left click.
+* IE/Edge: rich combo becomes open.

--- a/tests/plugins/richcombo/manual/rightclick.md
+++ b/tests/plugins/richcombo/manual/rightclick.md
@@ -1,5 +1,5 @@
 @bender-ui: collapsed
-@bender-tags: 2845, 4.11.4, bug
+@bender-tags: 2845, 4.12.0, bug
 @bender-ckeditor-plugins: wysiwygarea, stylescombo, toolbar
 
 ## Procedure

--- a/tests/plugins/richcombo/manual/rightclick.md
+++ b/tests/plugins/richcombo/manual/rightclick.md
@@ -1,5 +1,5 @@
 @bender-ui: collapsed
-@bender-tags: 2845, 4.12.0, bug
+@bender-tags: 2845, 4.13.0, bug
 @bender-ckeditor-plugins: wysiwygarea, stylescombo, toolbar
 
 ## Procedure

--- a/tests/plugins/richcombo/manual/rightclick.md
+++ b/tests/plugins/richcombo/manual/rightclick.md
@@ -12,4 +12,4 @@ Nothing happens.
 
 ### Unexpected result
 
-Rich combo becomes open.
+Rich combo opens.

--- a/tests/plugins/richcombo/richcombo.js
+++ b/tests/plugins/richcombo/richcombo.js
@@ -56,5 +56,47 @@ bender.test( {
 
 		assert.areEqual( 0, combo._.listeners.length, 'Listeners array is empty.' );
 		assert.isTrue( listenersRemoved, 'All listeners are removed.' );
+	},
+
+	// (#2565)
+	'test right-clicking combo': function() {
+		if ( !CKEDITOR.env.ie ) {
+			assert.ignore();
+		}
+
+		var editor = this.editor,
+			combo = editor.ui.get( 'custom_combo' ),
+			comboBtn = CKEDITOR.document.findOne( '#cke_' + combo.id + ' .cke_combo_button' ),
+			spy;
+
+		combo.createPanel( editor );
+		spy = sinon.spy( combo._.panel, 'onShow' );
+		dispatchMouseEvent( comboBtn, 'mouseup', CKEDITOR.MOUSE_BUTTON_RIGHT );
+		spy.restore();
+
+		assert.areSame( 0, spy.callCount, 'rich combo was no opened' );
 	}
 } );
+
+function dispatchMouseEvent( element, type, button ) {
+	var ie8ButtonMap = {
+			0: 1, // CKEDITOR.MOUSE_BUTTON_LEFT
+			1: 4, // CKEDITOR.MOUSE_BUTTON_MIDDLE
+			2: 2 // CKEDITOR.MOUSE_BUTTON_RIGHT
+		},
+		mouseEvent;
+	element = element.$;
+
+	// Thanks to http://help.dottoro.com/ljhlvomw.php
+	if ( document.createEventObject ) {
+		mouseEvent = document.createEventObject();
+
+		mouseEvent.button = ie8ButtonMap[ button ];
+		element.fireEvent( 'on' + type, mouseEvent );
+	} else {
+		mouseEvent = document.createEvent( 'MouseEvent' );
+
+		mouseEvent.initMouseEvent( type, true, true, window, 0, 0, 0, 80, 20, false, false, false, false, button, null );
+		element.dispatchEvent( mouseEvent );
+	}
+}

--- a/tests/plugins/richcombo/richcombo.js
+++ b/tests/plugins/richcombo/richcombo.js
@@ -71,32 +71,9 @@ bender.test( {
 
 		combo.createPanel( editor );
 		spy = sinon.spy( combo._.panel, 'onShow' );
-		dispatchMouseEvent( comboBtn, 'mouseup', CKEDITOR.MOUSE_BUTTON_RIGHT );
+		bender.tools.dispatchMouseEvent( comboBtn, 'mouseup', CKEDITOR.MOUSE_BUTTON_RIGHT );
 		spy.restore();
 
 		assert.areSame( 0, spy.callCount, 'rich combo was no opened' );
 	}
 } );
-
-function dispatchMouseEvent( element, type, button ) {
-	var ie8ButtonMap = {
-			0: 1, // CKEDITOR.MOUSE_BUTTON_LEFT
-			1: 4, // CKEDITOR.MOUSE_BUTTON_MIDDLE
-			2: 2 // CKEDITOR.MOUSE_BUTTON_RIGHT
-		},
-		mouseEvent;
-	element = element.$;
-
-	// Thanks to http://help.dottoro.com/ljhlvomw.php
-	if ( document.createEventObject ) {
-		mouseEvent = document.createEventObject();
-
-		mouseEvent.button = ie8ButtonMap[ button ];
-		element.fireEvent( 'on' + type, mouseEvent );
-	} else {
-		mouseEvent = document.createEvent( 'MouseEvent' );
-
-		mouseEvent.initMouseEvent( type, true, true, window, 0, 0, 0, 80, 20, false, false, false, false, button, null );
-		element.dispatchEvent( mouseEvent );
-	}
-}


### PR DESCRIPTION
## What is the purpose of this pull request?

Bug fix

## Does your PR contain necessary tests?

All patches which change the editor code must include tests. You can always read more
on [PR testing](https://ckeditor.com/docs/ckeditor4/latest/guide/dev_contributing_code.html#tests),
[how to set the testing environment](https://ckeditor.com/docs/ckeditor4/latest/guide/dev_tests.html) and
[how to create tests](https://ckeditor.com/docs/ckeditor4/latest/guide/dev_tests.html#creating-your-own-test)
in the official CKEditor documentation.

### This PR contains

- [x] Unit tests
- [x] Manual tests

## What is the proposed changelog entry for this pull request?

```
Fixed Issues:

* [IE, Edge] Fixed: Various editor's UI elements react to right mouse button click:
	* [#2845](https://github.com/ckeditor/ckeditor-dev/issues/2845): [Rich Combo](https://ckeditor.com/cke4/addon/richcombo).
	* [#2857](https://github.com/ckeditor/ckeditor-dev/issues/2857): [List Block](https://ckeditor.com/cke4/addon/listblock).
	* [#2858](https://github.com/ckeditor/ckeditor-dev/issues/2858): [Menu](https://ckeditor.com/cke4/addon/menu).

API Changes:

* [#2845](https://github.com/ckeditor/ckeditor-dev/issues/2845): The [`CKEDITOR.tools.normalizeMouseButton`](https://ckeditor.com/docs/ckeditor4/latest/api/CKEDITOR_tools.html#method-normalizeMouseButton) was added.
* [#2975](https://github.com/ckeditor/ckeditor-dev/issues/2975): The [`CKEDITOR.dom.element#fireEventHandler`](https://ckeditor.com/docs/ckeditor4/latest/api/CKEDITOR_dom_element.html#method-fireEventHandler) was added.

```

## What changes did you make?

I've fixed ability to use rich combos, listblocks and menus with right mouse button.

To do so I had to add `CKEDITOR.tools.fireElementEventHandler` to be able to emulate `mouseup` events with correct mouse button info in keystrokes handler in `panel`.

Closes #2845.
Closes #2857.
Closes #2858.
Closes #2975.