### PR TITLE
Remove unnecessary version tag from imageurl test

### DIFF
--- a/tests/plugins/tableselection/integrations/image/imageurl.js
+++ b/tests/plugins/tableselection/integrations/image/imageurl.js
@@ -1,4 +1,4 @@
-/* bender-tags: tableselection,2235,4.12.0 */
+/* bender-tags: tableselection,2235 */
 /* bender-ckeditor-plugins: tableselection */
 
 ( function() {


### PR DESCRIPTION
## What is the purpose of this pull request?

Other

## Does your PR contain necessary tests?

All patches which change the editor code must include tests. You can always read more
on [PR testing](https://ckeditor.com/docs/ckeditor4/latest/guide/dev_contributing_code.html#tests),
[how to set the testing environment](https://ckeditor.com/docs/ckeditor4/latest/guide/dev_tests.html) and
[how to create tests](https://ckeditor.com/docs/ckeditor4/latest/guide/dev_tests.html#creating-your-own-test)
in the official CKEditor documentation.

### This PR contains

- [ ] Unit tests
- [ ] Manual tests

## What changes did you make?

I've removed unnecessary version tag from `tests/plugins/tableselection/integrations/image/imageurl` test.
