### PR TITLE
Improve tools.bind function with bound arguments

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -21,6 +21,7 @@ API Changes:
 * [#3245](https://github.com/ckeditor/ckeditor-dev/issues/3245): Added the [`CKEDITOR.plugins.undo.UndoManager.addFilterRule()`](https://ckeditor.com/docs/ckeditor4/latest/api/CKEDITOR_plugins_undo_UndoManager.html#method-addFilterRule) method which allows filtering undo snapshots contents.
 * [#2845](https://github.com/ckeditor/ckeditor-dev/issues/2845): Added the [`CKEDITOR.tools.normalizeMouseButton()`](https://ckeditor.com/docs/ckeditor4/latest/api/CKEDITOR_tools.html#method-normalizeMouseButton) method.
 * [#2975](https://github.com/ckeditor/ckeditor-dev/issues/2975): Added the [`CKEDITOR.dom.element#fireEventHandler()`](https://ckeditor.com/docs/ckeditor4/latest/api/CKEDITOR_dom_element.html#method-fireEventHandler) method.
+* [#3247](https://github.com/ckeditor/ckeditor-dev/issues/3247): Extended [`CKEditor.tools.bind()`](https://ckeditor.com/docs/ckeditor4/latest/api/CKEDITOR_tools.html#method-bind) method to accept arguments for bound functions.
 
 ## CKEditor 4.12.1
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -21,7 +21,7 @@ API Changes:
 * [#3245](https://github.com/ckeditor/ckeditor-dev/issues/3245): Added the [`CKEDITOR.plugins.undo.UndoManager.addFilterRule()`](https://ckeditor.com/docs/ckeditor4/latest/api/CKEDITOR_plugins_undo_UndoManager.html#method-addFilterRule) method which allows filtering undo snapshots contents.
 * [#2845](https://github.com/ckeditor/ckeditor-dev/issues/2845): Added the [`CKEDITOR.tools.normalizeMouseButton()`](https://ckeditor.com/docs/ckeditor4/latest/api/CKEDITOR_tools.html#method-normalizeMouseButton) method.
 * [#2975](https://github.com/ckeditor/ckeditor-dev/issues/2975): Added the [`CKEDITOR.dom.element#fireEventHandler()`](https://ckeditor.com/docs/ckeditor4/latest/api/CKEDITOR_dom_element.html#method-fireEventHandler) method.
-* [#3247](https://github.com/ckeditor/ckeditor-dev/issues/3247): Extended [`CKEditor.tools.bind()`](https://ckeditor.com/docs/ckeditor4/latest/api/CKEDITOR_tools.html#method-bind) method to accept arguments for bound functions.
+* [#3247](https://github.com/ckeditor/ckeditor-dev/issues/3247): Extended [`CKEDITOR.tools.bind()`](https://ckeditor.com/docs/ckeditor4/latest/api/CKEDITOR_tools.html#method-bind) method to accept arguments for bound functions.
 
 ## CKEditor 4.12.1
 

--- a/core/tools.js
+++ b/core/tools.js
@@ -717,12 +717,14 @@
 		 *
 		 * @param {Function} func The function to be executed.
 		 * @param {Object} obj The object to which the execution context will be bound.
+		 * @param {*} [args] Other arguments passed after object, will be bind to executed function.
 		 * @returns {Function} The function that can be used to execute the
 		 * `func` function in the context of `obj`.
 		 */
 		bind: function( func, obj ) {
+			var args = Array.prototype.slice.call( arguments, 2 );
 			return function() {
-				return func.apply( obj, arguments );
+				return func.apply( obj, args.concat( Array.prototype.slice.call( arguments ) ) );
 			};
 		},
 

--- a/core/tools.js
+++ b/core/tools.js
@@ -717,7 +717,7 @@
 		 *
 		 * @param {Function} func The function to be executed.
 		 * @param {Object} obj The object to which the execution context will be bound.
-		 * @param {*} [args] Other arguments passed after object, will be bind to executed function.
+		 * @param {*} [args] Arguments provided to the bound function when invoking the target function. Available since 4.13.0.
 		 * @returns {Function} The function that can be used to execute the
 		 * `func` function in the context of `obj`.
 		 */

--- a/core/tools.js
+++ b/core/tools.js
@@ -706,20 +706,35 @@
 		 * Creates a function that will always execute in the context of a
 		 * specified object.
 		 *
-		 *		var obj = { text: 'My Object' };
+		 * ```js
+		 * var obj = { text: 'My Object' };
 		 *
-		 *		function alertText() {
-		 *			alert( this.text );
-		 *		}
+		 * function alertText() {
+		 * 	alert( this.text );
+		 * }
 		 *
-		 *		var newFunc = CKEDITOR.tools.bind( alertText, obj );
-		 *		newFunc(); // Alerts 'My Object'.
+		 * var newFunc = CKEDITOR.tools.bind( alertText, obj );
+		 * newFunc(); // Alerts 'My Object'.
+		 * ```
+		 *
+		 * Since 4.13.0 additional arguments can be bound to a function.
+		 *
+		 * ```js
+		 * function logData( text, number1, number2 ) {
+		 * 	console.log( text, number1, number2 );
+		 * }
+		 *
+		 * var newFunc = CKEDITOR.tools.bind( logData, null, 'Foo', 1 );
+		 * newFunc(); // Logs: 'Foo', 1, undefined.
+		 * newFunc( 2 ); // Logs: 'Foo', 1, 2.
+		 *
+		 * ```
 		 *
 		 * @param {Function} func The function to be executed.
 		 * @param {Object} obj The object to which the execution context will be bound.
 		 * @param {*} [args] Arguments provided to the bound function when invoking the target function. Available since 4.13.0.
 		 * @returns {Function} The function that can be used to execute the
-		 * `func` function in the context of `obj`.
+		 * `func` function in the context of specified `obj` object.
 		 */
 		bind: function( func, obj ) {
 			var args = Array.prototype.slice.call( arguments, 2 );

--- a/tests/core/tools.js
+++ b/tests/core/tools.js
@@ -1069,6 +1069,68 @@
 			CKEDITOR.tools.array.forEach( conversionArray, function( item ) {
 				assert.areSame( item.output, CKEDITOR.tools.convertToPx( item.input ), 'Value ' + item.input + ' should be converted to ' + item.output );
 			} );
+		},
+
+		// (#3247)
+		'test bind without context and without arguments': function() {
+			var testSpy = sinon.spy(),
+				bindedFn = CKEDITOR.tools.bind( testSpy );
+
+			bindedFn( 'foo' );
+			assert.areSame( 1, testSpy.callCount );
+			assert.isTrue( testSpy.calledWithExactly( 'foo' ) );
+
+			bindedFn( 'bar' );
+			assert.areSame( 2, testSpy.callCount );
+			assert.isTrue( testSpy.calledWithExactly( 'bar' ) );
+		},
+
+		// (#3247)
+		'text bind with context and without arguments': function() {
+			var testSpy = sinon.spy(),
+				testObj = {},
+				bindedFn = CKEDITOR.tools.bind( testSpy, testObj );
+
+			bindedFn( 'foo' );
+			assert.areSame( 1, testSpy.callCount );
+			assert.areSame( testObj, testSpy.getCall( 0 ).thisValue );
+			assert.isTrue( testSpy.calledWithExactly( 'foo' ) );
+
+			bindedFn( 'bar' );
+			assert.areSame( 2, testSpy.callCount );
+			assert.areSame( testObj, testSpy.getCall( 1 ).thisValue );
+			assert.isTrue( testSpy.calledWithExactly( 'bar' ) );
+		},
+
+		// (#3247)
+		'test bind without context and with arguments': function() {
+			var testSpy = sinon.spy(),
+				bindedFn = CKEDITOR.tools.bind( testSpy, null, 'baz', 100 );
+
+			bindedFn( 'foo' );
+			assert.areSame( 1, testSpy.callCount );
+			assert.isTrue( testSpy.calledWithExactly( 'baz', 100, 'foo' ) );
+
+			bindedFn( 'bar' );
+			assert.areSame( 2, testSpy.callCount );
+			assert.isTrue( testSpy.calledWithExactly( 'baz', 100, 'bar' ) );
+		},
+
+		// (#3247)
+		'text bind with context and with arguments': function() {
+			var testSpy = sinon.spy(),
+				testObj = {},
+				bindedFn = CKEDITOR.tools.bind( testSpy, testObj, 'baz', 100 );
+
+			bindedFn( 'foo' );
+			assert.areSame( 1, testSpy.callCount );
+			assert.areSame( testObj, testSpy.getCall( 0 ).thisValue );
+			assert.isTrue( testSpy.calledWithExactly( 'baz', 100, 'foo' ) );
+
+			bindedFn( 'bar' );
+			assert.areSame( 2, testSpy.callCount );
+			assert.areSame( testObj, testSpy.getCall( 0 ).thisValue );
+			assert.isTrue( testSpy.calledWithExactly( 'baz', 100, 'bar' ) );
 		}
 	} );
 } )();

--- a/tests/core/tools.js
+++ b/tests/core/tools.js
@@ -1071,7 +1071,6 @@
 			} );
 		},
 
-		// (#3247)
 		'test bind without context and without arguments': function() {
 			var testSpy = sinon.spy(),
 				bindedFn = CKEDITOR.tools.bind( testSpy );
@@ -1085,7 +1084,6 @@
 			assert.isTrue( testSpy.calledWithExactly( 'bar' ) );
 		},
 
-		// (#3247)
 		'text bind with context and without arguments': function() {
 			var testSpy = sinon.spy(),
 				testObj = {},


### PR DESCRIPTION
## What is the purpose of this pull request?

New feature

## Does your PR contain necessary tests?

All patches which change the editor code must include tests. You can always read more
on [PR testing](https://ckeditor.com/docs/ckeditor4/latest/guide/dev_contributing_code.html#tests),
[how to set the testing environment](https://ckeditor.com/docs/ckeditor4/latest/guide/dev_tests.html) and
[how to create tests](https://ckeditor.com/docs/ckeditor4/latest/guide/dev_tests.html#creating-your-own-test)
in the official CKEditor documentation.

### This PR contains

- [x] Unit tests
- [ ] Manual tests

## What changes did you make?

I just restored this PR from https://github.com/ckeditor/ckeditor-dev/pull/2862 with some changes during a review. Kudos to @msamsel for most of the feature.

* Extend bind method to accepts more arguments passed to bound functions.
* Feature extracted from PR related to #1479.

## Proposed changelog entry for this PR

```
* [#3247](https://github.com/ckeditor/ckeditor-dev/issues/3247): Extended [`CKEditor.tools.bind`](https://ckeditor.com/docs/ckeditor4/latest/api/CKEDITOR_tools.html#method-bind) method, to accept arguments for bound functions.
```

Closes #3247