### PR TITLE
Add support for non-object in CKEDITOR.tools.object.keys in IE8

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -24,6 +24,7 @@ Fixed Issues:
 * [#3287](https://github.com/ckeditor/ckeditor-dev/issues/3287): Fixed: [`CKEDITOR.tools.promise`](https://ckeditor.com/docs/ckeditor4/latest/api/CKEDITOR_tools_promise.html) incorrectly initialized if an AMD loader is present.
 * [#3379](https://github.com/ckeditor/ckeditor-dev/issues/3379): Fixed: Incorrect [`CKEDITOR.editor#getData`](https://ckeditor.com/docs/ckeditor4/latest/api/CKEDITOR_editor.html#method-getData) call when inserting content into the editor.
 * [#3136](https://github.com/ckeditor/ckeditor-dev/issues/3136) [Firefox] Fixed: Clicking on [Balloon Toolbar](https://ckeditor.com/cke4/addon/balloontoolbar) items removes native table selection.
+* [#3381](https://github.com/ckeditor/ckeditor-dev/issues/3381): [IE8] Fixed: [`CKEDITOR.tools.object.keys`](https://ckeditor.com/docs/ckeditor4/latest/api/CKEDITOR_tools_object.html#method-keys) does not accept non-objects.
 
 API Changes:
 

--- a/core/tools.js
+++ b/core/tools.js
@@ -2266,7 +2266,14 @@
 			keys: function( obj ) {
 				var hasOwnProperty = Object.prototype.hasOwnProperty,
 					keys = [],
-					dontEnums = CKEDITOR.tools.object.DONT_ENUMS;
+					dontEnums = CKEDITOR.tools.object.DONT_ENUMS,
+					isNotObject = !obj || typeof obj !== 'object';
+
+				// We must handle non-object types differently in IE 8,
+				// due to the fact that it uses ES5 behaviour, not ES2015+ as others (#3381).
+				if ( CKEDITOR.env.ie && CKEDITOR.env.version < 9 && isNotObject ) {
+					return [];
+				}
 
 				for ( var prop in obj ) {
 					keys.push( prop );

--- a/core/tools.js
+++ b/core/tools.js
@@ -2270,7 +2270,7 @@
 					isNotObject = !obj || typeof obj !== 'object';
 
 				// We must handle non-object types differently in IE 8,
-				// due to the fact that it uses ES5 behaviour, not ES2015+ as others (#3381).
+				// due to the fact that it uses ES5 behaviour, not ES2015+ as other browsers (#3381).
 				if ( CKEDITOR.env.ie && CKEDITOR.env.version < 9 && isNotObject ) {
 					return createNonObjectKeys( obj );
 				}

--- a/core/tools.js
+++ b/core/tools.js
@@ -2272,7 +2272,7 @@
 				// We must handle non-object types differently in IE 8,
 				// due to the fact that it uses ES5 behaviour, not ES2015+ as others (#3381).
 				if ( CKEDITOR.env.ie && CKEDITOR.env.version < 9 && isNotObject ) {
-					return [];
+					return createNonObjectKeys( obj );
 				}
 
 				for ( var prop in obj ) {
@@ -2289,6 +2289,21 @@
 				}
 
 				return keys;
+
+				function createNonObjectKeys( value ) {
+					var keys = [],
+						i;
+
+					if ( typeof value !== 'string' ) {
+						return keys;
+					}
+
+					for ( i = 0; i < value.length; i++ ) {
+						keys.push( String( i ) );
+					}
+
+					return keys;
+				}
 			},
 
 			/**

--- a/tests/core/tools/object.js
+++ b/tests/core/tools/object.js
@@ -22,6 +22,36 @@
 				CKEDITOR.tools.object.keys( target ) );
 		},
 
+		// (#3381)
+		'test object.keys on non-objects': function() {
+			var keys = CKEDITOR.tools.object.keys,
+				fixtures = [
+					undefined,
+					null,
+					function() {},
+					1,
+					true
+				];
+
+			CKEDITOR.tools.array.forEach( fixtures, function( fixture ) {
+				arrayAssert.itemsAreEqual( [], keys( fixture ), showFixtureType( fixture ) );
+			} );
+
+			function showFixtureType( fixture ) {
+				if ( fixture === null ) {
+					return 'null';
+				}
+
+				return typeof fixture;
+			}
+		},
+
+		// (#3381)
+		'test object.keys for strings': function() {
+			arrayAssert.itemsAreEqual( [ '0', '1', '2', '3', '4', '5', '6', '7' ],
+				CKEDITOR.tools.object.keys( 'whatever' ) );
+		},
+
 		// (#3123)
 		'test object.entries': function() {
 			var obj = {


### PR DESCRIPTION
## What is the purpose of this pull request?

Bug fix

## Does your PR contain necessary tests?

All patches which change the editor code must include tests. You can always read more
on [PR testing](https://ckeditor.com/docs/ckeditor4/latest/guide/dev_contributing_code.html#tests),
[how to set the testing environment](https://ckeditor.com/docs/ckeditor4/latest/guide/dev_tests.html) and
[how to create tests](https://ckeditor.com/docs/ckeditor4/latest/guide/dev_tests.html#creating-your-own-test)
in the official CKEditor documentation.

### This PR contains

- [x] Unit tests
- [ ] Manual tests

## What is the proposed changelog entry for this pull request?

```
* [#3381](https://github.com/ckeditor/ckeditor-dev/issues/3381): [IE8] Fixed: [`CKEDITOR.tools.object.keys`](https://ckeditor.com/docs/ckeditor4/latest/api/CKEDITOR_tools_object.html#method-keys) does not accept non-objects.
```

## What changes did you make?

I've added support for non-objects, including strings in IE8.

Closes #3381.