### PR TITLE
Fix for incorrect selection when styling table using native selection

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -7,6 +7,7 @@ Fixed Issues:
 
 * [#808](https://github.com/ckeditor/ckeditor-dev/issues/808): Fixed: [Widget](https://ckeditor.com/cke4/addon/widget) and other content disappear on drag and drop in [read-only mode](https://ckeditor.com/docs/ckeditor4/latest/guide/dev_readonly.html).
 * [#3260](https://github.com/ckeditor/ckeditor-dev/issues/3260): Fixed: [Widget](https://ckeditor.com/cke4/addon/widget) drag handler is visible in [read-only mode](https://ckeditor.com/docs/ckeditor4/latest/guide/dev_readonly.html).
+* [#941](https://github.com/ckeditor/ckeditor-dev/issues/941): Fixed: Error is thrown after styling the text table cell selected using native selection when [Table Selection](https://ckeditor.com/cke4/addon/tableselection) is enabled.
 
 ## CKEditor 4.12.1
 

--- a/core/style.js
+++ b/core/style.js
@@ -1830,25 +1830,13 @@ CKEDITOR.STYLE_OBJECT = 3;
 	function applyStyleOnSelection( selection, remove, editor ) {
 		var ranges = selection.getRanges(),
 			func = remove ? this.removeFromRange : this.applyToRange,
-			originalRanges,
-			range,
-			i;
-
-		// In case of fake table selection, we would like to apply all styles and then select
-		// the original ranges. Otherwise browsers would complain about discontiguous selection.
-		if ( selection.isFake && selection.isInTable() ) {
-			originalRanges = [];
-
-			for ( i = 0; i < ranges.length; i++ ) {
-				originalRanges.push( ranges[ i ].clone() );
-			}
-		}
+			range;
 
 		var iterator = ranges.createIterator();
 		while ( ( range = iterator.getNextRange() ) )
 			func.call( this, range, editor );
 
-		selection.selectRanges( originalRanges || ranges );
+		selection.selectRanges( ranges );
 	}
 } )();
 

--- a/tests/plugins/tableselection/integrations/basicstyles/basicstyles.html
+++ b/tests/plugins/tableselection/integrations/basicstyles/basicstyles.html
@@ -1,0 +1,10 @@
+<textarea id="table">
+	<table>
+		<tbody>
+			<tr>
+				<td>Cell 1.1</td>
+				<td>Cell 1.2</td>
+			</tr>
+		</tbody>
+	</table>
+</textarea>

--- a/tests/plugins/tableselection/integrations/basicstyles/basicstyles.js
+++ b/tests/plugins/tableselection/integrations/basicstyles/basicstyles.js
@@ -1,0 +1,46 @@
+/* bender-tags: editor, tableselection */
+/* bender-ckeditor-plugins: basicstyles,tabletools,toolbar,tableselection */
+/* bender-include: ../../_helpers/tableselection.js */
+/* global tableSelectionHelpers */
+
+( function() {
+	'use strict';
+
+	bender.editor = {};
+
+	var tests = {
+		// (#941)
+		'test toggle style': function() {
+			var editor = this.editor;
+
+			this.editorBot.setHtmlWithSelection( CKEDITOR.document.getById( 'table' ).getValue() );
+
+			var cell = editor.editable().findOne( 'td' );
+
+			editor.getSelection().fake( cell );
+
+			selectElement( editor, cell );
+
+			editor.execCommand( 'bold' );
+
+			assert.areEqual( 'strong', cell.getFirst().getName(), 'Cell should be bolded' );
+
+			selectElement( editor, cell.findOne( 'strong' ) );
+
+			editor.execCommand( 'bold' );
+
+			assert.areEqual( CKEDITOR.NODE_TEXT, cell.getFirst().type, 'Cell should be unbolded' );
+		}
+	};
+
+	tableSelectionHelpers.ignoreUnsupportedEnvironment( tests );
+
+	bender.test( tests );
+
+	function selectElement( editor, element ) {
+		var range = editor.createRange();
+		range.setStartAt( element, CKEDITOR.POSITION_AFTER_START );
+		range.setEndAt( element, CKEDITOR.POSITION_BEFORE_END );
+		range.select();
+	}
+} )();

--- a/tests/plugins/tableselection/integrations/basicstyles/basicstyles.js
+++ b/tests/plugins/tableselection/integrations/basicstyles/basicstyles.js
@@ -1,7 +1,5 @@
 /* bender-tags: editor, tableselection */
 /* bender-ckeditor-plugins: basicstyles,tabletools,toolbar,tableselection */
-/* bender-include: ../../_helpers/tableselection.js */
-/* global tableSelectionHelpers */
 
 ( function() {
 	'use strict';
@@ -9,6 +7,10 @@
 	bender.editor = {};
 
 	var tests = {
+		setUp: function() {
+			bender.tools.ignoreUnsupportedEnvironment( 'tableselection' );
+		},
+
 		// (#941)
 		'test toggle style': function() {
 			var editor = this.editor;
@@ -32,8 +34,6 @@
 			assert.areEqual( CKEDITOR.NODE_TEXT, cell.getFirst().type, 'Cell should be unbolded' );
 		}
 	};
-
-	tableSelectionHelpers.ignoreUnsupportedEnvironment( tests );
 
 	bender.test( tests );
 

--- a/tests/plugins/tableselection/manual/integrations/basicstyles/native.html
+++ b/tests/plugins/tableselection/manual/integrations/basicstyles/native.html
@@ -1,0 +1,48 @@
+<div id="editor1">
+	<p>Some text</p>
+
+	<table border="1">
+		<tr>
+			<td>Cell 1.1</td>
+			<td>Cell 1.2</td>
+			<td>Cell 1.3</td>
+			<td>Cell 1.4</td>
+		</tr>
+		<tr>
+			<td>Cell 2.1</td>
+			<td>Cell 2.2</td>
+			<td>Cell 2.3</td>
+			<td>Cell 2.4</td>
+		</tr>
+		<tr>
+			<td>Cell 3.1</td>
+			<td>Cell 3.2</td>
+			<td>Cell 3.3</td>
+			<td>Cell 3.4</td>
+		</tr>
+		<tr>
+			<td>Cell 4.1</td>
+			<td>Cell 4.2</td>
+			<td>Cell 4.3</td>
+			<td>Cell 4.4</td>
+		</tr>
+		<tr>
+			<td>Cell 5.1</td>
+			<td>Cell 5.2</td>
+			<td>Cell 5.3</td>
+			<td>Cell 5.4</td>
+		</tr>
+	</table>
+
+	<p>Some text</p>
+</div>
+
+<script>
+	if ( ( CKEDITOR.env.ie && CKEDITOR.env.version < 11 ) || bender.tools.env.mobile ) {
+		bender.ignore();
+	}
+
+	CKEDITOR.replace( 'editor1', {
+		autoGrow_onStartup: true
+	} );
+</script>

--- a/tests/plugins/tableselection/manual/integrations/basicstyles/native.md
+++ b/tests/plugins/tableselection/manual/integrations/basicstyles/native.md
@@ -1,0 +1,16 @@
+@bender-ui: collapsed
+@bender-tags: bug, 4.11.4
+@bender-ckeditor-plugins: wysiwygarea, toolbar, tableselection, basicstyles
+
+1. Open console.
+2. Select the first cell text using native selection.
+3. Click `Bold` button.
+
+**Expected**: Text is bolded, selection changes into visual selection.
+
+4. Click `Bold` button again.
+
+**Expected:** Text is unbolded, visual selection is preserved.
+
+**Unexpected**: Console registers exception.
+

--- a/tests/plugins/tableselection/manual/integrations/basicstyles/native.md
+++ b/tests/plugins/tableselection/manual/integrations/basicstyles/native.md
@@ -1,5 +1,5 @@
 @bender-ui: collapsed
-@bender-tags: bug, 4.11.4
+@bender-tags: bug, 4.13.0, 941
 @bender-ckeditor-plugins: wysiwygarea, toolbar, tableselection, basicstyles
 
 1. Open console.


### PR DESCRIPTION
## What is the purpose of this pull request?

Bug fix

## Does your PR contain necessary tests?

All patches which change the editor code must include tests. You can always read more
on [PR testing](https://ckeditor.com/docs/ckeditor4/latest/guide/dev_contributing_code.html#tests),
[how to set the testing environment](https://ckeditor.com/docs/ckeditor4/latest/guide/dev_tests.html) and
[how to create tests](https://ckeditor.com/docs/ckeditor4/latest/guide/dev_tests.html#creating-your-own-test)
in the official CKEditor documentation.

### This PR contains

- [x] Unit tests
- [x] Manual tests

## What changes did you make?

I removed the code responsible for selecting detached DOM elements. The issue has been introduced with https://github.com/ckeditor/ckeditor-dev/commit/d4907f5634 commit as a part of https://dev.ckeditor.com/ticket/16755 feature.

I couldn't spot any issues after code removal nor manual or unit tests referencing the issue from comment. Not sure why it has been implemented in the first place. I can only suppose that it has been fixed by some editor changes.

Closes #941 
