### PR TITLE
Make autogrow work with divarea plugin

### DIFF
--- a/plugins/autogrow/plugin.js
+++ b/plugins/autogrow/plugin.js
@@ -17,15 +17,50 @@
 				return;
 
 			editor.on( 'instanceReady', function() {
-				// Simply set auto height with div wysiwyg.
+				// for editors with div editorarea
 				if ( editor.editable().isInline() )
-					editor.ui.space( 'contents' ).setStyle( 'height', 'auto' );
+					initAutogrow( editor );
 				// For classic (`iframe`-based) wysiwyg we need to resize the editor.
 				else
 					initIframeAutogrow( editor );
 			} );
 		}
 	} );
+	
+	/**
+     * autogrow options for div editorarea
+     * @param {type} editor
+     * @returns {undefined}
+     */
+    function initAutogrow(editor) {
+        var configBottomSpace = editor.config.autoGrow_bottomSpace || 0,
+			configTopSpace = editor.config.autoGrow_topSpace || 0,
+			configMaxHeight = editor.config.autoGrow_maxHeight || false,
+			autoGrowOnStartup = editor.config.autoGrow_onStartup,
+			configMinHeight = editor.config.autoGrow_minHeight;
+
+        editor.ui.space('contents').setStyle('min-height', configMinHeight !== undefined ? configMinHeight + "px" : '200px');
+        editor.ui.space('contents').setStyle('padding-bottom', configBottomSpace + "px");
+        editor.ui.space('contents').setStyle('padding-top', configTopSpace + "px");
+
+        if (configMaxHeight !== false) {
+            editor.ui.space('contents').setStyle('max-height', configMaxHeight + "px");
+        }
+
+        if (autoGrowOnStartup && editor.editable().isVisible()) {
+            editor.ui.space('contents').setStyle('height', 'auto');
+            editor.ui.space('contents').setStyle('height', document.getElementById(editor.id + '_contents').offsetHeight - configTopSpace - configBottomSpace + 'px');
+        }
+
+        editor.on('focus', function (evt) {
+            editor.ui.space('contents').setStyle('height', 'auto');
+        });
+        editor.on('blur', function (evt) {
+            console.log("height ckeditor:" + editor.id);
+            editor.ui.space('contents').setStyle('height', document.getElementById(editor.id + '_contents').offsetHeight - configTopSpace - configBottomSpace + 'px');
+        });
+
+    }
 
 	function initIframeAutogrow( editor ) {
 		var lastHeight,

--- a/plugins/autogrow/plugin.js
+++ b/plugins/autogrow/plugin.js
@@ -56,10 +56,8 @@
             editor.ui.space('contents').setStyle('height', 'auto');
         });
         editor.on('blur', function (evt) {
-            console.log("height ckeditor:" + editor.id);
             editor.ui.space('contents').setStyle('height', document.getElementById(editor.id + '_contents').offsetHeight - configTopSpace - configBottomSpace + 'px');
         });
-
     }
 
 	function initIframeAutogrow( editor ) {


### PR DESCRIPTION
## What is the purpose of this pull request?

adds options from the iframed editor to the divarea version (min-height, max-height, onstartup) and works around some quirks

## Does your PR contain necessary tests?

no

## What is the proposed changelog entry for this pull request?

* Make autogrow options work with divarea plugin

## What changes did you make?

I implemented a function to make the options of the plugin work with the divarea plugin like they do with the iframed editor.
