### PR TITLE
Fix typo in dutch translations (nl.js) of table plugin

### DIFF
--- a/plugins/table/lang/nl.js
+++ b/plugins/table/lang/nl.js
@@ -14,7 +14,7 @@ CKEDITOR.plugins.setLang( 'table', 'nl', {
 		mergeRight: 'Voeg samen naar rechts',
 		mergeDown: 'Voeg samen naar beneden',
 		splitHorizontal: 'Splits cel horizontaal',
-		splitVertical: 'Splits cel vertikaal',
+		splitVertical: 'Splits cel verticaal',
 		title: 'Celeigenschappen',
 		cellType: 'Celtype',
 		rowSpan: 'Rijen samenvoegen',


### PR DESCRIPTION
## What is the purpose of this pull request?
Typo fix: Fixing a wrong translation in the dutch language file (nl.js) of the table plugin.

## Does your PR contain necessary tests?
.

### This PR contains
.

## What is the proposed changelog entry for this pull request?
Fixed typo in nl.js of table plugin (vertikaal --> verticaal).

## What changes did you make?
_Vertical_ is in Dutch standard spelling _Verti*c*aal_ and not _Verti*k*aal_. This fix makes the translations also more in line with the translation of the `vAlign` key, which already translated _vertical_ with _verticaal_.
*Give an overview…*
