### PR TITLE
Allow passing config.ignoreStyle to widgetTools.addTests as function type

### DIFF
--- a/tests/plugins/mathjax/mathjax-mock.js
+++ b/tests/plugins/mathjax/mathjax-mock.js
@@ -169,7 +169,7 @@
 			[ 'info', 'equation', '2 + 2 = 4' ]
 		],
 		newWidgetPattern: /<span class="math-tex">\\\(2 \+ 2 = 4\\\)<\/span>/,
-		ignoreStyle: ( CKEDITOR.env.ie && CKEDITOR.env.version < 9 ) ? true : false
+		ignoreStyle: isSupportedEnvironment
 	} );
 
 	tools.addTests( tcs, {
@@ -188,7 +188,7 @@
 			[ 'info', 'equation', '2 + 2 = 4' ]
 		],
 		newWidgetPattern: /<span class="mjx">\\\(2 \+ 2 = 4\\\)<\/span>/,
-		ignoreStyle: ( CKEDITOR.env.ie && CKEDITOR.env.version < 9 ) ? true : false
+		ignoreStyle: isSupportedEnvironment
 	} );
 
 	tools.addTests( tcs, {
@@ -204,8 +204,12 @@
 			[ 'info', 'equation', '2 + 2 = 4' ]
 		],
 		newWidgetPattern: /<span class="math-tex">\\\(2 \+ 2 = 4\\\)<\/span>/,
-		ignoreStyle: ( CKEDITOR.env.ie && CKEDITOR.env.version < 9 ) ? true : false
+		ignoreStyle: isSupportedEnvironment
 	} );
 
 	bender.test( tcs );
+
+	function isSupportedEnvironment( editor ) {
+		return !editor.plugins.mathjax.isSupportedEnvironment();
+	}
 } )();

--- a/tests/plugins/mathjax/mathjax-mock.js
+++ b/tests/plugins/mathjax/mathjax-mock.js
@@ -169,7 +169,7 @@
 			[ 'info', 'equation', '2 + 2 = 4' ]
 		],
 		newWidgetPattern: /<span class="math-tex">\\\(2 \+ 2 = 4\\\)<\/span>/,
-		ignoreStyle: isSupportedEnvironment
+		ignoreStyle: shouldIgnoreStyle
 	} );
 
 	tools.addTests( tcs, {
@@ -188,7 +188,7 @@
 			[ 'info', 'equation', '2 + 2 = 4' ]
 		],
 		newWidgetPattern: /<span class="mjx">\\\(2 \+ 2 = 4\\\)<\/span>/,
-		ignoreStyle: isSupportedEnvironment
+		ignoreStyle: shouldIgnoreStyle
 	} );
 
 	tools.addTests( tcs, {
@@ -204,12 +204,12 @@
 			[ 'info', 'equation', '2 + 2 = 4' ]
 		],
 		newWidgetPattern: /<span class="math-tex">\\\(2 \+ 2 = 4\\\)<\/span>/,
-		ignoreStyle: isSupportedEnvironment
+		ignoreStyle: shouldIgnoreStyle
 	} );
 
 	bender.test( tcs );
 
-	function isSupportedEnvironment( editor ) {
+	function shouldIgnoreStyle( editor ) {
 		return !editor.plugins.mathjax.isSupportedEnvironment();
 	}
 } )();

--- a/tests/plugins/widget/_helpers/tools.js
+++ b/tests/plugins/widget/_helpers/tools.js
@@ -18,7 +18,7 @@ var widgetTestsTools = ( function() {
 	//
 	// @param config.newData
 	// @param config.newWidgetPattern
-	// @param {Boolean/function} [config.ignoreStyle=false]
+	// @param {Boolean/Function} [config.ignoreStyle=false]
 	function addTests( tcs, config ) {
 		var editor,
 			editorBot,

--- a/tests/plugins/widget/_helpers/tools.js
+++ b/tests/plugins/widget/_helpers/tools.js
@@ -33,10 +33,7 @@ var widgetTestsTools = ( function() {
 					loaded: function( evt ) {
 						editor = evt.editor;
 
-						var ignoreStyle = config.ignoreStyle;
-						ignoreStyle = typeof ignoreStyle === 'function' ? ignoreStyle( editor ) : ignoreStyle;
-
-						initialData = fixHtml( editor.getData(), ignoreStyle );
+						initialData = fixHtml( editor.getData(), config.ignoreStyle, editor );
 
 						editor.dataProcessor.writer.sortAttributes = true;
 					},
@@ -73,7 +70,7 @@ var widgetTestsTools = ( function() {
 				// Wait & ensure async.
 				wait( function() {
 					editor.setMode( 'source', function() {
-						sourceModeData = fixHtml( editor.getData(), config.ignoreStyle );
+						sourceModeData = fixHtml( editor.getData(), config.ignoreStyle, editor );
 
 						editor.setMode( 'wysiwyg', function() {
 							resume( function() {
@@ -137,7 +134,7 @@ var widgetTestsTools = ( function() {
 			var instances = bender.tools.objToArray( editor.widgets.instances );
 			assert.areSame( config.initialInstancesNumber, instances.length, 'instances number ' + msg );
 
-			checkData && assert.areSame( initialData, fixHtml( editor.getData(), config.ignoreStyle ), 'data ' + msg );
+			checkData && assert.areSame( initialData, fixHtml( editor.getData(), config.ignoreStyle, editor ), 'data ' + msg );
 
 			var editable = editor.editable();
 			for ( var i = 0; i < instances.length; ++i )
@@ -151,12 +148,15 @@ var widgetTestsTools = ( function() {
 		return CKEDITOR.tools.object.keys( classesObj ).sort();
 	}
 
-	function fixHtml( html, ignoreStyle ) {
+	function fixHtml( html, ignoreStyle, editor ) {
 		// Because IE modify style attribute we should fix it or totally ignore style attribute.
 		html = html.replace( /style="([^"]*)"/g, function( styleStr ) {
+			ignoreStyle = typeof ignoreStyle === 'function' ? ignoreStyle( editor ) : ignoreStyle;
+
 			// If there are too many problems with styles just ignore them.
-			if ( ignoreStyle )
+			if ( ignoreStyle ) {
 				return '';
+			}
 
 			// If it is only the matter of spacers and semicolons fix attributes.
 			var style = styleStr.substr( 7, styleStr.length - 8 );

--- a/tests/plugins/widget/_helpers/tools.js
+++ b/tests/plugins/widget/_helpers/tools.js
@@ -18,6 +18,7 @@ var widgetTestsTools = ( function() {
 	//
 	// @param config.newData
 	// @param config.newWidgetPattern
+	// @param {Boolean/function} [config.ignoreStyle=false]
 	function addTests( tcs, config ) {
 		var editor,
 			editorBot,
@@ -32,7 +33,10 @@ var widgetTestsTools = ( function() {
 					loaded: function( evt ) {
 						editor = evt.editor;
 
-						initialData = fixHtml( editor.getData(), config.ignoreStyle );
+						var ignoreStyle = config.ignoreStyle;
+						ignoreStyle = typeof ignoreStyle === 'function' ? ignoreStyle( this ) : ignoreStyle;
+
+						initialData = fixHtml( editor.getData(), ignoreStyle );
 
 						editor.dataProcessor.writer.sortAttributes = true;
 					},

--- a/tests/plugins/widget/_helpers/tools.js
+++ b/tests/plugins/widget/_helpers/tools.js
@@ -34,7 +34,7 @@ var widgetTestsTools = ( function() {
 						editor = evt.editor;
 
 						var ignoreStyle = config.ignoreStyle;
-						ignoreStyle = typeof ignoreStyle === 'function' ? ignoreStyle( this ) : ignoreStyle;
+						ignoreStyle = typeof ignoreStyle === 'function' ? ignoreStyle( editor ) : ignoreStyle;
 
 						initialData = fixHtml( editor.getData(), ignoreStyle );
 


### PR DESCRIPTION
## What is the purpose of this pull request?

Task

## Does your PR contain necessary tests?

All patches which change the editor code must include tests. You can always read more
on [PR testing](https://ckeditor.com/docs/ckeditor4/latest/guide/dev_contributing_code.html#tests),
[how to set the testing environment](https://ckeditor.com/docs/ckeditor4/latest/guide/dev_tests.html) and
[how to create tests](https://ckeditor.com/docs/ckeditor4/latest/guide/dev_tests.html#creating-your-own-test)
in the official CKEditor documentation.

### This PR contains

- [ ] Unit tests
- [ ] Manual tests

## What is the proposed changelog entry for this pull request?

none

## What changes did you make?

`config.ignoreStyle` passed to `widgetTools.addTests` can now be function type. Also updated uses in `mathjax-mock` test.

Closes #3173