### PR TITLE
Fix for: magicline plugin leaks memory

### DIFF
--- a/plugins/magicline/plugin.js
+++ b/plugins/magicline/plugin.js
@@ -340,7 +340,7 @@
 
 			// This one allows testing and debugging. It reveals some
 			// inner methods to the world.
-			this.backdoor = {
+			editor._.magiclineBackdoor = {
 				accessFocusSpace: accessFocusSpace,
 				boxTrigger: boxTrigger,
 				isLine: isLine,

--- a/tests/plugins/magicline/magicline.js
+++ b/tests/plugins/magicline/magicline.js
@@ -44,7 +44,7 @@
 					);
 
 					tc.resume( function() {
-						callback( editor, editable, editor.plugins.magicline.backdoor );
+						callback( editor, editable, editor._.magiclineBackdoor );
 					} );
 				}
 			}

--- a/tests/plugins/magicline/memory.js
+++ b/tests/plugins/magicline/memory.js
@@ -1,0 +1,19 @@
+/* bender-tags: editor,magicline */
+/* bender-ckeditor-plugins: magicline */
+
+( function() {
+	'use strict';
+
+	bender.editor = {};
+
+	bender.test( {
+		// (#589)
+		'test magicline backdoor reference is removed after editor.destroy': function() {
+			var editor = this.editor;
+
+			editor.destroy();
+
+			assert.isUndefined( CKEDITOR.plugins.registered.magicline.backdoor );
+		}
+	} );
+} )();

--- a/tests/plugins/magicline/widgets.js
+++ b/tests/plugins/magicline/widgets.js
@@ -149,7 +149,7 @@
 			editor = this.editorBot.editor;
 			doc = editor.document;
 
-			var backdoor = editor.plugins.magicline.backdoor;
+			var backdoor = editor._.magiclineBackdoor;
 
 			this.editorBot.setData( html, function() {
 				if ( cfg.that.element )
@@ -184,7 +184,7 @@
 			editor = this.editorBot.editor;
 			doc = editor.document;
 
-			var backdoor = editor.plugins.magicline.backdoor;
+			var backdoor = editor._.magiclineBackdoor;
 
 			this.editorBot.setData( html, function() {
 				var widget = cfg.widget();


### PR DESCRIPTION
## What is the purpose of this pull request?

Bug fix/ memory leaks

## Does your PR contain necessary tests?

All patches which change the editor code must include tests. You can always read more
on [PR testing](https://ckeditor.com/docs/ckeditor4/latest/guide/dev_contributing_code.html#tests),
[how to set the testing environment](https://ckeditor.com/docs/ckeditor4/latest/guide/dev_tests.html) and
[how to create tests](https://ckeditor.com/docs/ckeditor4/latest/guide/dev_tests.html#creating-your-own-test)
in the official CKEditor documentation.

### This PR contains

- [X] Unit tests
- [ ] Manual tests - manual test is located in `memory-test` branch.

## What changes did you make?

Magic line plugin exposes `backdoor` object property for debugging purposes in `CKEDITOR.plugins.magicline`, this object is replaced with each editor creation.
To fix memory leaks I've moved this property into `editor._.magicLineBackdoor`, so all references are removed along with editor instance.

For manual testing enable test on your current branch by:
```git checkout memory-test tests/_assets/memorytest.html```

Then read:
https://github.com/ckeditor/ckeditor-dev/blob/memory-test/tests/core/memory/memory.md

`master` branch
![Screenshot 2019-03-19 at 12 09 34](https://user-images.githubusercontent.com/23366849/54602617-73a4fc00-4a42-11e9-9868-6ef87a6579a9.png)
After applying fix
![Screenshot 2019-03-19 at 12 07 29](https://user-images.githubusercontent.com/23366849/54602616-71db3880-4a42-11e9-8c83-1ef19004db4b.png)

Snapshots
1. After page load.
1. After creating and destroying first editor.
1. After creating and destroying second editor.
1. After 100 next cycles of create-destroy editor.

Notes
- First editor takes plenty of memory which is not released, but most of it is reused by next editors.
- Second editor takes more memory than any next editors. I assume that Chrome after second creating of editor performs some optimizations which trade some memory for performance.

Partially solves #589