### PR TITLE
Fix for: failing filetools related tests 

### DIFF
--- a/tests/plugins/filetools/fileloader.js
+++ b/tests/plugins/filetools/fileloader.js
@@ -436,6 +436,12 @@
 		},
 
 		'test if name of file is correctly attached (https://dev.ckeditor.com/ticket/13518)': function() {
+			// Ignore because of Edge upstream (#3184).
+			// developer.microsoft.com/en-us/microsoft-edge/platform/issues/22326784
+			if ( CKEDITOR.env.edge && CKEDITOR.env.version >= 18 ) {
+				assert.ignore();
+			}
+
 			var name = 'customName.png',
 				loader = new FileLoader( editorMock, pngBase64, name );
 

--- a/tests/plugins/uploadwidget/additionalrequestparameters.js
+++ b/tests/plugins/uploadwidget/additionalrequestparameters.js
@@ -112,15 +112,13 @@
 
 			File = window.File;
 
-			// Edge 18+ upstream issue breaks tests, workaround by forcing polyfill (#3184).
-			// developer.microsoft.com/en-us/microsoft-edge/platform/issues/22326784
-			if ( CKEDITOR.env.edge && CKEDITOR.env.version >= 18 ) {
-				assert.ignore();
-			}
 			var isEdge18 = CKEDITOR.env.edge && CKEDITOR.env.version >= 18;
 
 			// FormData in IE & Chrome 47- supports only adding data, not getting it, so mocking (polyfilling?) is required.
-			// Note that mocking is needed only for tests, as CKEditor.fileTools uses only append method
+			// Note that mocking is needed only for tests, as CKEditor.fileTools uses only append method.
+			// Edge 18+ upstream issue breaks tests, workaround by forcing polyfill (#3184).
+			// developer.microsoft.com/en-us/microsoft-edge/platform/issues/22326784
+
 			if ( !FormData.prototype.get || !FormData.prototype.has || isEdge18 ) {
 				createFormDataMock();
 			}

--- a/tests/plugins/uploadwidget/additionalrequestparameters.js
+++ b/tests/plugins/uploadwidget/additionalrequestparameters.js
@@ -112,10 +112,18 @@
 
 			File = window.File;
 
+			// Edge 18+ upstream issue breaks tests, workaround by forcing polyfill (#3184).
+			// developer.microsoft.com/en-us/microsoft-edge/platform/issues/22326784
+			if ( CKEDITOR.env.edge && CKEDITOR.env.version >= 18 ) {
+				assert.ignore();
+			}
+			var isEdge18 = CKEDITOR.env.edge && CKEDITOR.env.version >= 18;
+
 			// FormData in IE & Chrome 47- supports only adding data, not getting it, so mocking (polyfilling?) is required.
 			// Note that mocking is needed only for tests, as CKEditor.fileTools uses only append method
-			if ( !FormData.prototype.get || !FormData.prototype.has )
+			if ( !FormData.prototype.get || !FormData.prototype.has || isEdge18 ) {
 				createFormDataMock();
+			}
 
 			createXMLHttpRequestMock();
 


### PR DESCRIPTION
## What is the purpose of this pull request?

Fix failing tests

## Does your PR contain necessary tests?

All patches which change the editor code must include tests. You can always read more
on [PR testing](https://ckeditor.com/docs/ckeditor4/latest/guide/dev_contributing_code.html#tests),
[how to set the testing environment](https://ckeditor.com/docs/ckeditor4/latest/guide/dev_tests.html) and
[how to create tests](https://ckeditor.com/docs/ckeditor4/latest/guide/dev_tests.html#creating-your-own-test)
in the official CKEditor documentation.

### This PR contains

- [ ] Unit tests
- [ ] Manual tests

## What is the proposed changelog entry for this pull request?

None

## What changes did you make?

Tests are failing due to upstream issue, so I ignored one of them, and forced polyfill which is used in IE for another test.

Closes #3184