### PR TITLE
Fix for incorrect getData when content is inserted into the editor

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -21,7 +21,8 @@ Fixed Issues:
 * [#3158](https://github.com/ckeditor/ckeditor-dev/issues/3158): [Chrome, Safari] Fixed: [Undo](https://ckeditor.com/cke4/addon/undo) plugin breaks with filling character.
 * [#504](https://github.com/ckeditor/ckeditor-dev/issues/504): [Edge] Fixed: Editor's selection is collapsed to the beginning of the content when focusing editor for the first time.
 * [#3101](https://github.com/ckeditor/ckeditor-dev/issues/3101): Fixed: [`CKEDITOR.dom.range#_getTableElement()`](https://ckeditor.com/docs/ckeditor4/latest/api/CKEDITOR_dom_range.html#method-_getTableElement) returns `null` instead of a table element for edge cases.
-* [#3287](https://github.com/ckeditor/ckeditor-dev/issues/3287) Fixed: [`CKEDITOR.tools.promise`](https://ckeditor.com/docs/ckeditor4/latest/api/CKEDITOR_tools_promise.html) incorrectly initialized if an AMD loader is present.
+* [#3287](https://github.com/ckeditor/ckeditor-dev/issues/3287): Fixed: [`CKEDITOR.tools.promise`](https://ckeditor.com/docs/ckeditor4/latest/api/CKEDITOR_tools_promise.html) incorrectly initialized if an AMD loader is present.
+* [#3379](https://github.com/ckeditor/ckeditor-dev/issues/3379): Fixed: Incorrect [`CKEDITOR.editor#getData`](https://ckeditor.com/docs/ckeditor4/latest/api/CKEDITOR_editor.html#method-getData) call when inserting content into the editor.
 
 API Changes:
 

--- a/core/editable.js
+++ b/core/editable.js
@@ -1654,7 +1654,9 @@
 
 			prepareRangeToDataInsertion( that );
 
-			if ( editor.getData() === '' && editor.enterMode === CKEDITOR.ENTER_DIV ) {
+			// When enter mode is set to div and content wrapped with div is pasted,
+			// we must ensure that no additional divs are created (#2751, #3379).
+			if ( editor.enterMode === CKEDITOR.ENTER_DIV && editor.getData( true ) === '' ) {
 				clearEditable( editable, range );
 			}
 

--- a/tests/core/editable/enterdiv.js
+++ b/tests/core/editable/enterdiv.js
@@ -16,16 +16,16 @@ bender.editors = {
 
 var tests = {
 	// (#2751)
-	'insert div': testInsertHtml( '<div>foo</div>' ),
+	'test insert div': testInsertHtml( '<div>foo</div>' ),
 
 	// (#2751)
-	'insert div wrapped in another div': testInsertHtml( '<div><div>foo</div></div>' ),
+	'test insert div wrapped in another div': testInsertHtml( '<div><div>foo</div></div>' ),
 
 	// (#2751)
-	'insert two divs': testInsertHtml( '<div>foo</div><div>bar</div>' ),
+	'test insert two divs': testInsertHtml( '<div>foo</div><div>bar</div>' ),
 
 	// (#2751)
-	'insert two divs wrapped in another div': testInsertHtml( '<div><div>foo</div><div>bar</div></div>' ),
+	'test insert two divs wrapped in another div': testInsertHtml( '<div><div>foo</div><div>bar</div></div>' ),
 
 	// (#3379)
 	'test getData call (div enter mode)': testGetData()

--- a/tests/core/editable/manual/insertgetdata.html
+++ b/tests/core/editable/manual/insertgetdata.html
@@ -1,0 +1,37 @@
+<p>Count of <code>beforeGetData</code> events: <b id="counter-editor1">0</b></p>
+<div id="editor1">
+	<p>Drop h^ere</p>
+	<p>
+		<img src="%BASE_PATH%_assets/logo.png" alt="Logo">
+	</p>
+</div>
+
+<p>Count of <code>beforeGetData</code> events: <b id="counter-editor2">0</b></p>
+<div id="editor2">
+	<div>Drop h^ere</div>
+	<div>
+		<img src="%BASE_PATH%_assets/logo.png" alt="Logo">
+	</div>
+</div>
+
+<script>
+	( function() {
+		var config = {
+			on: {
+				beforeGetData: updateCounter
+			}
+		};
+
+		CKEDITOR.replace( 'editor1', config );
+		CKEDITOR.replace( 'editor2', CKEDITOR.tools.object.merge( config, {
+			enterMode: CKEDITOR.ENTER_DIV
+		} ) );
+
+		function updateCounter( evt ) {
+			var counter = CKEDITOR.document.getById( 'counter-' + evt.editor.name ),
+				i = parseInt( counter.getHtml(), 10 );
+
+			counter.setHtml( ++i );
+		}
+	}() );
+</script>

--- a/tests/core/editable/manual/insertgetdata.md
+++ b/tests/core/editable/manual/insertgetdata.md
@@ -1,0 +1,16 @@
+@bender-tags: 4.13.0, bug, 3379
+@bender-ui: collapsed
+@bender-ckeditor-plugins: toolbar, wysiwygarea, clipboard, image2
+
+## For each editor
+
+1. Drag and drop image into "Drop here" place.
+2. Inspect the number of `beforeGetData` events above the editor.
+
+## Expected
+
+The number of events equal 0.
+
+## Unexpected
+
+The number of events is higher than 0.


### PR DESCRIPTION
## What is the purpose of this pull request?

Bug fix

## Does your PR contain necessary tests?

All patches which change the editor code must include tests. You can always read more
on [PR testing](https://ckeditor.com/docs/ckeditor4/latest/guide/dev_contributing_code.html#tests),
[how to set the testing environment](https://ckeditor.com/docs/ckeditor4/latest/guide/dev_tests.html) and
[how to create tests](https://ckeditor.com/docs/ckeditor4/latest/guide/dev_tests.html#creating-your-own-test)
in the official CKEditor documentation.

### This PR contains

- [x] Unit tests
- [x] Manual tests

## What is the proposed changelog entry for this pull request?

```
* [#3379](https://github.com/ckeditor/ckeditor-dev/issues/3379): Fixed: Incorrect [`CKEDITOR.editor#getData`](https://ckeditor.com/docs/ckeditor4/latest/api/CKEDITOR_editor.html#method-getData) call when inserting content into the editor.
```

## What changes did you make?

I've reversed the conditional introduced by #2776 and forced `getData` to be called as an internal one.

Closes #3379.