### PR TITLE
Fix for: Additional undo step created when editor is blurred while widget focused

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -9,10 +9,12 @@ Fixed Issues:
 * [#3260](https://github.com/ckeditor/ckeditor-dev/issues/3260): Fixed: [Widget](https://ckeditor.com/cke4/addon/widget) drag handler is visible in [read-only mode](https://ckeditor.com/docs/ckeditor4/latest/guide/dev_readonly.html).
 * [#941](https://github.com/ckeditor/ckeditor-dev/issues/941): Fixed: Error is thrown after styling the text table cell selected using native selection when [Table Selection](https://ckeditor.com/cke4/addon/tableselection) is enabled.
 * [#3261](https://github.com/ckeditor/ckeditor-dev/issues/3261): Fixed: [Widget](https://ckeditor.com/cke4/addon/widget) initialized using dialog has incorrect owner document.
+* [#3198](https://github.com/ckeditor/ckeditor-dev/issues/3198): Fixed: Blurring and focusing editor when [widget](https://ckeditor.com/cke4/addon/widget) is focused creates additional undo step.
 
 API Changes:
 
 * [#3154](https://github.com/ckeditor/ckeditor-dev/issues/3154): Added the [`CKEDITOR.tools.array.some()`](https://ckeditor.com/docs/ckeditor4/latest/api/CKEDITOR_tools_array.html#method-some) method.
+* [#3245](https://github.com/ckeditor/ckeditor-dev/issues/3245): Added the [`CKEDITOR.plugins.undo.UndoManager.addFilterRule()`](https://ckeditor.com/docs/ckeditor4/latest/api/CKEDITOR_plugins_undo_UndoManager.html#method-addFilterRule) method which allows filtering undo snapshots contents.
 
 ## CKEditor 4.12.1
 

--- a/plugins/undo/plugin.js
+++ b/plugins/undo/plugin.js
@@ -188,12 +188,18 @@
 
 	CKEDITOR.plugins.undo = {};
 
-	var UndoFilter = CKEDITOR.tools.createClass( {
+	/**
+	 * Filter class which stores and applies rules to filter Undo snapshot data.
+	 *
+	 * @class CKEDITOR.plugins.undo.UndoFilter
+	 * @since 4.12.2
+	 * @class
+	 */
+	var UndoFilter = CKEDITOR.plugins.undo.UndoFilter = CKEDITOR.tools.createClass( {
 		/**
-		 * Filter class which stores and applies rules to filter Undo snapshot data.
+		 * Creates UndoFilter instance.
 		 *
 		 * @since 4.12.2
-		 * @class
 		 * @constructor
 		 */
 		$: function() {
@@ -284,7 +290,7 @@
 		this.strokesLimit = 25;
 
 		/**
-		 * {@link CKEDITOR.plugins.undo.UndoManager.filter} instance.
+		 * {@link CKEDITOR.plugins.undo.UndoFilter} instance.
 		 *
 		 * @since 4.12.2
 		 * @property

--- a/plugins/undo/plugin.js
+++ b/plugins/undo/plugin.js
@@ -205,7 +205,7 @@
 			 * Adds new rule to filter.
 			 *
 			 * @since 4.12.2
-			 * @param {function} rule Callback function that returns filtered data..
+			 * @param {function} rule Callback function that returns filtered data.
 			 * @param {String} rule.data Data passed to callback.
 			 */
 			addRule: function( rule ) {

--- a/plugins/undo/plugin.js
+++ b/plugins/undo/plugin.js
@@ -244,11 +244,6 @@
 		 */
 		this.strokesLimit = 25;
 
-		this.editor = editor;
-
-		// Reset the undo stack.
-		this.reset();
-
 		/**
 		 * Array of filter rules.
 		 *
@@ -257,6 +252,11 @@
 		 * @property {Function[]}
 		 */
 		this._filterRules = [];
+
+		this.editor = editor;
+
+		// Reset the undo stack.
+		this.reset();
 
 		// In IE, we need to remove the expando attributes.
 		if ( CKEDITOR.env.ie ) {

--- a/plugins/undo/plugin.js
+++ b/plugins/undo/plugin.js
@@ -814,7 +814,9 @@
 
 			var contents = editor.getSnapshot();
 
-			this.contents = applyRules( contents, editor.undoManager._filterRules );
+			if ( contents ) {
+				this.contents = applyRules( contents, editor.undoManager._filterRules );
+			}
 
 			if ( !contentsOnly ) {
 				var selection = contents && editor.getSelection();

--- a/plugins/undo/plugin.js
+++ b/plugins/undo/plugin.js
@@ -692,7 +692,7 @@
 		/**
 		 * Registers a filtering rule.
 		 *
-		 * @since 4.12.2
+		 * @since 4.13.0
 		 * @param {Function} rule Callback function that returns filtered data.
 		 * @param {String} rule.data Data passed to callback.
 		 */

--- a/plugins/undo/plugin.js
+++ b/plugins/undo/plugin.js
@@ -257,6 +257,13 @@
 		 * @property {Function[]}
 		 */
 		this._filterRules = [];
+
+		// In IE, we need to remove the expando attributes.
+		if ( CKEDITOR.env.ie ) {
+			this.addFilterRule( function( data ) {
+				return data.replace( /\s+data-cke-expando=".*?"/g, '' );
+			} );
+		}
 	};
 
 	UndoManager.prototype = {
@@ -806,10 +813,6 @@
 			editor.fire( 'beforeUndoImage' );
 
 			var contents = editor.getSnapshot();
-
-			// In IE, we need to remove the expando attributes.
-			if ( CKEDITOR.env.ie && contents )
-				contents = contents.replace( /\s+data-cke-expando=".*?"/g, '' );
 
 			this.contents = applyRules( contents, editor.undoManager._filterRules );
 

--- a/plugins/undo/plugin.js
+++ b/plugins/undo/plugin.js
@@ -211,7 +211,7 @@
 			 * Adds new rule to filter.
 			 *
 			 * @since 4.12.2
-			 * @param {function} rule Callback function that returns filtered data.
+			 * @param {Function} rule Callback function that returns filtered data.
 			 * @param {String} rule.data Data passed to callback.
 			 */
 			addRule: function( rule ) {

--- a/plugins/widget/plugin.js
+++ b/plugins/widget/plugin.js
@@ -3106,7 +3106,7 @@
 			return;
 		}
 
-		undoManager.filter.addRule( function( data ) {
+		undoManager.addFilterRule( function( data ) {
 			return data.replace( /\s*cke_widget_selected/g, '' )
 				.replace( /\s*cke_widget_focused/g, '' )
 				.replace( /<span[^>]*cke_widget_drag_handler_container[^>]*.*?<\/span>/gmi, '' );

--- a/plugins/widget/plugin.js
+++ b/plugins/widget/plugin.js
@@ -118,6 +118,7 @@
 			}
 			addWidgetButtons( editor );
 			setupContextMenu( editor );
+			setupUndoFilters( editor.undoManager );
 		}
 	} );
 
@@ -3100,6 +3101,17 @@
 		};
 	}
 
+	function setupUndoFilters( undoManager ) {
+		if ( !undoManager ) {
+			return;
+		}
+
+		undoManager.filter.addRule( function( data ) {
+			return data.replace( /\s*cke_widget_selected/g, '' )
+				.replace( /\s*cke_widget_focused/g, '' )
+				.replace( /<span[^>]*cke_widget_drag_handler_container[^>]*.*?<\/span>/gmi, '' );
+		} );
+	}
 
 	//
 	// WIDGET helpers ---------------------------------------------------------

--- a/plugins/widget/plugin.js
+++ b/plugins/widget/plugin.js
@@ -118,7 +118,7 @@
 			}
 			addWidgetButtons( editor );
 			setupContextMenu( editor );
-			setupUndoFilters( editor.undoManager );
+			setupUndoFilter( editor.undoManager );
 		}
 	} );
 
@@ -3101,7 +3101,7 @@
 		};
 	}
 
-	function setupUndoFilters( undoManager ) {
+	function setupUndoFilter( undoManager ) {
 		if ( !undoManager ) {
 			return;
 		}

--- a/tests/plugins/undo/filter.js
+++ b/tests/plugins/undo/filter.js
@@ -1,0 +1,37 @@
+/* bender-tags: editor */
+/* bender-ckeditor-plugins: undo,clipboard,toolbar,wysiwygarea */
+
+( function() {
+	'use strict';
+
+	bender.editor = {};
+
+	bender.test( {
+		// (#3245)
+		'test filter.addRule': function() {
+			var undoFilter = this.editor.undoManager.filter,
+				rule = function() {};
+
+			undoFilter.addRule( rule );
+
+			assert.areSame( rule, undoFilter.rules.pop() );
+		},
+		// (#3245)
+		'test filter.filterData': function() {
+			var undoFilter = this.editor.undoManager.filter,
+				data = 'foobarfoobazfoobar';
+
+			undoFilter.addRule( function( data ) {
+				return data.replace( /foo/g, '' );
+			} );
+
+			undoFilter.addRule( function( data) {
+				return data.replace( /bar/g, 'far' );
+			} );
+
+			var newData = undoFilter.filterData( data );
+
+			assert.areEqual( 'farbazfar', newData );
+		}
+	} );
+} )();

--- a/tests/plugins/undo/filter.js
+++ b/tests/plugins/undo/filter.js
@@ -7,6 +7,12 @@
 	bender.editor = {};
 
 	bender.test( {
+
+		setUp: function() {
+			this.editor.undoManager.reset();
+			this.editor.undoManager._filterRules = [];
+		},
+
 		// (#3245)
 		'test filter.addRule': function() {
 			var undoManager = this.editor.undoManager,
@@ -16,6 +22,7 @@
 
 			assert.areSame( rule, undoManager._filterRules.pop() );
 		},
+
 		// (#3245)
 		'test filter.filterData': function() {
 			var editor = this.editor,
@@ -37,6 +44,56 @@
 			editor.getSnapshot.restore();
 
 			assert.areEqual( 'farbazfar', newData );
+		},
+
+		// (#3245)
+		'test filter.filterData (double replace)': function() {
+			var editor = this.editor,
+				undoManager = editor.undoManager,
+				data = 'foobarfoobazfoobar';
+
+			undoManager.addFilterRule( function( data ) {
+				return data.replace( /foo/g, 'ba' );
+			} );
+
+			undoManager.addFilterRule( function( data ) {
+				return data.replace( /bab/g, 'f' );
+			} );
+
+			sinon.stub( editor, 'getSnapshot' ).returns( data );
+
+			var newData = new CKEDITOR.plugins.undo.Image( editor, true ).contents;
+
+			editor.getSnapshot.restore();
+
+			assert.areEqual( 'farfazfar', newData );
+		},
+
+		// (#3245)
+		'test filter.filterData (multiple replace)': function() {
+			var editor = this.editor,
+				undoManager = editor.undoManager,
+				data = 'foobarfoobazfoobar';
+
+			undoManager.addFilterRule( function( data ) {
+				return data.replace( /foo/g, 'bar' );
+			} );
+
+			undoManager.addFilterRule( function( data ) {
+				return data.replace( /bar/g, 'far' );
+			} );
+
+			undoManager.addFilterRule( function( data ) {
+				return data.replace( /farfar/g, '-' );
+			} );
+
+			sinon.stub( editor, 'getSnapshot' ).returns( data );
+
+			var newData = new CKEDITOR.plugins.undo.Image( editor, true ).contents;
+
+			editor.getSnapshot.restore();
+
+			assert.areEqual( '-farbaz-', newData );
 		}
 	} );
 } )();

--- a/tests/plugins/undo/filter.js
+++ b/tests/plugins/undo/filter.js
@@ -9,27 +9,32 @@
 	bender.test( {
 		// (#3245)
 		'test filter.addRule': function() {
-			var undoFilter = this.editor.undoManager.filter,
+			var undoManager = this.editor.undoManager,
 				rule = function() {};
 
-			undoFilter.addRule( rule );
+			undoManager.addFilterRule( rule );
 
-			assert.areSame( rule, undoFilter.rules.pop() );
+			assert.areSame( rule, undoManager._filterRules.pop() );
 		},
 		// (#3245)
 		'test filter.filterData': function() {
-			var undoFilter = this.editor.undoManager.filter,
+			var editor = this.editor,
+				undoManager = editor.undoManager,
 				data = 'foobarfoobazfoobar';
 
-			undoFilter.addRule( function( data ) {
+			undoManager.addFilterRule( function( data ) {
 				return data.replace( /foo/g, '' );
 			} );
 
-			undoFilter.addRule( function( data) {
+			undoManager.addFilterRule( function( data ) {
 				return data.replace( /bar/g, 'far' );
 			} );
 
-			var newData = undoFilter.filterData( data );
+			sinon.stub( editor, 'getSnapshot' ).returns( data );
+
+			var newData = new CKEDITOR.plugins.undo.Image( editor, true ).contents;
+
+			editor.getSnapshot.restore();
 
 			assert.areEqual( 'farbazfar', newData );
 		}

--- a/tests/plugins/widget/manual/undo.html
+++ b/tests/plugins/widget/manual/undo.html
@@ -1,0 +1,19 @@
+<textarea id="editor">
+	<img src="../../../_assets/lena.jpg">
+</textarea>
+
+<p>Undo steps count: <span id="counter"></span></p>
+
+<script>
+	var counter = CKEDITOR.document.findOne( '#counter' ),
+		editor = CKEDITOR.replace( 'editor', {
+			height: 300,
+			on: {
+				instanceReady: function() {
+					setInterval( function() {
+						counter.setText( editor.undoManager.snapshots.length );
+					}, 50 );
+				}
+			}
+		} );
+</script>

--- a/tests/plugins/widget/manual/undo.html
+++ b/tests/plugins/widget/manual/undo.html
@@ -1,5 +1,7 @@
 <textarea id="editor">
-	<img src="../../../_assets/lena.jpg">
+	<p><img src="../../../_assets/lena.jpg"></p>
+	<p>Foo</p>
+	<p>Bar</p>
 </textarea>
 
 <p>Undo steps count: <span id="counter"></span></p>

--- a/tests/plugins/widget/manual/undo.md
+++ b/tests/plugins/widget/manual/undo.md
@@ -1,0 +1,13 @@
+@bender-tags: 4.12.2, bug, widget, 3198
+@bender-ui: collapsed
+@bender-ckeditor-plugins: image2, wysiwygarea, toolbar, sourcearea, undo
+
+1. Click on a widget.
+1. Click outside of the editor.
+1. Click on the widget again.
+
+## Expected
+Undo steps count is 1.
+
+## Expected
+Undo steps count is 2 or more.

--- a/tests/plugins/widget/manual/undo.md
+++ b/tests/plugins/widget/manual/undo.md
@@ -2,12 +2,35 @@
 @bender-ui: collapsed
 @bender-ckeditor-plugins: image2, wysiwygarea, toolbar, sourcearea, undo
 
+## Scenario 1
+
 1. Click on a widget.
 1. Click outside of the editor.
 1. Click on the widget again.
 
-## Expected
+### Expected
 Undo steps count is 1.
 
-## Expected
+### Expected
 Undo steps count is 2 or more.
+
+## Scenario 2
+
+1. Place caret in text after `Foo`.
+1. Type something.
+1. Click on widget.
+1. Click outside of the editor.
+1. Place caret in text after `Bar`.
+1. Repeat step 2.
+1. Press `Undo` button exactly two times.
+
+### Expected
+
+- Undo button is disabled.
+- Changes from step 1 and 5 are reverted.
+
+## Unexpected
+
+- Undo button is enabled.
+- Widget is focused.
+- Changes from step 1 is not reverted.

--- a/tests/plugins/widget/manual/undo.md
+++ b/tests/plugins/widget/manual/undo.md
@@ -1,4 +1,4 @@
-@bender-tags: 4.12.2, bug, widget, 3198
+@bender-tags: 4.13.0, bug, widget, 3198
 @bender-ui: collapsed
 @bender-ckeditor-plugins: image2, wysiwygarea, toolbar, sourcearea, undo
 

--- a/tests/plugins/widget/undo.js
+++ b/tests/plugins/widget/undo.js
@@ -458,13 +458,14 @@
 				var widget = getWidgetById( editor, 'w1' );
 
 				editor.resetUndo();
+
 				editor.fire( 'blur' );
 
 				widget.focus();
 
 				editor.fire( 'saveSnapshot' );
 
-				assert.areEqual( 2, editor.undoManager.snapshots.length, 'UndoManager should have one snapshot' );
+				assert.isFalse( editor.undoManager.hasUndo, 'UndoManager.hasUndo' );
 			} );
 		}
 	} );

--- a/tests/plugins/widget/undo.js
+++ b/tests/plugins/widget/undo.js
@@ -451,7 +451,7 @@
 		},
 
 		// (#3245)
-		'test undo steps': function() {
+		'test undo when widget is focused and blurred': function() {
 			var editor = this.editor;
 
 			this.editorBot.setData( widgetData1, function() {
@@ -459,13 +459,18 @@
 
 				editor.resetUndo();
 
-				editor.fire( 'blur' );
-
 				widget.focus();
 
+				editor.fire( 'blur' );
 				editor.fire( 'saveSnapshot' );
 
-				assert.isFalse( editor.undoManager.hasUndo, 'UndoManager.hasUndo' );
+				setTimeout( function() {
+					resume( function() {
+						assert.isFalse( editor.undoManager.hasUndo, 'UndoManager.hasUndo' );
+					} );
+				} );
+
+				wait();
 			} );
 		}
 	} );

--- a/tests/plugins/widget/undo.js
+++ b/tests/plugins/widget/undo.js
@@ -448,6 +448,24 @@
 				assert.areSame( 0, objToArray( editor.widgets.instances ).length, '0 widgets after redo' );
 				assertCommands( editor, true, false, 'after redo' );
 			} );
+		},
+
+		// (#3245)
+		'test undo steps': function() {
+			var editor = this.editor;
+
+			this.editorBot.setData( widgetData1, function() {
+				var widget = getWidgetById( editor, 'w1' );
+
+				editor.resetUndo();
+				editor.fire( 'blur' );
+
+				widget.focus();
+
+				editor.fire( 'saveSnapshot' );
+
+				assert.areEqual( 2, editor.undoManager.snapshots.length, 'UndoManager should have one snapshot' );
+			} );
 		}
 	} );
 } )();


### PR DESCRIPTION
## What is the purpose of this pull request?

Bug fix + new feature

## Does your PR contain necessary tests?

All patches which change the editor code must include tests. You can always read more
on [PR testing](https://ckeditor.com/docs/ckeditor4/latest/guide/dev_contributing_code.html#tests),
[how to set the testing environment](https://ckeditor.com/docs/ckeditor4/latest/guide/dev_tests.html) and
[how to create tests](https://ckeditor.com/docs/ckeditor4/latest/guide/dev_tests.html#creating-your-own-test)
in the official CKEditor documentation.

### This PR contains

- [X] Unit tests
- [X] Manual tests

## What is the proposed changelog entry for this pull request?
```
Bug Fixes:
* [3198](https://github.com/ckeditor/ckeditor-dev/issues/3198) Fixed: Blurring and focusing editor creates undo step.

API Changes:
* [3245](https://github.com/ckeditor/ckeditor-dev/issues/3245) Added [`UndoManager.filter`]() class which is responsible for filtering Undo snapshot contents.
```
## What changes did you make?

- New class `undoManager.filter` which is responsible for filtering content of undo snapshots.
- Widget plugin registers undo filters so that `focus`, `active` CSS classes and drag handler are removed from snapshots.

Closes #3198
Closes #3245