### PR TITLE
Fixed unstable test in `tests/plugins/balloontoolbar/positioning`

### DIFF
--- a/tests/plugins/balloontoolbar/positioning.js
+++ b/tests/plugins/balloontoolbar/positioning.js
@@ -162,12 +162,12 @@
 					spy = sinon.spy( balloonToolbar, 'reposition' ),
 					// This test randomly fails when run from dashboard. That's because balloon toolbar
 					// uses also other listeners to reposition, which might be fired before `change`.
-					// Prevent all other event's for this TC check if it's correctly repositions on `change` #(2979).
+					// Prevent all other event's for this TC to check if it's correctly repositions on `change` #(2979).
 					listeners = [
-							editor.on( 'resize', cancelEvent ),
-							CKEDITOR.document.getWindow().on( 'resize', cancelEvent ),
-							editor.editable().getDocument().on( 'scroll', cancelEvent )
-						],
+						editor.on( 'resize', cancelEvent ),
+						CKEDITOR.document.getWindow().on( 'resize', cancelEvent ),
+						editor.editable().getDocument().on( 'scroll', cancelEvent )
+					],
 					initialPosition,
 					currentPosition;
 


### PR DESCRIPTION
## What is the purpose of this pull request?

Failing test

## What changes did you make?

Balloon toolbar uses few events to reposition itself. In failing TC we manually fire `change` to force reposition, however sometimes it is triggered by some other event due to some race condition. 

There are few ways to fix this:
1. Change assertion type from `reposition.callCount === 1` to` >= 1`. However if `change` listener was removed this would lead to false positive test as balloon could still be repositioned due to other listeners.
1. Wrap test function with `setTimeout`. It seems to help, however you never know if it won't fail in future.
1. Cancel other events used by balloon toolbar.

So I chose the last option.

Closes #2979