### PR TITLE
Fix for: failing test on Firefox 66 plugins/uploadfile/uploadfile

### DIFF
--- a/tests/plugins/uploadfile/uploadfile.js
+++ b/tests/plugins/uploadfile/uploadfile.js
@@ -103,7 +103,12 @@ bender.test( {
 	},
 
 	'test with uploadfile plugin': function() {
-		var editor = this.editors.uploadfile;
+		var editor = this.editors.uploadfile,
+			rng = editor.createRange();
+
+		// Fix possible case, when there might be no ranges in Firefox 66 (#2971).
+		rng.setStartAt( editor.editable().getFirst(), CKEDITOR.POSITION_AFTER_START );
+		rng.select();
 
 		pasteFiles( editor, [ bender.tools.getTestTxtFile() ] );
 


### PR DESCRIPTION
## What is the purpose of this pull request?

Fix for failing test

## What changes did you make?

For inline editor:
```
editor.focus();
editor.getSelection().getRanges(); // returns empty array
```

It looks like browser bug, especially that it wasn't present in previous version, but I couldn't reproduce it without CKEditor. Also no other tests seems to be affected - it looks like some edge case.
In such case I don't think we need any workarounds for the browser issue. In this PR I propose to fix TC by just creating proper selection.

Closes #2971 