### PR TITLE
Typo for for `event.getKey()` docs

### DIFF
--- a/core/dom/event.js
+++ b/core/dom/event.js
@@ -28,7 +28,7 @@ CKEDITOR.dom.event.prototype = {
 	/**
 	 * Gets the key code associated to the event.
 	 *
-	 *		alert( event.getKey() ); // '65' is 'a' has been pressed
+	 *		alert( event.getKey() ); // '65' if 'a' has been pressed
 	 *
 	 * @returns {Number} The key code.
 	 */


### PR DESCRIPTION
## What is the purpose of this pull request?

Typo fix

## Does your PR contain necessary tests?

I don't think tests are needed for a documentation change.

### This PR contains

- [ ] Unit tests
- [ ] Manual tests

## What is the proposed changelog entry for this pull request?


Fixed: Typo in [`CKEDITOR.dom.event.getKey()`](https://ckeditor.com/docs/ckeditor4/latest/api/CKEDITOR_dom_event.html#method-getKey) API documentation

## What changes did you make?

Change "is" -> "if" in the documentation for `event.getKey()`