### PR TITLE
Fix for: range._getTableElement which sometimes not return a table element

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -20,6 +20,7 @@ Fixed Issues:
 	* [#2858](https://github.com/ckeditor/ckeditor-dev/issues/2858): [Menu](https://ckeditor.com/cke4/addon/menu).
 * [#3158](https://github.com/ckeditor/ckeditor-dev/issues/3158): [Chrome, Safari] Fixed: [Undo](https://ckeditor.com/cke4/addon/undo) plugin breaks with filling character.
 * [#504](https://github.com/ckeditor/ckeditor-dev/issues/504): [Edge] Fixed: Editor's selection is collapsed to the beginning of the content when focusing editor for the first time.
+* [#3101](https://github.com/ckeditor/ckeditor-dev/issues/3101): Fixed: [`CKEDITOR.dom.range#_getTableElement()`](https://ckeditor.com/docs/ckeditor4/latest/api/CKEDITOR_dom_range.html#method-_getTableElement) returns `null` instead of a table element for edge cases.
 
 API Changes:
 

--- a/core/dom/range.js
+++ b/core/dom/range.js
@@ -2754,13 +2754,6 @@ CKEDITOR.dom.range = function( root ) {
 				return null;
 			}
 
-			// Super weird edge case in Safari: if there is a table with only one cell inside and that cell
-			// is selected, then the end boundary of the table is moved into editor's editable.
-			// That case is also present when selecting the last cell inside nested table.
-			if ( CKEDITOR.env.safari && startTable && end.equals( this.root ) ) {
-				return start.getAscendant( tableElements, true );
-			}
-
 			if ( this.getEnclosedNode() ) {
 				return this.getEnclosedNode().getAscendant( tableElements, true );
 			}

--- a/core/dom/range.js
+++ b/core/dom/range.js
@@ -2744,8 +2744,8 @@ CKEDITOR.dom.range = function( root ) {
 				table: 1
 			};
 
-			var start = this.startContainer,
-				end = this.endContainer,
+			var start = this.getTouchedStartNode(),
+				end = this.getTouchedEndNode(),
 				startTable = start.getAscendant( 'table', true ),
 				endTable = end.getAscendant( 'table', true );
 

--- a/tests/core/dom/range/gettableelement.js
+++ b/tests/core/dom/range/gettableelement.js
@@ -42,11 +42,11 @@
 		return range;
 	}
 
-	function assertElements( expected, range, selectors ) {
+	function assertElements( expected, range, selectors, message ) {
 		if ( !expected ) {
 			assert.isNull( range._getTableElement() );
 		} else {
-			assert.isTrue( expected.equals( range._getTableElement( selectors ) ), 'Correct element is returned' );
+			assert.isTrue( expected.equals( range._getTableElement( selectors ) ), message || 'Correct element is returned' );
 		}
 	}
 
@@ -310,20 +310,78 @@
 			assertElements( null, range );
 		},
 
-		'get table with selection on the edge of it': function() {
-			var range,
-				table;
+		// (#3101)
+		'should return table when range is just before or after table element': function() {
+			var range;
 
-			insertTable( [ 'paragraph', 'simple' ] );
+			range = bender.tools.range.setWithHtml( playground, '[<table>' +
+				'<tr>' +
+					'<td>foo</td>]' +
+					'<td>bar</td>' +
+				'</tr>' +
+			'</table>' );
+			assertElements( playground.findOne( 'table' ), range, null,
+				'Table element is returned when selection start just before table' );
 
-			table = playground.findOne( 'table' );
+			range = bender.tools.range.setWithHtml( playground, '<table>' +
+				'<tr>' +
+					'<td>foo</td>' +
+					'[<td id="_td2">bar</td>' +
+				'</tr>' +
+			'</table>]' );
+			assertElements( playground.findOne( '#_td2' ), range, null,
+				'First selected table cell element is returned when selection ends just after table' );
 
-			range = new CKEDITOR.dom.range( doc );
+			range = bender.tools.range.setWithHtml( playground, '[<table>' +
+				'<tr>' +
+					'<td>foo</td>' +
+					'<td>bar</td>' +
+				'</tr>' +
+			'</table>]' );
+			assertElements( playground.findOne( 'table' ), range, null,
+				'Table element is returned when selection wraps entire table just before and after table' );
 
-			range.setStartBefore( table );
-			range.setEndAfter( table.findOne( 'td' ) );
+			range = bender.tools.range.setWithHtml( playground, '<table>' +
+				'<tr>' +
+					'<td>foo</td>' +
+					'<td>[<table id="nested">' +
+						'<tr>' +
+							'<td>one</td>]' +
+							'<td>two</td>' +
+						'</tr>' +
+					'</table></td>' +
+				'</tr>' +
+			'</table>' );
+			assertElements( playground.findOne( 'table#nested' ), range, null,
+				'Nested table element is returned when selection start just before nested table' );
 
-			assertElements( table, range );
+			range = bender.tools.range.setWithHtml( playground, '<table>' +
+				'<tr>' +
+					'<td>foo</td>' +
+					'<td><table id="nested">' +
+						'<tr>' +
+							'<td>one</td>' +
+							'[<td id="_td2">two</td>' +
+						'</tr>' +
+					'</table>]</td>' +
+				'</tr>' +
+			'</table>' );
+			assertElements( playground.findOne( '#_td2' ), range, null,
+				'First selected nested table cell element is returned when selection start just after nested table' );
+
+			range = bender.tools.range.setWithHtml( playground, '<table>' +
+				'<tr>' +
+					'<td>foo</td>' +
+					'<td>[<table id="nested">' +
+						'<tr>' +
+							'<td>one</td>' +
+							'<td>two</td>' +
+						'</tr>' +
+					'</table>]</td>' +
+				'</tr>' +
+			'</table>' );
+			assertElements( playground.findOne( 'table#nested' ), range, null,
+				'Nested table element is returned when selection wraps entire table just before and after nested table' );
 		}
 	} );
 } )();

--- a/tests/core/dom/range/gettableelement.js
+++ b/tests/core/dom/range/gettableelement.js
@@ -42,11 +42,19 @@
 		return range;
 	}
 
-	function assertElements( expected, range, selectors, message ) {
+	// @param {CKEDITOR.dom.node/null} expected node or null if there is nothing to be returned
+	// @param {CKEDITOR.dom.range} range where is searched table element
+	// @param {Object} options
+	// @param {String/Object} options.selectors mapping of elements which should be found
+	// @param {String} options.message customised assert message
+	function assertElements( expected, range, options ) {
+		var selectors = options && options.selectors,
+			message = options && options.message || 'Correct element is returned';
+
 		if ( !expected ) {
 			assert.isNull( range._getTableElement() );
 		} else {
-			assert.isTrue( expected.equals( range._getTableElement( selectors ) ), message || 'Correct element is returned' );
+			assert.isTrue( expected.equals( range._getTableElement( selectors ) ), message );
 		}
 	}
 
@@ -94,7 +102,7 @@
 			cell = playground.findOne( 'td' );
 			range = createRange( { start: cell.getChild( 0 ), startOffset: 3, collapse: true } );
 
-			assertElements( row, range, 'tr' );
+			assertElements( row, range, { selectors: 'tr' } );
 		},
 
 		'get table (collapsed selection inside)': function() {
@@ -107,7 +115,7 @@
 			cell = playground.findOne( 'td' );
 			range = createRange( { start: cell.getChild( 0 ), startOffset: 3, collapse: true } );
 
-			assertElements( table, range, 'table' );
+			assertElements( table, range, { selectors: 'table' } );
 		},
 
 		'get row (selected text node inside)': function() {
@@ -120,7 +128,7 @@
 			cell = playground.findOne( 'td' );
 			range = createRange( { element: cell.getChild( 0 ) } );
 
-			assertElements( row, range, 'tr' );
+			assertElements( row, range, { selectors: 'tr' } );
 		},
 
 		'get row (selected cell)': function() {
@@ -133,7 +141,7 @@
 			cell = playground.findOne( 'td' );
 			range = createRange( { element: cell } );
 
-			assertElements( row, range, 'tr' );
+			assertElements( row, range, { selectors: 'tr' } );
 		},
 
 		'get row (collapsed selection inside with multiple selectors passed)': function() {
@@ -146,7 +154,9 @@
 			cell = playground.findOne( 'td' );
 			range = createRange( { start: cell.getChild( 0 ), startOffset: 3, collapse: true } );
 
-			assertElements( row, range, { table: 1, tr: 1 } );
+			assertElements( row, range, {
+				selectors: { table: 1, tr: 1 }
+			} );
 		},
 
 		'get row (row selected)': function() {
@@ -214,7 +224,7 @@
 			cell = row.findOne( 'td' );
 			range = createRange( { element: cell } );
 
-			assertElements( row, range, 'tr' );
+			assertElements( row, range, { selectors: 'tr' } );
 		},
 
 		'get nested table from selected cell': function() {
@@ -227,7 +237,7 @@
 			cell = table.findOne( 'td' );
 			range = createRange( { element: cell } );
 
-			assertElements( table, range, 'table' );
+			assertElements( table, range, { selectors: 'table' } );
 		},
 
 		'get parent cell from selected nested table': function() {
@@ -240,7 +250,7 @@
 			table = playground.findOne( 'table table' );
 			range = createRange( { element: table } );
 
-			assertElements( cell, range, 'td' );
+			assertElements( cell, range, { selectors: 'td' } );
 		},
 
 		// (#2403)
@@ -320,8 +330,9 @@
 					'<td>bar</td>' +
 				'</tr>' +
 			'</table>' );
-			assertElements( playground.findOne( 'table' ), range, null,
-				'Table element is returned when selection start just before table' );
+			assertElements( playground.findOne( 'table' ), range, {
+				message: 'Table element is returned when selection start just before table'
+			} );
 
 			range = bender.tools.range.setWithHtml( playground, '<table>' +
 				'<tr>' +
@@ -329,8 +340,9 @@
 					'[<td id="_td2">bar</td>' +
 				'</tr>' +
 			'</table>]' );
-			assertElements( playground.findOne( '#_td2' ), range, null,
-				'First selected table cell element is returned when selection ends just after table' );
+			assertElements( playground.findOne( '#_td2' ), range,{
+				message: 'First selected table cell element is returned when selection ends just after table'
+			} );
 
 			range = bender.tools.range.setWithHtml( playground, '[<table>' +
 				'<tr>' +
@@ -338,8 +350,9 @@
 					'<td>bar</td>' +
 				'</tr>' +
 			'</table>]' );
-			assertElements( playground.findOne( 'table' ), range, null,
-				'Table element is returned when selection wraps entire table just before and after table' );
+			assertElements( playground.findOne( 'table' ), range, {
+				message: 'Table element is returned when selection wraps entire table just before and after table'
+			} );
 
 			range = bender.tools.range.setWithHtml( playground, '<table>' +
 				'<tr>' +
@@ -352,8 +365,9 @@
 					'</table></td>' +
 				'</tr>' +
 			'</table>' );
-			assertElements( playground.findOne( 'table#nested' ), range, null,
-				'Nested table element is returned when selection start just before nested table' );
+			assertElements( playground.findOne( 'table#nested' ), range, {
+				message: 'Nested table element is returned when selection start just before nested table'
+			} );
 
 			range = bender.tools.range.setWithHtml( playground, '<table>' +
 				'<tr>' +
@@ -366,8 +380,9 @@
 					'</table>]</td>' +
 				'</tr>' +
 			'</table>' );
-			assertElements( playground.findOne( '#_td2' ), range, null,
-				'First selected nested table cell element is returned when selection start just after nested table' );
+			assertElements( playground.findOne( '#_td2' ), range, {
+				message: 'First selected nested table cell element is returned when selection start just after nested table'
+			} );
 
 			range = bender.tools.range.setWithHtml( playground, '<table>' +
 				'<tr>' +
@@ -380,8 +395,9 @@
 					'</table>]</td>' +
 				'</tr>' +
 			'</table>' );
-			assertElements( playground.findOne( 'table#nested' ), range, null,
-				'Nested table element is returned when selection wraps entire table just before and after nested table' );
+			assertElements( playground.findOne( 'table#nested' ), range, {
+				message: 'Nested table element is returned when selection wraps entire table just before and after nested table'
+			} );
 		}
 	} );
 } )();

--- a/tests/core/dom/range/gettableelement.js
+++ b/tests/core/dom/range/gettableelement.js
@@ -308,6 +308,22 @@
 				end: end.getChild( 0 ), endOffset: 3 } );
 
 			assertElements( null, range );
+		},
+
+		'get table with selection on the edge of it': function() {
+			var range,
+				table;
+
+			insertTable( [ 'paragraph', 'simple' ] );
+
+			table = playground.findOne( 'table' );
+
+			range = new CKEDITOR.dom.range( doc );
+
+			range.setStartBefore( table );
+			range.setEndAfter( table.findOne( 'td' ) );
+
+			assertElements( table, range );
 		}
 	} );
 } )();

--- a/tests/core/dom/range/manual/gettableelement.html
+++ b/tests/core/dom/range/manual/gettableelement.html
@@ -1,31 +1,44 @@
 <textarea id="editor" cols="30" rows="10">
+		<table border="1"><tbody><tr><td>foo</td><td>bar</td></tr><tr><td>baz</td><td>baz</td></tr></tbody></table>
 </textarea>
-<button onclick="selection()">Set editor data and get range result</button>
-<p id="rangeResult"></p>
+<button onclick="getSelectedTable()">Get range result</button>
+<p style="border:1px solid red;height:20px;padding:2px;" id="rangeResult"></p>
+<div style='background-color:#EEE' id="rawData"></div>
 <script>
-	var editor = CKEDITOR.replace( 'editor' );
-	var resultElement = document.getElementById( 'rangeResult' )
+	// Firefox doesn't allow on such selection.
+	if ( CKEDITOR.env.gecko ) {
+		bender.ignore();
+	}
 
-	function selection() {
-		editor.setData( '<table>' +
-				'<tr>' +
-					'<td>foo</td>' +
-					'<td>bar</td>' +
-				'</tr>' +
-			'</table>',
-			function() {
-				var range = editor.createRange(),
-					table = editor.editable().findOne( 'table' ),
-					tableElement,
-					tableElementName;
+	var resultElement = document.getElementById( 'rangeResult' ),
+		rawDataElement = document.getElementById( 'rawData' ),
+		editor = CKEDITOR.replace( 'editor', {
+			on: {
+				instanceReady: function() {
+					var buffer = new CKEDITOR.tools.buffers.throttle( 200, function() {
+						var insertedData = bender.tools.range.getWithHtml( editor.editable(), editor.getSelection().getRanges()[ 0 ] );
 
-				range.setStartBefore( table );
-				range.setEndAfter( table.findOne( 'td' ) );
+						rawData.innerHTML = insertedData.replace( />/g, '>' ).replace( /</g, '&lt;' ).replace( />/g, '&gt;<br>' )
+							.replace( /[\[\]\{\}]/g, function( match ) {
+							return '<span style="color:red">' + match + '</span>';
+						} );
+					} );
 
-				tableElement = range._getTableElement();
-				tableElementName = tableElement instanceof CKEDITOR.dom.element ? tableElement.getName() : String( tableElement );
+					CKEDITOR.document.on( 'mousemove', buffer.input );
+					editor.document.on( 'mousemove', buffer.input );
+					editor.document.on( 'touchmove', buffer.input );
+					editor.on( 'selectionChange', buffer.input );
+				}
+			}
+		} );
 
-				resultElement.innerText = 'Range contains "' + tableElementName + '" element';
-			} );
+	function getSelectedTable() {
+		var range = editor.getSelection().getRanges()[ 0 ],
+			tableElement
+
+		tableElement = range._getTableElement();
+		tableElementName = tableElement instanceof CKEDITOR.dom.element ? tableElement.getName() : String( tableElement );
+
+		resultElement.innerText = 'Range contains "' + tableElementName + '" element';
 	}
 </script>

--- a/tests/core/dom/range/manual/gettableelement.html
+++ b/tests/core/dom/range/manual/gettableelement.html
@@ -1,0 +1,31 @@
+<textarea id="editor" cols="30" rows="10">
+</textarea>
+<button onclick="selection()">Set editor data and get range result</button>
+<p id="rangeResult"></p>
+<script>
+	var editor = CKEDITOR.replace( 'editor' );
+	var resultElement = document.getElementById( 'rangeResult' )
+
+	function selection() {
+		editor.setData( '<table>' +
+				'<tr>' +
+					'<td>foo</td>' +
+					'<td>bar</td>' +
+				'</tr>' +
+			'</table>',
+			function() {
+				var range = editor.createRange(),
+					table = editor.editable().findOne( 'table' ),
+					tableElement,
+					tableElementName;
+
+				range.setStartBefore( table );
+				range.setEndAfter( table.findOne( 'td' ) );
+
+				tableElement = range._getTableElement();
+				tableElementName = tableElement instanceof CKEDITOR.dom.element ? tableElement.getName() : String( tableElement );
+
+				resultElement.innerText = 'Range contains "' + tableElementName + '" element';
+			} );
+	}
+</script>

--- a/tests/core/dom/range/manual/gettableelement.md
+++ b/tests/core/dom/range/manual/gettableelement.md
@@ -1,12 +1,18 @@
 @bender-tags: 4.13.0, bug, range, 3101
-@bender-ckeditor-plugins: wysiwygarea, toolbar, table, tableselection, sourcearea
+@bender-ckeditor-plugins: wysiwygarea, toolbar, table, sourcearea
 
-1. Press button below editor.
+1. Make selection in editor described below:
+  * use mousedown inside first cell in first row in text node. For example here: `fo^o`,
+  * select the beginning of the word and the table by dragging cusor to the margin before table,
+  * below editor is displayed selection inspector with red pointer showing where it starts and ends,
+  * desired result is to start selection before `<table>` element, to look like this: `[<table><tr><td>fo}o</td>...`,
+  * you can try to use `shift+arrow` to select desired part, however, selection inspector reacts on mousemve events. This is why you need also move mouse to udpate its state.
+2. Press the button below editor: `Get range result`.
 
 ## Expected:
 
-There is message below editor: `Range contains "table" element`
+There is message below editor in red box: `Range contains "table" element`
 
 ## Unexpected:
 
-There is message below editor: `Range contains "null" element`
+There is message below editor in red box: `Range contains "null" element`

--- a/tests/core/dom/range/manual/gettableelement.md
+++ b/tests/core/dom/range/manual/gettableelement.md
@@ -1,0 +1,5 @@
+@bender-tags: 4.13.0, bug, range, 3101
+@bender-ckeditor-plugins: wysiwygarea, toolbar, table, tableselection, sourcearea
+
+1. Press button below editor.
+2. Check if there is message below editor: `Range contains "table" element`

--- a/tests/core/dom/range/manual/gettableelement.md
+++ b/tests/core/dom/range/manual/gettableelement.md
@@ -2,4 +2,11 @@
 @bender-ckeditor-plugins: wysiwygarea, toolbar, table, tableselection, sourcearea
 
 1. Press button below editor.
-2. Check if there is message below editor: `Range contains "table" element`
+
+## Expected:
+
+There is message below editor: `Range contains "table" element`
+
+## Unexpected:
+
+There is message below editor: `Range contains "null" element`

--- a/tests/core/dom/range/misc.js
+++ b/tests/core/dom/range/misc.js
@@ -376,7 +376,7 @@
 			range.setStartBefore( doc.getById( '_td1' ) );
 			range.setEndAfter( doc.getById( '_td2' ) );
 
-			assert.isTrue( range._getTableElement().equals( doc.getById( '_tr2' ) ), 'selected 2 tds' );
+			assert.isTrue( range._getTableElement().equals( doc.getById( '_td1' ) ), 'selected 2 tds and returns first of it' );
 
 			// Selected two cells from different tables.
 			range = new CKEDITOR.dom.range( doc );


### PR DESCRIPTION
## What is the purpose of this pull request?

Bugfix

## Does your PR contain necessary tests?

All patches which change the editor code must include tests. You can always read more
on [PR testing](https://ckeditor.com/docs/ckeditor4/latest/guide/dev_contributing_code.html#tests),
[how to set the testing environment](https://ckeditor.com/docs/ckeditor4/latest/guide/dev_tests.html) and
[how to create tests](https://ckeditor.com/docs/ckeditor4/latest/guide/dev_tests.html#creating-your-own-test)
in the official CKEditor documentation.

### This PR contains

- [x] Unit tests
- [x] Manual tests <- might be not required and removed from this PR if you consider it 
redundant

## What is the proposed changelog entry for this pull request?

```
* [#3101](https://github.com/ckeditor/ckeditor-dev/issues/3101): Fixed: [`range._getTableElement()`](https://ckeditor.com/docs/ckeditor4/latest/api/CKEDITOR_dom_range.html#method-_getTableElement) return `null` instead of a table element for edge cases. 
```

## What changes did you make?

Replace `range.startContainer` and `range.endContainer` with `range.getTouchedStartNode()` and `range.getTouchedEndNode()`.
That results with accepting the situation when range starts just before the table for example
```
<p>foo</p>[<table><tr><td>bar</td>]<td>baz</td></tr></table>
```
or ends just after the table
```
<p>foo</p><table><tr><td>bar</td>[<td>baz</td></tr></table>]
```
Previously in such cases start or end containers returned editable (or outer element) and prevent table detection.

Closes #3101.