### PR TITLE
Fix for: 'Permission Denied' error in Firefox when using divarea plugin

### DIFF
--- a/core/selection.js
+++ b/core/selection.js
@@ -1384,6 +1384,7 @@
 		if ( nativeSel ) {
 			if ( nativeSel.getRangeAt ) {
 				range = nativeSel.rangeCount && nativeSel.getRangeAt( 0 );
+				// Firefox throws an error here because it can't access ancestor (#2216).
 				try {
 					rangeParent = range && new CKEDITOR.dom.node( range.commonAncestorContainer );
 				} catch ( err ) {}

--- a/core/selection.js
+++ b/core/selection.js
@@ -1384,7 +1384,9 @@
 		if ( nativeSel ) {
 			if ( nativeSel.getRangeAt ) {
 				range = nativeSel.rangeCount && nativeSel.getRangeAt( 0 );
-				rangeParent = range && new CKEDITOR.dom.node( range.commonAncestorContainer );
+				try {
+					rangeParent = range && new CKEDITOR.dom.node( range.commonAncestorContainer );
+				} catch ( err ) {}
 			}
 			// For old IEs.
 			else {

--- a/plugins/clipboard/plugin.js
+++ b/plugins/clipboard/plugin.js
@@ -1203,8 +1203,9 @@
 		}
 
 		function setToolbarStates() {
-			if ( editor.mode != 'wysiwyg' )
+			if ( editor.mode != 'wysiwyg' ) {
 				return;
+			}
 
 			var pasteState = stateFromNamedCommand( 'paste' );
 
@@ -1229,9 +1230,8 @@
 			}
 
 			// Cut, copy - check if the selection is not empty.
-			var sel = editor.getSelection(),
-				ranges = sel.getRanges(),
-				selectionIsEmpty = sel.getType() == CKEDITOR.SELECTION_NONE || ( ranges.length == 1 && ranges[ 0 ].collapsed );
+			var ranges = selection.getRanges(),
+				selectionIsEmpty = selection.getType() == CKEDITOR.SELECTION_NONE || ( ranges.length == 1 && ranges[ 0 ].collapsed );
 
 			return selectionIsEmpty ? CKEDITOR.TRISTATE_DISABLED : CKEDITOR.TRISTATE_OFF;
 		}

--- a/tests/plugins/divarea/manual/editorunderinput.html
+++ b/tests/plugins/divarea/manual/editorunderinput.html
@@ -1,0 +1,14 @@
+<div>
+	<input type="number" value="3">
+	<textarea name="editor1" id="editor1" rows="10" cols="80"></textarea>
+</div>
+
+<script>
+	if ( !CKEDITOR.env.gecko ) {
+		bender.ignore();
+	}
+
+	CKEDITOR.replace( 'editor1', {
+		extraPlugins: 'divarea'
+	} );
+</script>

--- a/tests/plugins/divarea/manual/editorunderinput.md
+++ b/tests/plugins/divarea/manual/editorunderinput.md
@@ -1,0 +1,17 @@
+@bender-ui: collapsed
+@bender-tags: 4.13.0, bug
+@bender-ckeditor-plugins: wysiwygarea, toolbar, undo, divarea, clipboard
+
+### Note:
+Test has to be performed with console opened.
+
+### Test scenario:
+* Click the input above editor.
+
+**Expected:**
+
+Console remains clean.
+
+**Unexpected:**
+
+A `Permission denied` error is thrown.


### PR DESCRIPTION
## What is the purpose of this pull request?

Bugfix

## Does your PR contain necessary tests?

All patches which change the editor code must include tests. You can always read more
on [PR testing](https://ckeditor.com/docs/ckeditor4/latest/guide/dev_contributing_code.html#tests),
[how to set the testing environment](https://ckeditor.com/docs/ckeditor4/latest/guide/dev_tests.html) and
[how to create tests](https://ckeditor.com/docs/ckeditor4/latest/guide/dev_tests.html#creating-your-own-test)
in the official CKEditor documentation.

### This PR contains

Writing unit test recreating the correct environment seemed unfeasible due to the way Bender handles HTML from the .html file.

- [ ] Unit tests
- [x] Manual tests

## What is the proposed changelog entry for this pull request?

`*[#2216](https://github.com/ckeditor/ckeditor-dev/issues/2216) Fixed: 'Permission Denied' error is thrown in Firefox when using [Div Editing Area](https://ckeditor.com/cke4/addon/divarea) plugin with number input before editor.`

## What changes did you make?

The problem occures because some node properties are unaccessible and editor throws an error. As the whole thing is happening outside editor itself, I just added error handling.

Closes #2216.