### PR TITLE
Fix for: Paste buttons has wrong state in read-only mode

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -10,7 +10,7 @@ Fixed Issues:
 * [#1479](https://github.com/ckeditor/ckeditor-dev/issues/1479): Fixed: [Justification](https://ckeditor.com/cke4/addon/justify) for styled content in BR mode is disabled.
 * [#2816](https://github.com/ckeditor/ckeditor-dev/issues/2816): Fixed: [Enhanced Image](https://ckeditor.com/cke4/addon/image2) resize handler is visible in [read-only mode](https://ckeditor.com/docs/ckeditor4/latest/guide/dev_readonly.html).
 * [#2874](https://github.com/ckeditor/ckeditor-dev/issues/2874): Fixed: [Enhanced Image](https://ckeditor.com/cke4/addon/image2) resize handler is not added when editor is initialized in [read-only mode](https://ckeditor.com/docs/ckeditor4/latest/guide/dev_readonly.html).
-* [#2775](https://github.com/ckeditor/ckeditor-dev/issues/2775): Fixed: [Clipboard](https://ckeditor.com/cke4/addon/clipboard) Paste buttons had wrong state when [Read-Only](https://ckeditor.com/docs/ckeditor4/latest/guide/dev_readonly.html) mode was set by mouse event listener with [Div Editing Area](https://ckeditor.com/cke4/addon/divarea) plugin.
+* [#2775](https://github.com/ckeditor/ckeditor-dev/issues/2775): Fixed: [Clipboard](https://ckeditor.com/cke4/addon/clipboard) paste buttons has wrong state when [read-only](https://ckeditor.com/docs/ckeditor4/latest/guide/dev_readonly.html) mode is set by mouse event listener with [Div Editing Area](https://ckeditor.com/cke4/addon/divarea) plugin.
 
 ## CKEditor 4.11.3
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -10,7 +10,7 @@ Fixed Issues:
 * [#1479](https://github.com/ckeditor/ckeditor-dev/issues/1479): Fixed: [Justification](https://ckeditor.com/cke4/addon/justify) for styled content in BR mode is disabled.
 * [#2816](https://github.com/ckeditor/ckeditor-dev/issues/2816): Fixed: [Enhanced Image](https://ckeditor.com/cke4/addon/image2) resize handler is visible in [read-only mode](https://ckeditor.com/docs/ckeditor4/latest/guide/dev_readonly.html).
 * [#2874](https://github.com/ckeditor/ckeditor-dev/issues/2874): Fixed: [Enhanced Image](https://ckeditor.com/cke4/addon/image2) resize handler is not added when editor is initialized in [read-only mode](https://ckeditor.com/docs/ckeditor4/latest/guide/dev_readonly.html).
-* [#2775](https://github.com/ckeditor/ckeditor-dev/issues/2775): Fixed: [Clipboard](https://ckeditor.com/cke4/addon/clipboard) paste buttons has wrong state when [read-only](https://ckeditor.com/docs/ckeditor4/latest/guide/dev_readonly.html) mode is set by mouse event listener with [Div Editing Area](https://ckeditor.com/cke4/addon/divarea) plugin.
+* [#2775](https://github.com/ckeditor/ckeditor-dev/issues/2775): Fixed: [Clipboard](https://ckeditor.com/cke4/addon/clipboard) paste buttons have wrong state when [read-only](https://ckeditor.com/docs/ckeditor4/latest/guide/dev_readonly.html) mode is set by mouse event listener with [Div Editing Area](https://ckeditor.com/cke4/addon/divarea) plugin.
 
 ## CKEditor 4.11.3
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -10,6 +10,7 @@ Fixed Issues:
 * [#1479](https://github.com/ckeditor/ckeditor-dev/issues/1479): Fixed: [Justification](https://ckeditor.com/cke4/addon/justify) for styled content in BR mode is disabled.
 * [#2816](https://github.com/ckeditor/ckeditor-dev/issues/2816): Fixed: [Enhanced Image](https://ckeditor.com/cke4/addon/image2) resize handler is visible in [read-only mode](https://ckeditor.com/docs/ckeditor4/latest/guide/dev_readonly.html).
 * [#2874](https://github.com/ckeditor/ckeditor-dev/issues/2874): Fixed: [Enhanced Image](https://ckeditor.com/cke4/addon/image2) resize handler is not added when editor is initialized in [read-only mode](https://ckeditor.com/docs/ckeditor4/latest/guide/dev_readonly.html).
+* [#2775](https://github.com/ckeditor/ckeditor-dev/issues/2775): Fixed: [Clipboard](https://ckeditor.com/cke4/addon/clipboard) Paste buttons had wrong state when [Read-Only](https://ckeditor.com/docs/ckeditor4/latest/guide/dev_readonly.html) mode was set by mouse event listener with [Div Editing Area](https://ckeditor.com/cke4/addon/divarea) plugin.
 
 ## CKEditor 4.11.3
 

--- a/plugins/clipboard/plugin.js
+++ b/plugins/clipboard/plugin.js
@@ -557,14 +557,6 @@
 				setToolbarStates();
 			} );
 
-			// We need to correctly update toolbar states on readOnly.(#2775).
-			editor.on( 'readOnly', function() {
-				var selection = this.getSelection(),
-					range = selection && selection.getRanges()[ 0 ];
-
-				inReadOnly = this.readOnly || ( range ? range.checkReadOnly() : false );
-			} );
-
 			// If the "contextmenu" plugin is loaded, register the listeners.
 			if ( editor.contextMenu ) {
 				editor.contextMenu.addListener( function( element, selection ) {
@@ -1230,11 +1222,14 @@
 		}
 
 		function stateFromNamedCommand( command ) {
-			if ( inReadOnly && command in { paste: 1, cut: 1 } )
+			// We need to correctly update toolbar states on readOnly.(#2775).
+			if ( ( inReadOnly || editor.readOnly ) && command in { paste: 1, cut: 1 } ) {
 				return CKEDITOR.TRISTATE_DISABLED;
+			}
 
-			if ( command == 'paste' )
+			if ( command == 'paste' ) {
 				return CKEDITOR.TRISTATE_OFF;
+			}
 
 			// Cut, copy - check if the selection is not empty.
 			var sel = editor.getSelection(),

--- a/plugins/clipboard/plugin.js
+++ b/plugins/clipboard/plugin.js
@@ -557,6 +557,14 @@
 				setToolbarStates();
 			} );
 
+			// We need to correctly update toolbar states on readOnly.(#2775).
+			editor.on( 'readOnly', function() {
+				var selection = this.getSelection(),
+					range = selection && selection.getRanges()[ 0 ];
+
+				inReadOnly = this.readOnly || ( range ? range.checkReadOnly() : false );
+			} );
+
 			// If the "contextmenu" plugin is loaded, register the listeners.
 			if ( editor.contextMenu ) {
 				editor.contextMenu.addListener( function( element, selection ) {

--- a/plugins/clipboard/plugin.js
+++ b/plugins/clipboard/plugin.js
@@ -421,8 +421,7 @@
 	function initPasteClipboard( editor ) {
 		var clipboard = CKEDITOR.plugins.clipboard,
 			preventBeforePasteEvent = 0,
-			preventPasteEvent = 0,
-			inReadOnly = 0;
+			preventPasteEvent = 0;
 
 		addListeners();
 		addButtonsCommands();
@@ -553,14 +552,12 @@
 
 			// For improved performance, we're checking the readOnly state on selectionChange instead of hooking a key event for that.
 			editor.on( 'selectionChange', function( evt ) {
-				inReadOnly = evt.data.selection.getRanges()[ 0 ].checkReadOnly();
 				setToolbarStates();
 			} );
 
 			// If the "contextmenu" plugin is loaded, register the listeners.
 			if ( editor.contextMenu ) {
 				editor.contextMenu.addListener( function( element, selection ) {
-					inReadOnly = selection.getRanges()[ 0 ].checkReadOnly();
 					return {
 						cut: stateFromNamedCommand( 'cut' ),
 						copy: stateFromNamedCommand( 'copy' ),
@@ -1222,8 +1219,12 @@
 		}
 
 		function stateFromNamedCommand( command ) {
-			// We need to correctly update toolbar states on readOnly (#2775).
-			if ( ( inReadOnly || editor.readOnly ) && command in { paste: 1, cut: 1 } ) {
+			var selection = editor.getSelection(),
+				range = selection && selection.getRanges()[ 0 ],
+				// We need to correctly update toolbar states on readOnly (#2775).
+				inReadOnly = editor.readOnly || ( range && range.checkReadOnly() );
+
+			if ( inReadOnly && command in { paste: 1, cut: 1 } ) {
 				return CKEDITOR.TRISTATE_DISABLED;
 			}
 

--- a/plugins/clipboard/plugin.js
+++ b/plugins/clipboard/plugin.js
@@ -551,13 +551,11 @@
 			editor.on( 'contentDom', addPasteListenersToEditable );
 
 			// For improved performance, we're checking the readOnly state on selectionChange instead of hooking a key event for that.
-			editor.on( 'selectionChange', function( evt ) {
-				setToolbarStates();
-			} );
+			editor.on( 'selectionChange', setToolbarStates );
 
 			// If the "contextmenu" plugin is loaded, register the listeners.
 			if ( editor.contextMenu ) {
-				editor.contextMenu.addListener( function( element, selection ) {
+				editor.contextMenu.addListener( function() {
 					return {
 						cut: stateFromNamedCommand( 'cut' ),
 						copy: stateFromNamedCommand( 'copy' ),
@@ -735,9 +733,7 @@
 			// since editable won't fire the event if selection process started within
 			// iframe and ended out of the editor (https://dev.ckeditor.com/ticket/9851).
 			editable.attachListener( CKEDITOR.env.ie ? editable : editor.document.getDocumentElement(), 'mouseup', function() {
-				mouseupTimeout = setTimeout( function() {
-					setToolbarStates();
-				}, 0 );
+				mouseupTimeout = setTimeout( setToolbarStates, 0 );
 			} );
 
 			// Make sure that deferred mouseup callback isn't executed after editor instance

--- a/plugins/clipboard/plugin.js
+++ b/plugins/clipboard/plugin.js
@@ -1222,7 +1222,7 @@
 		}
 
 		function stateFromNamedCommand( command ) {
-			// We need to correctly update toolbar states on readOnly.(#2775).
+			// We need to correctly update toolbar states on readOnly (#2775).
 			if ( ( inReadOnly || editor.readOnly ) && command in { paste: 1, cut: 1 } ) {
 				return CKEDITOR.TRISTATE_DISABLED;
 			}

--- a/tests/plugins/clipboard/manual/readonlystate.html
+++ b/tests/plugins/clipboard/manual/readonlystate.html
@@ -1,0 +1,10 @@
+<textarea id="editor"></textarea>
+<label><input id="readonly" type="checkbox">Readonly</label>
+
+<script>
+	var editor = CKEDITOR.replace( 'editor' );
+
+	CKEDITOR.document.findOne( '#readonly' ).on( 'click', function() {
+		editor.setReadOnly( this.$.checked );
+	} );
+</script>

--- a/tests/plugins/clipboard/manual/readonlystate.md
+++ b/tests/plugins/clipboard/manual/readonlystate.md
@@ -2,7 +2,7 @@
 @bender-ui: collapsed
 @bender-ckeditor-plugins: wysiwygarea, clipboard, toolbar, divarea, pastetext
 
-1. Click with mouse on checkbox.
+Click or touch on checkbox.
 
 ## Expected
 

--- a/tests/plugins/clipboard/manual/readonlystate.md
+++ b/tests/plugins/clipboard/manual/readonlystate.md
@@ -1,0 +1,13 @@
+@bender-tags: bug, 4.11.4, 2775
+@bender-ui: collapsed
+@bender-ckeditor-plugins: wysiwygarea, clipboard, toolbar, divarea, pastetext
+
+1. Click with mouse on checkbox.
+
+## Expected
+
+Paste and Paste as Text buttons are disabled.
+
+## Unexpected
+
+Paste and Paste as Text buttons are enabled.

--- a/tests/plugins/clipboard/readonly.js
+++ b/tests/plugins/clipboard/readonly.js
@@ -58,47 +58,45 @@ var tests = {
 
 tests = bender.tools.createTestsForEditors( CKEDITOR.tools.objectKeys( bender.editors ), tests );
 
-tests = CKEDITOR.tools.object.merge( tests, {
-	// (#2775)
-	'test paste command state in divarea editor': function() {
-		bender.editorBot.create( {
-			name: 'divarea',
-			creator: 'replace',
-			config: {
-				extraPlugins: 'divarea'
-			}
-		}, function( bot ) {
-			var editor = bot.editor,
-				commandNames = [ 'paste', 'pastetext' ],
-				target = CKEDITOR.env.ie ? editor.editable() : editor.document.getDocumentElement();
+tests[ 'test paste command state in divarea editor' ] = function() {
+	bender.editorBot.create( {
+		name: 'divarea',
+		creator: 'replace',
+		config: {
+			extraPlugins: 'divarea'
+		}
+	}, function( bot ) {
+		var editor = bot.editor,
+			commandNames = [ 'paste', 'pastetext' ],
+			target = CKEDITOR.env.ie ? editor.editable() : editor.document.getDocumentElement();
 
-			target.fire( 'mouseup', new CKEDITOR.dom.event( {
-				button: CKEDITOR.MOUSE_BUTTON_LEFT,
-				target: null
-			} ) );
+		target.fire( 'mouseup', new CKEDITOR.dom.event( {
+			button: CKEDITOR.MOUSE_BUTTON_LEFT,
+			target: null
+		} ) );
 
-			editor.setReadOnly( true );
+		editor.setReadOnly( true );
 
-			// mouseup listener updates state in timeout, so we need to make test asynchronous.
-			setTimeout( function() {
-				resume( function() {
-					assertCommands( CKEDITOR.TRISTATE_DISABLED, 'true' );
+		// mouseup listener updates state in timeout, so we need to make test asynchronous.
+		setTimeout( function() {
+			resume( function() {
+				assertCommands( CKEDITOR.TRISTATE_DISABLED, 'true' );
 
-					editor.setReadOnly( false );
-					assertCommands( CKEDITOR.TRISTATE_OFF, 'false.' );
-				} );
+				editor.setReadOnly( false );
+				assertCommands( CKEDITOR.TRISTATE_OFF, 'false.' );
 			} );
-
-			wait();
-
-			function assertCommands( expected, msg ) {
-				CKEDITOR.tools.array.forEach( commandNames, function( commandName ) {
-					var state = editor.getCommand( commandName ).state;
-					assert.areSame( expected, state, commandName + ' state when readonly=' + msg );
-				} );
-			}
 		} );
-	}
-} );
+
+		wait();
+
+		function assertCommands( expected, msg ) {
+			CKEDITOR.tools.array.forEach( commandNames, function( commandName ) {
+				var state = editor.getCommand( commandName ).state;
+				assert.areSame( expected, state, commandName + ' state when readonly=' + msg );
+			} );
+		}
+	} );
+};
+
 
 bender.test( tests );

--- a/tests/plugins/clipboard/readonly.js
+++ b/tests/plugins/clipboard/readonly.js
@@ -67,7 +67,6 @@ tests[ 'test paste command state in divarea editor' ] = function() {
 		}
 	}, function( bot ) {
 		var editor = bot.editor,
-			commandNames = [ 'paste', 'pastetext' ],
 			target = CKEDITOR.env.ie ? editor.editable() : editor.document.getDocumentElement();
 
 		target.fire( 'mouseup', new CKEDITOR.dom.event( {
@@ -77,7 +76,7 @@ tests[ 'test paste command state in divarea editor' ] = function() {
 
 		editor.setReadOnly( true );
 
-		// mouseup listener updates state in timeout, so we need to make test asynchronous.
+		// The mouseup listener updates state in timeout, so we need to make test asynchronous.
 		setTimeout( function() {
 			resume( function() {
 				assertCommands( CKEDITOR.TRISTATE_DISABLED, 'state when readOnly="true"' );
@@ -90,10 +89,8 @@ tests[ 'test paste command state in divarea editor' ] = function() {
 		wait();
 
 		function assertCommands( expected, msg ) {
-			CKEDITOR.tools.array.forEach( commandNames, function( commandName ) {
-				var state = editor.getCommand( commandName ).state;
-				assert.areSame( expected, state, commandName + msg );
-			} );
+			assert.areSame( expected, editor.getCommand( 'paste' ).state, 'paste ' + msg );
+			assert.areSame( expected, editor.getCommand( 'pastetext' ).state, 'pastetext ' + msg );
 		}
 	} );
 };

--- a/tests/plugins/clipboard/readonly.js
+++ b/tests/plugins/clipboard/readonly.js
@@ -74,7 +74,7 @@ tests = CKEDITOR.tools.object.merge( tests, {
 
 			target.fire( 'mouseup', new CKEDITOR.dom.event( {
 				button: CKEDITOR.MOUSE_BUTTON_LEFT,
-				target: editor.editable()
+				target: null
 			} ) );
 
 			editor.setReadOnly( true );

--- a/tests/plugins/clipboard/readonly.js
+++ b/tests/plugins/clipboard/readonly.js
@@ -80,10 +80,10 @@ tests[ 'test paste command state in divarea editor' ] = function() {
 		// mouseup listener updates state in timeout, so we need to make test asynchronous.
 		setTimeout( function() {
 			resume( function() {
-				assertCommands( CKEDITOR.TRISTATE_DISABLED, 'true' );
+				assertCommands( CKEDITOR.TRISTATE_DISABLED, 'state when readOnly="true"' );
 
 				editor.setReadOnly( false );
-				assertCommands( CKEDITOR.TRISTATE_OFF, 'false.' );
+				assertCommands( CKEDITOR.TRISTATE_OFF, 'state when readOnly="false"' );
 			} );
 		} );
 
@@ -92,11 +92,10 @@ tests[ 'test paste command state in divarea editor' ] = function() {
 		function assertCommands( expected, msg ) {
 			CKEDITOR.tools.array.forEach( commandNames, function( commandName ) {
 				var state = editor.getCommand( commandName ).state;
-				assert.areSame( expected, state, commandName + ' state when readonly=' + msg );
+				assert.areSame( expected, state, commandName + msg );
 			} );
 		}
 	} );
 };
-
 
 bender.test( tests );


### PR DESCRIPTION
## What is the purpose of this pull request?

Bugfix

## Does your PR contain necessary tests?

All patches which change the editor code must include tests. You can always read more
on [PR testing](https://ckeditor.com/docs/ckeditor4/latest/guide/dev_contributing_code.html#tests),
[how to set the testing environment](https://ckeditor.com/docs/ckeditor4/latest/guide/dev_tests.html) and
[how to create tests](https://ckeditor.com/docs/ckeditor4/latest/guide/dev_tests.html#creating-your-own-test)
in the official CKEditor documentation.

### This PR contains

- [X] Unit tests
- [X] Manual tests

## What changes did you make?

Included `editor.readOnly` in check for command state function.

Closes #2775 