### PR TITLE
Fixed dutch label translation for caption

### DIFF
--- a/plugins/table/lang/nl.js
+++ b/plugins/table/lang/nl.js
@@ -4,7 +4,7 @@ For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-oss-license
 */
 CKEDITOR.plugins.setLang( 'table', 'nl', {
 	border: 'Randdikte',
-	caption: 'Titel',
+	caption: 'Bijschrift',
 	cell: {
 		menu: 'Cel',
 		insertBefore: 'Voeg cel in voor',


### PR DESCRIPTION
caption = Bijschrift (not Titel = title)

## What is the purpose of this pull request?

This is a fix for a Dutch translation of the label "caption".
It was translated as "title".

## Does your PR contain necessary tests?

All patches which change the editor code must include tests. You can always read more
on [PR testing](https://ckeditor.com/docs/ckeditor4/latest/guide/dev_contributing_code.html#tests),
[how to set the testing environment](https://ckeditor.com/docs/ckeditor4/latest/guide/dev_tests.html) and
[how to create tests](https://ckeditor.com/docs/ckeditor4/latest/guide/dev_tests.html#creating-your-own-test)
in the official CKEditor documentation.

### This PR contains

- [ ] Unit tests
- [ ] Manual tests

## What changes did you make?

Translated "caption" to "Bijschrift".