### PR TITLE
Pass the same document for detached widget wrapper element as for editor instance

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -8,6 +8,7 @@ Fixed Issues:
 * [#808](https://github.com/ckeditor/ckeditor-dev/issues/808): Fixed: [Widget](https://ckeditor.com/cke4/addon/widget) and other content disappear on drag and drop in [read-only mode](https://ckeditor.com/docs/ckeditor4/latest/guide/dev_readonly.html).
 * [#3260](https://github.com/ckeditor/ckeditor-dev/issues/3260): Fixed: [Widget](https://ckeditor.com/cke4/addon/widget) drag handler is visible in [read-only mode](https://ckeditor.com/docs/ckeditor4/latest/guide/dev_readonly.html).
 * [#941](https://github.com/ckeditor/ckeditor-dev/issues/941): Fixed: Error is thrown after styling the text table cell selected using native selection when [Table Selection](https://ckeditor.com/cke4/addon/tableselection) is enabled.
+* [#3261](https://github.com/ckeditor/ckeditor-dev/issues/3261): Fixed: [Widget](https://ckeditor.com/cke4/addon/widget) initialized using dialog has incorrect owner document.
 
 API Changes:
 

--- a/plugins/widget/plugin.js
+++ b/plugins/widget/plugin.js
@@ -664,7 +664,7 @@
 					preserveSpaces( element );
 				}
 
-				wrapper = new CKEDITOR.dom.element( isInline ? 'span' : 'div' );
+				wrapper = new CKEDITOR.dom.element( isInline ? 'span' : 'div', element.getDocument() );
 				wrapper.setAttributes( getWrapperAttributes( isInline, widgetName ) );
 
 				wrapper.data( 'cke-display-name', widgetDef.pathName ? widgetDef.pathName : element.getName() );
@@ -1945,7 +1945,7 @@
 				} else if ( widgetDef.template ) {
 					// ... or create a brand-new widget from template.
 					var defaults = typeof widgetDef.defaults == 'function' ? widgetDef.defaults() : widgetDef.defaults,
-						element = CKEDITOR.dom.element.createFromHtml( widgetDef.template.output( defaults ) ),
+						element = CKEDITOR.dom.element.createFromHtml( widgetDef.template.output( defaults ), editor.document ),
 						instance,
 						wrapper = editor.widgets.wrapElement( element, widgetDef.name ),
 						temp = new CKEDITOR.dom.documentFragment( wrapper.getDocument() );

--- a/tests/plugins/widget/editing.js
+++ b/tests/plugins/widget/editing.js
@@ -443,7 +443,6 @@
 			} );
 		},
 
-
 		// (#3261)
 		'test widget document': function() {
 			var editor = this.editor;

--- a/tests/plugins/widget/editing.js
+++ b/tests/plugins/widget/editing.js
@@ -443,6 +443,25 @@
 			} );
 		},
 
+
+		// (#3261)
+		'test widget document': function() {
+			var editor = this.editor;
+
+			this.editorBot.setData( '<p>x</p>', function() {
+				editor.widgets.add( 'insertingdocument', {
+					dialog: 'foo',
+					template: '<b>foo</b>',
+					init: function() {
+						assert.areSame( editor.document.$, this.wrapper.getDocument().$ );
+					}
+				} );
+
+				editor.focus();
+				editor.execCommand( 'insertingdocument' );
+			} );
+		},
+
 		'test creating widget using command - no data-cke-widget attribute in template': function() {
 			var editor = this.editor,
 				editFired = 0;

--- a/tests/plugins/widget/editing.js
+++ b/tests/plugins/widget/editing.js
@@ -453,7 +453,7 @@
 					dialog: 'foo',
 					template: '<b>foo</b>',
 					init: function() {
-						assert.areSame( editor.document.$, this.wrapper.getDocument().$ );
+						assert.isTrue( this.wrapper.getDocument().equals( editor.document ) );
 					}
 				} );
 


### PR DESCRIPTION
## What is the purpose of this pull request?

Bug fix

## Does your PR contain necessary tests?

All patches which change the editor code must include tests. You can always read more
on [PR testing](https://ckeditor.com/docs/ckeditor4/latest/guide/dev_contributing_code.html#tests),
[how to set the testing environment](https://ckeditor.com/docs/ckeditor4/latest/guide/dev_tests.html) and
[how to create tests](https://ckeditor.com/docs/ckeditor4/latest/guide/dev_tests.html#creating-your-own-test)
in the official CKEditor documentation.

### This PR contains

- [x] Unit tests
- [ ] Manual tests

## What is the proposed changelog entry for this pull request?

```
* [#3261](https://github.com/ckeditor/ckeditor-dev/issues/3261): Fixed: [Widget](https://ckeditor.com/cke4/addon/widget) initialized using dialog has incorrect owner document.
```

## What changes did you make?

Passing the same document for detached wrapper element as for editor instance.

Closes #3261 
