### PR TITLE
Fix for: Table selection moved into the topmost element when clicking balloon button

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -23,6 +23,7 @@ Fixed Issues:
 * [#3101](https://github.com/ckeditor/ckeditor-dev/issues/3101): Fixed: [`CKEDITOR.dom.range#_getTableElement()`](https://ckeditor.com/docs/ckeditor4/latest/api/CKEDITOR_dom_range.html#method-_getTableElement) returns `null` instead of a table element for edge cases.
 * [#3287](https://github.com/ckeditor/ckeditor-dev/issues/3287): Fixed: [`CKEDITOR.tools.promise`](https://ckeditor.com/docs/ckeditor4/latest/api/CKEDITOR_tools_promise.html) incorrectly initialized if an AMD loader is present.
 * [#3379](https://github.com/ckeditor/ckeditor-dev/issues/3379): Fixed: Incorrect [`CKEDITOR.editor#getData`](https://ckeditor.com/docs/ckeditor4/latest/api/CKEDITOR_editor.html#method-getData) call when inserting content into the editor.
+* [#3136](https://github.com/ckeditor/ckeditor-dev/issues/3136) [Firefox] Fixed: Clicking on [Balloon Toolbar](https://ckeditor.com/cke4/addon/balloontoolbar) items removes native table selection.
 
 API Changes:
 

--- a/tests/core/selection/manual/tableselection.html
+++ b/tests/core/selection/manual/tableselection.html
@@ -1,0 +1,73 @@
+<h2>Classic Editor</h2>
+<div id="classic">
+	Hello world
+	<table border=1>
+		<tr>
+			<td>foo</td>
+			<td>foo</td>
+			<td>foo</td>
+		</tr>
+		<tr>
+			<td>bar</td>
+			<td>bar</td>
+			<td>bar</td>
+		</tr>
+	</table>
+</div>
+
+<h2>Divarea Editor</h2>
+<div id="divarea">
+	Hello world
+	<table border=1>
+		<tr>
+			<td>foo</td>
+			<td>foo</td>
+			<td>foo</td>
+		</tr>
+		<tr>
+			<td>bar</td>
+			<td>bar</td>
+			<td>bar</td>
+		</tr>
+	</table>
+</div>
+
+<script>
+	if ( !CKEDITOR.env.gecko ) {
+		bender.ignore();
+	}
+
+	CKEDITOR.plugins.add( 'testplugin', {
+		requires: 'balloontoolbar',
+		icons: 'foo',
+		init: function( editor ) {
+			editor.addCommand( 'foo', {
+				exec: function() {}
+			} );
+
+			editor.ui.addButton( 'foo', {
+				label: 'foo',
+				command: 'foo',
+				toolbar: 'none,99'
+			} );
+
+		},
+
+		afterInit: function( editor ) {
+			editor.balloonToolbars.create( {
+				buttons: 'foo',
+				cssSelector: 'table'
+			} );
+		}
+	} );
+
+	CKEDITOR.replace( 'classic', {
+		extraPlugins: 'testplugin',
+		removePlugins: 'tableselection'
+	} );
+
+	CKEDITOR.replace( 'divarea', {
+		extraPlugins: 'testplugin,divarea',
+		removePlugins: 'tableselection'
+	} );
+</script>

--- a/tests/core/selection/manual/tableselection.html
+++ b/tests/core/selection/manual/tableselection.html
@@ -33,41 +33,61 @@
 </div>
 
 <script>
-	if ( !CKEDITOR.env.gecko ) {
-		bender.ignore();
-	}
-
-	CKEDITOR.plugins.add( 'testplugin', {
-		requires: 'balloontoolbar',
-		icons: 'foo',
-		init: function( editor ) {
-			editor.addCommand( 'foo', {
-				exec: function() {}
-			} );
-
-			editor.ui.addButton( 'foo', {
-				label: 'foo',
-				command: 'foo',
-				toolbar: 'none,99'
-			} );
-
-		},
-
-		afterInit: function( editor ) {
-			editor.balloonToolbars.create( {
-				buttons: 'foo',
-				cssSelector: 'table'
-			} );
+	( function() {
+		if ( !CKEDITOR.env.gecko ) {
+			bender.ignore();
 		}
-	} );
 
-	CKEDITOR.replace( 'classic', {
-		extraPlugins: 'testplugin',
-		removePlugins: 'tableselection'
-	} );
+		var editorConfig =  {
+			extraPlugins: 'testplugin',
+			removePlugins: 'tableselection',
+			on: {
+				selectionCheck: function( evt ) {
+					var editor = evt.editor,
+						editable = editor.editable(),
+						selectedCells = CKEDITOR.plugins.tabletools.getSelectedCells( editor.getSelection() );
 
-	CKEDITOR.replace( 'divarea', {
-		extraPlugins: 'testplugin,divarea',
-		removePlugins: 'tableselection'
-	} );
+					CKEDITOR.tools.array.forEach( editable.find( 'td' ).toArray(), function( cell ) {
+						cell.removeClass( 'selected' );
+					} );
+
+					CKEDITOR.tools.array.forEach( selectedCells, function( cell ) {
+						cell.addClass( 'selected' );
+					} );
+				}
+			}
+		};
+
+		CKEDITOR.addCss( '.selected { background-color: cyan; }' );
+
+		CKEDITOR.plugins.add( 'testplugin', {
+			requires: 'balloontoolbar',
+			icons: 'foo',
+			init: function( editor ) {
+				editor.addCommand( 'foo', {
+					exec: function() {}
+				} );
+
+				editor.ui.addButton( 'foo', {
+					label: 'foo',
+					command: 'foo',
+					toolbar: 'none,99'
+				} );
+
+			},
+
+			afterInit: function( editor ) {
+				editor.balloonToolbars.create( {
+					buttons: 'foo',
+					cssSelector: 'table'
+				} );
+			}
+		} );
+
+		CKEDITOR.replace( 'classic', editorConfig );
+
+		CKEDITOR.replace( 'divarea', CKEDITOR.tools.object.merge( editorConfig, {
+			extraPlugins: 'testplugin,divarea'
+		} ) );
+	}() );
 </script>

--- a/tests/core/selection/manual/tableselection.md
+++ b/tests/core/selection/manual/tableselection.md
@@ -1,4 +1,4 @@
-@bender-tags: selection, 4.12.2, bug, 3136
+@bender-tags: selection, 4.13.0, bug, 3136
 @bender-ui: collapsed
 @bender-ckeditor-plugins: wysiwygarea, table, toolbar
 

--- a/tests/core/selection/manual/tableselection.md
+++ b/tests/core/selection/manual/tableselection.md
@@ -1,4 +1,4 @@
-@bender-tags: selection, 4.12.1, bug, 3136
+@bender-tags: selection, 4.12.2, bug, 3136
 @bender-ui: collapsed
 @bender-ckeditor-plugins: wysiwygarea, table, toolbar
 

--- a/tests/core/selection/manual/tableselection.md
+++ b/tests/core/selection/manual/tableselection.md
@@ -1,0 +1,16 @@
+@bender-tags: selection, 4.12.1, bug, 3136
+@bender-ui: collapsed
+@bender-ckeditor-plugins: wysiwygarea, table, toolbar
+
+## For each editors
+
+1. Select few table cells, so that they have blue highlight.
+1. Press button in balloon toolbar.
+
+## Expected
+
+Selection in editor looks the same.
+
+## Unexpected
+
+Selection is changed.

--- a/tests/core/selection/manual/tableselection.md
+++ b/tests/core/selection/manual/tableselection.md
@@ -1,10 +1,12 @@
 @bender-tags: selection, 4.13.0, bug, 3136
 @bender-ui: collapsed
-@bender-ckeditor-plugins: wysiwygarea, table, toolbar
+@bender-ckeditor-plugins: wysiwygarea, table, tabletools, toolbar
 
 ## For each editors
 
 1. Select few table cells, so that they have blue highlight.
+
+	**Note:** for better visibility, all cells, in which there is selection, has cyan backgrund.
 1. Press button in balloon toolbar.
 
 ## Expected

--- a/tests/core/selection/tableselection.html
+++ b/tests/core/selection/tableselection.html
@@ -1,5 +1,5 @@
 <textarea id="selection-container"></textarea>
-<textarea id="editor">
+<div id="content">
 	Hello world
 	<table border=1>
 		<tr>
@@ -13,4 +13,4 @@
 			<td>bar</td>
 		</tr>
 	</table>
-</textarea>
+</div>

--- a/tests/core/selection/tableselection.html
+++ b/tests/core/selection/tableselection.html
@@ -1,0 +1,16 @@
+<textarea id="selection-container"></textarea>
+<textarea id="editor">
+	Hello world
+	<table border=1>
+		<tr>
+			<td>foo</td>
+			<td>foo</td>
+			<td>foo</td>
+		</tr>
+		<tr>
+			<td>bar</td>
+			<td>bar</td>
+			<td>bar</td>
+		</tr>
+	</table>
+</textarea>

--- a/tests/core/selection/tableselection.js
+++ b/tests/core/selection/tableselection.js
@@ -1,0 +1,72 @@
+/* bender-tags: editor */
+/* bender-ckeditor-plugins: table, wysiwygarea, toolbar */
+
+( function() {
+	'use strict';
+
+	bender.editor = {
+		name: 'editor',
+		creator: 'inline',
+		config: {
+			removePlugins: 'tableselection'
+		}
+	};
+
+	var selectionContainer = CKEDITOR.document.findOne( '#selection-container' );
+
+	bender.test( {
+		'test ranges are restored when editor is focused': function() {
+			// Only Firefox has native table selection.
+			if ( !CKEDITOR.env.gecko ) {
+				assert.ignore();
+			}
+
+			var bot = this.editorBot,
+				editor = bot.editor,
+				ranges = getRangesContainingEachCell( editor ),
+				selection = editor.getSelection();
+
+			selection.selectRanges( ranges );
+
+			assert.areSame( ranges.length, selection.getRanges().length, 'ranges selected' );
+
+			selectionContainer.focus();
+
+			editor.focus();
+
+			var newRanges = selection.getRanges();
+
+			assert.areSame( ranges.length, newRanges.length, 'ranges count' );
+
+			CKEDITOR.tools.array.forEach( ranges, function( range, index ) {
+				var newRange = newRanges[ index ];
+
+				assertRange( range, newRange );
+			} );
+		}
+	} );
+
+	function getRangesContainingEachCell( editor ) {
+		var cells = editor.editable().find( 'td' ).toArray();
+
+		return CKEDITOR.tools.array.map( cells, getRangeContainingElement( editor ) );
+	}
+
+	function getRangeContainingElement( editor ) {
+		return function( element ) {
+			var range = editor.createRange();
+
+			range.setStartBefore( element );
+			range.setEndBefore( element );
+
+			return range;
+		};
+	}
+
+	function assertRange( expected, actual ) {
+		assert.areSame( expected.startOffset, actual.startOffset, 'startOffset shouldn\'t change' );
+		assert.areSame( expected.endOffset, actual.endOffset, 'endOffset shouldn\'t change' );
+		assert.isTrue( expected.startContainer.equals( actual.startContainer ), 'startContainer shouldn\'t change' );
+		assert.isTrue( expected.endContainer.equals( actual.endContainer ), 'endContainer shouldn\'t change' );
+	}
+} )();


### PR DESCRIPTION
## What is the purpose of this pull request?

Bug fix

## Does your PR contain necessary tests?

All patches which change the editor code must include tests. You can always read more
on [PR testing](https://ckeditor.com/docs/ckeditor4/latest/guide/dev_contributing_code.html#tests),
[how to set the testing environment](https://ckeditor.com/docs/ckeditor4/latest/guide/dev_tests.html) and
[how to create tests](https://ckeditor.com/docs/ckeditor4/latest/guide/dev_tests.html#creating-your-own-test)
in the official CKEditor documentation.

### This PR contains

- [X] Unit tests
- [X] Manual tests

## What is the proposed changelog entry for this pull request?

```
* [#3136](https://github.com/ckeditor/ckeditor-dev/issues/3136) [Firefox] Fixed: Clicking on [Balloon Toolbar](https://ckeditor.com/cke4/addon/balloontoolbar) items removes selection.
```

## What changes did you make?

When clicking on button command execution causes `editor.focus()`, however the click itself blurs editor. In case of inline editors we restore last selection on `focus`. However in case of native table selection it was wrongly restored, so I've adjusted conditional to reach proper path of restoring sel.

In case of `iframe` editors selection doesn't need to be restored, however due to upstream issue in Firefox native table selection is lost when `editor.focus()` is triggered by click. As a workaround logic for restoring selection in this case logic for locking/unlocking selection from inline editors is used.

The second case is not covered by unit test because I couldn't reproduce it without a real mouse click.

Closes #3136