### PR TITLE
Fix for: Failing test `tests/plugins/emoji/dropdown`

### DIFF
--- a/tests/plugins/emoji/dropdown.js
+++ b/tests/plugins/emoji/dropdown.js
@@ -32,169 +32,190 @@
 		},
 		'test emoji dropdown has proper components': function() {
 			var bot = this.editorBot;
-			bot.panel( 'EmojiPanel', function( panel ) {
-				try {
-					var doc = panel._.iframe.getFrameDocument();
-					assert.areNotSame( 0, doc.find( '.cke_emoji-navigation_item' ).count(), 'There is no navigation in Emoji Panel.' );
-					assert.areSame( 1, doc.find( 'input' ).count(), 'There is no search input in Emoji Panel.' );
-					assert.areSame( 1, doc.find( '.cke_emoji-outer_emoji_block' ).count(), 'There is no emoji block in Emoji Panel.' );
-					assert.areSame( 1, doc.find( '.cke_emoji-status_bar' ).count(), 'There is no emoji status bar in Emoji Panel.' );
 
-					assert.isTrue( doc.findOne( 'input' ).hasListeners( 'input' ), 'Searchbox doesn\'t have listener.' );
-					assert.isTrue( doc.findOne( '.cke_emoji-outer_emoji_block' ).hasListeners( 'mouseover' ), 'Emoji block should have mouseover listener.' );
-					assert.isTrue( doc.findOne( '.cke_emoji-outer_emoji_block' ).hasListeners( 'click' ), 'Emoji block should have click listener.' );
-					assert.isTrue( doc.findOne( '.cke_emoji-outer_emoji_block' ).hasListeners( 'scroll' ), 'Emoji block should have scroll listener.' );
-					assert.isTrue( doc.findOne( 'nav' ).hasListeners( 'click' ), 'Navigation element should have click listener.' );
-				} finally {
-					panel.hide();
-				}
+			waitForEmoji( bot.editor, function() {
+				bot.panel( 'EmojiPanel', function( panel ) {
+					try {
+						var doc = panel._.iframe.getFrameDocument();
+						assert.areNotSame( 0, doc.find( '.cke_emoji-navigation_item' ).count(), 'There is no navigation in Emoji Panel.' );
+						assert.areSame( 1, doc.find( 'input' ).count(), 'There is no search input in Emoji Panel.' );
+						assert.areSame( 1, doc.find( '.cke_emoji-outer_emoji_block' ).count(), 'There is no emoji block in Emoji Panel.' );
+						assert.areSame( 1, doc.find( '.cke_emoji-status_bar' ).count(), 'There is no emoji status bar in Emoji Panel.' );
+
+						assert.isTrue( doc.findOne( 'input' ).hasListeners( 'input' ), 'Searchbox doesn\'t have listener.' );
+						assert.isTrue( doc.findOne( '.cke_emoji-outer_emoji_block' ).hasListeners( 'mouseover' ), 'Emoji block should have mouseover listener.' );
+						assert.isTrue( doc.findOne( '.cke_emoji-outer_emoji_block' ).hasListeners( 'click' ), 'Emoji block should have click listener.' );
+						assert.isTrue( doc.findOne( '.cke_emoji-outer_emoji_block' ).hasListeners( 'scroll' ), 'Emoji block should have scroll listener.' );
+						assert.isTrue( doc.findOne( 'nav' ).hasListeners( 'click' ), 'Navigation element should have click listener.' );
+					} finally {
+						panel.hide();
+					}
+				} );
 			} );
 		},
 
 		'test emoji dropdown filter search results': function() {
 			var bot = this.editorBot;
-			bot.panel( 'EmojiPanel', function( panel ) {
-				var doc = panel._.iframe.getFrameDocument(),
-					input = doc.findOne( 'input' );
 
-				input.setValue( 'kebab' );
-				input.fire( 'input', new CKEDITOR.dom.event( {
-					sender: input
-				} ) );
-				// Timeouts are necessary for IE11, which has problem with refreshing DOM. That's why asserts run asynchronously.
-				CKEDITOR.tools.setTimeout( function() {
-					resume( function() {
-						assert.areSame( 2, doc.find( 'li.cke_emoji-item :not(.hidden)' ).count(), 'There should be returned 2 values for kebab `keyword`' );
-						panel.hide();
-						bot.panel( 'EmojiPanel', function() {
-							CKEDITOR.tools.setTimeout( function() {
-								resume( function() {
-									panel.hide();
-									assert.areSame( '', input.getValue(), 'Search value should be reset after hiding panel.' );
-									assert.areSame( 0, doc.find( 'li.cke_emoji-item.hidden' ).count(), 'All emoji items should be reset to visible state after closing panel.' );
-								} );
-							}, 200 );
-							wait();
+			waitForEmoji( bot.editor, function() {
+				bot.panel( 'EmojiPanel', function( panel ) {
+					var doc = panel._.iframe.getFrameDocument(),
+						input = doc.findOne( 'input' );
+
+					input.setValue( 'kebab' );
+					input.fire( 'input', new CKEDITOR.dom.event( {
+						sender: input
+					} ) );
+					// Timeouts are necessary for IE11, which has problem with refreshing DOM. That's why asserts run asynchronously.
+					CKEDITOR.tools.setTimeout( function() {
+						resume( function() {
+							assert.areSame( 2, doc.find( 'li.cke_emoji-item :not(.hidden)' ).count(), 'There should be returned 2 values for kebab `keyword`' );
+							panel.hide();
+							bot.panel( 'EmojiPanel', function() {
+								CKEDITOR.tools.setTimeout( function() {
+									resume( function() {
+										panel.hide();
+										assert.areSame( '', input.getValue(), 'Search value should be reset after hiding panel.' );
+										assert.areSame( 0, doc.find( 'li.cke_emoji-item.hidden' ).count(), 'All emoji items should be reset to visible state after closing panel.' );
+									} );
+								}, 200 );
+								wait();
+							} );
 						} );
-					} );
-				}, 200 );
-				wait();
+					}, 200 );
+					wait();
+				} );
 			} );
 		},
 
 		'test emoji dropdown update status': function() {
 			var bot = this.editorBot;
-			bot.panel( 'EmojiPanel', function( panel ) {
-				try {
-					var doc = panel._.iframe.getFrameDocument(),
-						statusBarIcon = doc.findOne( '.cke_emoji-status_icon' ),
-						statusBarDescription = doc.findOne( 'p.cke_emoji-status_description' ),
-						testElement;
 
-					assert.areSame( '', statusBarIcon.getText(), 'Status bar icon should be empty when panel is open.' );
-					assert.areSame( '', statusBarDescription.getText(), 'Status bar description should be empty when panel is open.' );
+			waitForEmoji( bot.editor, function() {
+				bot.panel( 'EmojiPanel', function( panel ) {
+					try {
+						var doc = panel._.iframe.getFrameDocument(),
+							statusBarIcon = doc.findOne( '.cke_emoji-status_icon' ),
+							statusBarDescription = doc.findOne( 'p.cke_emoji-status_description' ),
+							testElement;
 
-					testElement = doc.findOne( 'a[data-cke-emoji-name="star"]' );
+						assert.areSame( '', statusBarIcon.getText(), 'Status bar icon should be empty when panel is open.' );
+						assert.areSame( '', statusBarDescription.getText(), 'Status bar description should be empty when panel is open.' );
 
-					doc.findOne( '.cke_emoji-outer_emoji_block' ).fire( 'mouseover', new CKEDITOR.dom.event( {
-						target: testElement.$
-					} ) );
+						testElement = doc.findOne( 'a[data-cke-emoji-name="star"]' );
 
-					assert.areSame( '⭐', statusBarIcon.getText(), 'Status bar icon should contain star after mouseover event.' );
-					assert.areSame( 'star', statusBarDescription.getText(), 'Status bar description should contain "star" name after mouseover.' );
-				} finally {
-					panel.hide();
-				}
+						doc.findOne( '.cke_emoji-outer_emoji_block' ).fire( 'mouseover', new CKEDITOR.dom.event( {
+							target: testElement.$
+						} ) );
+
+						assert.areSame( '⭐', statusBarIcon.getText(), 'Status bar icon should contain star after mouseover event.' );
+						assert.areSame( 'star', statusBarDescription.getText(), 'Status bar description should contain "star" name after mouseover.' );
+					} finally {
+						panel.hide();
+					}
+				} );
 			} );
 		},
 
 		'test emoji list scrolls when navigation is clicked': function() {
 			var bot = this.editorBot;
-			bot.panel( 'EmojiPanel', function( panel ) {
-				try {
-					var doc = panel._.iframe.getFrameDocument(),
-						emojiBlock = doc.findOne( '.cke_emoji-outer_emoji_block' );
 
-					assert.areSame( 0, emojiBlock.$.scrollTop, 'Emoji elements should be scrolled to the top.' );
+			waitForEmoji( bot.editor, function() {
+				bot.panel( 'EmojiPanel', function( panel ) {
+					try {
+						var doc = panel._.iframe.getFrameDocument(),
+							emojiBlock = doc.findOne( '.cke_emoji-outer_emoji_block' );
 
-					doc.findOne( 'a[title="Flags"]' ).$.click();
+						assert.areSame( 0, emojiBlock.$.scrollTop, 'Emoji elements should be scrolled to the top.' );
 
-					assert.areNotSame( 0, emojiBlock.$.scrollTop, 'Emoji elements should be scrolled somewhere down.' );
-				} finally {
-					panel.hide();
-				}
+						doc.findOne( 'a[title="Flags"]' ).$.click();
+
+						assert.areNotSame( 0, emojiBlock.$.scrollTop, 'Emoji elements should be scrolled somewhere down.' );
+					} finally {
+						panel.hide();
+					}
+				} );
 			} );
 		},
 
 		'test navigation highlights proper section when scrolls': function() {
 			var bot = this.editorBot;
-			bot.panel( 'EmojiPanel', function( panel ) {
-				var doc = panel._.iframe.getFrameDocument(),
-					testElement = doc.findOne( 'a[data-cke-emoji-name="star"]' );
 
-				testElement.scrollIntoView( true );
+			waitForEmoji( bot.editor, function() {
+				bot.panel( 'EmojiPanel', function( panel ) {
+					var doc = panel._.iframe.getFrameDocument(),
+						testElement = doc.findOne( 'a[data-cke-emoji-name="star"]' );
 
-				doc.findOne( '.cke_emoji-outer_emoji_block' ).fire( 'scroll', new CKEDITOR.dom.event() );
-				// Scroll event is throttled that's why we need wait a little bit.
-				CKEDITOR.tools.setTimeout( function() {
-					resume( function() {
-						panel.hide();
-						assert.isTrue( doc.findOne( 'li[data-cke-emoji-group="travel"]' ).hasClass( 'active' ), 'Travel item in navigation should be highlighted' );
-					} );
-				}, 160 );
-				wait();
+					testElement.scrollIntoView( true );
+
+					doc.findOne( '.cke_emoji-outer_emoji_block' ).fire( 'scroll', new CKEDITOR.dom.event() );
+					// Scroll event is throttled that's why we need wait a little bit.
+					CKEDITOR.tools.setTimeout( function() {
+						resume( function() {
+							panel.hide();
+							assert.isTrue( doc.findOne( 'li[data-cke-emoji-group="travel"]' ).hasClass( 'active' ), 'Travel item in navigation should be highlighted' );
+						} );
+					}, 160 );
+					wait();
+				} );
 			} );
 		},
 
 		'test input is focused element when dropdown opens': function() {
 			var bot = this.editorBot;
-			bot.panel( 'EmojiPanel', function( panel ) {
-				var doc = panel._.iframe.getFrameDocument(),
-					inputElement = doc.findOne( 'input' ),
-					panelBlock = emojiTools.getEmojiPanelBlock( panel ),
-					inputIndex = CKEDITOR.tools.getIndex( panelBlock._.getItems().toArray(), function( el ) {
-						return el.equals( inputElement );
-					} );
 
-				assert.areNotSame( 0, panelBlock._.focusIndex, 'Focus should not be in first element which is navigation.' );
-				assert.areSame( inputIndex, panelBlock._.focusIndex, 'First selected item should be input.' );
-				CKEDITOR.tools.setTimeout( function() {
-					resume( function() {
-						try {
-							assert.isTrue( inputElement.equals( new CKEDITOR.dom.element( doc.$.activeElement ) ), 'Input should be focused element.' );
-						} finally {
-							panel.hide();
-						}
-					} );
-				}, 100 );
-				wait();
+			waitForEmoji( bot.editor, function() {
+				bot.panel( 'EmojiPanel', function( panel ) {
+					var doc = panel._.iframe.getFrameDocument(),
+						inputElement = doc.findOne( 'input' ),
+						panelBlock = emojiTools.getEmojiPanelBlock( panel ),
+						inputIndex = CKEDITOR.tools.getIndex( panelBlock._.getItems().toArray(), function( el ) {
+							return el.equals( inputElement );
+						} );
+
+					assert.areNotSame( 0, panelBlock._.focusIndex, 'Focus should not be in first element which is navigation.' );
+					assert.areSame( inputIndex, panelBlock._.focusIndex, 'First selected item should be input.' );
+					CKEDITOR.tools.setTimeout( function() {
+						resume( function() {
+							try {
+								assert.isTrue( inputElement.equals( new CKEDITOR.dom.element( doc.$.activeElement ) ), 'Input should be focused element.' );
+							} finally {
+								panel.hide();
+							}
+						} );
+					}, 100 );
+					wait();
+				} );
 			} );
 		},
 
 		'test click inserts emoji to editor and has proper focus': function() {
 			var bot = this.editorBot,
 				editor = this.editor;
+
 			bot.setData( '', function() {
-				bot.panel( 'EmojiPanel', function( panel ) {
-					try {
-						var doc = panel._.iframe.getFrameDocument(),
-							testElement = doc.findOne( 'a[data-cke-emoji-name="star"]' );
+				waitForEmoji( bot.editor, function() {
+					bot.panel( 'EmojiPanel', function( panel ) {
+						try {
+							var doc = panel._.iframe.getFrameDocument(),
+								testElement = doc.findOne( 'a[data-cke-emoji-name="star"]' );
 
-						doc.findOne( '.cke_emoji-outer_emoji_block' ).fire( 'click', new CKEDITOR.dom.event( {
-							target: testElement.$
-						} ) );
-						assert.areSame( '<p>⭐</p>', bot.getData(), 'Star should be inserted in editor after click.' );
-					} finally {
-						panel.hide();
-					}
+							doc.findOne( '.cke_emoji-outer_emoji_block' ).fire( 'click', new CKEDITOR.dom.event( {
+								target: testElement.$
+							} ) );
+							assert.areSame( '<p>⭐</p>', bot.getData(), 'Star should be inserted in editor after click.' );
+						} finally {
+							panel.hide();
+						}
 
-					CKEDITOR.tools.setTimeout( function() {
-						resume( function() {
-							assert.isTrue( editor.editable().hasFocus, 'Editable should have focus after emoji insertion.' );
-						} );
-					}, 100 );
+						CKEDITOR.tools.setTimeout( function() {
+							resume( function() {
+								assert.isTrue( editor.editable().hasFocus, 'Editable should have focus after emoji insertion.' );
+							} );
+						}, 100 );
 
-					wait();
+						wait();
+					} );
 				} );
 			} );
 		},
@@ -202,80 +223,89 @@
 		'test keyboard event should inserts emoji to editor and had proper focus': function() {
 			var bot = this.editorBot,
 				editor = this.editor;
+
 			bot.setData( '', function() {
-				bot.panel( 'EmojiPanel', function( panel ) {
-					try {
-						var doc = panel._.iframe.getFrameDocument(),
-							testElement = doc.findOne( 'a[data-cke-emoji-name="star"]' ),
-							panelBlock = emojiTools.getEmojiPanelBlock( panel );
+				waitForEmoji( bot.editor, function() {
+					bot.panel( 'EmojiPanel', function( panel ) {
+						try {
+							var doc = panel._.iframe.getFrameDocument(),
+								testElement = doc.findOne( 'a[data-cke-emoji-name="star"]' ),
+								panelBlock = emojiTools.getEmojiPanelBlock( panel );
 
-						panelBlock._.focusIndex = CKEDITOR.tools.getIndex( panelBlock._.getItems().toArray(), function( el ) {
-							return el.data( 'cke-emoji-name' ) === 'star';
-						} );
+							panelBlock._.focusIndex = CKEDITOR.tools.getIndex( panelBlock._.getItems().toArray(), function( el ) {
+								return el.data( 'cke-emoji-name' ) === 'star';
+							} );
 
-						doc.fire( 'keydown', new CKEDITOR.dom.event( {
-							target: testElement.$,
-							keyCode: 32
-						} ) );
+							doc.fire( 'keydown', new CKEDITOR.dom.event( {
+								target: testElement.$,
+								keyCode: 32
+							} ) );
 
-						assert.areSame( '<p>⭐</p>', bot.getData(), 'Star should be inserted in editor after pressing space.' );
-					} finally {
-						panel.hide();
-					}
+							assert.areSame( '<p>⭐</p>', bot.getData(), 'Star should be inserted in editor after pressing space.' );
+						} finally {
+							panel.hide();
+						}
 
-					CKEDITOR.tools.setTimeout( function() {
-						resume( function() {
-							assert.isTrue( editor.editable().hasFocus, 'Editable should have focus after emoji insertion.' );
-						} );
-					}, 100 );
+						CKEDITOR.tools.setTimeout( function() {
+							resume( function() {
+								assert.isTrue( editor.editable().hasFocus, 'Editable should have focus after emoji insertion.' );
+							} );
+						}, 100 );
 
-					wait();
+						wait();
+					} );
 				} );
 			} );
 		},
 
 		'test clicking into navigation list item does not throw an error': function() {
 			var bot = this.editorBot;
-			bot.panel( 'EmojiPanel', function( panel ) {
-				try {
-					var doc = panel._.iframe.getFrameDocument(),
-						focusedElement = doc.findOne( 'a[data-cke-emoji-group="flags"' );
 
-					doc.findOne( 'a[title="Flags"]' ).getAscendant( 'li' ).$.click();
-					assert.isTrue( focusedElement.equals( new CKEDITOR.dom.element( doc.$.activeElement ) ), 'First flag should be focused.' );
-				} finally {
-					panel.hide();
-				}
+			waitForEmoji( bot.editor, function() {
+				bot.panel( 'EmojiPanel', function( panel ) {
+					try {
+						var doc = panel._.iframe.getFrameDocument(),
+							focusedElement = doc.findOne( 'a[data-cke-emoji-group="flags"' );
+
+						doc.findOne( 'a[title="Flags"]' ).getAscendant( 'li' ).$.click();
+						assert.isTrue( focusedElement.equals( new CKEDITOR.dom.element( doc.$.activeElement ) ), 'First flag should be focused.' );
+					} finally {
+						panel.hide();
+					}
+				} );
 			} );
 		},
 
 		'test left and right arrow does not change focus on input element': function() {
 			var bot = this.editorBot;
-			bot.panel( 'EmojiPanel', function( panel ) {
-				var doc = panel._.iframe.getFrameDocument(),
-					input = doc.findOne( 'input' );
 
-				// Input is focused asynchronously, that's why we need to run test asynchronously.
-				CKEDITOR.tools.setTimeout( function() {
-					resume( function() {
-						try {
-							doc.fire( 'keydown', new CKEDITOR.dom.event( {
-								target: input.$,
-								keyCode: 37
-							} ) );
-							assert.isTrue( input.equals( new CKEDITOR.dom.element( doc.$.activeElement ), 'Input should be focused after pressing left arrow.' ) );
+			waitForEmoji( bot.editor, function() {
+				bot.panel( 'EmojiPanel', function( panel ) {
+					var doc = panel._.iframe.getFrameDocument(),
+						input = doc.findOne( 'input' );
 
-							doc.fire( 'keydown', new CKEDITOR.dom.event( {
-								target: input.$,
-								keyCode: 39
-							} ) );
-							assert.isTrue( input.equals( new CKEDITOR.dom.element( doc.$.activeElement ), 'Input should be focused after pressing right arrow.' ) );
-						} finally {
-							panel.hide();
-						}
-					} );
-				}, 100 );
-				wait();
+					// Input is focused asynchronously, that's why we need to run test asynchronously.
+					CKEDITOR.tools.setTimeout( function() {
+						resume( function() {
+							try {
+								doc.fire( 'keydown', new CKEDITOR.dom.event( {
+									target: input.$,
+									keyCode: 37
+								} ) );
+								assert.isTrue( input.equals( new CKEDITOR.dom.element( doc.$.activeElement ), 'Input should be focused after pressing left arrow.' ) );
+
+								doc.fire( 'keydown', new CKEDITOR.dom.event( {
+									target: input.$,
+									keyCode: 39
+								} ) );
+								assert.isTrue( input.equals( new CKEDITOR.dom.element( doc.$.activeElement ), 'Input should be focused after pressing right arrow.' ) );
+							} finally {
+								panel.hide();
+							}
+						} );
+					}, 100 );
+					wait();
+				} );
 			} );
 		},
 
@@ -294,22 +324,39 @@
 			}
 
 			body.setStyle( 'height', '10000px' );
-			bot.panel( 'EmojiPanel', function( panel ) {
-				try {
-					var doc = panel._.iframe.getFrameDocument(),
-						scrollPosition = win.getScrollPosition().y;
 
-					doc.findOne( 'a[title="Flags"]' ).$.click();
-					assert.areEqual( scrollPosition, win.getScrollPosition().y, 'Window should not be scrolled down after clicking into navigation' );
-				} finally {
-					if ( parentHeight ) {
-						parentIframe.setStyle( 'height', parentHeight );
+			waitForEmoji( bot.editor, function() {
+				bot.panel( 'EmojiPanel', function( panel ) {
+					try {
+						var doc = panel._.iframe.getFrameDocument(),
+							scrollPosition = win.getScrollPosition().y;
+
+						doc.findOne( 'a[title="Flags"]' ).$.click();
+						assert.areEqual( scrollPosition, win.getScrollPosition().y, 'Window should not be scrolled down after clicking into navigation' );
+					} finally {
+						if ( parentHeight ) {
+							parentIframe.setStyle( 'height', parentHeight );
+						}
+						body.removeStyle( 'height' );
+						panel.hide();
 					}
-					body.removeStyle( 'height' );
-					panel.hide();
-				}
+				} );
 			} );
 		}
 	} );
 
+	// Loading emoji list is asynchronous, we can't run tests without making sure they are loaded (#3094).
+	function waitForEmoji( editor, callback ) {
+		if ( editor._.emoji ) {
+			callback();
+		} else {
+			setTimeout( function() {
+				resume( function() {
+					waitForEmoji( editor, callback );
+				} );
+			}, 50 );
+
+			wait();
+		}
+	}
 } )();

--- a/tests/plugins/emoji/dropdown.js
+++ b/tests/plugins/emoji/dropdown.js
@@ -146,7 +146,11 @@
 					var doc = panel._.iframe.getFrameDocument(),
 						testElement = doc.findOne( 'a[data-cke-emoji-name="star"]' );
 
-					testElement.scrollIntoView( true );
+					if ( CKEDITOR.env.gecko ) {
+						testElement.$.scrollIntoView( true );
+					} else {
+						testElement.scrollIntoView( true );
+					}
 
 					// Scroll event is throttled that's why we need wait a little bit.
 					CKEDITOR.tools.setTimeout( function() {

--- a/tests/plugins/emoji/dropdown.js
+++ b/tests/plugins/emoji/dropdown.js
@@ -203,7 +203,7 @@
 							doc.findOne( '.cke_emoji-outer_emoji_block' ).fire( 'click', new CKEDITOR.dom.event( {
 								target: testElement.$
 							} ) );
-							assert.areSame( '<p>⭐</p>', bot.getData(), 'Star should be inserted in editor after click.' );
+							assert.areSame( '<p>⭐</p>', bot.getData().replace( /<p>\s<\/p>/, '' ), 'Star should be inserted in editor after click.' );
 						} finally {
 							panel.hide();
 						}
@@ -241,7 +241,7 @@
 								keyCode: 32
 							} ) );
 
-							assert.areSame( '<p>⭐</p>', bot.getData(), 'Star should be inserted in editor after pressing space.' );
+							assert.areSame( '<p>⭐</p>', bot.getData().replace( /<p>\s<\/p>/, '' ), 'Star should be inserted in editor after pressing space.' );
 						} finally {
 							panel.hide();
 						}

--- a/tests/plugins/emoji/dropdown.js
+++ b/tests/plugins/emoji/dropdown.js
@@ -21,7 +21,7 @@
 				'test keyboard event should inserts emoji to editor and had proper focus': CKEDITOR.env.safari,
 				'test clicking into navigation list item does not throw an error': CKEDITOR.env.safari,
 				'test input is focused element when dropdown opens': CKEDITOR.env.safari,
-				'test navigation highlights proper section when scrolls': CKEDITOR.env.safari
+				'test navigation highlights proper section when scrolls': CKEDITOR.env.safari || CKEDITOR.env.gecko // Firefox (#2831).
 			}
 		},
 

--- a/tests/plugins/emoji/dropdown.js
+++ b/tests/plugins/emoji/dropdown.js
@@ -146,11 +146,7 @@
 					var doc = panel._.iframe.getFrameDocument(),
 						testElement = doc.findOne( 'a[data-cke-emoji-name="star"]' );
 
-					if ( CKEDITOR.env.gecko ) {
-						testElement.$.scrollIntoView( true );
-					} else {
-						testElement.scrollIntoView( true );
-					}
+					testElement.scrollIntoView( true );
 
 					// Scroll event is throttled that's why we need wait a little bit.
 					CKEDITOR.tools.setTimeout( function() {

--- a/tests/plugins/emoji/dropdown.js
+++ b/tests/plugins/emoji/dropdown.js
@@ -146,19 +146,18 @@
 					var doc = panel._.iframe.getFrameDocument(),
 						testElement = doc.findOne( 'a[data-cke-emoji-name="star"]' );
 
-					if ( CKEDITOR.env.gecko ) {
-						testElement.$.scrollIntoView( true );
-					} else {
-						testElement.scrollIntoView( true );
-					}
-
-					// Scroll event is throttled that's why we need wait a little bit.
 					CKEDITOR.tools.setTimeout( function() {
-						resume( function() {
-							panel.hide();
-							assert.isTrue( doc.findOne( 'li[data-cke-emoji-group="travel"]' ).hasClass( 'active' ), 'Travel item in navigation should be highlighted' );
-						} );
-					}, 160 );
+						testElement.scrollIntoView( true );
+
+						// Scroll event is throttled that's why we need wait a little bit.
+						CKEDITOR.tools.setTimeout( function() {
+							resume( function() {
+								panel.hide();
+								assert.isTrue( doc.findOne( 'li[data-cke-emoji-group="travel"]' ).hasClass( 'active' ), 'Travel item in navigation should be highlighted' );
+							} );
+						}, 160 );
+					} );
+
 					wait();
 				} );
 			} );

--- a/tests/plugins/emoji/dropdown.js
+++ b/tests/plugins/emoji/dropdown.js
@@ -148,7 +148,6 @@
 
 					testElement.scrollIntoView( true );
 
-					doc.findOne( '.cke_emoji-outer_emoji_block' ).fire( 'scroll', new CKEDITOR.dom.event() );
 					// Scroll event is throttled that's why we need wait a little bit.
 					CKEDITOR.tools.setTimeout( function() {
 						resume( function() {

--- a/tests/plugins/emoji/dropdown.js
+++ b/tests/plugins/emoji/dropdown.js
@@ -146,18 +146,19 @@
 					var doc = panel._.iframe.getFrameDocument(),
 						testElement = doc.findOne( 'a[data-cke-emoji-name="star"]' );
 
-					CKEDITOR.tools.setTimeout( function() {
+					if ( CKEDITOR.env.gecko ) {
+						testElement.$.scrollIntoView( true );
+					} else {
 						testElement.scrollIntoView( true );
+					}
 
-						// Scroll event is throttled that's why we need wait a little bit.
-						CKEDITOR.tools.setTimeout( function() {
-							resume( function() {
-								panel.hide();
-								assert.isTrue( doc.findOne( 'li[data-cke-emoji-group="travel"]' ).hasClass( 'active' ), 'Travel item in navigation should be highlighted' );
-							} );
-						}, 160 );
-					} );
-
+					// Scroll event is throttled that's why we need wait a little bit.
+					CKEDITOR.tools.setTimeout( function() {
+						resume( function() {
+							panel.hide();
+							assert.isTrue( doc.findOne( 'li[data-cke-emoji-group="travel"]' ).hasClass( 'active' ), 'Travel item in navigation should be highlighted' );
+						} );
+					}, 160 );
 					wait();
 				} );
 			} );


### PR DESCRIPTION
## What is the purpose of this pull request?

Fix failing tests

## What changes did you make?

Original issue reported only one case, however I could see three different reasons for tests to fail on Firefox.

### Emoji List is loaded asynchronously

Sometimes tests were run earlier resulting in type error. This is fixed by adding `waitForEmoji` which is delaying each test case until Emoji List is loaded. Related issue: #3094.

### After fix above some tests started to fail on Firefox, because of wrong assertion.
	- expected: `'<p>⭐</p>'`
	- actual: `'<p>⭐</p><p> </p>'`

	Fixed by adding `result.replace( regex )` to cut empty paragraph.

### Lastly the original issue.
Firefox seems to not respond very well to multiple synchronous changes of `scrollTop` of various elements, and that's what we do in our implementation of `scrollIntoView`. When this TC fails scroll position is incorrect. Fixed by calling native `scrollIntoView` for Firefox.

Additionally take a look at the code:
https://github.com/ckeditor/ckeditor-dev/blob/08ea0051cedd75c0bbb55d88d47fe9e05cddd1f5/tests/plugins/emoji/dropdown.js#L135-L137
	`scrollIntoView` is already causing a `scroll` event, so no need to manually trigger it. Although I didn't find it to interfere with tests, it's redundant so I'm removing it.

### Note
All of the issues are causing tests to fail randomly. After applying the fixes I did run tests multiple times and they seem to not fail, but Reviewer should check few times too.

Closes #2831