### PR TITLE
Treat chromium filling char sequence text node as empty

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -14,6 +14,7 @@ Fixed Issues:
 	* [#2845](https://github.com/ckeditor/ckeditor-dev/issues/2845): [Rich Combo](https://ckeditor.com/cke4/addon/richcombo).
 	* [#2857](https://github.com/ckeditor/ckeditor-dev/issues/2857): [List Block](https://ckeditor.com/cke4/addon/listblock).
 	* [#2858](https://github.com/ckeditor/ckeditor-dev/issues/2858): [Menu](https://ckeditor.com/cke4/addon/menu).
+* [#3158](https://github.com/ckeditor/ckeditor-dev/issues/3158): [Chrome, Safari] Fixed: [Undo](https://ckeditor.com/cke4/addon/undo) plugin breaks with filling character.
 
 API Changes:
 
@@ -22,6 +23,7 @@ API Changes:
 * [#2845](https://github.com/ckeditor/ckeditor-dev/issues/2845): Added the [`CKEDITOR.tools.normalizeMouseButton()`](https://ckeditor.com/docs/ckeditor4/latest/api/CKEDITOR_tools.html#method-normalizeMouseButton) method.
 * [#2975](https://github.com/ckeditor/ckeditor-dev/issues/2975): Added the [`CKEDITOR.dom.element#fireEventHandler()`](https://ckeditor.com/docs/ckeditor4/latest/api/CKEDITOR_dom_element.html#method-fireEventHandler) method.
 * [#3247](https://github.com/ckeditor/ckeditor-dev/issues/3247): Extended [`CKEDITOR.tools.bind()`](https://ckeditor.com/docs/ckeditor4/latest/api/CKEDITOR_tools.html#method-bind) method to accept arguments for bound functions.
+* [#3326](https://github.com/ckeditor/ckeditor-dev/issues/3326): Added [`CKEDITOR.dom.text#isEmpty()`](https://ckeditor.com/docs/ckeditor4/latest/api/CKEDITOR_dom_text.html#method-isEmpty) method.
 
 ## CKEditor 4.12.1
 

--- a/core/dom/range.js
+++ b/core/dom/range.js
@@ -839,7 +839,7 @@ CKEDITOR.dom.range = function( root ) {
 					var precedingLength = getLengthOfPrecedingTextNodes( container );
 
 					// Normal case - text node is not empty.
-					if ( container.getText() ) {
+					if ( !container.isEmpty() ) {
 						offset += precedingLength;
 
 					// Awful case - the text node is empty and thus will be totally lost.

--- a/core/dom/text.js
+++ b/core/dom/text.js
@@ -81,7 +81,8 @@ CKEDITOR.tools.extend( CKEDITOR.dom.text.prototype, {
 	 * {@link CKEDITOR.dom.selection#FILLING_CHAR_SEQUENCE FILLING_CHAR_SEQUENCE} string.
 	 *
 	 * @since 4.13.0
-	 * @param {Boolean} ignoreWhiteSpace Only check non-whitespace characters.
+	 * @param {Boolean} [ignoreWhiteSpace] Specify whether content consists of only whitespace characters
+	 * should be treated as an empty one.
 	 * @returns {Boolean}
 	 */
 	isEmpty: function( ignoreWhiteSpace ) {

--- a/core/dom/text.js
+++ b/core/dom/text.js
@@ -81,10 +81,17 @@ CKEDITOR.tools.extend( CKEDITOR.dom.text.prototype, {
 	 * {@link CKEDITOR.dom.selection#FILLING_CHAR_SEQUENCE FILLING_CHAR_SEQUENCE} string.
 	 *
 	 * @since 4.13.0
+	 * @param {Boolean} ignoreWhiteSpace Only check non-whitespace characters.
 	 * @returns {Boolean}
 	 */
-	isEmpty: function() {
-		return !this.getText() || this.getText() === CKEDITOR.dom.selection.FILLING_CHAR_SEQUENCE;
+	isEmpty: function( ignoreWhiteSpace ) {
+		var text = this.getText();
+
+		if ( ignoreWhiteSpace ) {
+			text = CKEDITOR.tools.trim( text );
+		}
+
+		return !text || text === CKEDITOR.dom.selection.FILLING_CHAR_SEQUENCE;
 	},
 
 	/**

--- a/core/dom/text.js
+++ b/core/dom/text.js
@@ -77,6 +77,17 @@ CKEDITOR.tools.extend( CKEDITOR.dom.text.prototype, {
 	},
 
 	/**
+	 * Checks whether a node is empty or is
+	 * {@link CKEDITOR.dom.selection#FILLING_CHAR_SEQUENCE FILLING_CHAR_SEQUENCE} string.
+	 *
+	 * @since 4.13.0
+	 * @returns {Boolean}
+	 */
+	isEmpty: function() {
+		return !this.getText() || this.getText() === CKEDITOR.dom.selection.FILLING_CHAR_SEQUENCE;
+	},
+
+	/**
 	 * Breaks this text node into two nodes at the specified offset,
 	 * keeping both in the tree as siblings. This node then only contains
 	 * all the content up to the offset point. A new text node, which is

--- a/tests/core/dom/range/bookmarks.js
+++ b/tests/core/dom/range/bookmarks.js
@@ -392,8 +392,12 @@ addBookmark2TCs( tcs, {
 		'tc 6': [ '<b>%(foo)<i>def</i></b>', { sc: 'b', so: 2, ec: '#def', eo: 1 }, { sc: 'b', so: 0, ec: '#def', eo: 1 } ],
 		'tc 6b': [ '<b>%(foo)(bar)<i>def</i></b>', { sc: 'b', so: 2, ec: '#def', eo: 1 }, { sc: 'b', so: 0, ec: '#def', eo: 1 } ],
 		'tc 6c': [ '<b>%(foo)(bar)<i>def</i></b>', { sc: '(bar)', so: 0, ec: '#def', eo: 1 }, { sc: 'b', so: 0, ec: '#def', eo: 1 } ],
+
 		// between foo and bar.
-		'tc 6d': [ '<b>abc%(foo)(bar)cba<i>def</i></b>', { sc: 'b', so: 3, ec: '#def', eo: 1 }, { sc: '#abccba', so: 3, ec: '#def', eo: 1 } ]
+		'tc 6d': [ '<b>abc%(foo)(bar)cba<i>def</i></b>', { sc: 'b', so: 3, ec: '#def', eo: 1 }, { sc: '#abccba', so: 3, ec: '#def', eo: 1 } ],
+
+		// (#3158)
+		'tc 7a': [ '(foo)<b>a</b>%<b>b</b>', { sc: '%', so: 1 }, { sc: 'root', so: 1 } ]
 	}
 } );
 

--- a/tests/core/dom/range/manual/followingfcs.html
+++ b/tests/core/dom/range/manual/followingfcs.html
@@ -1,0 +1,6 @@
+<div id="editor">
+</div>
+
+<script>
+	CKEDITOR.replace( 'editor' );
+</script>

--- a/tests/core/dom/range/manual/followingfcs.html
+++ b/tests/core/dom/range/manual/followingfcs.html
@@ -1,5 +1,4 @@
-<div id="editor">
-</div>
+<div id="editor"></div>
 
 <script>
 	CKEDITOR.replace( 'editor' );

--- a/tests/core/dom/range/manual/followingfcs.html
+++ b/tests/core/dom/range/manual/followingfcs.html
@@ -1,5 +1,9 @@
 <div id="editor"></div>
 
 <script>
+	if ( !CKEDITOR.env.webkit ) {
+		bender.ignore();
+	}
+
 	CKEDITOR.replace( 'editor' );
 </script>

--- a/tests/core/dom/range/manual/followingfcs.md
+++ b/tests/core/dom/range/manual/followingfcs.md
@@ -1,0 +1,28 @@
+@bender-tags: 4.13.0, bug, range
+@bender-ui: collapsed
+@bender-ckeditor-plugins: wysiwygarea, toolbar, undo, enterkey, list
+
+1. Open dev console.
+2. Add list into the editor.
+3. Create list item with 3 lines separated by soft enter using <kbd>SHIFT + ENTER</kbd> keyboard combination, i.e:
+
+```
+1. foo
+
+   foo
+
+   foo^
+```
+
+**Note** that you need to use 2x soft enter to create empty space.
+
+4. Press undo button.
+
+## Expected
+
+Undo button undoes changes.
+
+## Unexpected
+
+* Error thrown in a dev console.
+* Undo button is no longer responsive.

--- a/tests/core/dom/range/manual/followingfcs.md
+++ b/tests/core/dom/range/manual/followingfcs.md
@@ -25,4 +25,4 @@ Undo button undoes changes.
 ## Unexpected
 
 * Error thrown in a dev console.
-* Undo button is no longer responsive.
+* Undo button clicks produces errors in a console and no longer undoes changes.

--- a/tests/core/dom/range/manual/followingfcs.md
+++ b/tests/core/dom/range/manual/followingfcs.md
@@ -1,4 +1,4 @@
-@bender-tags: 4.13.0, bug, range
+@bender-tags: 4.13.0, bug, range, 3158
 @bender-ui: collapsed
 @bender-ckeditor-plugins: wysiwygarea, toolbar, undo, enterkey, list
 

--- a/tests/core/dom/text.js
+++ b/tests/core/dom/text.js
@@ -106,14 +106,31 @@
 
 		// (#3158)
 		'test isEmpty': function() {
+			var fillingCharSequence = CKEDITOR.dom.selection.FILLING_CHAR_SEQUENCE;
+
 			assert.isFalse( isEmptyNode( 'foobar' ), 'Node should not be empty' );
+			assert.isFalse( isEmptyNode( ' ' ), 'White space should be treated as valid charater' );
+			assert.isFalse( isEmptyNode( ' ' + fillingCharSequence + ' ' ),
+				'White space with filling char sequence should be treated as valid character' );
+
 			assert.isTrue( isEmptyNode( '' ), 'Node should be empty when empty' );
-			assert.isTrue( isEmptyNode( CKEDITOR.dom.selection.FILLING_CHAR_SEQUENCE ), 'Node should be empty when filling char sequence' );
+			assert.isTrue( isEmptyNode( fillingCharSequence ), 'Node should be empty when filling char sequence' );
+		},
+
+		// (#3158)
+		'test isEmpty ignore white space': function() {
+			var fillingCharSequence = CKEDITOR.dom.selection.FILLING_CHAR_SEQUENCE;
+
+			assert.isFalse( isEmptyNode( ' foobar ', true ), 'Mixed white space with text should not be empty' );
+
+			assert.isTrue( isEmptyNode( ' ', true ), 'White space should be ignored' );
+			assert.isTrue( isEmptyNode( ' ' + fillingCharSequence + ' ', true ),
+				'Mixed white space with filling char sequence should be treated as empty' );
 		}
 	} );
 
-	function isEmptyNode( text ) {
-		return new CKEDITOR.dom.text( document.createTextNode( text ) ).isEmpty();
+	function isEmptyNode( text, ignoreWhiteSpace ) {
+		return new CKEDITOR.dom.text( document.createTextNode( text ) ).isEmpty( ignoreWhiteSpace );
 	}
 
 } )();

--- a/tests/core/dom/text.js
+++ b/tests/core/dom/text.js
@@ -102,7 +102,18 @@
 			parent.getFirst().split( 2 );	// Right before "B"
 			parent.getChildren().getItem( 3 ).split( 2 );	// Right before "E"
 			assert.areSame( 5, parent.getChildren().count(), 'Child nodes num doesn\'t match after split' );
+		},
+
+		// (#3158)
+		'test isEmpty': function() {
+			assert.isFalse( isEmptyNode( 'foobar' ), 'Node should not be empty' );
+			assert.isTrue( isEmptyNode( '' ), 'Node should be empty when empty' );
+			assert.isTrue( isEmptyNode( CKEDITOR.dom.selection.FILLING_CHAR_SEQUENCE ), 'Node should be empty when filling char sequence' );
 		}
 	} );
+
+	function isEmptyNode( text ) {
+		return new CKEDITOR.dom.text( document.createTextNode( text ) ).isEmpty();
+	}
 
 } )();

--- a/tests/core/dom/text.js
+++ b/tests/core/dom/text.js
@@ -104,7 +104,7 @@
 			assert.areSame( 5, parent.getChildren().count(), 'Child nodes num doesn\'t match after split' );
 		},
 
-		// (#3158)
+		// (#3326)
 		'test isEmpty': function() {
 			var fillingCharSequence = CKEDITOR.dom.selection.FILLING_CHAR_SEQUENCE;
 
@@ -117,7 +117,7 @@
 			assert.isTrue( isEmptyNode( fillingCharSequence ), 'Node should be empty when filling char sequence' );
 		},
 
-		// (#3158)
+		// (#3326)
 		'test isEmpty ignore white space': function() {
 			var fillingCharSequence = CKEDITOR.dom.selection.FILLING_CHAR_SEQUENCE;
 


### PR DESCRIPTION
## What is the purpose of this pull request?

Bug fix

## Does your PR contain necessary tests?

All patches which change the editor code must include tests. You can always read more
on [PR testing](https://ckeditor.com/docs/ckeditor4/latest/guide/dev_contributing_code.html#tests),
[how to set the testing environment](https://ckeditor.com/docs/ckeditor4/latest/guide/dev_tests.html) and
[how to create tests](https://ckeditor.com/docs/ckeditor4/latest/guide/dev_tests.html#creating-your-own-test)
in the official CKEditor documentation.

### This PR contains

- [x] Unit tests
- [x] Manual tests

## What is the proposed changelog entry for this pull request?

```
Fixed Issues:
* [#3158](https://github.com/ckeditor/ckeditor-dev/issues/3158): [Chrome] Fixed: [Undo](https://ckeditor.com/cke4/addon/undo) plugin breaks with soft enter characters.
API Changes:
* [#3326](https://github.com/ckeditor/ckeditor-dev/issues/3326): Added [`text.isEmpty()`](https://ckeditor.com/docs/ckeditor4/latest/api/CKEDITOR_dom_text.html#method-isEmpty) method.
```
## What changes did you make?

It looks like there is an edge case where zero width space added for Chromium enclosed inside a text node, produces concrete range offset when used with `range.createBookmark2`. However, filling char sequence is removed during selection change as no longer needed, and it should be treated as an empty text node thus we are using it for our internal purposes. Otherwise, we end up with an invalid range for undo snapshot which no longer contains empty text nodes.

I also added `text.isEmpty` method to avoid code duplication and refactored common code.

Closes #3158 
Closes #3326