### PR TITLE
Replace deprecated 'arguments.callee'

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -25,6 +25,10 @@ API Changes:
 
 ## CKEditor 4.11.4
 
+Other Changes:
+
+* [#2741](https://github.com/ckeditor/ckeditor-dev/issues/2721): Replaced deprecated [arguments.callee](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Functions/arguments/callee#Why_was_arguments.callee_removed_from_ES5_strict_mode) code.
+
 ## CKEditor 4.11.3
 
 Fixed Issues:

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -27,7 +27,6 @@ Other Changes:
 
 * [#2741](https://github.com/ckeditor/ckeditor-dev/issues/2721): Replaced deprecated `arguments.callee` calls with named function expressions.
 
-
 ## CKEditor 4.11.4
 
 ## CKEditor 4.11.3

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -23,11 +23,12 @@ API Changes:
 * [#2748](https://github.com/ckeditor/ckeditor-dev/issues/2748): Enhance errors thrown while creating editor on a nonexistent element or while trying to instantiate second editor on the same element. Thanks to [Byran Zaugg](https://github.com/blzaugg)!
 * [#2698](https://github.com/ckeditor/ckeditor-dev/issues/2698): Added the [`CKEDITOR.htmlParser.element.findOne`](https://ckeditor.com/docs/ckeditor4/latest/api/CKEDITOR_htmlParser_element.html#method-findOne) method.
 
-## CKEditor 4.11.4
-
 Other Changes:
 
-* [#2741](https://github.com/ckeditor/ckeditor-dev/issues/2721): Replaced deprecated [arguments.callee](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Functions/arguments/callee#Why_was_arguments.callee_removed_from_ES5_strict_mode) code.
+* [#2741](https://github.com/ckeditor/ckeditor-dev/issues/2721): Replaced deprecated `arguments.callee` calls with named function expressions.
+
+
+## CKEditor 4.11.4
 
 ## CKEditor 4.11.3
 

--- a/adapters/jquery.js
+++ b/adapters/jquery.js
@@ -157,10 +157,10 @@
 					editor.on( 'instanceReady', function( evt ) {
 						var editor = evt.editor;
 
-						setTimeout( function() {
+						setTimeout( function delayEditor() {
 							// Delay bit more if editor is still not ready.
 							if ( !editor.element ) {
-								setTimeout( arguments.callee, 100 );
+								setTimeout( delayEditor, 100 );
 								return;
 							}
 

--- a/adapters/jquery.js
+++ b/adapters/jquery.js
@@ -265,10 +265,10 @@
 				} else {
 					// Editor is already during creation process, bind our code to the event.
 					editor.once( 'instanceReady', function() {
-						setTimeout( function integrateWithjQuery() {
+						setTimeout( function waitForEditor() {
 							// Delay bit more if editor is still not ready.
 							if ( !editor.element ) {
-								setTimeout( integrateWithjQuery, 100 );
+								setTimeout( waitForEditor, 100 );
 								return;
 							}
 

--- a/adapters/jquery.js
+++ b/adapters/jquery.js
@@ -265,10 +265,11 @@
 				} else {
 					// Editor is already during creation process, bind our code to the event.
 					editor.once( 'instanceReady', function() {
-						setTimeout( function() {
+						setTimeout( function integrateWithjQuery() {
 							// Delay bit more if editor is still not ready.
 							if ( !editor.element ) {
-								setTimeout( arguments.callee, 100 );
+								// Replaced arguments.callee (#2741)
+								setTimeout( integrateWithjQuery, 100 );
 								return;
 							}
 

--- a/adapters/jquery.js
+++ b/adapters/jquery.js
@@ -268,7 +268,6 @@
 						setTimeout( function integrateWithjQuery() {
 							// Delay bit more if editor is still not ready.
 							if ( !editor.element ) {
-								// Replaced arguments.callee (#2741)
 								setTimeout( integrateWithjQuery, 100 );
 								return;
 							}

--- a/adapters/jquery.js
+++ b/adapters/jquery.js
@@ -157,10 +157,10 @@
 					editor.on( 'instanceReady', function( evt ) {
 						var editor = evt.editor;
 
-						setTimeout( function delayEditor() {
+						setTimeout( function waitForEditor() {
 							// Delay bit more if editor is still not ready.
 							if ( !editor.element ) {
-								setTimeout( delayEditor, 100 );
+								setTimeout( waitForEditor, 100 );
 								return;
 							}
 

--- a/core/tools.js
+++ b/core/tools.js
@@ -776,7 +776,6 @@
 				$.prototype.base = function baseClassConstructor() {
 					this.base = baseClass.prototype.base;
 					baseClass.apply( this, arguments );
-					// Replaced arguments.callee (#2741)
 					this.base = baseClassConstructor;
 				};
 			}

--- a/core/tools.js
+++ b/core/tools.js
@@ -773,10 +773,11 @@
 				$.base = baseClass;
 				$.baseProto = baseClass.prototype;
 				// Super constructor.
-				$.prototype.base = function() {
+				$.prototype.base = function baseClassConstructor() {
 					this.base = baseClass.prototype.base;
 					baseClass.apply( this, arguments );
-					this.base = arguments.callee;
+					// Replaced arguments.callee (#2741)
+					this.base = baseClassConstructor;
 				};
 			}
 

--- a/plugins/adobeair/plugin.js
+++ b/plugins/adobeair/plugin.js
@@ -151,11 +151,12 @@
 					var panel = ui._.panel._.panel,
 						holder;
 
-					( function() {
+					( function addListeners() {
 						// Adding dom event listeners off-line are not supported in AIR,
 						// waiting for panel iframe loaded.
 						if ( !panel.isLoaded ) {
-							setTimeout( arguments.callee, 30 );
+							// Replaced arguments.callee (#2741)
+							setTimeout( addListeners, 30 );
 							return;
 						}
 						holder = panel._.holder;

--- a/plugins/adobeair/plugin.js
+++ b/plugins/adobeair/plugin.js
@@ -155,7 +155,6 @@
 						// Adding dom event listeners off-line are not supported in AIR,
 						// waiting for panel iframe loaded.
 						if ( !panel.isLoaded ) {
-							// Replaced arguments.callee (#2741)
 							setTimeout( addListeners, 30 );
 							return;
 						}

--- a/plugins/adobeair/plugin.js
+++ b/plugins/adobeair/plugin.js
@@ -151,11 +151,11 @@
 					var panel = ui._.panel._.panel,
 						holder;
 
-					( function addListeners() {
+					( function waitForPanel() {
 						// Adding dom event listeners off-line are not supported in AIR,
 						// waiting for panel iframe loaded.
 						if ( !panel.isLoaded ) {
-							setTimeout( addListeners, 30 );
+							setTimeout( waitForPanel, 30 );
 							return;
 						}
 						holder = panel._.holder;

--- a/plugins/dialog/plugin.js
+++ b/plugins/dialog/plugin.js
@@ -2210,7 +2210,6 @@ CKEDITOR.DIALOG_STATE_BUSY = 2;
 			// So we need to invent a really funny way to make it work.
 			var myScrollHandler = function() {
 					scrollFunc();
-					// Replaced arguments.callee (#2741)
 					myScrollHandler.prevScrollHandler.apply( this, arguments );
 				};
 			win.$.setTimeout( function() {

--- a/plugins/dialog/plugin.js
+++ b/plugins/dialog/plugin.js
@@ -2210,7 +2210,8 @@ CKEDITOR.DIALOG_STATE_BUSY = 2;
 			// So we need to invent a really funny way to make it work.
 			var myScrollHandler = function() {
 					scrollFunc();
-					arguments.callee.prevScrollHandler.apply( this, arguments );
+					// Replaced arguments.callee (#2741)
+					myScrollHandler.prevScrollHandler.apply( this, arguments );
 				};
 			win.$.setTimeout( function() {
 				myScrollHandler.prevScrollHandler = window.onscroll ||

--- a/plugins/find/dialogs/find.js
+++ b/plugins/find/dialogs/find.js
@@ -451,7 +451,6 @@
 				if ( matchCyclic && !cyclicRerun ) {
 					this.searchRange = getSearchRange( 1 );
 					this.matchRange = null;
-					// Replaced arguments.callee (#2741)
 					return finder.find.apply( this, Array.prototype.slice.call( arguments ).concat( [ true ] ) );
 				}
 

--- a/plugins/find/dialogs/find.js
+++ b/plugins/find/dialogs/find.js
@@ -451,7 +451,8 @@
 				if ( matchCyclic && !cyclicRerun ) {
 					this.searchRange = getSearchRange( 1 );
 					this.matchRange = null;
-					return arguments.callee.apply( this, Array.prototype.slice.call( arguments ).concat( [ true ] ) );
+					// Replaced arguments.callee (#2741)
+					return finder.find.apply( this, Array.prototype.slice.call( arguments ).concat( [ true ] ) );
 				}
 
 				return false;


### PR DESCRIPTION
## What is the purpose of this pull request?

Replacement of deprecated code.

## Does your PR contain necessary tests?

Tests already in place.

### This PR contains

## What changes did you make?

Replaced 'arguments.callee' in 5 files, mostly using named function expressions.

Closes #2741.