### PR TITLE
Add method to disable tableselection feature for the given element

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -28,6 +28,7 @@ API Changes:
 * [#2935](https://github.com/ckeditor/ckeditor-dev/issues/2935): Introduced [`CKEDITOR.config.pasteFromWord_keepZeroMargins`](https://ckeditor.com/docs/ckeditor4/latest/api/CKEDITOR_config.html#cfg-pasteFromWord_keepZeroMargins) config option, that allows keeping any `margin-*: 0` style that would be otherwise removed when pasting content with [Paste from Word](https://ckeditor.com/cke4/addon/pastefromword) plugin.
 * [#2962](https://github.com/ckeditor/ckeditor-dev/issues/2962): Added the [`CKEDITOR.tools.promise`](https://ckeditor.com/docs/ckeditor4/latest/api/CKEDITOR_tools_promise.html) class.
 * [#2924](https://github.com/ckeditor/ckeditor-dev/issues/2924): Added the [`CKEDITOR.tools.style.border`](https://ckeditor.com/docs/ckeditor4/latest/api/CKEDITOR_tools_style_border.html) object wrapping CSS border style helpers under single type.
+* [#2495](https://github.com/ckeditor/ckeditor-dev/issues/2495): Added the [`CKEDITOR.plugins.tableselection`](https://ckeditor.com/docs/ckeditor4/latest/api/CKEDITOR_plugins_tableselection.html#method-addIgnoredElement) and [`CKEDITOR.plugins.tableselection`](https://ckeditor.com/docs/ckeditor4/latest/api/CKEDITOR_plugins_tableselection.html#method-removeIgnoredElement) methods.
 
 Other Changes:
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -28,7 +28,7 @@ API Changes:
 * [#2935](https://github.com/ckeditor/ckeditor-dev/issues/2935): Introduced [`CKEDITOR.config.pasteFromWord_keepZeroMargins`](https://ckeditor.com/docs/ckeditor4/latest/api/CKEDITOR_config.html#cfg-pasteFromWord_keepZeroMargins) config option, that allows keeping any `margin-*: 0` style that would be otherwise removed when pasting content with [Paste from Word](https://ckeditor.com/cke4/addon/pastefromword) plugin.
 * [#2962](https://github.com/ckeditor/ckeditor-dev/issues/2962): Added the [`CKEDITOR.tools.promise`](https://ckeditor.com/docs/ckeditor4/latest/api/CKEDITOR_tools_promise.html) class.
 * [#2924](https://github.com/ckeditor/ckeditor-dev/issues/2924): Added the [`CKEDITOR.tools.style.border`](https://ckeditor.com/docs/ckeditor4/latest/api/CKEDITOR_tools_style_border.html) object wrapping CSS border style helpers under single type.
-* [#2495](https://github.com/ckeditor/ckeditor-dev/issues/2495): Added the [`CKEDITOR.plugins.tableselection`](https://ckeditor.com/docs/ckeditor4/latest/api/CKEDITOR_plugins_tableselection.html#method-addIgnoredElement) and [`CKEDITOR.plugins.tableselection`](https://ckeditor.com/docs/ckeditor4/latest/api/CKEDITOR_plugins_tableselection.html#method-removeIgnoredElement) methods.
+* [#2495](https://github.com/ckeditor/ckeditor-dev/issues/2495): Added the [`CKEDITOR.plugins.tableselection.addIgnoredElement`](https://ckeditor.com/docs/ckeditor4/latest/api/CKEDITOR_plugins_tableselection.html#method-addIgnoredElement) and [`CKEDITOR.plugins.tableselection.removeIgnoredElement`](https://ckeditor.com/docs/ckeditor4/latest/api/CKEDITOR_plugins_tableselection.html#method-removeIgnoredElement) methods.
 
 Other Changes:
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -28,7 +28,7 @@ API Changes:
 * [#2935](https://github.com/ckeditor/ckeditor-dev/issues/2935): Introduced [`CKEDITOR.config.pasteFromWord_keepZeroMargins`](https://ckeditor.com/docs/ckeditor4/latest/api/CKEDITOR_config.html#cfg-pasteFromWord_keepZeroMargins) config option, that allows keeping any `margin-*: 0` style that would be otherwise removed when pasting content with [Paste from Word](https://ckeditor.com/cke4/addon/pastefromword) plugin.
 * [#2962](https://github.com/ckeditor/ckeditor-dev/issues/2962): Added the [`CKEDITOR.tools.promise`](https://ckeditor.com/docs/ckeditor4/latest/api/CKEDITOR_tools_promise.html) class.
 * [#2924](https://github.com/ckeditor/ckeditor-dev/issues/2924): Added the [`CKEDITOR.tools.style.border`](https://ckeditor.com/docs/ckeditor4/latest/api/CKEDITOR_tools_style_border.html) object wrapping CSS border style helpers under single type.
-* [#2495](https://github.com/ckeditor/ckeditor-dev/issues/2495): Added the [`CKEDITOR.plugins.tableselection.addIgnoredElement`](https://ckeditor.com/docs/ckeditor4/latest/api/CKEDITOR_plugins_tableselection.html#method-addIgnoredElement) and [`CKEDITOR.plugins.tableselection.removeIgnoredElement`](https://ckeditor.com/docs/ckeditor4/latest/api/CKEDITOR_plugins_tableselection.html#method-removeIgnoredElement) methods.
+* [#2495](https://github.com/ckeditor/ckeditor-dev/issues/2495): [Table Selection](https://ckeditor.com/cke4/addon/tableselection) plugin can be now disabled for the given table by the `data-cke-tableselection-ignored` attribute.
 
 Other Changes:
 

--- a/core/selection.js
+++ b/core/selection.js
@@ -2018,6 +2018,7 @@
 
 			// Handle special case - fake selection of table cells.
 			if ( editor && editor.plugins.tableselection &&
+				// (#2945)
 				!editor.plugins.tableselection.isElementIgnored( ranges[ 0 ] && ranges[ 0 ].startContainer ) &&
 				CKEDITOR.plugins.tableselection.isSupportedEnvironment &&
 				isTableSelection( ranges ) && !isSelectingTable

--- a/core/selection.js
+++ b/core/selection.js
@@ -2018,6 +2018,7 @@
 
 			// Handle special case - fake selection of table cells.
 			if ( editor && editor.plugins.tableselection &&
+				!editor.plugins.tableselection.isElementIgnored( ranges[ 0 ] && ranges[ 0 ].startContainer ) &&
 				CKEDITOR.plugins.tableselection.isSupportedEnvironment &&
 				isTableSelection( ranges ) && !isSelectingTable
 			) {

--- a/core/selection.js
+++ b/core/selection.js
@@ -2018,10 +2018,10 @@
 
 			// Handle special case - fake selection of table cells.
 			if ( editor && editor.plugins.tableselection &&
-				// (#2945)
-				!editor.plugins.tableselection.isElementIgnored( ranges[ 0 ] && ranges[ 0 ].startContainer ) &&
 				CKEDITOR.plugins.tableselection.isSupportedEnvironment &&
-				isTableSelection( ranges ) && !isSelectingTable
+				isTableSelection( ranges ) &&
+				!isSelectingTable &&
+				!ranges[ 0 ]._getTableElement( { table: 1 } ).data( 'cke-tableselection-ignored' )
 			) {
 				performFakeTableSelection.call( this, ranges );
 				return;

--- a/core/selection.js
+++ b/core/selection.js
@@ -2021,7 +2021,7 @@
 				CKEDITOR.plugins.tableselection.isSupportedEnvironment &&
 				isTableSelection( ranges ) &&
 				!isSelectingTable &&
-				!ranges[ 0 ]._getTableElement( { table: 1 } ).data( 'cke-tableselection-ignored' )
+				!ranges[ 0 ]._getTableElement( { table: 1 } ).hasAttribute( 'data-cke-tableselection-ignored' )
 			) {
 				performFakeTableSelection.call( this, ranges );
 				return;

--- a/plugins/tableselection/plugin.js
+++ b/plugins/tableselection/plugin.js
@@ -900,7 +900,6 @@
 	 * @class CKEDITOR.plugins.tableselection
 	 */
 	CKEDITOR.plugins.tableselection = {
-
 		/**
 		 * Fetches all cells between cells passed as parameters, including these cells.
 		 *

--- a/plugins/tableselection/plugin.js
+++ b/plugins/tableselection/plugin.js
@@ -1135,6 +1135,13 @@
 		 */
 		isSupportedEnvironment: !( CKEDITOR.env.ie && CKEDITOR.env.version < 11 ),
 
+		/**
+		 * Blacklist table child nodes of the given element to disable table selection feature
+		 * for this table.
+		 *
+		 * @param {CKEDITOR.editor} editor Editor instance containing blacklisted element.
+		 * @param {CKEDITOR.dom.element} element Blacklisted element.
+		 */
 		addIgnoredElement: function( editor, element ) {
 			var tableselection = editor.plugins.tableselection;
 
@@ -1143,6 +1150,13 @@
 			}
 		},
 
+		/**
+		 * Remove blacklisted element by {@link #addIgnoredElement} function, so it will use
+		 * table selection feature again.
+		 *
+		 * @param {CKEDITOR.editor} editor Editor instance containing blacklisted element.
+		 * @param {CKEDITOR.dom.element} element Blacklisted element.
+		 */
 		removeIgnoredElement: function( editor, element ) {
 			var tableselection = editor.plugins.tableselection;
 

--- a/plugins/tableselection/plugin.js
+++ b/plugins/tableselection/plugin.js
@@ -1211,8 +1211,8 @@
 
 				// Setup copybin.
 				if ( CKEDITOR.plugins.clipboard && !CKEDITOR.plugins.clipboard.isCustomCopyCutSupported ) {
-					editable.attachListener( editable, 'cut', fakeSelectionCopyCutHandler );
-					editable.attachListener( editable, 'copy', fakeSelectionCopyCutHandler );
+					editable.attachListener( editable, 'cut', fakeSelectionCopyCutHandler, this );
+					editable.attachListener( editable, 'copy', fakeSelectionCopyCutHandler, this );
 				}
 			}, this );
 

--- a/plugins/tableselection/plugin.js
+++ b/plugins/tableselection/plugin.js
@@ -1136,11 +1136,11 @@
 		isSupportedEnvironment: !( CKEDITOR.env.ie && CKEDITOR.env.version < 11 ),
 
 		/**
-		 * Blacklist table child nodes of the given element to disable table selection feature
-		 * for this table.
+		 * Ignore table child nodes of the given element to disable table selection feature
+		 * for these nodes.
 		 *
-		 * @param {CKEDITOR.editor} editor Editor instance containing blacklisted element.
-		 * @param {CKEDITOR.dom.element} element Blacklisted element.
+		 * @param {CKEDITOR.editor} editor Editor instance containing ignored element.
+		 * @param {CKEDITOR.dom.element} element Ignored element.
 		 */
 		addIgnoredElement: function( editor, element ) {
 			var tableselection = editor.plugins.tableselection;
@@ -1151,11 +1151,11 @@
 		},
 
 		/**
-		 * Remove blacklisted element by {@link #addIgnoredElement} function, so it will use
+		 * Remove ignored element by {@link #addIgnoredElement} function, so it will use
 		 * table selection feature again.
 		 *
-		 * @param {CKEDITOR.editor} editor Editor instance containing blacklisted element.
-		 * @param {CKEDITOR.dom.element} element Blacklisted element.
+		 * @param {CKEDITOR.editor} editor Editor instance containing ignored element.
+		 * @param {CKEDITOR.dom.element} element Ignored element.
 		 */
 		removeIgnoredElement: function( editor, element ) {
 			var tableselection = editor.plugins.tableselection;

--- a/plugins/tableselection/plugin.js
+++ b/plugins/tableselection/plugin.js
@@ -236,11 +236,6 @@
 			return;
 		}
 
-		// (#2945)
-		if ( this.isElementIgnored( ranges[ 0 ].startContainer ) ) {
-			return;
-		}
-
 		clearFakeCellSelection( editor );
 
 		if ( !selection.isInTable() || !selection.isFake ) {
@@ -1019,12 +1014,6 @@
 					}
 
 					ranges = selection.getRanges();
-
-					// (#2945)
-					if ( this.isElementIgnored( ranges[ 0 ].startContainer ) ) {
-						return;
-					}
-
 					firstCell = ranges[ 0 ]._getTableElement();
 					lastCell = ranges[ ranges.length - 1 ]._getTableElement();
 
@@ -1076,11 +1065,6 @@
 			}
 
 			function tableKeyPressListener( evt ) {
-				// (#2945)
-				if ( this.isElementIgnored( evt.data.getTarget() ) ) {
-					return;
-				}
-
 				var selection = editor.getSelection(),
 					// Enter key also produces character, but Firefox doesn't think so (gh#415).
 					isCharKey = evt.data.$.charCode || ( evt.data.getKey() === 13 ),
@@ -1134,8 +1118,8 @@
 			// Automatically select non-editable element when navigating into
 			// it by left/right or backspace/del keys.
 			var editable = editor.editable();
-			editable.attachListener( editable, 'keydown', getTableOnKeyDownListener( editor ), editor.plugins.tableselection, null, -1 );
-			editable.attachListener( editable, 'keypress', tableKeyPressListener, editor.plugins.tableselection, null, -1 );
+			editable.attachListener( editable, 'keydown', getTableOnKeyDownListener( editor ), null, null, -1 );
+			editable.attachListener( editable, 'keypress', tableKeyPressListener, null, null, -1 );
 		},
 
 		/**

--- a/plugins/tableselection/plugin.js
+++ b/plugins/tableselection/plugin.js
@@ -766,7 +766,8 @@
 			selection = editor.getSelection();
 
 		// (#2945)
-		if ( editor.plugins.tableselection.isElementIgnored( selection.getRanges()[ 0 ].startContainer ) ) {
+		if ( selection &&
+			editor.plugins.tableselection.isElementIgnored( selection.getRanges()[ 0 ].startContainer ) ) {
 			return;
 		}
 

--- a/plugins/tableselection/plugin.js
+++ b/plugins/tableselection/plugin.js
@@ -899,6 +899,15 @@
 	 * Namespace providing a set of helper functions for working with tables, exposed by
 	 * [Table Selection](https://ckeditor.com/cke4/addon/tableselection) plugin.
 	 *
+	 * **NOTE** Since 4.12.0 you can use `cke-tableselection-ignored` attribute to disable
+	 * table selection feature for the given table.
+	 *
+	 * ```javascript
+	 * var table = new CKEDITOR.dom.element( 'table' );
+	 *
+	 * table.data( 'cke-tableselection-ignored', 1 );
+	 * ```
+	 *
 	 * @since 4.7.0
 	 * @singleton
 	 * @class CKEDITOR.plugins.tableselection

--- a/plugins/tableselection/plugin.js
+++ b/plugins/tableselection/plugin.js
@@ -236,6 +236,11 @@
 			return;
 		}
 
+		// (#2945)
+		if ( this.isElementIgnored( ranges[ 0 ].startContainer ) ) {
+			return;
+		}
+
 		clearFakeCellSelection( editor );
 
 		if ( !selection.isInTable() || !selection.isFake ) {

--- a/plugins/tableselection/plugin.js
+++ b/plugins/tableselection/plugin.js
@@ -9,7 +9,7 @@
 	var fakeSelectedClass = 'cke_table-faked-selection',
 		fakeSelectedEditorClass = fakeSelectedClass + '-editor',
 		fakeSelectedTableDataAttribute = 'cke-table-faked-selection-table',
-		ignoredTableAttribute = 'cke-tableselection-ignored',
+		ignoredTableAttribute = 'data-cke-tableselection-ignored',
 		fakeSelection = { active: false },
 		tabletools,
 		getSelectedCells,
@@ -244,7 +244,7 @@
 		}
 
 		// (#2945)
-		if ( ranges[ 0 ]._getTableElement( { table: 1 } ).data( ignoredTableAttribute ) ) {
+		if ( ranges[ 0 ]._getTableElement( { table: 1 } ).hasAttribute( ignoredTableAttribute ) ) {
 			return;
 		}
 
@@ -295,7 +295,7 @@
 			tableElements = { table: 1, thead: 1, tbody: 1, tfoot: 1, tr: 1, td: 1, th: 1 };
 
 		// (#2945)
-		if ( table && !!table.data( ignoredTableAttribute ) ) {
+		if ( table && table.hasAttribute( ignoredTableAttribute ) ) {
 			return;
 		}
 
@@ -372,7 +372,7 @@
 		var table = evt.data.getTarget().getAscendant( 'table', true );
 
 		// (#2945)
-		if ( table && table.data( ignoredTableAttribute ) ) {
+		if ( table && table.hasAttribute( ignoredTableAttribute ) ) {
 			return;
 		}
 
@@ -480,7 +480,7 @@
 		}
 
 		// (#2945)
-		if ( selection.getRanges()[ 0 ]._getTableElement( { table: 1 } ).data( ignoredTableAttribute ) ) {
+		if ( selection.getRanges()[ 0 ]._getTableElement( { table: 1 } ).hasAttribute( ignoredTableAttribute ) ) {
 			return;
 		}
 
@@ -771,7 +771,7 @@
 			table = ranges.length && ranges[ 0 ]._getTableElement( { table: 1 } );
 
 		// (#2945)
-		if ( table && table.data( ignoredTableAttribute ) ) {
+		if ( table && table.hasAttribute( ignoredTableAttribute ) ) {
 			return;
 		}
 
@@ -913,6 +913,7 @@
 	 * @class CKEDITOR.plugins.tableselection
 	 */
 	CKEDITOR.plugins.tableselection = {
+
 		/**
 		 * Fetches all cells between cells passed as parameters, including these cells.
 		 *

--- a/tests/plugins/tableselection/integrations/clipboard/pastemerge.html
+++ b/tests/plugins/tableselection/integrations/clipboard/pastemerge.html
@@ -397,3 +397,33 @@
 		</tr>
 	</tbody>
 </table>
+
+<textarea id="ignored">
+<table>
+	<tbody>
+		<tr>
+			<td>cell1</td>
+			<td>[cell2]</td>
+		</tr>
+	</tbody>
+</table>
+
+=>
+<table>
+	<tbody>
+	<tr>
+		<td>cell1</td>
+		<td>
+			<table>
+				<tbody>
+					<tr>
+						<td>foo</td>
+						<td>foo^</td>
+					</tr>
+				</tbody>
+			</table>
+		</td>
+	</tr>
+	</tbody>
+</table>
+</textarea>

--- a/tests/plugins/tableselection/integrations/clipboard/pastemerge.js
+++ b/tests/plugins/tableselection/integrations/clipboard/pastemerge.js
@@ -24,6 +24,32 @@
 			wait();
 		},
 
+		// (#2945)
+		'test paste into ignored table': function( editor, bot ) {
+			var table;
+
+			bender.tools.testInputOut( 'ignored', function( source, expected ) {
+				editor.once( 'afterPaste', function() {
+					resume( function() {
+						CKEDITOR.plugins.tableselection.removeIgnoredElement( editor, table );
+
+						bender.assert.beautified.html( expected, bender.tools.getHtmlWithSelection( editor ) );
+					} );
+				}, null, null, 999 );
+
+				bot.setHtmlWithSelection( source );
+
+				table = editor.editable().findOne( 'table' );
+
+				CKEDITOR.plugins.tableselection.addIgnoredElement( editor, table );
+
+				// Use clone, so that pasted table does not have an ID.
+				bender.tools.emulatePaste( editor, CKEDITOR.document.getById( '2cells1row' ).clone( true ).getOuterHtml() );
+
+				wait();
+			} );
+		},
+
 		'test merge row after': createPasteTestCase( 'merge-row-after', '2cells1row' ),
 
 		'test merge row before': createPasteTestCase( 'merge-row-before', '2cells1row' ),

--- a/tests/plugins/tableselection/integrations/clipboard/pastemerge.js
+++ b/tests/plugins/tableselection/integrations/clipboard/pastemerge.js
@@ -31,8 +31,6 @@
 			bender.tools.testInputOut( 'ignored', function( source, expected ) {
 				editor.once( 'afterPaste', function() {
 					resume( function() {
-						CKEDITOR.plugins.tableselection.removeIgnoredElement( editor, table );
-
 						bender.assert.beautified.html( expected, bender.tools.getHtmlWithSelection( editor ) );
 					} );
 				}, null, null, 999 );
@@ -41,7 +39,7 @@
 
 				table = editor.editable().findOne( 'table' );
 
-				CKEDITOR.plugins.tableselection.addIgnoredElement( editor, table );
+				table.data( 'cke-tableselection-ignored', 1 );
 
 				// Use clone, so that pasted table does not have an ID.
 				bender.tools.emulatePaste( editor, CKEDITOR.document.getById( '2cells1row' ).clone( true ).getOuterHtml() );

--- a/tests/plugins/tableselection/integrations/core/selection.js
+++ b/tests/plugins/tableselection/integrations/core/selection.js
@@ -41,7 +41,7 @@
 		return start.getAscendant( tableElements, true );
 	}
 
-	function getRangesForCells( editor, table, indexes ) {
+	function getRangesForCells( editor, table, indexes, skipClass ) {
 		var ranges = [],
 			range,
 			cell,
@@ -51,7 +51,9 @@
 			cell = table.find( 'td' ).getItem( indexes[ i ] );
 			range = editor.createRange();
 
-			cell.addClass( selectedClass );
+			if ( !skipClass ) {
+				cell.addClass( selectedClass );
+			}
 
 			range.setStartBefore( cell );
 			range.setEndAfter( cell );
@@ -297,6 +299,32 @@
 			assert.isFalse( editor.getSelection().isInTable(), 'Selection is not in table' );
 
 			clearTableSelection( editor.editable() );
+		},
+
+		// (#2945)
+		'Test selecting ignored element': function() {
+			var editor = this.editor,
+				selection = editor.getSelection();
+
+			bender.tools.setHtmlWithSelection( editor, CKEDITOR.document.getById( 'simpleTable' ).getHtml() );
+
+			var table = editor.editable().findOne( 'table' ),
+				ranges = getRangesForCells( editor, table, [ 0, 1 ], true );
+
+			CKEDITOR.plugins.tableselection.addIgnoredElement( editor, table );
+
+			selection.selectRanges( ranges );
+
+			assert.areEqual( 0, selection.isFake, 'Selection is not fake' );
+
+			assert.isTrue( selection.isInTable(), 'isInTable is true' );
+			assert.areEqual( 1, selection.getRanges().length, 'Single range is selected' );
+			assert.isNotNull( selection.getNative(), 'getNative() should be available' );
+			assert.isNotNull( selection.getSelectedText(), 'getSelectedText() should not be null' );
+
+			assert.areSame( CKEDITOR.SELECTION_ELEMENT, selection.getType(), 'Element type selection' );
+			assert.isTrue( _getTableElementFromRange( ranges[ 0 ] ).equals( selection.getSelectedElement() ),
+				'Selected element equals to the first selected cell' );
 		},
 
 		'Change selection': function() {

--- a/tests/plugins/tableselection/integrations/core/selection.js
+++ b/tests/plugins/tableselection/integrations/core/selection.js
@@ -311,7 +311,7 @@
 			var table = editor.editable().findOne( 'table' ),
 				ranges = getRangesForCells( editor, table, [ 0, 1 ], true );
 
-			CKEDITOR.plugins.tableselection.addIgnoredElement( editor, table );
+			table.data( 'cke-tableselection-ignored', 1 );
 
 			selection.selectRanges( ranges );
 
@@ -319,16 +319,6 @@
 			assert.isTrue( selection.isInTable(), 'isInTable is true' );
 			assert.isNotNull( selection.getNative(), 'getNative() should be available' );
 			assert.isNotNull( selection.getSelectedText(), 'getSelectedText() should not be null' );
-
-			// Remove blacklisted element to check if funciton is working correctly.
-			CKEDITOR.plugins.tableselection.removeIgnoredElement( editor, table );
-
-			selection.selectRanges( ranges );
-
-			assert.areEqual( 1, selection.isFake, 'Selection is fake' );
-			assert.isTrue( selection.isInTable(), 'isInTable is true' );
-			assert.isNull( selection.getNative(), 'getNative() should be null' );
-			assert.isNotNull( selection.getSelectedText(), 'getSelectedText() should be null' );
 		},
 
 		'Change selection': function() {

--- a/tests/plugins/tableselection/integrations/core/selection.js
+++ b/tests/plugins/tableselection/integrations/core/selection.js
@@ -319,6 +319,16 @@
 			assert.isTrue( selection.isInTable(), 'isInTable is true' );
 			assert.isNotNull( selection.getNative(), 'getNative() should be available' );
 			assert.isNotNull( selection.getSelectedText(), 'getSelectedText() should not be null' );
+
+			// Remove blacklisted element to check if funciton is working correctly.
+			CKEDITOR.plugins.tableselection.removeIgnoredElement( editor, table );
+
+			selection.selectRanges( ranges );
+
+			assert.areEqual( 1, selection.isFake, 'Selection is fake' );
+			assert.isTrue( selection.isInTable(), 'isInTable is true' );
+			assert.isNull( selection.getNative(), 'getNative() should be null' );
+			assert.isNotNull( selection.getSelectedText(), 'getSelectedText() should be null' );
 		},
 
 		'Change selection': function() {

--- a/tests/plugins/tableselection/integrations/core/selection.js
+++ b/tests/plugins/tableselection/integrations/core/selection.js
@@ -316,15 +316,9 @@
 			selection.selectRanges( ranges );
 
 			assert.areEqual( 0, selection.isFake, 'Selection is not fake' );
-
 			assert.isTrue( selection.isInTable(), 'isInTable is true' );
-			assert.areEqual( 1, selection.getRanges().length, 'Single range is selected' );
 			assert.isNotNull( selection.getNative(), 'getNative() should be available' );
 			assert.isNotNull( selection.getSelectedText(), 'getSelectedText() should not be null' );
-
-			assert.areSame( CKEDITOR.SELECTION_ELEMENT, selection.getType(), 'Element type selection' );
-			assert.isTrue( _getTableElementFromRange( ranges[ 0 ] ).equals( selection.getSelectedElement() ),
-				'Selected element equals to the first selected cell' );
 		},
 
 		'Change selection': function() {

--- a/tests/plugins/tableselection/integrations/core/selection.js
+++ b/tests/plugins/tableselection/integrations/core/selection.js
@@ -308,6 +308,25 @@
 
 			bender.tools.setHtmlWithSelection( editor, CKEDITOR.document.getById( 'simpleTable' ).getHtml() );
 
+			var table = editor.editable().findOne( 'table' );
+
+			table.data( 'cke-tableselection-ignored', 1 );
+
+			selection.selectElement( table.findOne( 'td' ) );
+
+			assert.areEqual( 0, selection.isFake, 'Selection is not fake' );
+			assert.isTrue( selection.isInTable(), 'isInTable is true' );
+			assert.isNotNull( selection.getNative(), 'getNative() should be available' );
+			assert.isNotNull( selection.getSelectedText(), 'getSelectedText() should not be null' );
+		},
+
+		// (#2945)
+		'Test selecting ignored element (ranges)': function() {
+			var editor = this.editor,
+				selection = editor.getSelection();
+
+			bender.tools.setHtmlWithSelection( editor, CKEDITOR.document.getById( 'simpleTable' ).getHtml() );
+
 			var table = editor.editable().findOne( 'table' ),
 				ranges = getRangesForCells( editor, table, [ 0, 1 ], true );
 

--- a/tests/plugins/tableselection/manual/ignore.html
+++ b/tests/plugins/tableselection/manual/ignore.html
@@ -1,0 +1,45 @@
+<button id="toggleIgnore">Toggle ignore</button>
+<div id="editor">
+	<table border="1">
+		<tr>
+			<td>Cell 1.1</td>
+			<td>Cell 1.2</td>
+			<td>Cell 1.3</td>
+			<td>Cell 1.4</td>
+		</tr>
+		<tr>
+			<td>Cell 2.1</td>
+			<td>Cell 2.2</td>
+			<td>Cell 2.3</td>
+			<td>Cell 2.4</td>
+		</tr>
+	</table>
+</div>
+
+<script>
+	if ( ( CKEDITOR.env.ie && CKEDITOR.env.version < 11 ) || bender.tools.env.mobile ) {
+		bender.ignore();
+	}
+
+	var editor = CKEDITOR.replace( 'editor' );
+
+	editor.once( 'instanceReady', function() {
+		var table = editor.editable().findOne( 'table' ),
+			tableselection = CKEDITOR.plugins.tableselection,
+			ignored = false;
+
+		toggleIgnore();
+
+		CKEDITOR.document.getById( 'toggleIgnore' ).on( 'click', toggleIgnore );
+
+		function toggleIgnore() {
+			if ( ignored ) {
+				tableselection.removeIgnoredElement( editor, table );
+			} else {
+				tableselection.addIgnoredElement( editor, table );
+			}
+
+			ignored = !ignored;
+		}
+	} );
+</script>

--- a/tests/plugins/tableselection/manual/ignore.html
+++ b/tests/plugins/tableselection/manual/ignore.html
@@ -1,4 +1,3 @@
-<button id="toggleIgnore">Toggle ignore</button>
 <div id="editor">
 	<table data-cke-tableselection-ignored="1" border="1">
 		<tr>
@@ -21,17 +20,5 @@
 		bender.ignore();
 	}
 
-	var editor = CKEDITOR.replace( 'editor' );
-
-	editor.once( 'instanceReady', function() {
-		var table = editor.editable().findOne( 'table' ),
-			tableselection = CKEDITOR.plugins.tableselection,
-			ignoredTableselectionDataAttribute = 'cke-tableselection-ignored';
-
-		CKEDITOR.document.getById( 'toggleIgnore' ).on( 'click', function() {
-			var next = table.data( ignoredTableselectionDataAttribute ) == '1' ? false : '1';
-
-			table.data( ignoredTableselectionDataAttribute, next );
-		} );
-	} );
+	CKEDITOR.replace( 'editor' );
 </script>

--- a/tests/plugins/tableselection/manual/ignore.html
+++ b/tests/plugins/tableselection/manual/ignore.html
@@ -1,6 +1,6 @@
 <button id="toggleIgnore">Toggle ignore</button>
 <div id="editor">
-	<table border="1">
+	<table data-cke-tableselection-ignored="1" border="1">
 		<tr>
 			<td>Cell 1.1</td>
 			<td>Cell 1.2</td>
@@ -26,20 +26,12 @@
 	editor.once( 'instanceReady', function() {
 		var table = editor.editable().findOne( 'table' ),
 			tableselection = CKEDITOR.plugins.tableselection,
-			ignored = false;
+			ignoredTableselectionDataAttribute = 'cke-tableselection-ignored';
 
-		toggleIgnore();
+		CKEDITOR.document.getById( 'toggleIgnore' ).on( 'click', function() {
+			var next = table.data( ignoredTableselectionDataAttribute ) == '1' ? false : '1';
 
-		CKEDITOR.document.getById( 'toggleIgnore' ).on( 'click', toggleIgnore );
-
-		function toggleIgnore() {
-			if ( ignored ) {
-				tableselection.removeIgnoredElement( editor, table );
-			} else {
-				tableselection.addIgnoredElement( editor, table );
-			}
-
-			ignored = !ignored;
-		}
+			table.data( ignoredTableselectionDataAttribute, next );
+		} );
 	} );
 </script>

--- a/tests/plugins/tableselection/manual/ignore.md
+++ b/tests/plugins/tableselection/manual/ignore.md
@@ -2,15 +2,8 @@
 @bender-tags: feature, 4.12.0, 2945
 @bender-ckeditor-plugins: wysiwygarea, toolbar, tableselection, clipboard
 
-1. Select the first table row.
+Select the first table row.
 
 **Expected:** Cells are selected with native browser selection.
 
 **Unexpected:** Cells are selected with `tableselection` visual selection.
-
-2. Click `Toggle ignore` button.
-3. Again, select the first table row.
-
-**Expected:** Cells are selected with `tableselection` visual selection.
-
-**Unexpected:** Cells are selected with native browser selection.

--- a/tests/plugins/tableselection/manual/ignore.md
+++ b/tests/plugins/tableselection/manual/ignore.md
@@ -1,0 +1,16 @@
+@bender-ui: collapsed
+@bender-tags: feature, 4.12.0, 2945
+@bender-ckeditor-plugins: wysiwygarea, toolbar, tableselection, clipboard
+
+1. Select the first table row.
+
+**Expected:** Cells are selected with native browser selection.
+
+**Unexpected:** Cells are selected with `tableselection` visual selection.
+
+2. Click `Toggle ignore` button.
+3. Again, select the first table row.
+
+**Expected:** Cells are selected with `tableselection` visual selection.
+
+**Unexpected:** Cells are selected with native browser selection.

--- a/tests/plugins/tableselection/tableselection.js
+++ b/tests/plugins/tableselection/tableselection.js
@@ -148,6 +148,25 @@
 			} );
 		},
 
+		// (#2945)
+		'test simulating mouse events while the table is ignored': function( editor ) {
+			bender.tools.setHtmlWithSelection( editor, CKEDITOR.document.getById( 'simpleTable' ).getHtml() );
+
+			var table = editor.editable().findOne( 'table' ),
+				cells = table.find( 'td' );
+
+			CKEDITOR.plugins.tableselection.addIgnoredElement( editor, table );
+
+			mockMouseSelection( editor, [ cells.getItem( 1 ), cells.getItem( 2 ) ], function() {
+				var selection = editor.getSelection();
+
+				CKEDITOR.plugins.tableselection.removeIgnoredElement( editor, table );
+
+				assert.isFalse( selection.isInTable(), 'Selection is not in table' );
+				assert.isFalse( !!selection.isFake, 'Selection is not faked' );
+			} );
+		},
+
 		// (#2003)
 		'test right-click in cell with empty paragraph': function( editor, bot ) {
 			if ( !CKEDITOR.env.gecko ) {

--- a/tests/plugins/tableselection/tableselection.js
+++ b/tests/plugins/tableselection/tableselection.js
@@ -155,12 +155,10 @@
 			var table = editor.editable().findOne( 'table' ),
 				cells = table.find( 'td' );
 
-			CKEDITOR.plugins.tableselection.addIgnoredElement( editor, table );
+			table.data( 'cke-tableselection-ignored', 1 );
 
 			mockMouseSelection( editor, [ cells.getItem( 1 ), cells.getItem( 2 ) ], function() {
 				var selection = editor.getSelection();
-
-				CKEDITOR.plugins.tableselection.removeIgnoredElement( editor, table );
 
 				assert.isFalse( selection.isInTable(), 'Selection is not in table' );
 				assert.isFalse( !!selection.isFake, 'Selection is not faked' );
@@ -235,21 +233,12 @@
 					}
 				};
 
-			CKEDITOR.plugins.tableselection.addIgnoredElement( editor, table );
+			table.data( 'cke-tableselection-ignored', 1 );
 
 			var result = editable.fire( 'dragstart', evt );
 
 			assert.areEqual( 0, preventDefaultCallCount, 'Event should not be prevented' );
 			assert.isTrue( Boolean( result ), 'Event should not be canceled' );
-
-			// Check if removing element from ignored list reverses event flow.
-			CKEDITOR.plugins.tableselection.removeIgnoredElement( editor, table );
-
-			result = editable.fire( 'dragstart', evt );
-
-			assert.areEqual( 1, preventDefaultCallCount, 'Event should be prevented' );
-			assert.isFalse( result, 'Event should be canceled' );
-
 		},
 
 		// (#2945)
@@ -282,18 +271,12 @@
 						}
 					};
 
-				CKEDITOR.plugins.tableselection.addIgnoredElement( editor, table );
+				table.data( 'cke-tableselection-ignored', 1 );
 
 				editor.getSelection().selectElement( cell );
 
 				editable.fire( eventName, evt );
 				assert.isNull( editable.findOne( '#cke_table_copybin' ), eventName + ' event should be ignored' );
-
-				// Check if removing element from ignored list reverses event flow.
-				CKEDITOR.plugins.tableselection.removeIgnoredElement( editor, table );
-
-				editable.fire( eventName, evt );
-				assert.isNotNull( editable.findOne( '#cke_table_copybin' ), eventName + ' event should not be ignored' );
 			}
 		}
 	};


### PR DESCRIPTION
## What is the purpose of this pull request?

New feature

## Does your PR contain necessary tests?

All patches which change the editor code must include tests. You can always read more
on [PR testing](https://ckeditor.com/docs/ckeditor4/latest/guide/dev_contributing_code.html#tests),
[how to set the testing environment](https://ckeditor.com/docs/ckeditor4/latest/guide/dev_tests.html) and
[how to create tests](https://ckeditor.com/docs/ckeditor4/latest/guide/dev_tests.html#creating-your-own-test)
in the official CKEditor documentation.

### This PR contains

- [x] Unit tests
- [x] Manual tests

**Note** Keyboard listeners don't need this improvement thus they handle faked table selection only which should be already disabled for the given element.

Closes #2945
