### PR TITLE
Support strikethrough in BBCode plugin

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -3,6 +3,10 @@
 
 ## CKEditor 4.13
 
+New Features:
+
+* [#3315](https://github.com/ckeditor/ckeditor-dev/issues/3315): Added support for strikethrough in [BBCode](https://ckeditor.com/cke4/addon/bbcode) plugin. Thanks to [Alexander Kahl](https://github.com/akahl-owl)!
+
 Fixed Issues:
 
 * [#808](https://github.com/ckeditor/ckeditor-dev/issues/808): Fixed: [Widget](https://ckeditor.com/cke4/addon/widget) and other content disappear on drag and drop in [read-only mode](https://ckeditor.com/docs/ckeditor4/latest/guide/dev_readonly.html).

--- a/plugins/bbcode/plugin.js
+++ b/plugins/bbcode/plugin.js
@@ -27,8 +27,8 @@
 	} );
 
 	var bbcodeMap = { b: 'strong', u: 'u', i: 'em', s: 's', color: 'span', size: 'span', left: 'div', right: 'div', center: 'div', justify: 'div', quote: 'blockquote', code: 'code', url: 'a', email: 'span', img: 'span', '*': 'li', list: 'ol' },
-		convertMap = { strong: 'b', b: 'b', u: 'u', em: 'i', i: 'i', code: 'code', li: '*' },
-		tagnameMap = { strong: 'b', em: 'i', u: 'u', li: '*', ul: 'list', ol: 'list', code: 'code', a: 'link', img: 'img', blockquote: 'quote' },
+		convertMap = { strong: 'b', b: 'b', u: 'u', em: 'i', i: 'i', s: 's', code: 'code', li: '*' },
+		tagnameMap = { strong: 'b', em: 'i', u: 'u', s: 's', li: '*', ul: 'list', ol: 'list', code: 'code', a: 'link', img: 'img', blockquote: 'quote' },
 		stylesMap = { color: 'color', size: 'font-size', left: 'text-align', center: 'text-align', right: 'text-align', justify: 'text-align' },
 		attributesMap = { url: 'href', email: 'mailhref', quote: 'cite', list: 'listType' };
 
@@ -159,9 +159,9 @@
 						}
 					}
 
-					// Three special handling - image, email and strikethrough, protect them
+					// Two special handling - image and email, protect them
 					// as "span" with an attribute marker.
-					if ( part == 'email' || part == 'img' || part == 's' )
+					if ( part == 'email' || part == 'img' )
 						attribs.bbcode = part;
 
 					this.onTagOpen( tagName, attribs, CKEDITOR.dtd.$empty[ tagName ] );
@@ -615,8 +615,6 @@
 							} else if ( bbcode == 'email' ) {
 								element.name = 'a';
 								element.attributes.href = 'mailto:' + element.children[ 0 ].value;
-							} else if ( bbcode == 's' ) {
-								element.attributes.style = 'text-decoration: line-through';
 							}
 
 							delete element.attributes.bbcode;

--- a/plugins/bbcode/plugin.js
+++ b/plugins/bbcode/plugin.js
@@ -26,7 +26,7 @@
 		}
 	} );
 
-	var bbcodeMap = { b: 'strong', u: 'u', i: 'em', color: 'span', size: 'span', left: 'div', right: 'div', center: 'div', justify: 'div', quote: 'blockquote', code: 'code', url: 'a', email: 'span', img: 'span', '*': 'li', list: 'ol' },
+	var bbcodeMap = { b: 'strong', u: 'u', i: 'em', s: 's', color: 'span', size: 'span', left: 'div', right: 'div', center: 'div', justify: 'div', quote: 'blockquote', code: 'code', url: 'a', email: 'span', img: 'span', '*': 'li', list: 'ol' },
 		convertMap = { strong: 'b', b: 'b', u: 'u', em: 'i', i: 'i', code: 'code', li: '*' },
 		tagnameMap = { strong: 'b', em: 'i', u: 'u', li: '*', ul: 'list', ol: 'list', code: 'code', a: 'link', img: 'img', blockquote: 'quote' },
 		stylesMap = { color: 'color', size: 'font-size', left: 'text-align', center: 'text-align', right: 'text-align', justify: 'text-align' },
@@ -159,9 +159,9 @@
 						}
 					}
 
-					// Two special handling - image and email, protect them
+					// Three special handling - image, email and strikethrough, protect them
 					// as "span" with an attribute marker.
-					if ( part == 'email' || part == 'img' )
+					if ( part == 'email' || part == 'img' || part == 's' )
 						attribs.bbcode = part;
 
 					this.onTagOpen( tagName, attribs, CKEDITOR.dtd.$empty[ tagName ] );
@@ -615,6 +615,8 @@
 							} else if ( bbcode == 'email' ) {
 								element.name = 'a';
 								element.attributes.href = 'mailto:' + element.children[ 0 ].value;
+							} else if ( bbcode == 's' ) {
+								element.attributes.style = 'text-decoration: line-through';
 							}
 
 							delete element.attributes.bbcode;

--- a/tests/plugins/bbcode/bbcode.js
+++ b/tests/plugins/bbcode/bbcode.js
@@ -31,6 +31,7 @@ bender.test( {
 		this.assertToBBCode( '[b]foo[/b]', '<strong>foo</strong>' );
 		this.assertToBBCode( '[i]foo[/i]', '<em>foo</em>' );
 		this.assertToBBCode( '[u]foo[/u]', '<u>foo</u>' );
+		this.assertToBBCode( '[s]foo[/s]', '<s>foo</s>' );
 		this.assertToBBCode( '[url]http://example.org[/url]', '<a href="http://example.org">http://example.org</a>' );
 		this.assertToBBCode( '[url=http://example.com]example[/url]', '<a href="http://example.com">example</a>' );
 		this.assertToBBCode( '[img]http://a.cksource.com/c/1/inc/img/demo-little-red.jpg[/img]',
@@ -59,6 +60,7 @@ bender.test( {
 		this.assertToHtml( '<strong>foo</strong>', '[b]foo[/b]' );
 		this.assertToHtml( '<em>foo</em>', '[i]foo[/i]' );
 		this.assertToHtml( '<u>foo</u>', '[u]foo[/u]' );
+		this.assertToHtml( '<s>foo</s>', '[s]foo[/s]' );
 
 		this.assertToHtml( '<a href="http://example.org">http://example.org</a>', '[url]http://example.org[/url]' );
 		this.assertToHtml( '<a href="http://example.com">example</a>', '[url=http://example.com]example[/url]' );

--- a/tests/plugins/bbcode/manual/strikethrough.html
+++ b/tests/plugins/bbcode/manual/strikethrough.html
@@ -1,0 +1,7 @@
+<textarea name="editor" id="editor" cols="30" rows="10">
+	This is sample [s]bbcode[/s] text, here are few lines to play with.
+</textarea>
+
+<script>
+	CKEDITOR.replace( 'editor', { height: 200 } );
+</script>

--- a/tests/plugins/bbcode/manual/strikethrough.md
+++ b/tests/plugins/bbcode/manual/strikethrough.md
@@ -1,0 +1,28 @@
+@bender-tags: 3315, feature, 4.13.0
+@bender-ui: collapsed
+@bender-ckeditor-plugins: wysiwygarea, toolbar, bbcode, undo, justify, basicstyles, sourcearea, elementspath
+
+# BBCode strikethrough
+
+1. Focus the editor.
+1. Select some text.
+1. Apply Strikethrough.
+1. Press "Source" button.
+
+  ## Expected
+
+  Strikethrough text is represented with `[s]...text[/s]`.
+
+  ## Unexpected
+
+  There's no `[s]` tag.
+  
+5. Switch back to WYSIWYG mode.
+
+  ## Expected
+
+  Strikethrough text formatting is still visible.
+
+  ## Unexpected
+
+  Strikethrough text lost it's formatting.


### PR DESCRIPTION
## What is the purpose of this pull request?

New feature

## Does your PR contain necessary tests?

All patches which change the editor code must include tests. You can always read more
on [PR testing](https://ckeditor.com/docs/ckeditor4/latest/guide/dev_contributing_code.html#tests),
[how to set the testing environment](https://ckeditor.com/docs/ckeditor4/latest/guide/dev_tests.html) and
[how to create tests](https://ckeditor.com/docs/ckeditor4/latest/guide/dev_tests.html#creating-your-own-test)
in the official CKEditor documentation.

### This PR contains

- [x] Unit tests
- [ ] Manual tests

## What is the proposed changelog entry for this pull request?

```
* [#3315](https://github.com/ckeditor/ckeditor-dev/issues/3315): Added support for strikethrough in [BBCode](https://ckeditor.com/cke4/addon/bbcode) plugin. Thanks to [Alexander Kahl](https://github.com/akahl-owl)!
```

## What changes did you make?

This is a copy of https://github.com/ckeditor/ckeditor-dev/pull/217 PR rebased onto latest `major`. There is another PR providing same functionality (https://github.com/ckeditor/ckeditor-dev/pull/3316), however we follow FIFO pattern in such cases and so https://github.com/ckeditor/ckeditor-dev/pull/217 should be merged.

Closes #3315.
