### PR TITLE
Fix for: Failing tests in /tests/plugins/easyimage/uploadintegrations

### DIFF
--- a/tests/plugins/easyimage/uploadintegrations.html
+++ b/tests/plugins/easyimage/uploadintegrations.html
@@ -1,6 +1,6 @@
 <div id="expected-progress-bar-downcast">
 	<figure class="easyimage easyimage-full">
-		<img alt="" src="%BASE_PATH%_assets/logo.png" width="163" />
+		<img alt="" src="%BASE_PATH%_assets/logo.png"/>
 		<figcaption></figcaption>
 	</figure>
 	<p>&nbsp;</p>

--- a/tests/plugins/easyimage/uploadintegrations.js
+++ b/tests/plugins/easyimage/uploadintegrations.js
@@ -258,8 +258,8 @@
 					files: [ bender.tools.getTestPngFile() ],
 					callback: function() {
 						var expected = CKEDITOR.document.getById( 'expected-progress-bar-downcast' ).getHtml(),
-							// In Edge 18 test callback is fired before image image width can be set.
-							// Remove it as it's irrelevant to this TC (#2057).
+							// In Edge 18 test callback is fired before image width can be set.
+							// Remove width attribute as it's irrelevant to this TC (#2057).
 							actual = editor.getData().replace( 'width="163"', '' );
 
 						assert.beautified.html( expected, actual );

--- a/tests/plugins/easyimage/uploadintegrations.js
+++ b/tests/plugins/easyimage/uploadintegrations.js
@@ -257,7 +257,12 @@
 				assertPasteFiles( editor, {
 					files: [ bender.tools.getTestPngFile() ],
 					callback: function() {
-						assert.beautified.html( CKEDITOR.document.getById( 'expected-progress-bar-downcast' ).getHtml(), editor.getData() );
+						var expected = CKEDITOR.document.getById( 'expected-progress-bar-downcast' ).getHtml(),
+							// In Edge 18 test callback is fired before image image width can be set.
+							// Remove it as it's irrelevant to this TC (#2057).
+							actual = editor.getData().replace( 'width="163"', '' );
+
+						assert.beautified.html( expected, actual );
 					}
 				} );
 			},


### PR DESCRIPTION
## What is the purpose of this pull request?

Fix failing test

## Does your PR contain necessary tests?

All patches which change the editor code must include tests. You can always read more
on [PR testing](https://ckeditor.com/docs/ckeditor4/latest/guide/dev_contributing_code.html#tests),
[how to set the testing environment](https://ckeditor.com/docs/ckeditor4/latest/guide/dev_tests.html) and
[how to create tests](https://ckeditor.com/docs/ckeditor4/latest/guide/dev_tests.html#creating-your-own-test)
in the official CKEditor documentation.

### This PR contains

- [ ] Unit tests
- [ ] Manual tests

## What is the proposed changelog entry for this pull request?

None

## What changes did you make?

Failing TC compares html, it's purpose is to make sure progress bar is not downcasted. In Edge 18 it happens before image natural width can be reached hence the `width` attribute remains unset. I've removed `width`, as it's irrelevant to this TC.

Closes #2057