### PR TITLE
Fix for: Image in table cell has an empty URL field when edited from context menu opened by right-click

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -16,6 +16,7 @@ Fixed Issues:
 * [#1478](https://github.com/ckeditor/ckeditor-dev/issues/1478): Fixed: Custom colors added to [Color Button](https://ckeditor.com/cke4/addon/colorbutton) via [`config.colorButton_colors`](https://ckeditor.com/docs/ckeditor4/latest/api/CKEDITOR_config.html#cfg-colorButton_colors) in form label/code don't work correctly.
 * [#1469](https://github.com/ckeditor/ckeditor-dev/issues/1469): Fixed: Trying to get data from nested editable inside freshly pasted widget throws an error.
 * [#2923](https://github.com/ckeditor/ckeditor-dev/issues/2923): Fixed: CSS `windowtext` color is not correctly recognized by [`CKEDITOR.tools.style.parse`](https://ckeditor.com/docs/ckeditor4/latest/api/CKEDITOR_tools_style_parse.html) functions.
+* [#2235](https://github.com/ckeditor/ckeditor-dev/issues/2235): Fixed: [Image](https://ckeditor.com/cke4/addon/image) in table cell has an empty URL field when edited from context menu opened by right-click when [Table Selection](https://ckeditor.com/cke4/addon/tableselection) plugin is in use.
 
 API Changes:
 
@@ -35,10 +36,6 @@ Other Changes:
 
 * [#2741](https://github.com/ckeditor/ckeditor-dev/issues/2721): Replaced deprecated `arguments.callee` calls with named function expressions.
 * [#2924](https://github.com/ckeditor/ckeditor-dev/issues/2924): Marked [`CKEDITOR.tools.style.parse.border`](https://ckeditor.com/docs/ckeditor4/latest/api/CKEDITOR_tools_style_border.html) as deprecated in favor of [`CKEDITOR.tools.style.border.fromCssRule`](https://ckeditor.com/docs/ckeditor4/latest/api/CKEDITOR_tools_style_border.html#static-method-fromCssRule) function.
-
-Fixed Issues:
-
-* [#2235](https://github.com/ckeditor/ckeditor-dev/issues/2235): Fixed: [Image](https://ckeditor.com/cke4/addon/image) in table cell has an empty URL field when edited from context menu opened by right-click when [Table Selection](https://ckeditor.com/cke4/addon/tableselection) plugin is in use.
 
 ## CKEditor 4.11.4
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -36,6 +36,10 @@ Other Changes:
 * [#2741](https://github.com/ckeditor/ckeditor-dev/issues/2721): Replaced deprecated `arguments.callee` calls with named function expressions.
 * [#2924](https://github.com/ckeditor/ckeditor-dev/issues/2924): Marked [`CKEDITOR.tools.style.parse.border`](https://ckeditor.com/docs/ckeditor4/latest/api/CKEDITOR_tools_style_border.html) as deprecated in favor of [`CKEDITOR.tools.style.border.fromCssRule`](https://ckeditor.com/docs/ckeditor4/latest/api/CKEDITOR_tools_style_border.html#static-method-fromCssRule) function.
 
+Fixed Issues:
+
+* [#2235](https://github.com/ckeditor/ckeditor-dev/issues/2235): Fixed: [Image](https://ckeditor.com/cke4/addon/image) in table cell has an empty URL field when edited from context menu opened by right-click when [Table Selection](https://ckeditor.com/cke4/addon/tableselection) plugin is in use.
+
 ## CKEditor 4.11.4
 
 Fixed Issues:

--- a/core/selection.js
+++ b/core/selection.js
@@ -27,6 +27,13 @@
 		if ( isWidget( ranges[ 0 ].getEnclosedNode() ) ) {
 			return false;
 		}
+		// Also it's not table selection when image is selected. (#2235).
+		if ( ranges[ 0 ].getEnclosedNode() && ranges[ 0 ].getEnclosedNode().type == CKEDITOR.NODE_ELEMENT ) {
+			if ( ranges[ 0 ].getEnclosedNode().is( 'img' ) ) {
+				return false;
+			}
+		}
+
 		var node,
 			i;
 

--- a/core/selection.js
+++ b/core/selection.js
@@ -28,10 +28,10 @@
 			return false;
 		}
 		// Also it's not table selection when image is selected (#2235).
-		if ( ranges[ 0 ].getEnclosedNode() && ranges[ 0 ].getEnclosedNode().type == CKEDITOR.NODE_ELEMENT ) {
-			if ( ranges[ 0 ].getEnclosedNode().is( 'img' ) ) {
-				return false;
-			}
+		if ( ranges[ 0 ].getEnclosedNode() &&
+			ranges[ 0 ].getEnclosedNode().type == CKEDITOR.NODE_ELEMENT &&
+			ranges[ 0 ].getEnclosedNode().is( 'img' ) ) {
+			return false;
 		}
 
 		var node,

--- a/core/selection.js
+++ b/core/selection.js
@@ -27,7 +27,7 @@
 		if ( isWidget( ranges[ 0 ].getEnclosedNode() ) ) {
 			return false;
 		}
-		// Also it's not table selection when image is selected. (#2235).
+		// Also it's not table selection when image is selected (#2235).
 		if ( ranges[ 0 ].getEnclosedNode() && ranges[ 0 ].getEnclosedNode().type == CKEDITOR.NODE_ELEMENT ) {
 			if ( ranges[ 0 ].getEnclosedNode().is( 'img' ) ) {
 				return false;

--- a/core/selection.js
+++ b/core/selection.js
@@ -23,16 +23,6 @@
 		if ( ranges.length === 0 ) {
 			return false;
 		}
-		// It's not table selection when selected node is a widget (#1027).
-		if ( isWidget( ranges[ 0 ].getEnclosedNode() ) ) {
-			return false;
-		}
-		// Also it's not table selection when image is selected (#2235).
-		if ( ranges[ 0 ].getEnclosedNode() &&
-			ranges[ 0 ].getEnclosedNode().type == CKEDITOR.NODE_ELEMENT &&
-			ranges[ 0 ].getEnclosedNode().is( 'img' ) ) {
-			return false;
-		}
 
 		var node,
 			i;

--- a/core/selection.js
+++ b/core/selection.js
@@ -24,6 +24,11 @@
 			return false;
 		}
 
+		// It's not table selection when selected node is a widget (#1027).
+		if ( isWidget( ranges[ 0 ].getEnclosedNode() ) ) {
+			return false;
+		}
+
 		var node,
 			i;
 

--- a/plugins/tableselection/plugin.js
+++ b/plugins/tableselection/plugin.js
@@ -230,6 +230,8 @@
 			selection = editor && editor.getSelection(),
 			ranges = selection && selection.getRanges() || [],
 			enclosedNode = ranges && ranges[ 0 ].getEnclosedNode(),
+			isEnclosedNodeAnElement = enclosedNode && enclosedNode.type == CKEDITOR.NODE_ELEMENT,
+			isEnclosedNodeAnImage = isEnclosedNodeAnElement && enclosedNode.is( 'img' ),
 			cells,
 			table,
 			i;
@@ -246,9 +248,7 @@
 		}
 
 		// Also don't perform fake selection when image is selected (#2235).
-		if ( enclosedNode &&
-			enclosedNode.type == CKEDITOR.NODE_ELEMENT &&
-			enclosedNode.is( 'img' ) ) {
+		if ( enclosedNode && isEnclosedNodeAnElement && isEnclosedNodeAnImage ) {
 			return false;
 		}
 

--- a/plugins/tableselection/plugin.js
+++ b/plugins/tableselection/plugin.js
@@ -230,8 +230,7 @@
 			selection = editor && editor.getSelection(),
 			ranges = selection && selection.getRanges() || [],
 			enclosedNode = ranges && ranges[ 0 ].getEnclosedNode(),
-			isEnclosedNodeAnElement = enclosedNode && enclosedNode.type == CKEDITOR.NODE_ELEMENT,
-			isEnclosedNodeAnImage = isEnclosedNodeAnElement && enclosedNode.is( 'img' ),
+			isEnclosedNodeAnImage = enclosedNode && ( enclosedNode.type == CKEDITOR.NODE_ELEMENT ) && enclosedNode.is( 'img' ),
 			cells,
 			table,
 			i;
@@ -241,16 +240,6 @@
 		}
 
 		clearFakeCellSelection( editor );
-
-		// Don't perform fake selection when selected node is a widget (#1027).
-		if ( isWidget( enclosedNode ) ) {
-			return false;
-		}
-
-		// Also don't perform fake selection when image is selected (#2235).
-		if ( enclosedNode && isEnclosedNodeAnElement && isEnclosedNodeAnImage ) {
-			return false;
-		}
 
 		if ( !selection.isInTable() || !selection.isFake ) {
 			return;
@@ -269,6 +258,12 @@
 		}
 
 		cells = getSelectedCells( selection, table );
+
+		// Don't perform fake selection when selected node is a widget (#1027).
+		// Also don't perform fake selection when image is selected (#2235).
+		if ( isWidget( enclosedNode ) || isEnclosedNodeAnImage ) {
+			return;
+		}
 
 		editor.fire( 'lockSnapshot' );
 

--- a/plugins/tableselection/plugin.js
+++ b/plugins/tableselection/plugin.js
@@ -244,11 +244,13 @@
 		clearFakeCellSelection( editor );
 
 		if ( !selection.isInTable() || !selection.isFake ) {
+			editor.getSelection().reset();
 			return;
 		}
 
 		// Don't perform fake selection when image is selected (#2235).
 		if ( isEnclosedNodeAnImage ) {
+			editor.getSelection().reset();
 			return;
 		}
 

--- a/plugins/tableselection/plugin.js
+++ b/plugins/tableselection/plugin.js
@@ -119,6 +119,7 @@
 
 	function clearFakeCellSelection( editor, reset ) {
 		var selectedCells = editor.editable().find( '.' + fakeSelectedClass ),
+			selectedTable = editor.editable().findOne( '[data-' + fakeSelectedTableDataAttribute + ']' ),
 			i;
 
 		editor.fire( 'lockSnapshot' );
@@ -129,8 +130,9 @@
 			selectedCells.getItem( i ).removeClass( fakeSelectedClass );
 		}
 
-		if ( selectedCells.count() > 0 ) {
-			selectedCells.getItem( 0 ).getAscendant( 'table' ).data( fakeSelectedTableDataAttribute, false );
+		// Table may be selected even though no cells are selected (e.g. after deleting cells.)
+		if ( selectedTable ) {
+			selectedTable.data( fakeSelectedTableDataAttribute, false );
 		}
 
 		editor.fire( 'unlockSnapshot' );
@@ -262,9 +264,6 @@
 		// Don't perform fake selection when selected node is a widget (#1027).
 		// Also don't perform fake selection when image is selected (#2235).
 		if ( isWidget( enclosedNode ) || isEnclosedNodeAnImage ) {
-			// Table isn't fake selected when selection is just widget or image.
-			// This is necessary to be able to select them after deleting some cells as it doesn't change table class.
-			cells[ 0 ].getAscendant( 'table' ).data( fakeSelectedTableDataAttribute, false );
 			return;
 		}
 

--- a/plugins/tableselection/plugin.js
+++ b/plugins/tableselection/plugin.js
@@ -262,6 +262,9 @@
 		// Don't perform fake selection when selected node is a widget (#1027).
 		// Also don't perform fake selection when image is selected (#2235).
 		if ( isWidget( enclosedNode ) || isEnclosedNodeAnImage ) {
+			// Table isn't fake selected when selection is just widget or image.
+			// This is necessary to be able to select them after deleting some cells as it doesn't change table class.
+			cells[ 0 ].getAscendant( 'table' ).data( fakeSelectedTableDataAttribute, false );
 			return;
 		}
 

--- a/plugins/tableselection/plugin.js
+++ b/plugins/tableselection/plugin.js
@@ -261,9 +261,8 @@
 
 		cells = getSelectedCells( selection, table );
 
-		// Don't perform fake selection when selected node is a widget (#1027).
-		// Also don't perform fake selection when image is selected (#2235).
-		if ( isWidget( enclosedNode ) || isEnclosedNodeAnImage ) {
+		// Don't perform fake selection when image is selected (#2235).
+		if ( isEnclosedNodeAnImage ) {
 			return;
 		}
 

--- a/plugins/tableselection/plugin.js
+++ b/plugins/tableselection/plugin.js
@@ -235,7 +235,7 @@
 			isEnclosedNodeAnImage = enclosedNode && ( enclosedNode.type == CKEDITOR.NODE_ELEMENT ) && enclosedNode.is( 'img' ),
 			cells,
 			table,
-			i;
+			iterator;
 
 		if ( !selection ) {
 			return;
@@ -244,6 +244,11 @@
 		clearFakeCellSelection( editor );
 
 		if ( !selection.isInTable() || !selection.isFake ) {
+			return;
+		}
+
+		// Don't perform fake selection when image is selected (#2235).
+		if ( isEnclosedNodeAnImage ) {
 			return;
 		}
 
@@ -261,15 +266,10 @@
 
 		cells = getSelectedCells( selection, table );
 
-		// Don't perform fake selection when image is selected (#2235).
-		if ( isEnclosedNodeAnImage ) {
-			return;
-		}
-
 		editor.fire( 'lockSnapshot' );
 
-		for ( i = 0; i < cells.length; i++ ) {
-			cells[ i ].addClass( fakeSelectedClass );
+		for ( iterator = 0; iterator < cells.length; iterator++ ) {
+			cells[ iterator ].addClass( fakeSelectedClass );
 		}
 
 		if ( cells.length > 0 ) {

--- a/plugins/tableselection/plugin.js
+++ b/plugins/tableselection/plugin.js
@@ -229,6 +229,7 @@
 		var editor = evt.editor || evt.sender.editor,
 			selection = editor && editor.getSelection(),
 			ranges = selection && selection.getRanges() || [],
+			enclosedNode = ranges && ranges[ 0 ].getEnclosedNode(),
 			cells,
 			table,
 			i;
@@ -238,6 +239,18 @@
 		}
 
 		clearFakeCellSelection( editor );
+
+		// Don't perform fake selection when selected node is a widget (#1027).
+		if ( isWidget( enclosedNode ) ) {
+			return false;
+		}
+
+		// Also don't perform fake selection when image is selected (#2235).
+		if ( enclosedNode &&
+			enclosedNode.type == CKEDITOR.NODE_ELEMENT &&
+			enclosedNode.is( 'img' ) ) {
+			return false;
+		}
 
 		if ( !selection.isInTable() || !selection.isFake ) {
 			return;

--- a/plugins/tableselection/plugin.js
+++ b/plugins/tableselection/plugin.js
@@ -244,7 +244,6 @@
 		clearFakeCellSelection( editor );
 
 		if ( !selection.isInTable() || !selection.isFake ) {
-			editor.getSelection().reset();
 			return;
 		}
 

--- a/tests/plugins/tableselection/integrations/image/imageurl.html
+++ b/tests/plugins/tableselection/integrations/image/imageurl.html
@@ -1,0 +1,27 @@
+<div id="test">
+	<table border="1" cellpadding="5" cellspacing="5" style="width:500px">
+		<tbody>
+			<tr>
+				<td>&nbsp;</td>
+				<td>&nbsp;</td>
+			</tr>
+			<tr>
+				<td>
+				<table border="1" cellpadding="5" cellspacing="5" style="width:300px">
+					<tbody>
+						<tr>
+							<td>[<img alt="" src="%BASE_PATH%_assets/lena.jpg" style="height:100px; width:100px" />]</td>
+							<td>&nbsp;</td>
+						</tr>
+						<tr>
+							<td>&nbsp;</td>
+							<td>&nbsp;</td>
+						</tr>
+					</tbody>
+				</table>
+				</td>
+				<td>&nbsp;</td>
+			</tr>
+		</tbody>
+	</table>
+</div>

--- a/tests/plugins/tableselection/integrations/image/imageurl.js
+++ b/tests/plugins/tableselection/integrations/image/imageurl.js
@@ -9,7 +9,7 @@
 	bender.editor = true;
 
 	var tests =  {
-		'is cell fake selected when img inside is selected': function() {
+		'Is whole cell fake selected when img inside is selected': function() {
 			var editor = this.editor,
 				bot = this.editorBot;
 

--- a/tests/plugins/tableselection/integrations/image/imageurl.js
+++ b/tests/plugins/tableselection/integrations/image/imageurl.js
@@ -1,0 +1,27 @@
+/* bender-tags: tableselection,2235 */
+/* bender-ckeditor-plugins: tableselection */
+/* bender-include: ../../_helpers/tableselection.js */
+/* global tableSelectionHelpers */
+
+( function() {
+	'use strict';
+
+	bender.editor = true;
+
+	var tests =  {
+		'is cell fake selected when img inside is selected': function() {
+			var editor = this.editor,
+				bot = this.editorBot;
+
+			var html = CKEDITOR.document.getById( 'test' ).getHtml();
+			bot.setHtmlWithSelection( html );
+
+			assert.isFalse( editor.getSelection().getSelectedElement().hasClass( 'cke_table-faked-selection' ) );
+		}
+	};
+
+	// Tests should be ignored in browsers which don't support tableselection plugin, i.e. IE < 11
+	tableSelectionHelpers.ignoreUnsupportedEnvironment( tests );
+	bender.test( tests );
+
+} )();

--- a/tests/plugins/tableselection/integrations/image/imageurl.js
+++ b/tests/plugins/tableselection/integrations/image/imageurl.js
@@ -11,9 +11,9 @@
 	var tests =  {
 		'Is whole cell fake selected when img inside is selected': function() {
 			var editor = this.editor,
-				bot = this.editorBot;
+				bot = this.editorBot,
+				html = CKEDITOR.document.getById( 'test' ).getHtml();
 
-			var html = CKEDITOR.document.getById( 'test' ).getHtml();
 			bot.setHtmlWithSelection( html );
 
 			assert.isFalse( editor.getSelection().getSelectedElement().hasClass( 'cke_table-faked-selection' ) );

--- a/tests/plugins/tableselection/integrations/image/imageurl.js
+++ b/tests/plugins/tableselection/integrations/image/imageurl.js
@@ -1,4 +1,4 @@
-/* bender-tags: tableselection,2235 */
+/* bender-tags: tableselection,2235,4.12.0 */
 /* bender-ckeditor-plugins: tableselection */
 /* bender-include: ../../_helpers/tableselection.js */
 /* global tableSelectionHelpers */

--- a/tests/plugins/tableselection/manual/integrations/image/nestedimage.html
+++ b/tests/plugins/tableselection/manual/integrations/image/nestedimage.html
@@ -1,0 +1,18 @@
+<div id="editor">
+	<table border="1" cellpadding="1" cellspacing="1" style="width:500px">
+		<tbody>
+			<tr>
+				<td><img alt="" src="https://cdn.emojics.com/v1.0.0/emojis/like/symbols/1f60a-color.png" style="height:50px; width:50px" /></td>
+				<td>&nbsp;</td>
+			</tr>
+			<tr>
+				<td>&nbsp;</td>
+				<td>&nbsp;</td>
+			</tr>
+		</tbody>
+	</table>
+</div>
+
+<script>
+	CKEDITOR.replace( 'editor' );
+</script>

--- a/tests/plugins/tableselection/manual/integrations/image/nestedimage.html
+++ b/tests/plugins/tableselection/manual/integrations/image/nestedimage.html
@@ -14,5 +14,9 @@
 </div>
 
 <script>
+	// Table Selection plugin doesn't work on IE < 11 so ignore test for that browsers.
+	if ( CKEDITOR.env.ie && CKEDITOR.env.version < 11 ) {
+		bender.ignore();
+	}
 	CKEDITOR.replace( 'editor' );
 </script>

--- a/tests/plugins/tableselection/manual/integrations/image/nestedimage.html
+++ b/tests/plugins/tableselection/manual/integrations/image/nestedimage.html
@@ -2,11 +2,25 @@
 	<table border="1" cellpadding="1" cellspacing="1" style="width:500px">
 		<tbody>
 			<tr>
-				<td><img alt="" src="https://cdn.emojics.com/v1.0.0/emojis/like/symbols/1f60a-color.png" style="height:50px; width:50px" /></td>
+				<td>&nbsp;</td>
 				<td>&nbsp;</td>
 			</tr>
 			<tr>
-				<td>&nbsp;</td>
+				<td>
+				<table border="1" cellpadding="1" cellspacing="1" style="width:300px">
+					<tbody>
+						<tr>
+							<td><img alt="" src="https://cdn.emojics.com/v1.0.0/emojis/like/symbols/1f60a-color.png" style="height:100px; width:100px" /></td>
+							<td>&nbsp;</td>
+						</tr>
+						<tr>
+							<td>&nbsp;</td>
+							<td>&nbsp;</td>
+						</tr>
+					</tbody>
+				</table>
+				<p>&nbsp;</p>
+				</td>
 				<td>&nbsp;</td>
 			</tr>
 		</tbody>
@@ -18,5 +32,5 @@
 	if ( CKEDITOR.env.ie && CKEDITOR.env.version < 11 ) {
 		bender.ignore();
 	}
-	CKEDITOR.replace( 'editor' );
+	CKEDITOR.replace( 'editor', { height: 300 } );
 </script>

--- a/tests/plugins/tableselection/manual/integrations/image/nestedimage.html
+++ b/tests/plugins/tableselection/manual/integrations/image/nestedimage.html
@@ -1,5 +1,5 @@
 <div id="editor">
-	<table border="1" cellpadding="1" cellspacing="1" style="width:500px">
+	<table border="1" cellpadding="5" cellspacing="5" style="width:500px">
 		<tbody>
 			<tr>
 				<td>&nbsp;</td>
@@ -7,7 +7,7 @@
 			</tr>
 			<tr>
 				<td>
-				<table border="1" cellpadding="1" cellspacing="1" style="width:300px">
+				<table border="1" cellpadding="5" cellspacing="5" style="width:300px">
 					<tbody>
 						<tr>
 							<td><img alt="" src="https://cdn.emojics.com/v1.0.0/emojis/like/symbols/1f60a-color.png" style="height:100px; width:100px" /></td>

--- a/tests/plugins/tableselection/manual/integrations/image/nestedimage.html
+++ b/tests/plugins/tableselection/manual/integrations/image/nestedimage.html
@@ -10,7 +10,7 @@
 				<table border="1" cellpadding="5" cellspacing="5" style="width:300px">
 					<tbody>
 						<tr>
-							<td><img alt="" src="https://cdn.emojics.com/v1.0.0/emojis/like/symbols/1f60a-color.png" style="height:100px; width:100px" /></td>
+							<td><img alt="" src="%BASE_PATH%_assets/lena.jpg" style="height:100px; width:100px"/></td>
 							<td>&nbsp;</td>
 						</tr>
 						<tr>

--- a/tests/plugins/tableselection/manual/integrations/image/nestedimage.md
+++ b/tests/plugins/tableselection/manual/integrations/image/nestedimage.md
@@ -1,0 +1,16 @@
+@bender-ui: collapsed
+@bender-tags: bug, 2235, 4.11.5
+@bender-ckeditor-plugins: wysiwygarea, tableselection, image
+
+## Context menu for image in table
+
+1. Open context menu for image by right-clicking it.
+2. Choose `Image properties`.
+
+**Expected result:**
+
+URL field should be filled and image should be visible in the preview.
+
+**Unexpected result:**
+
+URL field is empty or image isn't visible in the preview.

--- a/tests/plugins/tableselection/manual/integrations/image/nestedimage.md
+++ b/tests/plugins/tableselection/manual/integrations/image/nestedimage.md
@@ -1,6 +1,6 @@
 @bender-ui: collapsed
 @bender-tags: bug, 2235, 4.11.5
-@bender-ckeditor-plugins: wysiwygarea, tableselection, image
+@bender-ckeditor-plugins: wysiwygarea, tableselection, image, undo
 
 ## Context menu for image in table
 
@@ -14,3 +14,14 @@ URL field should be filled and image should be visible in the preview.
 **Unexpected result:**
 
 URL field is empty or image isn't visible in the preview.
+
+3. Select first row of the outer table and delete it.
+4. Click on the image again.
+
+**Expected result:**
+
+Image is selected.
+
+**Unexpected result:**
+
+Image can't be selected.

--- a/tests/plugins/tableselection/manual/integrations/image/nestedimage.md
+++ b/tests/plugins/tableselection/manual/integrations/image/nestedimage.md
@@ -1,5 +1,5 @@
 @bender-ui: collapsed
-@bender-tags: bug, 2235, 4.11.5
+@bender-tags: bug, 2235, 4.12.0
 @bender-ckeditor-plugins: wysiwygarea, tableselection, image, undo
 
 ## Context menu for image in table

--- a/tests/plugins/tableselection/manual/integrations/image/nestedimage.md
+++ b/tests/plugins/tableselection/manual/integrations/image/nestedimage.md
@@ -4,24 +4,28 @@
 
 ## Context menu for image in table
 
+### Scenario 1:
+
 1. Open context menu for image by right-clicking it.
 2. Choose `Image properties`.
 
-**Expected result:**
+	**Expected result:**
 
-URL field should be filled and image should be visible in the preview.
+	URL field should be filled and image should be visible in the preview.
 
-**Unexpected result:**
+	**Unexpected result:**
 
-URL field is empty or image isn't visible in the preview.
+	URL field is empty or image isn't visible in the preview.
 
-3. Select first row of the outer table and delete it.
-4. Click on the image again.
+### Scenario 2:
 
-**Expected result:**
+1. Select first row of the outer table and delete it.
+2. Click on the image again.
 
-Image is selected.
+	**Expected result:**
 
-**Unexpected result:**
+	Image is selected.
 
-Image can't be selected.
+	**Unexpected result:**
+
+	Image can't be selected.


### PR DESCRIPTION
## What is the purpose of this pull request?

Bug

## Does your PR contain necessary tests?

All patches which change the editor code must include tests. You can always read more
on [PR testing](https://ckeditor.com/docs/ckeditor4/latest/guide/dev_contributing_code.html#tests),
[how to set the testing environment](https://ckeditor.com/docs/ckeditor4/latest/guide/dev_tests.html) and
[how to create tests](https://ckeditor.com/docs/ckeditor4/latest/guide/dev_tests.html#creating-your-own-test)
in the official CKEditor documentation.

### This PR contains

As this was a specific issue and required opening context menu by right-click (keyboard shortcuts were working fine before fix) there is just a short 15 seconds manual test included.

- [x] Unit tests
- [x] Manual tests

## What changes did you make?

I made `Table Selection` treat images from `Image` plugin the same way it operates on widgets, etc from `Enhanced Image` plugin (i.e. an early return in function checking if the table is selected).

Closes #2235.