### PR TITLE
Fix for: memory leaks

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -5,6 +5,7 @@
 
 Fixed Issues:
 
+* [#589](https://github.com/ckeditor/ckeditor-dev/issues/589): Fixed: Editor has many sources of potential memory leaks.
 * [#1397](https://github.com/ckeditor/ckeditor-dev/issues/1397): Fixed: Using dialog to remove headers from the [table](https://ckeditor.com/cke4/addon/table) with one headers row only throws an error.
 * [#1479](https://github.com/ckeditor/ckeditor-dev/issues/1479): Fixed: [Justification](https://ckeditor.com/cke4/addon/justify) for styled content in BR mode is disabled.
 * [#2816](https://github.com/ckeditor/ckeditor-dev/issues/2816): Fixed: [Enhanced Image](https://ckeditor.com/cke4/addon/image2) resize handler is visible in [read-only mode](https://ckeditor.com/docs/ckeditor4/latest/guide/dev_readonly.html).

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -5,7 +5,7 @@
 
 Fixed Issues:
 
-* [#589](https://github.com/ckeditor/ckeditor-dev/issues/589): Fixed: Editor has many sources of potential memory leaks.
+* [#589](https://github.com/ckeditor/ckeditor-dev/issues/589): Fixed: Editor causes memory leaks in create / destroy cycles.
 * [#1397](https://github.com/ckeditor/ckeditor-dev/issues/1397): Fixed: Using dialog to remove headers from the [table](https://ckeditor.com/cke4/addon/table) with one headers row only throws an error.
 * [#1479](https://github.com/ckeditor/ckeditor-dev/issues/1479): Fixed: [Justification](https://ckeditor.com/cke4/addon/justify) for styled content in BR mode is disabled.
 * [#2816](https://github.com/ckeditor/ckeditor-dev/issues/2816): Fixed: [Enhanced Image](https://ckeditor.com/cke4/addon/image2) resize handler is visible in [read-only mode](https://ckeditor.com/docs/ckeditor4/latest/guide/dev_readonly.html).

--- a/core/ckeditor.js
+++ b/core/ckeditor.js
@@ -49,14 +49,19 @@ CKEDITOR.add = function( editor ) {
 		}
 	} );
 
-	editor.on( 'blur', function() {
+	editor.on( 'blur', removeInstance );
+
+	// Remove currentInstance if it's destroyed (#589).
+	editor.on( 'destroy', removeInstance );
+
+	CKEDITOR.fire( 'instance', null, editor );
+
+	function removeInstance() {
 		if ( CKEDITOR.currentInstance == editor ) {
 			CKEDITOR.currentInstance = null;
 			CKEDITOR.fire( 'currentInstance' );
 		}
-	} );
-
-	CKEDITOR.fire( 'instance', null, editor );
+	}
 };
 
 /**

--- a/core/loader.js
+++ b/core/loader.js
@@ -158,6 +158,8 @@ if ( !CKEDITOR.loader ) {
 						// Some browsers, such as Safari, may call the onLoad function
 						// immediately. Which will break the loading sequence. (https://dev.ckeditor.com/ticket/3661)
 						setTimeout( function() {
+							// Once script loaded remove listener, which might lead to memory leaks (#589).
+							script.onload = null;
 							onScriptLoaded( scriptName );
 						}, 0 );
 					};

--- a/core/scriptloader.js
+++ b/core/scriptloader.js
@@ -132,11 +132,13 @@ CKEDITOR.scriptLoader = ( function() {
 								// Some browsers, such as Safari, may call the onLoad function
 								// immediately. Which will break the loading sequence. (https://dev.ckeditor.com/ticket/3661)
 								setTimeout( function() {
+									removeListeners( script );
 									onLoad( url, true );
 								}, 0 );
 							};
 
 							script.$.onerror = function() {
+								removeListeners( script );
 								onLoad( url, false );
 							};
 						}
@@ -146,11 +148,18 @@ CKEDITOR.scriptLoader = ( function() {
 					script.appendTo( CKEDITOR.document.getHead() );
 
 					CKEDITOR.fire( 'download', url ); // %REMOVE_LINE%
+
 				};
 
 			showBusy && CKEDITOR.document.getDocumentElement().setStyle( 'cursor', 'wait' );
 			for ( var i = 0; i < scriptCount; i++ ) {
 				loadScript( scriptUrl[ i ] );
+			}
+
+			function removeListeners( script ) {
+				// Once script loaded or failed remove listeners, which might lead to memory leaks (#589).
+				script.$.onload = null;
+				script.$.onerror = null;
 			}
 		},
 

--- a/core/skin.js
+++ b/core/skin.js
@@ -269,24 +269,32 @@
 
 	CKEDITOR.on( 'instanceLoaded', function( evt ) {
 		// The chameleon feature is not for IE quirks.
-		if ( CKEDITOR.env.ie && CKEDITOR.env.quirks )
+		if ( CKEDITOR.env.ie && CKEDITOR.env.quirks ) {
 			return;
+		}
 
 		var editor = evt.editor,
 			showCallback = function( event ) {
-				var panel = event.data[ 0 ] || event.data;
-				var iframe = panel.element.getElementsByTag( 'iframe' ).getItem( 0 ).getFrameDocument();
+				var panel = event.data[ 0 ] || event.data,
+					iframe = panel.element.getElementsByTag( 'iframe' ).getItem( 0 ).getFrameDocument();
 
 				// Add stylesheet if missing.
 				if ( !iframe.getById( 'cke_ui_color' ) ) {
 					var node = getStylesheet( iframe );
 					uiColorMenus.push( node );
 
+					// Cleanup after destroying editor (#589).
+					editor.on( 'destroy', function() {
+						uiColorMenus = CKEDITOR.tools.array.filter( uiColorMenus, function( storedNode ) {
+							return node !== storedNode;
+						} );
+					} );
+
 					var color = editor.getUiColor();
 					// Set uiColor for new panel.
-					if ( color )
+					if ( color ) {
 						updateStylesheets( [ node ], CKEDITOR.skin.chameleon( editor, 'panel' ), [ [ uiColorRegexp, color ] ] );
-
+					}
 				}
 			};
 

--- a/plugins/autocomplete/plugin.js
+++ b/plugins/autocomplete/plugin.js
@@ -240,7 +240,9 @@
 			}, this );
 		}
 
-		editor.on( 'destroy', this.destroy, this );
+		editor.on( 'destroy', function() {
+			this.destroy();
+		}, this );
 	}
 
 	Autocomplete.prototype = {
@@ -361,7 +363,7 @@
 
 			this._listeners = [];
 
-			this.view.element.remove();
+			this.view.element && this.view.element.remove();
 		},
 
 		/**

--- a/plugins/autocomplete/plugin.js
+++ b/plugins/autocomplete/plugin.js
@@ -239,6 +239,8 @@
 				this.attach();
 			}, this );
 		}
+
+		editor.on( 'destroy', this.destroy, this );
 	}
 
 	Autocomplete.prototype = {

--- a/plugins/codesnippet/plugin.js
+++ b/plugins/codesnippet/plugin.js
@@ -47,7 +47,7 @@
 					CKEDITOR.tools.objectKeys( langs ).join( '|' ) + ')(?:\\s|$)' );
 			};
 
-			editor.once( 'instanceReady', function() {
+			editor.once( 'pluginsLoaded', function() {
 				// Remove method once it can't be used, because it leaks editor reference (#589).
 				this.setHighlighter = null;
 			}, this );

--- a/plugins/codesnippet/plugin.js
+++ b/plugins/codesnippet/plugin.js
@@ -46,6 +46,11 @@
 				editor._.codesnippet.langsRegex = new RegExp( '(?:^|\\s)language-(' +
 					CKEDITOR.tools.objectKeys( langs ).join( '|' ) + ')(?:\\s|$)' );
 			};
+
+			editor.once( 'instanceReady', function() {
+				// Remove method once it can't be used, because it leaks editor reference (#589).
+				this.setHighlighter = null;
+			}, this );
 		},
 
 		onLoad: function() {

--- a/plugins/dialog/plugin.js
+++ b/plugins/dialog/plugin.js
@@ -2228,6 +2228,9 @@ CKEDITOR.DIALOG_STATE_BUSY = 2;
 		editor.focusManager.remove( currentCover );
 		var win = CKEDITOR.document.getWindow();
 		currentCover.hide();
+
+		// Remove current cover reference once it's removed (#589).
+		currentCover = null;
 		win.removeListener( 'resize', resizeCover );
 
 		if ( CKEDITOR.env.ie6Compat ) {

--- a/plugins/image2/plugin.js
+++ b/plugins/image2/plugin.js
@@ -1432,7 +1432,7 @@
 		if ( !editor.plugins.link )
 			return;
 
-		CKEDITOR.on( 'dialogDefinition', function( evt ) {
+		var listener = CKEDITOR.on( 'dialogDefinition', function( evt ) {
 			var dialog = evt.data;
 
 			if ( dialog.name == 'link' ) {
@@ -1482,6 +1482,10 @@
 					}
 				};
 			}
+		} );
+		// Listener has to be removed due to leaking editor reference (#589).
+		editor.on( 'destroy', function() {
+			listener.removeListener();
 		} );
 
 		// Overwrite default behaviour of unlink command.

--- a/plugins/magicline/plugin.js
+++ b/plugins/magicline/plugin.js
@@ -340,7 +340,7 @@
 
 			// This one allows testing and debugging. It reveals some
 			// inner methods to the world.
-			this.backdoor = {
+			editor._.magiclineBackdoor = {
 				accessFocusSpace: accessFocusSpace,
 				boxTrigger: boxTrigger,
 				isLine: isLine,

--- a/plugins/widget/plugin.js
+++ b/plugins/widget/plugin.js
@@ -3638,7 +3638,8 @@
 
 	function addCustomStyleHandler() {
 		// Styles categorized by group. It is used to prevent applying styles for the same group being used together.
-		var styleGroups = {};
+		var styleGroups = {},
+			styleDefinitions = [];
 
 		/**
 		 * The class representing a widget style. It is an {@link CKEDITOR#STYLE_OBJECT object} like
@@ -3875,7 +3876,7 @@
 		// Save and categorize style by its group.
 		function saveStyleGroup( style ) {
 			var widgetName = style.widget,
-				group;
+				group, styleDef;
 
 			if ( !styleGroups[ widgetName ] ) {
 				styleGroups[ widgetName ] = {};
@@ -3887,7 +3888,13 @@
 					styleGroups[ widgetName ][ group ] = [];
 				}
 
-				styleGroups[ widgetName ][ group ].push( style );
+				styleDef = style.getDefinition();
+
+				// Don't push style if it's already stored (#589).
+				if ( CKEDITOR.tools.indexOf( styleDefinitions, styleDef ) === -1 ) {
+					styleDefinitions.push( styleDef );
+					styleGroups[ widgetName ][ group ].push( style );
+				}
 			}
 		}
 

--- a/plugins/widget/plugin.js
+++ b/plugins/widget/plugin.js
@@ -3891,9 +3891,24 @@
 				group = styleGroups[ widgetName ][ groupName ];
 
 				// Don't push style if it's already stored (#589).
-				if ( !CKEDITOR.tools.array.find( group, getCompareFn( style ) ) ) {
+				if ( !find( group, getCompareFn( style ) ) ) {
 					group.push( style );
 				}
+			}
+
+			// Copied `CKEDITOR.tools.array` from major branch.
+			function find( array, fn, thisArg ) {
+				var length = array.length,
+					i = 0;
+
+				while ( i < length ) {
+					if ( fn.call( thisArg, array[ i ], i, array ) ) {
+						return array[ i ];
+					}
+					i++;
+				}
+
+				return undefined;
 			}
 
 			function getCompareFn( left ) {

--- a/plugins/widget/plugin.js
+++ b/plugins/widget/plugin.js
@@ -3876,24 +3876,48 @@
 		// Save and categorize style by its group.
 		function saveStyleGroup( style ) {
 			var widgetName = style.widget,
-				group, styleDef;
+				groupName, group;
 
 			if ( !styleGroups[ widgetName ] ) {
 				styleGroups[ widgetName ] = {};
 			}
 
 			for ( var i = 0, l = style.group.length; i < l; i++ ) {
-				group = style.group[ i ];
-				if ( !styleGroups[ widgetName ][ group ] ) {
-					styleGroups[ widgetName ][ group ] = [];
+				groupName = style.group[ i ];
+				if ( !styleGroups[ widgetName ][ groupName ] ) {
+					styleGroups[ widgetName ][ groupName ] = [];
 				}
 
-				styleDef = style.getDefinition();
+				group = styleGroups[ widgetName ][ groupName ];
 
 				// Don't push style if it's already stored (#589).
-				if ( CKEDITOR.tools.indexOf( styleDefinitions, styleDef ) === -1 ) {
-					styleDefinitions.push( styleDef );
-					styleGroups[ widgetName ][ group ].push( style );
+				if ( !CKEDITOR.tools.array.find( group, getCompareFn( style ) ) ) {
+					group.push( style );
+				}
+			}
+
+			function getCompareFn( left ) {
+				return function( right ) {
+					return deepCompare( left.getDefinition(), right.getDefinition() );
+				};
+
+				function deepCompare( left, right ) {
+					var leftKeys = CKEDITOR.tools.objectKeys( left ),
+						rightKeys = CKEDITOR.tools.objectKeys( right );
+
+					if ( leftKeys.length !== rightKeys.length ) {
+						return false;
+					}
+
+					for ( var key in left ) {
+						var areSameObjects = typeof left[ key ] === 'object' && typeof right[ key ] === 'object' && deepCompare( left[ key ], right[ key ] );
+
+						if ( !areSameObjects && left[ key ] !== right[ key ] ) {
+							return false;
+						}
+					}
+
+					return true;
 				}
 			}
 		}

--- a/tests/core/editor/currentInstance.js
+++ b/tests/core/editor/currentInstance.js
@@ -1,0 +1,27 @@
+/* bender-tags: editor */
+/* bender-ckeditor-plugins: wysiwygarea */
+
+( function() {
+	'use strict';
+
+	bender.editor = {};
+
+	bender.test( {
+		// (#589)
+		'test currentInstance after editor destroy': function() {
+			this.editor.fire( 'focus' );
+			this.editor.on( 'destroy', function() {
+				setTimeout( function() {
+					resume( function() {
+						assert.isNull( CKEDITOR.currentInstance );
+					} );
+				} );
+			} );
+
+			assert.areSame( this.editor, CKEDITOR.currentInstance );
+
+			this.editor.destroy();
+			wait();
+		}
+	} );
+} )();

--- a/tests/core/loader.js
+++ b/tests/core/loader.js
@@ -20,9 +20,9 @@
 
 			loader.load( scriptName, false );
 
-			getScript().on( 'load', function() {
-				var script = this;
+			var script = getScript();
 
+			script.on( script.$.onload ? 'load' : 'readystatechange', function() {
 				setTimeout( function() {
 					resume( function() {
 						assert.isFalse( !!script.$.onreadystatechange );
@@ -32,6 +32,7 @@
 			} );
 
 			wait();
+
 			function getScript() {
 				return CKEDITOR.document.findOne( 'script[src="' + CKEDITOR.getUrl( 'core/' + scriptName + '.js' ) + '"]' );
 			}

--- a/tests/core/loader.js
+++ b/tests/core/loader.js
@@ -1,0 +1,34 @@
+/* bender-tags: editor */
+( function() {
+	'use strict';
+
+	bender.test( {
+		// Script listeners should be removed because it might cause memory leaks (#589).
+		'test script load listeners removed': function() {
+			var loader = CKEDITOR.loader,
+				scriptName = loader.loadedScripts.pop();
+
+			getScript().remove();
+
+			delete loader.loadedScripts[ 's:' + scriptName ];
+
+			loader.load( scriptName, false );
+
+			getScript().on( 'load', function() {
+				var script = this;
+
+				setTimeout( function() {
+					resume( function() {
+						assert.isFalse( !!script.$.onreadystatechange );
+						assert.isFalse( !!script.$.onload );
+					} );
+				}, 50 );
+			} );
+
+			wait();
+			function getScript() {
+				return CKEDITOR.document.findOne( 'script[src="' + CKEDITOR.getUrl( 'core/' + scriptName + '.js' ) + '"]' );
+			}
+		}
+	} );
+} )();

--- a/tests/core/loader.js
+++ b/tests/core/loader.js
@@ -5,8 +5,14 @@
 	bender.test( {
 		// Script listeners should be removed because it might cause memory leaks (#589).
 		'test script load listeners removed': function() {
-			var loader = CKEDITOR.loader,
-				scriptName = loader.loadedScripts.pop();
+			var loader = CKEDITOR.loader;
+
+			if ( !loader ) {
+				// All core modules are bundled in release version, so we can't and don't need to test it there.
+				assert.ignore();
+			}
+
+			var scriptName = loader.loadedScripts.pop();
 
 			getScript().remove();
 

--- a/tests/core/scriptloader.js
+++ b/tests/core/scriptloader.js
@@ -104,6 +104,21 @@ var tests = {
 		] );
 
 		this.wait();
+	},
+
+	// Script listeners should be removed because it might cause memory leaks (#589).
+	'test script listeners removed when loaded': function() {
+		CKEDITOR.scriptLoader.load( '../_assets/sample.js', function() {
+			resume( function() {
+				var script = CKEDITOR.document.findOne( 'script[src="../_assets/sample.js"]' );
+
+				assert.isFalse( !!script.$.onreadystatechange );
+				assert.isFalse( !!script.$.onload );
+				assert.isFalse( !!script.$.onerror );
+			} );
+		} );
+
+		wait();
 	}
 };
 

--- a/tests/plugins/autocomplete/autocomplete.html
+++ b/tests/plugins/autocomplete/autocomplete.html
@@ -1,1 +1,2 @@
 <div id="init"></div>
+<textarea id="destroy"></textarea>

--- a/tests/plugins/autocomplete/autocomplete.js
+++ b/tests/plugins/autocomplete/autocomplete.js
@@ -563,6 +563,25 @@
 			} );
 
 			wait();
+		},
+
+		// (#589)
+		'test autocomplete is destroyed with editor': function() {
+			var editor = CKEDITOR.replace( 'destroy' ),
+				ac = new CKEDITOR.plugins.autocomplete( editor, configDefinition ),
+				spy = sinon.spy( ac, 'destroy' );
+
+			editor.on( 'destroy', function() {
+				setTimeout( function() {
+					resume( function() {
+						assert.isTrue( spy.called );
+					} );
+				} );
+			} );
+
+			editor.destroy();
+
+			wait();
 		}
 	} );
 

--- a/tests/plugins/codesnippet/highlighter.js
+++ b/tests/plugins/codesnippet/highlighter.js
@@ -4,7 +4,18 @@
 ( function() {
 	'use strict';
 
-	bender.editor = true;
+	var setHighlighter;
+
+	bender.editor = {
+		config: {
+			on: {
+				pluginsLoaded: function() {
+					// Normally setHighlighter can be used only during plugin init hooks, after that it is removed, so keep it for testing purposes.
+					setHighlighter = CKEDITOR.plugins.registered.codesnippet.setHighlighter;
+				}
+			}
+		}
+	};
 
 	var objToArray = bender.tools.objToArray,
 		html = '<pre>' +
@@ -20,6 +31,11 @@
 	}
 
 	bender.test( {
+		// (#589)
+		'test setHighlighter method is absent': function() {
+			assert.isNull( CKEDITOR.plugins.registered.codesnippet.setHighlighter );
+		},
+
 		'test highlighter: change highlighter': function() {
 			var editor = this.editor,
 				langs = {};
@@ -29,7 +45,7 @@
 				highlighter: function() {}
 			} );
 
-			editor.plugins.codesnippet.setHighlighter( highlighter );
+			setHighlighter( highlighter );
 
 			assert.areEqual( highlighter, getHighlighter( editor ), 'Highlighter has not been changed' );
 			assert.areEqual( langs, getLangs( this.editor ), 'Highlighter languages has not been changed' );
@@ -56,7 +72,7 @@
 				}
 			} );
 
-			editor.plugins.codesnippet.setHighlighter( highlighter );
+			setHighlighter( highlighter );
 
 			this.editorBot.setData( html, function() {
 				var widget = objToArray( editor.widgets.instances )[ 0 ];
@@ -97,7 +113,7 @@
 				}
 			} );
 
-			editor.plugins.codesnippet.setHighlighter( highlighter );
+			setHighlighter( highlighter );
 
 			this.editorBot.setData( html, function() {
 				var widget = objToArray( editor.widgets.instances )[ 0 ];

--- a/tests/plugins/image2/dialoglistener.html
+++ b/tests/plugins/image2/dialoglistener.html
@@ -1,0 +1,1 @@
+<textarea id="editor"></textarea>

--- a/tests/plugins/image2/dialoglistener.js
+++ b/tests/plugins/image2/dialoglistener.js
@@ -10,11 +10,11 @@
 				on: {
 					instanceReady: function() {
 						var listeners = CKEDITOR._.events.dialogDefinition.listeners,
-							listener = listeners[ 0 ];
+							listener = listeners[ listeners.length - 1 ];
 
 						this.on( 'destroy', function() {
 							resume( function() {
-								assert.areNotSame( listeners[ 0 ], listener, 'Listener is removed.' );
+								arrayAssert.doesNotContain( listener, listeners, 'Listener is removed' );
 							} );
 						} );
 

--- a/tests/plugins/image2/dialoglistener.js
+++ b/tests/plugins/image2/dialoglistener.js
@@ -1,0 +1,29 @@
+/* bender-tags: editor,widget */
+/* bender-ckeditor-plugins: wysiwygarea, image2, dialog, link  */
+
+( function() {
+	'use strict';
+
+	bender.test( {
+		'test dialog listener removed after editor destroy': function() {
+			CKEDITOR.replace( 'editor', {
+				on: {
+					instanceReady: function() {
+						var listeners = CKEDITOR._.events.dialogDefinition.listeners,
+							listener = listeners[ 0 ];
+
+						this.on( 'destroy', function() {
+							resume( function() {
+								assert.areNotSame( listeners[ 0 ], listener, 'Listener is removed.' );
+							} );
+						} );
+
+						this.destroy();
+					}
+				}
+			} );
+
+			wait();
+		}
+	} );
+} )();

--- a/tests/plugins/magicline/magicline.js
+++ b/tests/plugins/magicline/magicline.js
@@ -44,7 +44,7 @@
 					);
 
 					tc.resume( function() {
-						callback( editor, editable, editor.plugins.magicline.backdoor );
+						callback( editor, editable, editor._.magiclineBackdoor );
 					} );
 				}
 			}

--- a/tests/plugins/magicline/memory.js
+++ b/tests/plugins/magicline/memory.js
@@ -1,0 +1,19 @@
+/* bender-tags: editor,magicline */
+/* bender-ckeditor-plugins: magicline */
+
+( function() {
+	'use strict';
+
+	bender.editor = {};
+
+	bender.test( {
+		// (#589)
+		'test magicline backdoor reference is removed after editor.destroy': function() {
+			var editor = this.editor;
+
+			editor.destroy();
+
+			assert.isUndefined( CKEDITOR.plugins.registered.magicline.backdoor );
+		}
+	} );
+} )();

--- a/tests/plugins/magicline/widgets.js
+++ b/tests/plugins/magicline/widgets.js
@@ -149,7 +149,7 @@
 			editor = this.editorBot.editor;
 			doc = editor.document;
 
-			var backdoor = editor.plugins.magicline.backdoor;
+			var backdoor = editor._.magiclineBackdoor;
 
 			this.editorBot.setData( html, function() {
 				if ( cfg.that.element )
@@ -184,7 +184,7 @@
 			editor = this.editorBot.editor;
 			doc = editor.document;
 
-			var backdoor = editor.plugins.magicline.backdoor;
+			var backdoor = editor._.magiclineBackdoor;
 
 			this.editorBot.setData( html, function() {
 				var widget = cfg.widget();


### PR DESCRIPTION
## What is the purpose of this pull request?

Bug fix

## Does your PR contain necessary tests?

All patches which change the editor code must include tests. You can always read more
on [PR testing](https://ckeditor.com/docs/ckeditor4/latest/guide/dev_contributing_code.html#tests),
[how to set the testing environment](https://ckeditor.com/docs/ckeditor4/latest/guide/dev_tests.html) and
[how to create tests](https://ckeditor.com/docs/ckeditor4/latest/guide/dev_tests.html#creating-your-own-test)
in the official CKEditor documentation.

### This PR contains

- [X] Unit tests
- [ ] Manual tests

## What changes did you make?

List of found and fixed memory leaks/ potential memory leaks:

### Magicline

Magicline plugin exposes `backdoor` object property for debugging purposes in `CKEDITOR.plugins.magicline`, this object is replaced with each editor creation.
To fix memory leaks I've moved this property into `editor._.magicLineBackdoor`, so all references are removed along with editor instance.

### Widget styles

Widget plugin keeps registered styles in `styleGroups` local variable. With every editor creation new styles are added. I've added check that prevents adding same styles again. At first I've used `styleDefinition` object for comparisement, but `easyimage` creates them dynamically, so I've changed solution to deeply compare object, to make sure only new styles are stored.

### Script `onload` and `onerror`

`CKEDITOR.scriptLoader` and `CKEDITOR.loader` weren't removing `onload`/`onerror` listeners once loading is finished. Listeners keeps references to things that otherwise might be cleaned by Garbage Collector.

### Image2 dialog

Image2 plugin adds global listener via `CKEDITOR.on( 'dialogDefinition' )` for each editor. Listener was never removed, thus editor reference was leaking. I've removed this listener on editor destroy.

### Codesnippet highlighter

Codesnippet plugin on `beforeInit` registers method `CKEDITOR.plugins.registered.setHighlighter` which is bound to editor instance, hence editor reference is leaking. According to [docs](https://ckeditor.com/docs/ckeditor4/latest/api/CKEDITOR_plugins_codesnippet_highlighter.html#method-setHighlighter).

>This method can only be called while initialising plugins (in one of the three callbacks).

To fix leak I've forced removal of this method on `pluginsLoaded`.

### Autocomplete panel

Element `cke_autocomplete_panel` was leaking after each editor creation. It is fixed by calling `autocomplete.destroy` on `editor.destroy`.

### CKEDITOR.currentInstance

`CKEDITOR.currentInstance` points at editor even after it was destroyed. Added on `destroy` listener, to clean that.

### skin.js

In `skin.js`there is stored reference to `style` element for each editor. I've added destroy listener which removes the reference.

### Dialog cover

Dialog cover reference is stored in `currentCover` variable. I've forced removing reference when dialog is hidden.

## Testing

For manual testing enable test on your current branch by:
```git checkout memory-test tests/_assets/memorytest.html```

Then read:
https://github.com/ckeditor/ckeditor-dev/blob/memory-test/tests/core/memory/memory.md

`master` branch
![Screenshot 2019-03-19 at 12 09 34](https://user-images.githubusercontent.com/23366849/54602617-73a4fc00-4a42-11e9-9868-6ef87a6579a9.png)
After applying fix for magicline
![Screenshot 2019-03-19 at 12 07 29](https://user-images.githubusercontent.com/23366849/54602616-71db3880-4a42-11e9-8c83-1ef19004db4b.png)

Snapshots
1. After page load.
1. After creating and destroying first editor.
1. After creating and destroying second editor.
1. After 100 next cycles of create-destroy editor.

Notes
- First editor takes plenty of memory which is not released, but most of it is reused by next editors.
- Second editor takes more memory than any next editors. I assume that Chrome after second creating of editor performs some optimizations which trade some memory for performance.

## Other info

Branch is targeted on `major` because it uses `CKEDITOR.tools.array.find`.

Closes #589