### PR TITLE
Update contents.css

### DIFF
--- a/contents.css
+++ b/contents.css
@@ -75,6 +75,7 @@ hr
 {
 	border: 0px;
 	border-top: 1px solid #ccc;
+	clear: both;
 }
 
 img.right


### PR DESCRIPTION
If we insert an image above the Horizontal rule and align it right, it goes below horizontal rule instead of above it and right align #2950
Please see ticket #2950

## What is the purpose of this pull request?

<!-- Bug fix / New feature / Typo fix / Other, please explain  -->
Its a bug. If we insert an image above the Horizontal rule and align it right, it goes below horizontal rule instead of above it and right align

in the official CKEditor documentation.

- [ ] Unit tests
- [x] Manual test- Done.

## What changes did you make?

If we insert an image above the Horizontal rule and align it right, it goes below horizontal rule instead of above it and right align
