### PR TITLE
Fix for failing test in tests/core/dom/range/getclientrects

### DIFF
--- a/tests/core/dom/range/getclientrects.js
+++ b/tests/core/dom/range/getclientrects.js
@@ -206,7 +206,9 @@
 
 			if ( typeof document.getSelection !== 'function' ) {
 				expectedKey = 'polyfill';
-			} else if ( CKEDITOR.env.ie ) {
+			} else
+			// Edge 18+ has updated `getClientRects` so it matches Chrome and other modern browsers (#3183).
+			if ( CKEDITOR.env.ie && CKEDITOR.env.version < 18 ) {
 				expectedKey = 'ie';
 			}
 


### PR DESCRIPTION
## What is the purpose of this pull request?

Fix failing test

## Does your PR contain necessary tests?

All patches which change the editor code must include tests. You can always read more
on [PR testing](https://ckeditor.com/docs/ckeditor4/latest/guide/dev_contributing_code.html#tests),
[how to set the testing environment](https://ckeditor.com/docs/ckeditor4/latest/guide/dev_tests.html) and
[how to create tests](https://ckeditor.com/docs/ckeditor4/latest/guide/dev_tests.html#creating-your-own-test)
in the official CKEditor documentation.

### This PR contains

- [ ] Unit tests
- [ ] Manual tests

## What is the proposed changelog entry for this pull request?

None

## What changes did you make?

Edge 18 returns same rects as other browsers, so I've updated expected value.

Closes #3183
