### PR TITLE
Fix for: Resize handler was visible after entering read-only mode manually

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -7,6 +7,8 @@ Fixed Issues:
 
 * [#1397](https://github.com/ckeditor/ckeditor-dev/issues/1397): Fixed: Using dialog to remove headers from the [table](https://ckeditor.com/cke4/addon/table) with one headers row only throws an error.
 * [#1479](https://github.com/ckeditor/ckeditor-dev/issues/1479): Fixed: [Justification](https://ckeditor.com/cke4/addon/justify) for styled content in BR mode is disabled.
+* [#2816](https://github.com/ckeditor/ckeditor-dev/issues/2816): Fixed: Image resize handler for [image2](https://ckeditor.com/cke4/addon/image2) plugin is visible in [read-only mode](https://ckeditor.com/docs/ckeditor4/latest/guide/dev_readonly.html).
+* [#2874](https://github.com/ckeditor/ckeditor-dev/issues/2874): Fixed: Image resize handler is not created by [image2](https://ckeditor.com/cke4/addon/image2) plugin when editor initialized in [read-only mode](https://ckeditor.com/docs/ckeditor4/latest/guide/dev_readonly.html).
 
 ## CKEditor 4.11.3
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -7,8 +7,8 @@ Fixed Issues:
 
 * [#1397](https://github.com/ckeditor/ckeditor-dev/issues/1397): Fixed: Using dialog to remove headers from the [table](https://ckeditor.com/cke4/addon/table) with one headers row only throws an error.
 * [#1479](https://github.com/ckeditor/ckeditor-dev/issues/1479): Fixed: [Justification](https://ckeditor.com/cke4/addon/justify) for styled content in BR mode is disabled.
-* [#2816](https://github.com/ckeditor/ckeditor-dev/issues/2816): Fixed: Image resize handler for [image2](https://ckeditor.com/cke4/addon/image2) plugin is visible in [read-only mode](https://ckeditor.com/docs/ckeditor4/latest/guide/dev_readonly.html).
-* [#2874](https://github.com/ckeditor/ckeditor-dev/issues/2874): Fixed: Image resize handler is not created by [image2](https://ckeditor.com/cke4/addon/image2) plugin when editor initialized in [read-only mode](https://ckeditor.com/docs/ckeditor4/latest/guide/dev_readonly.html).
+* [#2816](https://github.com/ckeditor/ckeditor-dev/issues/2816): Fixed: [Enhanced Image](https://ckeditor.com/cke4/addon/image2) resize handler is visible in [read-only mode](https://ckeditor.com/docs/ckeditor4/latest/guide/dev_readonly.html).
+* [#2874](https://github.com/ckeditor/ckeditor-dev/issues/2874): Fixed: [Enhanced Image](https://ckeditor.com/cke4/addon/image2) resize handler is not added when editor is initialized in [read-only mode](https://ckeditor.com/docs/ckeditor4/latest/guide/dev_readonly.html).
 
 ## CKEditor 4.11.3
 

--- a/plugins/image2/plugin.js
+++ b/plugins/image2/plugin.js
@@ -61,6 +61,10 @@
 			'.cke_image_resizer.cke_image_resizing{' +
 				'display:block' +
 			'}' +
+			// Hide resizer in read only mode (#2816).
+			'.cke_editable[contenteditable="false"] .cke_image_resizer{' + 
+                'display:none;' +
+            '}' +
 			// Expand widget wrapper when linked inline image.
 			'.cke_widget_wrapper>a{' +
 				'display:inline-block' +

--- a/plugins/image2/plugin.js
+++ b/plugins/image2/plugin.js
@@ -438,9 +438,6 @@
 
 				// Setup dynamic image resizing with mouse.
 				// Don't initialize resizer when dimensions are disallowed (https://dev.ckeditor.com/ticket/11004).
-				// Don't initialize resizer when editor.readOnly is set to true (#719).
-				// Condition added for #719 caused #2874 (resized does not appear if you set editor.readOnly to false manually).
-				// Removed that condition as change made for #2816 fixed both cases.
 				if ( editor.filter.checkFeature( this.features.dimension ) && editor.config.image2_disableResizer !== true ) {
 					setupResizer( this );
 				}

--- a/plugins/image2/plugin.js
+++ b/plugins/image2/plugin.js
@@ -439,7 +439,9 @@
 				// Setup dynamic image resizing with mouse.
 				// Don't initialize resizer when dimensions are disallowed (https://dev.ckeditor.com/ticket/11004).
 				// Don't initialize resizer when editor.readOnly is set to true (#719).
-				if ( editor.filter.checkFeature( this.features.dimension ) && editor.config.image2_disableResizer !== true && editor.readOnly != true ) {
+				// Condition added for #719 caused #2874 (resized does not appear if you set editor.readOnly to false manually).
+				// Removed that condition as change made for #2816 fixed both cases.
+				if ( editor.filter.checkFeature( this.features.dimension ) && editor.config.image2_disableResizer !== true ) {
 					setupResizer( this );
 				}
 

--- a/plugins/image2/plugin.js
+++ b/plugins/image2/plugin.js
@@ -62,9 +62,9 @@
 				'display:block' +
 			'}' +
 			// Hide resizer in read only mode (#2816).
-			'.cke_editable[contenteditable="false"] .cke_image_resizer{' + 
-                'display:none;' +
-            '}' +
+			'.cke_editable[contenteditable="false"] .cke_image_resizer{' +
+				'display:none;' +
+			'}' +
 			// Expand widget wrapper when linked inline image.
 			'.cke_widget_wrapper>a{' +
 				'display:inline-block' +

--- a/tests/plugins/image2/manual/resizerwithreadonly.html
+++ b/tests/plugins/image2/manual/resizerwithreadonly.html
@@ -1,20 +1,14 @@
 <h2>
-	Classic editor
+	Classic Editor
 </h2>
 <div id="editor1" contenteditable="true">
 	<img src="%BASE_PATH%/_assets/logo.png" />
 </div>
 <h2>
-	Initialized as read-only
+	ReadOnly Editor
 </h2>
-<button id="disable">Toggle editor2 read-only mode</button>
+<button id="disable">Toggle read-only mode</button>
 <div id="editor2" contenteditable="true">
-	<img src="%BASE_PATH%/_assets/logo.png" />
-</div>
-<h2>
-	Read-only after initialization
-</h2>
-<div id="editor3" contenteditable="true">
 	<img src="%BASE_PATH%/_assets/logo.png" />
 </div>
 
@@ -27,13 +21,6 @@
 				CKEDITOR.document.getById( 'disable' ).on( 'click', function() {
 					editor2.setReadOnly( !editor2.readOnly );
 				} );
-			}
-		}
-	} );
-	var editor3 = CKEDITOR.replace( 'editor3', {
-		on: {
-			instanceReady: function() {
-				editor3.setReadOnly( true );
 			}
 		}
 	} );

--- a/tests/plugins/image2/manual/resizerwithreadonly.html
+++ b/tests/plugins/image2/manual/resizerwithreadonly.html
@@ -19,15 +19,14 @@
 </div>
 
 <script>
-	CKEDITOR.replace( 'editor1' );	
+	CKEDITOR.replace( 'editor1' );
 	var editor2 = CKEDITOR.replace( 'editor2', {
 		readOnly: true,
 		on: {
 			instanceReady: function() {
-			CKEDITOR.document.getById( 'disable' ).on( 'click', function() {
-				editor2.setReadOnly( !editor2.readOnly );
-
-				} )
+				CKEDITOR.document.getById( 'disable' ).on( 'click', function() {
+					editor2.setReadOnly( !editor2.readOnly );
+				} );
 			}
 		}
 	} );

--- a/tests/plugins/image2/manual/resizerwithreadonly.html
+++ b/tests/plugins/image2/manual/resizerwithreadonly.html
@@ -13,9 +13,11 @@
 	CKEDITOR.replace( 'editor2', {
 		readOnly: true
 	} );
-	CKEDITOR.replace( 'editor3' );
-
-	CKEDITOR.instances.editor3.on( 'instanceReady', function( ev ) {
-		ev.editor.setReadOnly( true );
-	});
+	var editor3 = CKEDITOR.replace( 'editor3', {
+		on: {
+			instanceReady: function() {
+				editor3.setReadOnly( true );
+			}
+		}
+	} );
 </script>

--- a/tests/plugins/image2/manual/resizerwithreadonly.html
+++ b/tests/plugins/image2/manual/resizerwithreadonly.html
@@ -1,9 +1,18 @@
+<h2>
+	Classic editor
+</h2>
 <div id="editor1" contenteditable="true">
 	<img src="%BASE_PATH%/_assets/logo.png" />
 </div>
+<h2>
+	Initialized as read-only
+</h2>
 <div id="editor2" contenteditable="true">
 	<img src="%BASE_PATH%/_assets/logo.png" />
 </div>
+<h2>
+	Read-only after initialization
+</h2>
 <div id="editor3" contenteditable="true">
 	<img src="%BASE_PATH%/_assets/logo.png" />
 </div>

--- a/tests/plugins/image2/manual/resizerwithreadonly.html
+++ b/tests/plugins/image2/manual/resizerwithreadonly.html
@@ -7,6 +7,7 @@
 <h2>
 	Initialized as read-only
 </h2>
+<button id="disable">Toggle editor2 read-only mode</button>
 <div id="editor2" contenteditable="true">
 	<img src="%BASE_PATH%/_assets/logo.png" />
 </div>
@@ -18,9 +19,17 @@
 </div>
 
 <script>
-	CKEDITOR.replace( 'editor1' );
-	CKEDITOR.replace( 'editor2', {
-		readOnly: true
+	CKEDITOR.replace( 'editor1' );	
+	var editor2 = CKEDITOR.replace( 'editor2', {
+		readOnly: true,
+		on: {
+			instanceReady: function() {
+			CKEDITOR.document.getById( 'disable' ).on( 'click', function() {
+				editor2.setReadOnly( !editor2.readOnly );
+
+				} )
+			}
+		}
 	} );
 	var editor3 = CKEDITOR.replace( 'editor3', {
 		on: {

--- a/tests/plugins/image2/manual/resizerwithreadonly.html
+++ b/tests/plugins/image2/manual/resizerwithreadonly.html
@@ -4,10 +4,18 @@
 <div id="editor2" contenteditable="true">
 	<img src="%BASE_PATH%/_assets/logo.png" />
 </div>
+<div id="editor3" contenteditable="true">
+	<img src="%BASE_PATH%/_assets/logo.png" />
+</div>
 
 <script>
 	CKEDITOR.replace( 'editor1' );
 	CKEDITOR.replace( 'editor2', {
 		readOnly: true
 	} );
+	CKEDITOR.replace( 'editor3' );
+
+	CKEDITOR.instances.editor3.on( 'instanceReady', function( ev ) {
+		ev.editor.setReadOnly( true );
+	});
 </script>

--- a/tests/plugins/image2/manual/resizerwithreadonly.md
+++ b/tests/plugins/image2/manual/resizerwithreadonly.md
@@ -1,4 +1,4 @@
-@bender-tags: 4.7.3, 4.11.4, bug, 719, 2816
+@bender-tags: 4.7.3, 4.11.4, bug, 719, 2816, 2874
 @bender-ui: collapsed
 @bender-ckeditor-plugins: wysiwygarea, toolbar, image2
 

--- a/tests/plugins/image2/manual/resizerwithreadonly.md
+++ b/tests/plugins/image2/manual/resizerwithreadonly.md
@@ -2,6 +2,18 @@
 @bender-ui: collapsed
 @bender-ckeditor-plugins: wysiwygarea, toolbar, image2
 
-Only **first** editor should have enabled mouse resizer on image.
+## Classic Editor
 
-Then click the toggle button. The image in **second** editor should be resizable.
+1. Focus the image.
+
+**Expected:** The image has enabled mouse resizer.
+
+## ReadOnly Editor
+
+1. Focus the image.
+
+**Expected:** The image doesn't have enabled mouse resizer.
+
+2. Click `Toggle read-only mode` multiple times focusing image every time after button click.
+
+**Expected:** The image mouse resizer is enabled and disabled depending on the read-only mode state.

--- a/tests/plugins/image2/manual/resizerwithreadonly.md
+++ b/tests/plugins/image2/manual/resizerwithreadonly.md
@@ -4,6 +4,4 @@
 
 Only **first** editor should have enabled mouse resizer on image.
 
-The **second** one is initialized in read-only mode.
-
-The **third** one is turned into read-only mode after initialization.
+Then click the toggle button. The image in **second** editor should be resizable.

--- a/tests/plugins/image2/manual/resizerwithreadonly.md
+++ b/tests/plugins/image2/manual/resizerwithreadonly.md
@@ -3,3 +3,7 @@
 @bender-ckeditor-plugins: wysiwygarea, toolbar, image2
 
 Only **first** editor should have enabled mouse resizer on image.
+
+The **second** one is initialized in read-only mode.
+
+The **third** one is turned into read-only mode after initialization.

--- a/tests/plugins/image2/manual/resizerwithreadonly.md
+++ b/tests/plugins/image2/manual/resizerwithreadonly.md
@@ -6,14 +6,14 @@
 
 1. Focus the image.
 
-**Expected:** The image has enabled mouse resizer.
+**Expected:** The image resize handler is visible.
 
 ## ReadOnly Editor
 
 1. Focus the image.
 
-**Expected:** The image doesn't have enabled mouse resizer.
+**Expected:** The image resize handler is not visible.
 
 2. Click `Toggle read-only mode` multiple times focusing image every time after button click.
 
-**Expected:** The image mouse resizer is enabled and disabled depending on the read-only mode state.
+**Expected:** The image resize handler is enabled/disabled depending on the read-only mode state.

--- a/tests/plugins/image2/manual/resizerwithreadonly.md
+++ b/tests/plugins/image2/manual/resizerwithreadonly.md
@@ -1,4 +1,4 @@
-@bender-tags: 4.7.3, bug, 719
+@bender-tags: 4.7.3, 4.11.4, bug, 719, 2816
 @bender-ui: collapsed
 @bender-ckeditor-plugins: wysiwygarea, toolbar, image2
 

--- a/tests/plugins/image2/resizerwithreadonly.js
+++ b/tests/plugins/image2/resizerwithreadonly.js
@@ -5,19 +5,56 @@
 	'use strict';
 
 	bender.test( {
-		// #719, #2816, #2874
-		'test readOnly set to false': createResizerTest( { name: 'editor1' } ),
+		init: function() {
+			var css = CKEDITOR.getCss();
+			css = css.replace( '.cke_widget_wrapper:hover .cke_image_resizer', '.cke_widget_wrapper.hover .cke_image_resizer' );
+			CKEDITOR.addCss( css );
+		},
 
 		// #719, #2874
-		'test readOnly set to true at initialization': createResizerTest( { name: 'editor2', config: { readOnly: true } } ),
+		'test resizer creation without readOnly': testResizerVisibility( { name: 'editor1' } ),
+
+		// #719, #2874
+		'test resizer creation with readOnly at initialization': testResizerVisibility( { name: 'editor2', config: { readOnly: true } } ),
+
+		// #719, #2874
+		'test resizer creation with readOnly after initialization': testResizerVisibility( { name: 'editor3' }, true ),
 
 		// #719, #2816
-		'test readOnly set to true after initialization': createResizerTest( { name: 'editor3' }, true )
+		'test hovering in read-only': function() {
+			bender.editorBot.create( { name: 'editor4', config: { readOnly: true } } , function( bot ) {
+				var editor = bot.editor;
+				editor.setData( '<img src="_assets/foo.png" alt="" />', function() {
+					resume( function() {
+						var wrapper = editor.editable().findOne( '.cke_widget_wrapper' ),
+							resizer = editor.editable().findOne( '.cke_widget_image .cke_image_resizer' );
+						wrapper.addClass( 'hover' );
+						assert.isTrue( Boolean( !resizer.isVisible() ) );
+					} );
+				} );
+				wait();
+			} );
+		},
 
+		// #719, #2816
+		'test hovering without read-only': function() {
+			bender.editorBot.create( { name: 'editor5', config: { readOnly: false } } , function( bot ) {
+				var editor = bot.editor;
+				editor.setData( '<img src="_assets/foo.png" alt="" />', function() {
+					resume( function() {
+						var wrapper = editor.editable().findOne( '.cke_widget_wrapper' ),
+							resizer = editor.editable().findOne( '.cke_widget_image .cke_image_resizer' );
+						wrapper.addClass( 'hover' );
+						assert.isTrue( Boolean( resizer.isVisible() ) );
+					} );
+				} );
+				wait();
+			} );
+		}
 	} );
 }() );
 
-function createResizerTest( profile, readOnly ) {
+function testResizerVisibility( profile, readOnly ) {
 	return function() {
 		bender.editorBot.create( profile, function( bot ) {
 			var editor = bot.editor;
@@ -28,7 +65,7 @@ function createResizerTest( profile, readOnly ) {
 						editor.setReadOnly( readOnly );
 					}
 					var resizer = editor.editable().findOne( '.cke_widget_image .cke_image_resizer' );
-					assert.isTrue( Boolean( resizer ), 'Resizer should be enabled'  );
+					assert.isTrue( Boolean( resizer ), 'Resizer should be created'  );
 				} );
 			} );
 

--- a/tests/plugins/image2/resizerwithreadonly.js
+++ b/tests/plugins/image2/resizerwithreadonly.js
@@ -14,7 +14,6 @@
 
 				editor.setData( '<img src="_assets/foo.png" alt="" />', function() {
 					resume( function() {
-						editor.setReadOnly( true );
 						var resizer = editor.editable().findOne( '.cke_widget_image .cke_image_resizer' );
 						assert.isTrue( Boolean( resizer ), 'Resizer should be enabled'  );
 					} );

--- a/tests/plugins/image2/resizerwithreadonly.js
+++ b/tests/plugins/image2/resizerwithreadonly.js
@@ -1,5 +1,5 @@
 /* bender-tags: editor,widget */
-/* bender-ckeditor-plugins: image2,toolbar */
+/* bender-ckeditor-plugins: image2 */
 
 ( function() {
 	'use strict';

--- a/tests/plugins/image2/resizerwithreadonly.js
+++ b/tests/plugins/image2/resizerwithreadonly.js
@@ -5,7 +5,7 @@
 	'use strict';
 
 	bender.test( {
-		// #719
+		// #719, #2816, #2874
 		'test readOnly set to false': function() {
 			bender.editorBot.create( {
 				name: 'editor1',
@@ -27,8 +27,8 @@
 			} );
 		},
 
-		// #719
-		'test readOnly set to true': function() {
+		// #719, #2874
+		'test readOnly set to true at initialization': function() {
 			bender.editorBot.create( {
 				name: 'editor2',
 				config: {
@@ -42,13 +42,37 @@
 					listener.removeListener();
 
 					resume( function() {
-						assert.areSame( 2, editor.editable().getElementsByTag( 'span' ).$.length );
+						assert.areSame( 3, editor.editable().getElementsByTag( 'span' ).$.length );
 					} );
 				} );
 
 				editor.setData( '<img src="_assets/foo.png" alt="" />' );
 				wait();
 			} );
-		}
+		},
+
+		// #719, #2816
+		'test readOnly set to true after initialization': function() {
+			bender.editorBot.create( {
+				name: 'editor3',
+				config: {
+					readOnly: true
+				}
+			}, function( bot ) {
+				var editor = bot.editor,
+					listener;
+
+				listener = editor.on( 'dataReady', function() {
+					listener.removeListener();
+
+					resume( function() {
+						assert.areSame( 3, editor.editable().getElementsByTag( 'span' ).$.length );
+					} );
+				} );
+
+				editor.setData( '<img src="_assets/foo.png" alt="" />' );
+				wait();
+			} );
+		}		
 	} );
 }() );

--- a/tests/plugins/image2/resizerwithreadonly.js
+++ b/tests/plugins/image2/resizerwithreadonly.js
@@ -54,15 +54,13 @@
 		// #719, #2816
 		'test readOnly set to true after initialization': function() {
 			bender.editorBot.create( {
-				name: 'editor3',
-				config: {
-					readOnly: true
-				}
+				name: 'editor3'
 			}, function( bot ) {
 				var editor = bot.editor,
 					listener;
 
 				listener = editor.on( 'dataReady', function() {
+					editor.setReadOnly( true );
 					listener.removeListener();
 
 					resume( function() {

--- a/tests/plugins/image2/resizerwithreadonly.js
+++ b/tests/plugins/image2/resizerwithreadonly.js
@@ -12,13 +12,13 @@
 		},
 
 		// #719, #2874
-		'test resizer creation without readOnly': testResizerVisibility( { name: 'editor1' } ),
+		'test resizer creation without readOnly': testResizerPresence( { name: 'editor1' } ),
 
 		// #719, #2874
-		'test resizer creation with readOnly at initialization': testResizerVisibility( { name: 'editor2', config: { readOnly: true } } ),
+		'test resizer creation with readOnly at initialization': testResizerPresence( { name: 'editor2', config: { readOnly: true } } ),
 
 		// #719, #2874
-		'test resizer creation with readOnly after initialization': testResizerVisibility( { name: 'editor3' }, true ),
+		'test resizer creation with readOnly after initialization': testResizerPresence( { name: 'editor3' }, true ),
 
 		// #719, #2816
 		'test hovering in read-only': function() {
@@ -27,9 +27,10 @@
 				editor.setData( '<img src="_assets/foo.png" alt="" />', function() {
 					resume( function() {
 						var wrapper = editor.editable().findOne( '.cke_widget_wrapper' ),
-							resizer = editor.editable().findOne( '.cke_widget_image .cke_image_resizer' );
+							resizer = wrapper.findOne( '.cke_image_resizer' );
+
 						wrapper.addClass( 'hover' );
-						assert.isTrue( Boolean( !resizer.isVisible() ) );
+						assert.isTrue( !resizer.isVisible() );
 					} );
 				} );
 				wait();
@@ -45,7 +46,7 @@
 						var wrapper = editor.editable().findOne( '.cke_widget_wrapper' ),
 							resizer = editor.editable().findOne( '.cke_widget_image .cke_image_resizer' );
 						wrapper.addClass( 'hover' );
-						assert.isTrue( Boolean( resizer.isVisible() ) );
+						assert.isTrue( resizer.isVisible() );
 					} );
 				} );
 				wait();
@@ -54,7 +55,7 @@
 	} );
 }() );
 
-function testResizerVisibility( profile, readOnly ) {
+function testResizerPresence( profile, readOnly ) {
 	return function() {
 		bender.editorBot.create( profile, function( bot ) {
 			var editor = bot.editor;
@@ -64,11 +65,9 @@ function testResizerVisibility( profile, readOnly ) {
 					if ( readOnly ) {
 						editor.setReadOnly( readOnly );
 					}
-					var resizer = editor.editable().findOne( '.cke_widget_image .cke_image_resizer' );
-					assert.isTrue( Boolean( resizer ), 'Resizer should be created'  );
+					assert.isNotNull( editor.editable().findOne( '.cke_widget_image .cke_image_resizer' ), 'Resizer should be created'  );
 				} );
 			} );
-
 			wait();
 		} );
 	};

--- a/tests/plugins/image2/resizerwithreadonly.js
+++ b/tests/plugins/image2/resizerwithreadonly.js
@@ -8,21 +8,22 @@
 		// #719, #2816, #2874
 		'test readOnly set to false': function() {
 			bender.editorBot.create( {
-				name: 'editor1',
-				config: {
-					language: 'en'
-				}
+				name: 'editor1'
 			}, function( bot ) {
-				var editor = bot.editor;
+				var editor = bot.editor,
+					listener;
 
-				bot.dialog( 'image', function( dialog ) {
-					dialog.setValueOf( 'info', 'src', '_assets/foo.png' );
-					dialog.getButton( 'ok' ).click();
+				listener = editor.on( 'dataReady', function() {
+					listener.removeListener();
 
-					var resizer = editor.editable().findOne( '.cke_widget_image .cke_image_resizer' );
-					assert.isTrue( Boolean( resizer ), 'Resizer should be enabled'  );
-
+					resume( function() {
+						var resizer = editor.editable().findOne( '.cke_widget_image .cke_image_resizer' );
+						assert.isTrue( Boolean( resizer ), 'Resizer should be enabled'  );
+					} );
 				} );
+
+				editor.setData( '<img src="_assets/foo.png" alt="" />' );
+				wait();
 			} );
 		},
 

--- a/tests/plugins/image2/resizerwithreadonly.js
+++ b/tests/plugins/image2/resizerwithreadonly.js
@@ -6,61 +6,33 @@
 
 	bender.test( {
 		// #719, #2816, #2874
-		'test readOnly set to false': function() {
-			bender.editorBot.create( {
-				name: 'editor1'
-			}, function( bot ) {
-				var editor = bot.editor;
-
-				editor.setData( '<img src="_assets/foo.png" alt="" />', function() {
-					resume( function() {
-						var resizer = editor.editable().findOne( '.cke_widget_image .cke_image_resizer' );
-						assert.isTrue( Boolean( resizer ), 'Resizer should be enabled'  );
-					} );
-				} );
-
-				wait();
-			} );
-		},
+		'test readOnly set to false': createResizerTest( { name: 'editor1' } ),
 
 		// #719, #2874
-		'test readOnly set to true at initialization': function() {
-			bender.editorBot.create( {
-				name: 'editor2',
-				config: {
-					readOnly: true
-				}
-			}, function( bot ) {
-				var editor = bot.editor;
-
-				editor.setData( '<img src="_assets/foo.png" alt="" />', function() {
-					resume( function() {
-						var resizer = editor.editable().findOne( '.cke_widget_image .cke_image_resizer' );
-						assert.isTrue( Boolean( resizer ), 'Resizer should be enabled'  );
-					} );
-				} );
-
-				wait();
-			} );
-		},
+		'test readOnly set to true at initialization': createResizerTest( { name: 'editor2', config: { readOnly: true } } ),
 
 		// #719, #2816
-		'test readOnly set to true after initialization': function() {
-			bender.editorBot.create( {
-				name: 'editor3'
-			}, function( bot ) {
-				var editor = bot.editor;
+		'test readOnly set to true after initialization': createResizerTest( { name: 'editor3' }, true )
 
-				editor.setData( '<img src="_assets/foo.png" alt="" />', function() {
-					resume( function() {
-						editor.setReadOnly( true );
-						var resizer = editor.editable().findOne( '.cke_widget_image .cke_image_resizer' );
-						assert.isTrue( Boolean( resizer ), 'Resizer should be enabled'  );
-					} );
-				} );
-
-				wait();
-			} );
-		}
 	} );
 }() );
+
+function createResizerTest( profile, readOnly ) {
+	return function() {
+		bender.editorBot.create( profile, function( bot ) {
+			var editor = bot.editor;
+
+			editor.setData( '<img src="_assets/foo.png" alt="" />', function() {
+				resume( function() {
+					if ( readOnly ) {
+						editor.setReadOnly( readOnly );
+					}
+					var resizer = editor.editable().findOne( '.cke_widget_image .cke_image_resizer' );
+					assert.isTrue( Boolean( resizer ), 'Resizer should be enabled'  );
+				} );
+			} );
+
+			wait();
+		} );
+	};
+}

--- a/tests/plugins/image2/resizerwithreadonly.js
+++ b/tests/plugins/image2/resizerwithreadonly.js
@@ -19,10 +19,9 @@
 					dialog.setValueOf( 'info', 'src', '_assets/foo.png' );
 					dialog.getButton( 'ok' ).click();
 
-					assert.sameData(
-						'cke_image_resizer',
-						editor.editable().getElementsByTag( 'span' ).$[ 2 ].outerHTML.match( /(cke_image_resizer)/g )[ 0 ]
-					);
+					var resizer = editor.editable().findOne( '.cke_widget_image .cke_image_resizer' );
+					assert.isTrue( Boolean( resizer ), 'Resizer should be enabled'  );
+
 				} );
 			} );
 		},
@@ -42,7 +41,8 @@
 					listener.removeListener();
 
 					resume( function() {
-						assert.areSame( 3, editor.editable().getElementsByTag( 'span' ).$.length );
+						var resizer = editor.editable().findOne( '.cke_widget_image .cke_image_resizer' );
+						assert.isTrue( Boolean( resizer ), 'Resizer should be enabled'  );
 					} );
 				} );
 
@@ -66,7 +66,8 @@
 					listener.removeListener();
 
 					resume( function() {
-						assert.areSame( 3, editor.editable().getElementsByTag( 'span' ).$.length );
+						var resizer = editor.editable().findOne( '.cke_widget_image .cke_image_resizer' );
+						assert.isTrue( Boolean( resizer ), 'Resizer should be enabled'  );
 					} );
 				} );
 

--- a/tests/plugins/image2/resizerwithreadonly.js
+++ b/tests/plugins/image2/resizerwithreadonly.js
@@ -10,19 +10,16 @@
 			bender.editorBot.create( {
 				name: 'editor1'
 			}, function( bot ) {
-				var editor = bot.editor,
-					listener;
+				var editor = bot.editor;
 
-				listener = editor.on( 'dataReady', function() {
-					listener.removeListener();
-
+				editor.setData( '<img src="_assets/foo.png" alt="" />', function() {
 					resume( function() {
+						editor.setReadOnly( true );
 						var resizer = editor.editable().findOne( '.cke_widget_image .cke_image_resizer' );
 						assert.isTrue( Boolean( resizer ), 'Resizer should be enabled'  );
 					} );
 				} );
 
-				editor.setData( '<img src="_assets/foo.png" alt="" />' );
 				wait();
 			} );
 		},
@@ -35,19 +32,15 @@
 					readOnly: true
 				}
 			}, function( bot ) {
-				var editor = bot.editor,
-					listener;
+				var editor = bot.editor;
 
-				listener = editor.on( 'dataReady', function() {
-					listener.removeListener();
-
+				editor.setData( '<img src="_assets/foo.png" alt="" />', function() {
 					resume( function() {
 						var resizer = editor.editable().findOne( '.cke_widget_image .cke_image_resizer' );
 						assert.isTrue( Boolean( resizer ), 'Resizer should be enabled'  );
 					} );
 				} );
 
-				editor.setData( '<img src="_assets/foo.png" alt="" />' );
 				wait();
 			} );
 		},
@@ -57,20 +50,16 @@
 			bender.editorBot.create( {
 				name: 'editor3'
 			}, function( bot ) {
-				var editor = bot.editor,
-					listener;
+				var editor = bot.editor;
 
-				listener = editor.on( 'dataReady', function() {
-					editor.setReadOnly( true );
-					listener.removeListener();
-
+				editor.setData( '<img src="_assets/foo.png" alt="" />', function() {
 					resume( function() {
+						editor.setReadOnly( true );
 						var resizer = editor.editable().findOne( '.cke_widget_image .cke_image_resizer' );
 						assert.isTrue( Boolean( resizer ), 'Resizer should be enabled'  );
 					} );
 				} );
 
-				editor.setData( '<img src="_assets/foo.png" alt="" />' );
 				wait();
 			} );
 		}

--- a/tests/plugins/image2/resizerwithreadonly.js
+++ b/tests/plugins/image2/resizerwithreadonly.js
@@ -73,6 +73,6 @@
 				editor.setData( '<img src="_assets/foo.png" alt="" />' );
 				wait();
 			} );
-		}		
+		}
 	} );
 }() );


### PR DESCRIPTION
## What is the purpose of this pull request?

Bugfix

## Does your PR contain necessary tests?

Yes

### This PR contains

- [x] Manual test
- [x] Unit test

## What changes did you make?

Resize handler does not show up on hover if content is not editable. I added one css rule for that.
Also unit test logic has been changed - now it checks if resize handler is properly initialized in all scenarios.

Closes #2816.
Closes #2874.